### PR TITLE
chore(flathub): bump amule commit pin to current master tip

### DIFF
--- a/packaging/flathub/org.amule.aMule.yaml
+++ b/packaging/flathub/org.amule.aMule.yaml
@@ -262,7 +262,7 @@ modules:
         # tip-of-master pin past the release tag can only be commit-
         # only. The x-checker-data block below still drives auto-
         # update PRs against new aMule release tags.
-        commit: 54a1ac350f73be07c3b7540d7ab2fb3630ef55df
+        commit: 5017da527d8e9d5a9a6da0ce954898289ad7fba5
         disable-shallow-clone: true
         x-checker-data:
           type: git


### PR DESCRIPTION
Bumps the Flathub-strict amule source `commit:` pin to the current master tip so the Flathub-built bundle inherits the locale fix from #25 (`separate-locales: false` → all 38 `.mo` files ship at canonical paths inside the main app, fixing silent English fallback on Flathub installs).