### PR TITLE
chore: add active-home ISSUE_TEMPLATE/config.yml and pull_request_template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Discussions
+    url: https://github.com/amule-org/amule/discussions
+    about: |
+      Have a question, an idea, or want to chat with the community?
+      Try Discussions first — they're better suited to open-ended
+      topics than the issue tracker.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Test plan
+
+<!-- How was this change verified? -->


### PR DESCRIPTION
## Summary

Adds amule-org/amule's own `.github/ISSUE_TEMPLATE/config.yml` and `.github/pull_request_template.md` so that when amule-project/amule#921 lands its mirror-redirect versions of the same paths, a future "Sync fork" pass into this repo doesn't propagate the "issues moved to amule-org" notice onto the active home (where it would be self-referential).

- `config.yml`: keeps blank issues enabled, adds a Discussions contact link as a soft funnel for question-style content (Discussions are already enabled on this repo).
- `pull_request_template.md`: minimal contributor scaffold — Summary + Test plan headers, no mirror notice.

## Divergence point

**Once this PR is merged, amule-org/amule and amule-project/amule lose sync on `.github/`.** From here on:

- **amule-org/amule** is the new active home — issues, PRs, and Discussions land here.
- **amule-project/amule** becomes a redirect mirror — its `.github/` (via #921) will send issue / PR openers to this repo.

No further "Sync fork" passes from amule-project should be needed; both repos are intentionally divergent on `.github/` going forward, and code changes flow `amule-org → amule-project` (not the other way) if a mirror update is wanted at all.

## Refs

- amule-project/amule#919 — removed the mirror-only static files in coordination with the 3.0.0 release sync.
- amule-project/amule#921 — the held-back follow-up that re-adds them on the mirror once both these files exist here.
