### PR TITLE
fix(ec): stop prior Kad search when EC client starts any new search

### DIFF
--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -355,12 +355,25 @@ wxString CSearchList::StartNewSearch(uint32* searchID, SearchType type, CSearchP
 	}
 
 	m_searchType = type;
+
+	// EC clients reuse the sentinel `0xffffffff` for every search regardless
+	// of network type. `Get_EC_Response_Search` -> `RemoveResults(0xffffffff)`
+	// already soft-stops the previous Kad search via `PrepareToStop()` so it
+	// can drain in-flight packets, but those late `KademliaSearchKeyword(
+	// 0xffffffff, ...)` callbacks would then land in the *new* search's
+	// `m_results[0xffffffff]` bucket -- the Kad results contaminate an ed2k
+	// (or vice-versa) result list whenever an EC client switches search type
+	// without restarting the daemon. Hard-delete the previous Kad search
+	// before either a Kad `PrepareFindKeywords` or an ed2k server packet
+	// starts feeding the shared bucket. Native-GUI searches allocate
+	// distinct top/bottom-half IDs (`3008ada0f`) so `*searchID != 0xffffffff`
+	// for them and they are unaffected.
+	if (*searchID == 0xffffffff) {
+		Kademlia::CSearchManager::StopSearch(0xffffffff, false);
+	}
+
 	if (type == KadSearch) {
 		try {
-			if (*searchID == 0xffffffff) {
-				Kademlia::CSearchManager::StopSearch(0xffffffff, false);
-			}
-
 			// searchstring will get tokenized there
 			// The tab must be created with the Kad search ID, so searchID is updated.
 			Kademlia::CSearch* search = Kademlia::CSearchManager::PrepareFindKeywords(params.strKeyword, data->GetLength(), data->GetRawBuffer(), *searchID);


### PR DESCRIPTION
## Summary

When an EC client (amuleweb / amulegui / amulecmd) starts a new search via `EC_OP_SEARCH_START`, the daemon's previous Kad search wasn't being terminated unless the *new* search was also Kad — so late-arriving Kad reply packets continued feeding the shared `m_results[0xffffffff]` bucket while the new search was filling it. Switching from Kad → ed2k (Local or Global) via the web UI ends up showing Kad results mixed in with the ed2k server replies.

## Root cause

EC clients pass `0xffffffff` to `CSearchList::StartNewSearch` regardless of search type, per the partition agreed in `3008ada0f` (native GUI uses bottom-half IDs, Kad-allocated uses top half, `0xffffffff` reserved as the EC sentinel).

The daemon's `Get_EC_Response_Search` already calls `RemoveResults(0xffffffff)` to clear the bucket, but that path invokes `CSearchManager::StopSearch(0xffffffff, /*delayDelete=*/true)` which only marks the prior Kad search for cleanup via `PrepareToStop()` so it can still drain in-flight packets. Those drained packets call `KademliaSearchKeyword(0xffffffff, ...)` and `AddToList` puts them right back into the bucket the new search has just started using.

Inside `CSearchList::StartNewSearch` itself there's already a hard-delete (`StopSearch(0xffffffff, false)`) — but it's gated under `if (type == KadSearch)`, so it only runs when the *new* search is also Kad. The cross-type case (Kad → ed2k) leaves the soft-stopped Kad search alive.

## Fix

Hoist the hard-delete out of the `if (type == KadSearch)` block so it fires for any EC-driven new search, before either Kad's `PrepareFindKeywords` or ed2k's server packet starts feeding `m_results[0xffffffff]`.

## Why monolithic / native GUI is unaffected

`CSearchDlg::StartNewSearch` allocates bottom-half IDs (`m_nSearchID & 0x7fffffff`), so the new gate `if (*searchID == 0xffffffff)` is false for native-GUI calls. Their per-tab `m_results[id]` isolation is unchanged. Multiple parallel Kad searches + one ed2k search continue to work because each tab's Kad-allocated top-half ID and each ed2k search's bottom-half ID are distinct buckets, fed by codepaths that own those IDs.

## Test plan

- [x] amuled with EC enabled.
- [x] amuleweb (or any EC client): run Kad search "ubuntu" → wait for results.
- [x] Start ed2k Local search "ubuntu" → click "Update results" after the server replies → result list contains only ed2k results, no Kad-flavored hits.
- [x] Native amule GUI: open multiple search tabs (multiple Kad + one ed2k) → each tab shows only its own search's results, no cross-contamination.

Discovered while triaging #31. PR #33 fixed the amuleweb-side rendering bug; this fixes the orthogonal daemon-side cross-type contamination.