### PR TITLE
fix(webserver): fix CWebSocket memory leaks and address AI quality findings

### DIFF
--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -73,7 +73,6 @@ CWebSocket::CWebSocket(CWebServerBase *parent)
 	// `m_dwBufSize - m_dwRecv` reads below still leave the spare slot
 	// free for the terminator.
 	m_pBuf = new char [4096 + 1];
-	m_Cookie = 0;
 	m_IsGet = false;
 	m_IsPost = false;
 
@@ -108,7 +107,7 @@ void CWebSocket::OnReceive(int)
 		// Buffer is too small. Make it bigger. Allocate one extra
 		// slot for the NUL terminator written below, matching the
 		// `+1` overhead the ctor uses (see #873).
-		uint32 newsize = m_dwBufSize + (m_dwBufSize  >> 1);
+		uint32 newsize = m_dwBufSize + (m_dwBufSize >> 1);
 		char* newbuffer = new char[newsize + 1];
 		char* oldbuffer = m_pBuf;
 		memcpy(newbuffer, oldbuffer, m_dwBufSize);
@@ -175,7 +174,7 @@ void CWebSocket::OnReceive(int)
 			cont += 4;
 			uint32 bodyOffset = static_cast<uint32>(cont - m_pBuf);
 			uint32 bodyLen = static_cast<uint32>(len);
-			if ( bodyLen <= m_dwRecv && bodyOffset <= m_dwRecv - bodyLen ) {
+			if ( bodyOffset <= m_dwRecv && bodyLen <= m_dwRecv - bodyOffset ) {
 				OnRequestReceived(m_pBuf, cont, len);
 			}
 		}

--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -83,6 +83,17 @@ CWebSocket::CWebSocket(CWebServerBase *parent)
 
 }
 
+CWebSocket::~CWebSocket()
+{
+	CChunk* pChunk = m_pHead;
+	while (pChunk) {
+		CChunk* pNext = pChunk->m_pNext;
+		delete pChunk;
+		pChunk = pNext;
+	}
+	delete[] m_pBuf;
+}
+
 void CWebSocket::OnLost(int)
 {
 	Close();

--- a/src/webserver/src/WebSocket.h
+++ b/src/webserver/src/WebSocket.h
@@ -69,7 +69,6 @@ class CWebSocket : public CLibSocket {
 		CChunk *m_pTail;
 
 		bool m_IsGet, m_IsPost;
-		char *m_Cookie;
 		char *m_pBuf;
 		uint32 m_dwBufSize;
 		uint32 m_dwRecv;

--- a/src/webserver/src/WebSocket.h
+++ b/src/webserver/src/WebSocket.h
@@ -38,6 +38,7 @@ class CWebServer;
 class CWebSocket : public CLibSocket {
 	public:
 		CWebSocket(CWebServerBase *parent);
+		~CWebSocket();
 
 		virtual void OnSend(int);
 		virtual void OnReceive(int);
@@ -53,15 +54,18 @@ class CWebSocket : public CLibSocket {
 
 		class CChunk {
 			public:
+				CChunk()
+					: m_pData(NULL), m_pToSend(NULL), m_dwSize(0), m_pNext(NULL)
+				{}
 				char* m_pData;
 				char* m_pToSend;
 				uint32 m_dwSize;
 
 				CChunk* m_pNext;
-				~CChunk() { if (m_pData) delete[] m_pData; }
+				~CChunk() { delete[] m_pData; }
 		};
 
-		CChunk *m_pHead; // tails of what has to be sent
+		CChunk *m_pHead; // head of what has to be sent
 		CChunk *m_pTail;
 
 		bool m_IsGet, m_IsPost;


### PR DESCRIPTION
## Summary

Addresses findings from the GitHub AI quality scan on `src/webserver/src/WebSocket.cpp`.

### fix: add CWebSocket destructor to prevent chunk list and buffer leaks

`CWebSocket` had no destructor, so when a socket was destroyed with pending
write data the entire `CChunk` linked list and `m_pBuf` were silently leaked.

The fix adds `~CWebSocket()` that walks the list using the same
save-next-then-delete pattern already used in `OnSend()`. Adding
`delete m_pNext` to `~CChunk()` instead (the AI's suggested approach)
would be wrong: `OnSend()` saves `pNext` before calling `delete m_pHead`,
so recursive chain deletion inside the destructor would cause a
use-after-free there.

Also adds a `CChunk` default constructor to zero-initialise all members,
removes the redundant null guard in `~CChunk()` (`delete[] NULL` is a
no-op), and fixes the `m_pHead` comment typo ("tails" → "head").

### fix: remove dead m_Cookie field, fix whitespace, clarify bounds check

- **Remove `m_Cookie`**: initialized in the constructor but never read or
  written anywhere in the codebase; removed from both the header and the
  constructor.
- **Whitespace**: `m_dwBufSize  >> 1` → `m_dwBufSize >> 1`.
- **Bounds check**: restructure the POST body check from
  `bodyLen <= m_dwRecv && bodyOffset <= m_dwRecv - bodyLen` to
  `bodyOffset <= m_dwRecv && bodyLen <= m_dwRecv - bodyOffset`.
  The original is safe due to short-circuit evaluation, but the new form
  removes the subtle ordering dependency and reads more naturally as
  "offset fits, then length fits within the remainder".

## Skipped findings

- **Rename `FindHeaderCaseInsensitive`**: anonymous-namespace function with
  a single call site searching for a header — the name accurately describes
  its use.
- **Replace `0` with `nullptr`**: the project consistently uses `NULL`/`0`
  throughout (~1400 occurrences vs ~20 `nullptr`); a two-line change would
  be inconsistent with the established style.