### PR TITLE
fix(amuleweb): clear search results across cycles + on new search (#31)

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -267,6 +267,11 @@ private:
 	std::set<uint32> m_lastSentFileIds;
 	std::set<uint32> m_lastSentSharedFileIds;
 	std::set<uint32> m_lastSentPartFileIds;
+	// `EC_OP_SEARCH_RESULTS` at `EC_DETAIL_UPDATE` (amuleweb's polling
+	// path). amulegui takes the `EC_DETAIL_INC_UPDATE` overload which
+	// uses the always-bulk-delete `CRemoteContainer::ProcessUpdate` and
+	// needs no tombstones, so search-results tracking is amuleweb-only.
+	std::set<uint32> m_lastSentSearchIds;
 
 	// Set of file ECIDs already sent to the client with full detail
 	// (EC_DETAIL_INC_UPDATE / EC_DETAIL_UPDATE payload, not the legacy
@@ -1386,7 +1391,8 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request)
 }
 
 
-static CECPacket *Get_EC_Response_Search_Results(const CECPacket *request)
+static CECPacket *Get_EC_Response_Search_Results(const CECPacket *request,
+	bool partial_update_active, std::set<uint32> &io_lastSentSearchIds)
 {
 	CECPacket *response = new CECPacket(EC_OP_SEARCH_RESULTS);
 
@@ -1395,6 +1401,22 @@ static CECPacket *Get_EC_Response_Search_Results(const CECPacket *request)
 	// request can contain list of queried items
 	CTagSet<uint32, EC_TAG_SEARCHFILE> queryitems(request);
 
+	// `EC_TAG_FILE_REMOVED` tombstoning is wired only for the
+	// `EC_DETAIL_UPDATE` polling path that amuleweb uses, and only when
+	// the client opted into the partial-update protocol at auth. The
+	// `EC_DETAIL_INC_UPDATE` dispatch (amulegui) takes the tagmap
+	// overload below; `EC_DETAIL_FULL` callers (amulecmd `search` and
+	// amuleweb's Phase-3 follow-up `req_full`, which defaults to FULL)
+	// remain unchanged. The `queryitems.empty()` check excludes
+	// per-ID subset queries: tombstoning is meaningful only when the
+	// client is polling the whole set.
+	const bool tombstone_path =
+		partial_update_active
+		&& detail_level == EC_DETAIL_UPDATE
+		&& queryitems.empty();
+
+	std::set<uint32> current_ids;
+
 	const CSearchResultList& list = theApp->searchlist->GetSearchResults(0xffffffff);
 	CSearchResultList::const_iterator it = list.begin();
 	while (it != list.end()) {
@@ -1402,7 +1424,29 @@ static CECPacket *Get_EC_Response_Search_Results(const CECPacket *request)
 		if ( !queryitems.empty() && !queryitems.count(sf->ECID()) ) {
 			continue;
 		}
+		if (tombstone_path) {
+			current_ids.insert(sf->ECID());
+		}
 		response->AddTag(CEC_SearchFile_Tag(sf, detail_level));
+	}
+
+	if (tombstone_path) {
+		// One `EC_TAG_FILE_REMOVED` per result that was in the previous
+		// response but is no longer in the daemon's searchlist —
+		// typically because the user started a new search, which clears
+		// the list via `EC_OP_SEARCH_START` → `searchlist->RemoveResults`.
+		// Without these markers, amuleweb's
+		// `UpdatableItemsContainer::ProcessUpdate` takes the partial-
+		// update branch (it expects explicit deletions) and sees no
+		// signal to drop the old results, so they accumulate across
+		// searches (#31, regression from ee1d92b75).
+		for (std::set<uint32>::const_iterator i = io_lastSentSearchIds.begin();
+			i != io_lastSentSearchIds.end(); ++i) {
+			if (!current_ids.count(*i)) {
+				response->AddTag(CECTag(EC_TAG_FILE_REMOVED, *i));
+			}
+		}
+		io_lastSentSearchIds.swap(current_ids);
 	}
 	return response;
 }
@@ -2059,7 +2103,8 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 			if ( request->GetDetailLevel() == EC_DETAIL_INC_UPDATE ) {
 				response = Get_EC_Response_Search_Results(m_obj_tagmap);
 			} else {
-				response = Get_EC_Response_Search_Results(request);
+				response = Get_EC_Response_Search_Results(request,
+					m_partialUpdateActive, m_lastSentSearchIds);
 			}
 			break;
 

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -823,7 +823,7 @@ bool UploadsInfo::ReQuery()
 	return true;
 }
 
-SearchFile::SearchFile(CEC_SearchFile_Tag *tag)
+SearchFile::SearchFile(CEC_SearchFile_Tag *tag) : CECID(tag->ID())
 {
 	nHash = tag->FileHash();
 	sHash = nHash.Encode();


### PR DESCRIPTION
## Summary

Fixes #31 — amuleweb's search results grow on every "Update results" click and don't clear when a new search starts. Two independent bugs, both contributing:

### Bug 1 — `SearchFile` ECID was never forwarded from the tag (latent forever)

`SearchFile(CEC_SearchFile_Tag *tag)` never calls `: CECID(tag->ID())`. The default `CECID()` constructor auto-increments a static counter, so every `SearchFile` instance ends up with a local counter as its ID — completely disconnected from the daemon's ECID the tag carries. Sibling `SharedFile` / `DownloadFile` / `UploadFile` all forward correctly; `SearchFile` alone was left with the default ctor.

Consequence: `m_items_hash.count(tag->ID())` always returns 0, every poll treats every result as new, `ProcessFull` re-appends each item — visible to the user as the result list growing on every "Update results" click.

Latent since the file was written. The pre-partial-update bulk "missing-from-reply == deleted" loop happened to wipe the list every cycle, so duplicates got rebuilt rather than accumulating. ee1d92b75 (`EC skip-unchanged 5/5`) made that loop conditional on `m_partialUpdateActive`, and the bug surfaced.

### Bug 2 — daemon never emitted `EC_TAG_FILE_REMOVED` tombstones for search results

`Get_EC_Response_GetSharedFiles` and `Get_EC_Response_GetDownloadQueue` got partial-update tombstoning in ee1d92b75. `Get_EC_Response_Search_Results` was missed. Once partial-update is negotiated, amuleweb's `UpdatableItemsContainer::ProcessUpdate` expects explicit `EC_TAG_FILE_REMOVED` markers and skips its legacy bulk-delete; without them, items from previous searches linger forever.

Bug 1 is a prerequisite for Bug 2's fix: tombstones carry daemon ECIDs, and without the `SearchFile` ECID forwarding, `m_items_hash.erase(ecid)` would have never matched.

## Fix

Two commits:

- `fix(ec): emit EC_TAG_FILE_REMOVED tombstones on EC_OP_SEARCH_RESULTS` — daemon-side. New per-session `m_lastSentSearchIds` on `CECServerSocket`; snapshot current search-result ECIDs each poll, emit one tombstone per ID that disappeared. Gated identically to the shared/download handlers (`m_partialUpdateActive && detail_level == EC_DETAIL_UPDATE && queryitems.empty()`).
- `fix(amuleweb): initialize SearchFile ECID from daemon tag` — client-side. One line: `SearchFile::SearchFile(...) : CECID(tag->ID())`.

## Backward compatibility

No protocol change.

The tombstone gate skips amulegui (different `EC_DETAIL_LEVEL` → different daemon overload), amulecmd (`EC_DETAIL_FULL` / `EC_DETAIL_CMD`), and amuleweb's Phase-3 follow-up (`EC_DETAIL_FULL` default from the single-arg `CECPacket` ctor). Old amuleweb against new daemon is unchanged — old client doesn't negotiate the protocol → gate off.

The SearchFile ctor fix is a pure client-side correction with no protocol effect.

## Test plan

- [x] amuleweb against self-built `amuled` from this branch on a Linux amule-dev VM
  - Kad search "ubuntu 24.04" min size 4 GB → click "Update results" several times → result count stable, no duplicates
  - Start a new search → previous results disappear