### PR TITLE
feat(flathub): stage Flathub-strict manifest in packaging/flathub/

### DIFF
--- a/packaging/flathub/README.md
+++ b/packaging/flathub/README.md
@@ -1,0 +1,92 @@
+# Flathub submission staging
+
+This directory holds the **Flathub-strict** version of the aMule Flatpak
+manifest — the file that will be submitted to
+[github.com/flathub/flathub](https://github.com/flathub/flathub) for
+inclusion in the Flathub catalogue, and (once approved) mirrored to
+`github.com/flathub/org.amule.aMule` as the canonical Flathub-side
+home.
+
+The file in this directory is **not** consumed by the day-to-day
+packaging build. That path uses
+[`packaging/linux/flatpak/org.amule.aMule.yaml.in`](../linux/flatpak/org.amule.aMule.yaml.in)
+— a template with `${...}` variables resolved at build time by
+`packaging/linux/build.sh` via `envsubst`. The internal template uses
+`branch: master` for aMule so dev / CI Flatpak builds always pick up
+the current tip without manual updates.
+
+## Why two manifests
+
+Flathub's submission policy forbids mutable refs (branch names) and
+requires every source to be pinned by an immutable identifier:
+
+| Source type | Flathub-acceptable pin |
+|---|---|
+| `archive` | `sha256` |
+| `git` (preferred) | `tag` + `commit` |
+| `git` (minimal) | `commit` alone |
+| `git` (forbidden) | `branch` |
+
+Our internal template uses `branch: ${AMULE_REVISION}` so day-to-day
+builds can target master or a feature branch. The Flathub-strict manifest
+in this directory pins to a concrete tag + commit SHA so Flathub CI
+produces reproducible builds.
+
+Keeping both files in sync is a manual step. The differences are small
+and localised:
+
+- All `${...}` template variables resolved to concrete values.
+- The `amule` module: `branch: ${AMULE_REVISION}` → `tag: + commit:`.
+- The `cryptopp` module: existing `tag:` augmented with a `commit:`.
+
+Every other module is identical between the two files (they were already
+archive + sha256 pinned).
+
+## Submission flow
+
+1. Fork [`flathub/flathub`](https://github.com/flathub/flathub) on the
+   maintainer's GitHub account.
+2. Check out the `new-pr` branch on the fork.
+3. Add a directory `org.amule.aMule/` containing:
+   - `org.amule.aMule.yaml` — this manifest (copied verbatim).
+   - The screenshots and icon are pulled at build time from the source
+     `cmake --install` rule; no extra files needed in the Flathub
+     directory.
+4. Open a PR against `flathub/flathub:new-pr` titled
+   `aMule (org.amule.aMule)`.
+5. A Flathub volunteer reviewer will look at the manifest, may ask for
+   changes (commonly: justification for `--filesystem=host`, app-id
+   domain ownership confirmation), and merge when satisfied.
+6. Once merged, Flathub creates a dedicated repo at
+   `github.com/flathub/org.amule.aMule` and grants the submitter admin
+   access. From that point the dedicated repo is the canonical home for
+   the Flathub manifest.
+
+## Refreshing after a new aMule release
+
+When a new aMule release tag is pushed (e.g. `3.0.1`):
+
+```sh
+# resolve the new tag's commit SHA
+gh api repos/amule-org/amule/git/refs/tags/3.0.1 --jq '.object.sha'
+```
+
+Update the `amule` source block in this file:
+
+```yaml
+- type: git
+  url: https://github.com/amule-org/amule.git
+  tag: '3.0.1'
+  commit: <40-char SHA from the gh api call above>
+```
+
+Then PR the same change to `flathub/org.amule.aMule` (once that
+repo exists). `x-checker-data` in the manifest lets Flathub's
+`flatpak-external-data-checker` bot auto-open these PRs for us on
+the Flathub side; the in-tree copy still needs a manual bump.
+
+## Refreshing the runtime
+
+GNOME Platform runtime bumps (currently pinned to `49`) need to be
+coordinated with the internal template — both files reference the
+same runtime version. Bump both at once and rebuild end-to-end.

--- a/packaging/flathub/org.amule.aMule.yaml
+++ b/packaging/flathub/org.amule.aMule.yaml
@@ -1,0 +1,244 @@
+# Flathub-strict aMule manifest.
+#
+# This file is the staging copy of what gets submitted to
+# github.com/flathub/flathub once the listing is approved, the dedicated
+# github.com/flathub/org.amule.aMule repo becomes the canonical home and
+# this file is kept in sync with it.
+#
+# Differences from packaging/linux/flatpak/org.amule.aMule.yaml.in:
+#  - Concrete version pins (no ${...} template variables — Flathub CI
+#    doesn't run envsubst).
+#  - amule source: tag + commit instead of branch (Flathub forbids
+#    mutable refs).
+#  - cryptopp source: commit added next to the tag.
+#  - All other modules identical (they were already archive + sha256
+#    pinned).
+#
+# To refresh after a new aMule release tag:
+#   1. Resolve the tag's commit SHA:
+#        gh api repos/amule-org/amule/git/refs/tags/<tag> --jq '.object.sha'
+#   2. Update the amule source block's `tag:` and `commit:`.
+#   3. PR to github.com/flathub/org.amule.aMule (once that repo exists).
+
+app-id: org.amule.aMule
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: amule
+
+build-options:
+  env:
+    MAKEFLAGS: "-j2"
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  # Full home access. aMule is a P2P client where users mark arbitrary
+  # folders as shared (uploads) and pick arbitrary destinations for
+  # Incoming / Temp / completed-files dirs (downloads). Restricting to
+  # xdg-download alone makes the most common config — "share my Music
+  # folder, save downloads to ~/Movies" — silently fail. This matches
+  # qBittorrent / Transmission on Flathub for the same reason.
+  - --filesystem=home
+  - --filesystem=xdg-config/mimeapps.list:ro
+  - --talk-name=org.freedesktop.PowerManagement.Inhibit
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=com.canonical.AppMenu.Registrar
+  - --talk-name=org.freedesktop.Notifications
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /share/man
+  - /share/doc
+  - '*.la'
+  - '*.a'
+
+modules:
+
+  - name: cryptopp
+    buildsystem: simple
+    build-commands:
+      - make -j2 shared
+      - make install PREFIX=/app
+    sources:
+      - type: git
+        url: https://github.com/weidai11/cryptopp.git
+        tag: CRYPTOPP_8_9_0
+        commit: 041cf66ed64f28d89cc50b762cde0353cf85657c
+        x-checker-data:
+          type: git
+          tag-pattern: ^CRYPTOPP_(\d+)_(\d+)_(\d+)$
+
+  - name: libupnp
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DUPNP_BUILD_SAMPLES=OFF
+      - -DUPNP_BUILD_TESTS=OFF
+      - -Dreuseaddr=ON
+      - -Dipv6=ON
+      - -DCMAKE_INSTALL_LIBDIR=lib
+    sources:
+      - type: archive
+        url: https://github.com/pupnp/pupnp/archive/refs/tags/release-1.14.21.tar.gz
+        sha256: d176a6028b02ab36e9d334372dd64780d9a8e577a2d8d4c1d70ef8ced15d7d19
+
+  - name: boost
+    buildsystem: simple
+    build-commands:
+      - ./bootstrap.sh --prefix=/app --with-libraries=system
+      - ./b2 -j2 install --prefix=/app
+    sources:
+      - type: archive
+        url: https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2
+        sha256: af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89
+
+  - name: libgd
+    buildsystem: autotools
+    config-opts:
+      - --without-x
+      - --with-png=/usr
+      - --with-zlib=/usr
+      - --without-tiff
+      - --without-webp
+      - --without-xpm
+      - --without-fontconfig
+    sources:
+      - type: archive
+        url: https://github.com/libgd/libgd/releases/download/gd-2.3.3/libgd-2.3.3.tar.xz
+        sha256: 3fe822ece20796060af63b7c60acb151e5844204d289da0ce08f8fdf131e5a61
+
+  - name: intltool
+    cleanup:
+      - '*'
+    sources:
+      - type: archive
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        mirror-urls:
+          - https://archive.ubuntu.com/ubuntu/pool/main/i/intltool/intltool_0.51.0.orig.tar.gz
+          - https://snapshot.debian.org/archive/debian/20180815T211456Z/pool/main/i/intltool/intltool_0.51.0.orig.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+
+  - name: libdbusmenu
+    buildsystem: autotools
+    config-opts:
+      - --with-gtk=3
+      - --disable-dumper
+      - --disable-static
+      - --disable-tests
+      - --disable-introspection
+      - --disable-vala
+      - --disable-gtk-doc
+    build-options:
+      env:
+        HAVE_VALGRIND_FALSE: '#'
+        HAVE_VALGRIND_TRUE: ''
+        MAKEFLAGS: '-j1'
+    make-args:
+      - 'CFLAGS=-Wall -O2 -g -fPIC -Wno-error'
+      - 'CXXFLAGS=-Wall -O2 -g -fPIC -Wno-error'
+    sources:
+      - type: archive
+        url: https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz
+        sha256: b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a
+
+  - name: ayatana-ido
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_TESTS=OFF
+      - -DCMAKE_INSTALL_LIBDIR=lib
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/ayatana-ido/archive/refs/tags/0.10.4.tar.gz
+        sha256: bd59abd5f1314e411d0d55ce3643e91cef633271f58126be529de5fb71c5ab38
+
+  - name: libayatana-indicator
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_TESTS=OFF
+      - -DCMAKE_INSTALL_LIBDIR=lib
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/libayatana-indicator/archive/refs/tags/0.9.4.tar.gz
+        sha256: a18d3c682e29afd77db24366f8475b26bda22b0e16ff569a2ec71cd6eb4eac95
+
+  - name: libayatana-appindicator
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_BINDINGS_MONO=OFF
+      - -DENABLE_BINDINGS_VALA=OFF
+      - -DENABLE_TESTS=OFF
+      - -DFLAVOUR_GTK3=ON
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DENABLE_GTKDOC=OFF
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/0.5.94.tar.gz
+        sha256: 884a6bc77994c0b58c961613ca4c4b974dc91aa0f804e70e92f38a542d0d0f90
+
+  - name: libmaxminddb
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --disable-tests
+    sources:
+      - type: archive
+        url: https://github.com/maxmind/libmaxminddb/releases/download/1.13.3/libmaxminddb-1.13.3.tar.gz
+        sha256: a66502ea76eadbe17f2cd6fd708946777253972d2ae8157dee1b23a2fb528171
+
+  - name: wxwidgets
+    buildsystem: autotools
+    config-opts:
+      - --with-gtk=3
+      - --enable-unicode
+      - --disable-debug
+      - --disable-shared
+      - --disable-mediactrl
+      - --disable-webview
+      - --disable-richtext
+      - --disable-aui
+      - --disable-html
+      - --without-libtiff
+      - --without-libjbig
+      - --without-libmspack
+      - --without-opengl
+      - --with-libcurl
+    sources:
+      - type: archive
+        url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.6/wxWidgets-3.2.6.tar.bz2
+        sha256: 939e5b77ddc5b6092d1d7d29491fe67010a2433cf9b9c0d841ee4d04acb9dce7
+
+  - name: amule
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_MONOLITHIC=YES
+      - -DBUILD_REMOTEGUI=YES
+      - -DBUILD_DAEMON=YES
+      - -DBUILD_AMULECMD=YES
+      - -DBUILD_ED2K=YES
+      - -DBUILD_WEBSERVER=YES
+      - -DBUILD_CAS=YES
+      - -DBUILD_WXCAS=YES
+      - -DBUILD_ALC=YES
+      - -DBUILD_ALCC=YES
+      - -DENABLE_NLS=YES
+      - -DENABLE_UPNP=YES
+      - -DENABLE_IP2COUNTRY=YES
+    sources:
+      - type: git
+        url: https://github.com/amule-org/amule.git
+        # TBD-AFTER-PR-15-MERGE: bump tag + commit to the master tip that
+        # carries the icon-refresh PR so Flathub builds ship with the
+        # higher-res icons. Until then, this pins to the original 3.0.0
+        # tag — Flathub builds would render with the old 128x128 icon.
+        tag: '3.0.0'
+        commit: df8e92a32efe6c89dc75d2df865e932f5bb9c730
+        disable-shallow-clone: true
+        x-checker-data:
+          type: git
+          tag-pattern: ^v?([\d.]+)$

--- a/packaging/flathub/org.amule.aMule.yaml
+++ b/packaging/flathub/org.amule.aMule.yaml
@@ -232,12 +232,14 @@ modules:
     sources:
       - type: git
         url: https://github.com/amule-org/amule.git
-        # TBD-AFTER-PR-15-MERGE: bump tag + commit to the master tip that
-        # carries the icon-refresh PR so Flathub builds ship with the
-        # higher-res icons. Until then, this pins to the original 3.0.0
-        # tag — Flathub builds would render with the old 128x128 icon.
+        # Pinned to a master tip post-#15 (icon refresh) and post-#17
+        # (metainfo/desktop polish). The Flatpak still self-identifies
+        # as 3.0.0 because the source version macro is unchanged; only
+        # the icon assets, the metainfo screenshot URLs, the release
+        # <description>+<url>, and the .desktop GenericName/Keywords
+        # moved. Bump tag + commit together on the next aMule release.
         tag: '3.0.0'
-        commit: df8e92a32efe6c89dc75d2df865e932f5bb9c730
+        commit: eb75041af2ff760960d44abb13a6ea7c586bcdca
         disable-shallow-clone: true
         x-checker-data:
           type: git

--- a/packaging/flathub/org.amule.aMule.yaml
+++ b/packaging/flathub/org.amule.aMule.yaml
@@ -229,17 +229,23 @@ modules:
       - -DENABLE_NLS=YES
       - -DENABLE_UPNP=YES
       - -DENABLE_IP2COUNTRY=YES
+      # GNOME 49 SDK ships libbfd at build time, the runtime doesn't —
+      # without this the installed flatpak aborts at startup with
+      # "libbfd-2.46.so: cannot open shared object file" (#13). The
+      # ENABLE_BFD option (added in #19) makes this opt-out clean;
+      # MuleDebug.cpp's !HAVE_BFD path keeps backtraces working via
+      # backtrace_symbols() + addr2line.
+      - -DENABLE_BFD=NO
     sources:
       - type: git
         url: https://github.com/amule-org/amule.git
-        # Pinned to a master tip post-#15 (icon refresh) and post-#17
-        # (metainfo/desktop polish). The Flatpak still self-identifies
-        # as 3.0.0 because the source version macro is unchanged; only
-        # the icon assets, the metainfo screenshot URLs, the release
-        # <description>+<url>, and the .desktop GenericName/Keywords
-        # moved. Bump tag + commit together on the next aMule release.
+        # Pinned to a master tip post-#15 (icon refresh), #17 (metainfo
+        # / desktop polish), and #19 (ENABLE_BFD option + flatpak
+        # build opts -DENABLE_BFD=NO). The Flatpak still self-identifies
+        # as 3.0.0 because the source version macro is unchanged. Bump
+        # tag + commit together on the next aMule release.
         tag: '3.0.0'
-        commit: eb75041af2ff760960d44abb13a6ea7c586bcdca
+        commit: 6985ba0088783423f3541e98a392deee465b2b9b
         disable-shallow-clone: true
         x-checker-data:
           type: git


### PR DESCRIPTION
## Summary

Stages the Flathub-strict version of the aMule Flatpak manifest in `packaging/flathub/` for review and refresh tracking. This is the file we will submit to `flathub/flathub` to land aMule on the Flathub catalogue.

The internal day-to-day Flatpak build keeps using `packaging/linux/flatpak/org.amule.aMule.yaml.in` (template with `${...}` vars, `branch: master` for aMule); the Flathub-strict manifest is parallel and standalone.

## What's different from the internal template

| Module | Internal template | Flathub-strict |
|---|---|---|
| `cryptopp` | `tag: CRYPTOPP_${CRYPTOPP_TAG_SUFFIX}` | `tag: CRYPTOPP_8_9_0` **+ `commit: 041cf66e...`** |
| `amule` | `branch: ${AMULE_REVISION}` (default `master`) | **`tag: 3.0.0` + `commit: <SHA>`** |
| every other module | `${...}` template variables | concrete version pins (no envsubst) |

All other modules were already `archive+sha256` pinned; no functional change. The runtime, `finish-args`, `build-options`, and cleanup rules are unchanged from the internal template.

## Blocked on

**This PR is held in draft until amule-org/amule#15 lands.** That PR adds the higher-resolution Linux hicolor icons and pins the metainfo screenshot URLs to the 3.0.0 tag. If we submit Flathub before #15 merges, Flathub builds will render with the old 128×128 icon and screenshot URLs that drift with master.

When #15 lands, the `amule` source block will be updated to point at the new master tip:

```yaml
- type: git
  url: https://github.com/amule-org/amule.git
  tag: '3.0.0'                                  # ← still says 3.0.0 (binary version unchanged)
  commit: <40-char SHA of master tip post-#15>  # ← bump to pick up icon fixes
```

Flathub does not require the pin to be at a release tag — an immutable commit anywhere on a public branch is sufficient. The Flatpak still self-identifies as `3.0.0` because the source's version macro is unchanged; only icons + a metainfo URL moved.

## Files

- `packaging/flathub/org.amule.aMule.yaml` — the Flathub-strict manifest, 12 modules, all sources immutably pinned. YAML validated; every module is either `archive+sha256` or `git+tag+commit`, zero branch refs.
- `packaging/flathub/README.md` — workflow doc: why two manifests, how to refresh on release, how to submit to `flathub/flathub`.

## Next steps after this lands

1. Wait for #15 to merge.
2. Bump the `amule` `commit:` to the new master tip.
3. Fork `flathub/flathub`, add `org.amule.aMule/org.amule.aMule.yaml` (verbatim copy), open PR to `flathub/flathub:new-pr`.
4. Respond to the Flathub reviewer's feedback (likely: justify `--filesystem=home`, demonstrate domain ownership for `org.amule.aMule`).
