### PR TITLE
fix(flathub): drop tag pin so the commit pin can sit past the 3.0.0 tag

### DIFF
--- a/packaging/flathub/org.amule.aMule.yaml
+++ b/packaging/flathub/org.amule.aMule.yaml
@@ -240,8 +240,12 @@ modules:
         url: https://github.com/amule-org/amule.git
         # Pinned to a master tip newer than the 3.0.0 tag to ship
         # post-release fixes. Flatpak still self-identifies as 3.0.0
-        # (source version macro unchanged).
-        tag: '3.0.0'
+        # (source version macro unchanged). Tag is intentionally
+        # omitted: flatpak-builder requires that any tag specified
+        # alongside a commit must resolve to that exact commit, so a
+        # tip-of-master pin past the release tag can only be commit-
+        # only. The x-checker-data block below still drives auto-
+        # update PRs against new aMule release tags.
         commit: 54a1ac350f73be07c3b7540d7ab2fb3630ef55df
         disable-shallow-clone: true
         x-checker-data:


### PR DESCRIPTION
#23 bumped the amule source pin to a master tip past the 3.0.0 release tag, but kept the existing `tag: '3.0.0'` line alongside it. flatpak-builder rejects that combination — if both `tag:` and `commit:` are set, the commit must be the exact one the tag resolves to. With the mismatch the build aborts:

```
Failed to download sources: module amule:
Git commit for branch (null) is 1791d2b8d3b60d16c9d2f32a9eadf456683c26cf,
but expected 54a1ac350f73be07c3b7540d7ab2fb3630ef55df
```

Drop `tag: '3.0.0'` from the amule source block, keep `commit:` only. flatpak-builder is happy with commit-only pinning, the Flatpak still self-identifies as 3.0.0 via the source's version macro, and the `x-checker-data` block below still drives auto-update PRs against new aMule release tags. When 3.0.1 (or similar) is cut, the auto-checker will propose restoring the tag pin alongside the bumped commit.

### Verified

End-to-end on Linux ARM64 (Ubuntu): `flatpak-builder` build of the corrected manifest completes; the resulting `.flatpak` installs cleanly; `flatpak run org.amule.aMule --version` returns the expected banner (`Snapshot: rev. 3.0.0-7-g54a1ac350`) with no libbfd dependency in `readelf -d`.