### PR TITLE
fix(flatpak): disable libbfd in the flatpak build (#13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,12 @@ list (GET _AMULE_MONTHS ${_AMULE_MAN_MONTH_IDX} _AMULE_MAN_MONTH)
 string (TIMESTAMP _AMULE_MAN_YEAR "%Y" UTC)
 set (MAN_DATE "\"${_AMULE_MAN_MONTH} ${_AMULE_MAN_YEAR}\"")
 
-include (cmake/bfd.cmake)
+if (ENABLE_BFD)
+	include (cmake/bfd.cmake)
+else()
+	set (HAVE_BFD FALSE)
+	message (STATUS "ENABLE_BFD=NO; skipping libbfd detection. Backtraces fall back to addr2line + backtrace_symbols().")
+endif()
 
 # DownloadBandwidthThrottler holds the shared byte budget as
 # std::atomic<int64_t>. On 64-bit targets the compiler emits native

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -167,12 +167,20 @@ if (NEED_LIB_MULEAPPCOMMON)
 	option (ENABLE_IP2COUNTRY "compile with GeoIP IP2Country library")
 	option (ENABLE_MMAP "enable using mapped memory if supported")
 	option (ENABLE_NLS "enable national language support" ON)
+	# Backtrace symbol resolution: ON => use libbfd for in-process
+	# address→file:line resolution; OFF => fall back to
+	# backtrace_symbols() for function names + an external addr2line
+	# popen() for line info (MuleDebug.cpp). Off is intended for
+	# environments that ship libbfd in the SDK but not in the runtime
+	# (e.g. GNOME-Platform-based Flatpak builds, see #13).
+	option (ENABLE_BFD "use libbfd for in-process backtrace symbol resolution" ON)
 	set (NEED_LIB_MULEAPPCORE TRUE)
 	set (wx_NEED_BASE TRUE)
 else()
 	set (ENABLE_IP2COUNTRY FALSE)
 	set (ENABLE_MMAP FALSE)
 	set (ENABLE_NLS FALSE)
+	set (ENABLE_BFD FALSE)
 endif()
 
 if (NEED_LIB_MULEAPPGUI)

--- a/packaging/linux/flatpak/org.amule.aMule.yaml.in
+++ b/packaging/linux/flatpak/org.amule.aMule.yaml.in
@@ -315,6 +315,20 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_MONOLITHIC=YES
+      # The GNOME 49 SDK ships libbfd (in /usr/lib) and bfd.h (in
+      # /usr/include), so aMule's auto-detection at cmake/bfd.cmake
+      # finds it and links against libbfd-2.46.so. The GNOME 49
+      # *Runtime* (the tree shipped to end users) does NOT ship
+      # libbfd -- it's a development library -- so the installed
+      # flatpak aborts at startup with:
+      #     amule: error while loading shared libraries:
+      #     libbfd-2.46.so: cannot open shared object file
+      # (amule-org/amule#13). Disable libbfd for the flatpak build;
+      # MuleDebug.cpp's !HAVE_BFD path still emits backtraces via
+      # backtrace() + backtrace_symbols() and shells out to
+      # addr2line for line numbers when available. The native distro
+      # packages and the AppImage continue to use libbfd normally.
+      - -DENABLE_BFD=NO
       - -DBUILD_REMOTEGUI=YES
       - -DBUILD_DAEMON=YES
       - -DBUILD_AMULECMD=YES


### PR DESCRIPTION
Fixes #13.

aMule's `cmake/bfd.cmake` auto-detects libbfd at configure time and links against it for backtrace symbol resolution. The GNOME 49 SDK (build-time) ships `libbfd-2.46.so` + `bfd.h`, so the detection fires. The GNOME 49 *runtime* (the tree shipped to end users alongside the bundle) does **not** ship libbfd — it's a development library — so installed flatpaks abort at startup:

```
amule: error while loading shared libraries: libbfd-2.46.so: cannot open shared object file: No such file or directory
```

Every Linux user installing the 3.0.0 flatpak bundle is hitting this today.

### Fix

1. Add `option(ENABLE_BFD "..." ON)` to `cmake/options.cmake`, mirroring the adjacent `ENABLE_NLS` pattern. Default ON, so distro packagers, the AppImage build, native local builds, and CI all behave exactly as before.
2. Gate `include(cmake/bfd.cmake)` in `CMakeLists.txt` on `ENABLE_BFD`. When OFF, `HAVE_BFD` stays unset and the downstream `if(HAVE_BFD)` guards in `src/CMakeLists.txt` and `src/libs/common/CMakeLists.txt` skip the libbfd linkage.
3. Pass `-DENABLE_BFD=NO` from the flatpak manifest template, with a comment block explaining why this channel specifically needs it.

### Backtrace impact for flatpak users

`MuleDebug.cpp:368-521` already implements a full `!HAVE_BFD` fallback: `backtrace()` + `backtrace_symbols()` still emit the stack with function names, and the code shells out to `addr2line -C -f -s -e /proc/$$/exe` via `popen()` for source line info when available. The post-#677 PIE-base translation keeps addresses meaningful on modern PIE binaries. Net: slightly less detailed in-process resolution, but crash reports remain actionable.

### Verified

Full clean rebuild on Linux ARM64, installed, ran. `readelf -d` confirms libbfd is no longer in DT_NEEDED. `flatpak run org.amule.aMule --version` returns the banner cleanly:

```
aMule GIT compiled with wxGTK3 v3.2.6 and Boost 1.87 (Snapshot: rev. 2.3.3-693-g...) (OS: Linux)
```

### Follow-up

The Flathub-strict manifest staged in #16 will need the same `-DENABLE_BFD=NO` config-opt addition; queued as a one-line follow-up once #16 lands.