### PR TITLE
fix(flatpak): ship .mo files inside main app instead of .Locale extension

### DIFF
--- a/packaging/flathub/org.amule.aMule.yaml
+++ b/packaging/flathub/org.amule.aMule.yaml
@@ -26,6 +26,22 @@ runtime-version: '49'
 sdk: org.gnome.Sdk
 command: amule
 
+# Ship all translation .mo files inside the main app instead of
+# splitting them into a sibling <app-id>.Locale extension. Default
+# flatpak-builder behaviour (`separate-locales: true`) extracts them
+# into the extension, but the resulting layout
+# (<lang>/share/<sub-lang>/LC_MESSAGES/amule.mo) doesn't match the
+# standard libintl lookup pattern, so wxLocale can't find the
+# catalogs even when the .Locale extension is installed — the UI
+# silently runs in English regardless of LANG.
+#
+# Keeping locales in the main app at the canonical
+# share/locale/<lang>/LC_MESSAGES/amule.mo path makes translations
+# load reliably on every distribution channel.
+#
+# Cost: ~8 MB added to the bundle (~30 .mo files).
+separate-locales: false
+
 build-options:
   env:
     MAKEFLAGS: "-j2"

--- a/packaging/linux/flatpak/org.amule.aMule.yaml.in
+++ b/packaging/linux/flatpak/org.amule.aMule.yaml.in
@@ -17,6 +17,26 @@ runtime-version: '${GNOME_RUNTIME_VERSION}'
 sdk: org.gnome.Sdk
 command: amule
 
+# Ship all translation .mo files inside the main app instead of
+# splitting them into a sibling <app-id>.Locale extension. Default
+# flatpak-builder behaviour (`separate-locales: true`) extracts them
+# into the extension, but the resulting layout
+# (<lang>/share/<sub-lang>/LC_MESSAGES/amule.mo) doesn't match the
+# standard libintl lookup pattern, so wxLocale can't find the
+# catalogs even when the .Locale extension is installed — the UI
+# silently runs in English regardless of LANG.
+#
+# Keeping locales in the main app makes the bundle self-sufficient
+# for both distribution channels:
+#  - the single-file .flatpak shipped from the GitHub Actions
+#    packaging workflow no longer needs a separate Locale bundle,
+#  - the Flathub-strict variant builds an app that actually loads
+#    translations without depending on the broken extension layout.
+#
+# Cost: ~8 MB added to the bundle (~30 .mo files). The Flatpak
+# spec's `separate-locales` field controls this.
+separate-locales: false
+
 # Cap module-build parallelism. flatpak-builder defaults
 # FLATPAK_BUILDER_N_JOBS to nproc inside the build sandbox; on hosts
 # with ≤ 8 GB RAM this OOM-kills wx/cryptopp/aMule mid-build because


### PR DESCRIPTION
flatpak-builder's default behaviour splits translation catalogs out of the main app into a sibling `<app-id>.Locale` extension. For aMule's install layout, that split produces a non-standard nested path inside the extension (`<lang>/share/<sub-lang>/LC_MESSAGES/amule.mo`) that `libintl` can't reach with any single `bindtextdomain` prefix — so even when the `.Locale` extension is installed (which happens automatically on Flathub but never with our single-file `.flatpak` bundle), `wxLocale` loads English and silently ignores translations.

### What changes

Set `separate-locales: false` in both manifests to keep the `.mo` files in the main app at the canonical `share/locale/<lang>/LC_MESSAGES/amule.mo` path. `wxLocale` + the install-prefix lookup registered in #22 then find them reliably.

| File | Change |
|---|---|
| `packaging/linux/flatpak/org.amule.aMule.yaml.in` (day-to-day bundle template) | `separate-locales: false` |
| `packaging/flathub/org.amule.aMule.yaml` (Flathub-strict submission) | `separate-locales: false` |

### Verified

End-to-end on Linux ARM64 (Ubuntu): rebuild of the day-to-day template produces a bundle with all 38 `.mo` files installed at the canonical path. `amulecmd --locale=it_IT` returns Italian:

```
Questo è amulecmd GIT rev. 3.0.0-9-g1f3eb54f6
Creazione del client in corso...
Connessione fallita. Impossibile connettersi a 127.0.0.1:9999
```

For reference, `find /app -name 'amule.mo'` inside the new bundle shows 38 files at `/app/share/locale/<lang>/LC_MESSAGES/amule.mo` (vs only `en_GB` before this change).

### Trade-off

Bundle size grows ~8 MB (the `.mo` files that used to live in the `.Locale` extension). Worth it: every distribution channel now ships working translations without depending on either the Flathub Locale-extension auto-install or the broken nested-path structure flatpak-builder produces by default.

### Follow-up

A separate small PR will bump the `packaging/flathub/org.amule.aMule.yaml` `commit:` SHA pin to this PR's merge commit, so the Flathub-built bundle inherits the locale fix.