### PR TITLE
fix(flatpak): register install-prefix locale dir for wxLocale lookup

### DIFF
--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -1102,10 +1102,34 @@ void InitLocale(wxLocale& locale, int language)
 	// .mo catalogs live under <bundle>/Contents/Resources alongside the
 	// other bundle resources -- which is what GetResourcesDir() returns.
 	// On Windows both methods return the directory containing the .exe,
-	// so this is equivalent there.  Linux falls through to libintl's
-	// system search paths (share/locale).
+	// so this is equivalent there.
 	locale.AddCatalogLookupPathPrefix(JoinPaths(wxStandardPaths::Get().GetResourcesDir(), "locale"));
-#endif /* (!)(defined(__WXMAC__) || defined(__WINDOWS__)) */
+#elif defined(__WXGTK__) || defined(__UNIX__)
+	// On Linux/*BSD, .mo catalogs are installed under
+	//   ${CMAKE_INSTALL_PREFIX}/share/locale/<lang>/LC_MESSAGES/amule.mo
+	// (see po/CMakeLists.txt -- DESTINATION ${CMAKE_INSTALL_LOCALEDIR}).
+	//
+	// libintl's default lookup path is baked in at wxGTK's build time.
+	// For system installs that build the binary and wxGTK against the
+	// same prefix (typical Debian/Fedora/Arch packages), the default
+	// path matches and translations work without explicit help.
+	//
+	// In a Flatpak however, the bundle installs under prefix=/app while
+	// the wxGTK shipped inside the GNOME runtime was built against
+	// prefix=/usr -- so libintl looks for amule.mo under /usr/share/locale,
+	// and our catalogs sit at /app/share/locale, untouched. Net result:
+	// every gettext() lookup misses and the UI runs in English regardless
+	// of LANG. See amule-org/amule#18 (DaRkViVi verified the path
+	// mismatch on Fedora 44: ls /app/share/locale shows it/, ls
+	// /usr/share/locale/it/LC_MESSAGES/amule.mo is missing).
+	//
+	// Explicitly registering ${install_prefix}/share/locale as a wxLocale
+	// lookup prefix makes the binary self-sufficient: it tells libintl to
+	// also look under its own runtime install prefix, which matches the
+	// install path on Flatpak and is a harmless no-op on system installs
+	// (libintl already finds the catalog under /usr/share/locale).
+	locale.AddCatalogLookupPathPrefix(JoinPaths(JoinPaths(wxStandardPaths::Get().GetInstallPrefix(), "share"), "locale"));
+#endif
 
 	locale.AddCatalog(PACKAGE);
 }


### PR DESCRIPTION
Fixes #18.

The flatpak bundle has shipped with `.mo` translation catalogs installed under `/app/share/locale/<lang>/LC_MESSAGES/amule.mo` (per `po/CMakeLists.txt` → `${CMAKE_INSTALL_LOCALEDIR}`), but the GNOME 49 runtime's bundled wxGTK / libintl was built with `--prefix=/usr` so its baked-in default lookup path is `/usr/share/locale`. Path mismatch → every `gettext()` lookup misses → UI shows English regardless of `LANG` / `LC_*` / aMule's own language preference.

## Root cause

[`InitLocale()`](https://github.com/amule-org/amule/blob/master/src/OtherFunctions.cpp#L1096-L1111) has an explicit `AddCatalogLookupPathPrefix(GetResourcesDir() + "/locale")` block for macOS/Windows (where catalogs live next to the binary / inside the .app bundle), but Linux/*BSD were left to rely on libintl's compiled-in default. That default matches for typical distro packages (binary and wxGTK share a prefix), so the bug never surfaced outside Flatpak.

## Fix

Extend the same block to also register `${install_prefix}/share/locale` on Linux/*BSD. `wxStandardPaths::Get().GetInstallPrefix()` resolves to `/app` inside the Flatpak sandbox, so we register `/app/share/locale` as a wxLocale lookup prefix — which is exactly where our catalogs are. On system installs (`/usr` or `/usr/local`), this overlaps with libintl's default lookup and is a harmless no-op.

## Reproduction

@DaRkViVi confirmed the path mismatch on Fedora 44 in #18:

```
$ flatpak run --command=sh org.amule.aMule -c 'ls /app/share/locale | head'
de es fr hu it pt_BR ...                # catalogs present in the bundle

$ flatpak run --command=sh org.amule.aMule -c 'ls -la /usr/share/locale/it/LC_MESSAGES/amule.mo'
No such file or directory               # libintl looks here, doesn't find it

$ LANG=it_IT.UTF-8 LC_ALL=it_IT.UTF-8 flatpak run org.amule.aMule
# opens in English even with System Language = it
```

## Scope

- **Flatpak**: this fixes the bug — once the packaging CI rebuilds with this commit, the bundled aMule will find its catalogs.
- **AppImage**: should already be fine — AppImage's portable prefix detection lands on the AppDir, but the same lookup-prefix addition is now in place as a belt-and-braces measure.
- **System distro packages (Debian, Fedora, Arch, etc.)**: unaffected — `${install_prefix}` matches libintl's default, so we just register a duplicate path that wxLocale dedupes / silently skips.
- **macOS / Windows**: untouched code path — the existing `__WXMAC__ || __WINDOWS__` block continues to use `GetResourcesDir()` exactly as before.

## Once merged

The next packaging CI run on master will produce a corrected `.flatpak`. The published Releases bundle won't refresh until 3.0.1 is cut, so for now users on Flatpak can grab the post-merge artefact from the packaging workflow run if they want translations restored before 3.0.1.