### PR TITLE
fix(ec): drop late ed2k server replies after EC client switches to Kad

### DIFF
--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -551,8 +551,29 @@ void CSearchList::ProcessSharedFileList(const uint8_t* in_packet, uint32 size,
 }
 
 
+// Symmetric counterpart to PR #36's Kad hard-stop on EC search-start.
+// Late ed2k server replies (TCP Local responses here, UDP Global responses
+// in ProcessUDPSearchAnswer below) keep arriving for seconds after the
+// search request is sent. When an EC client switches search type (ed2k ->
+// Kad) those late results would land in `m_results[m_currentSearch]` --
+// with the EC sentinel `0xffffffff` pinned across all EC searches, that
+// bucket is now the new Kad search's bucket, producing ed2k contamination
+// of a Kad result list. Drop late ed2k replies when the active search
+// type is no longer ed2k. Native-GUI parallel searches keep
+// `m_currentSearch` at bottom-half IDs and a Kad tab updates m_searchType
+// to KadSearch -- this gate makes late ed2k packets stop misrouting to
+// the Kad tab's bucket (a pre-existing GUI side bug that nobody noticed
+// because cross-protocol hits in a Kad tab look like noise).
+static inline bool IsActiveSearchTypeEd2k(SearchType t)
+{
+	return t == LocalSearch || t == GlobalSearch;
+}
+
 void CSearchList::ProcessSearchAnswer(const uint8_t* in_packet, uint32_t size, bool optUTF8, uint32_t serverIP, uint16_t serverPort)
 {
+	if (!IsActiveSearchTypeEd2k(m_searchType)) {
+		return;
+	}
 	CMemFile packet(in_packet, size);
 
 	uint32_t results = packet.ReadUInt32();
@@ -564,6 +585,9 @@ void CSearchList::ProcessSearchAnswer(const uint8_t* in_packet, uint32_t size, b
 
 void CSearchList::ProcessUDPSearchAnswer(const CMemFile& packet, bool optUTF8, uint32_t serverIP, uint16_t serverPort)
 {
+	if (!IsActiveSearchTypeEd2k(m_searchType)) {
+		return;
+	}
 	AddToList(new CSearchFile(packet, optUTF8, m_currentSearch, serverIP, serverPort), false);
 }
 


### PR DESCRIPTION
## Summary

Symmetric counterpart to #36. That PR hard-stopped the prior Kad search when an EC client starts a new search, blocking late `KademliaSearchKeyword(0xffffffff, ...)` callbacks from contaminating the new bucket. The reverse direction — ed2k → Kad — was unfixed: late ed2k server replies (TCP Local from `ProcessSearchAnswer`, UDP Global from `ProcessUDPSearchAnswer`) keep arriving for seconds after the original request and continue calling `AddToList` with `m_currentSearch = 0xffffffff`. With the EC sentinel pinned across all EC search types, those late results land in the new Kad search's `m_results[0xffffffff]`.

## Fix

Gate the two ed2k result-arrival paths on `m_searchType` being an ed2k type. Drop the packet otherwise.

```cpp
if (m_searchType != LocalSearch && m_searchType != GlobalSearch) {
    return;  // late ed2k reply after EC switched to Kad — drop
}
```

Mirrors PR #36's approach (cheap one-line gate, no protocol or state-machine refactor).

## Why monolithic / native GUI is (essentially) unaffected

Native GUI parallel searches keep `m_currentSearch` at bottom-half IDs allocated by `CSearchDlg::StartNewSearch`. When a Kad tab is opened, `m_searchType` becomes `KadSearch` and this gate drops late ed2k replies that *would* otherwise misroute to the Kad tab's bucket — a pre-existing GUI bug nobody noticed because cross-protocol hits in a Kad tab read as Kad noise.

The "correct" long-term fix on the GUI side is per-search-object tracking for ed2k searches mirroring Kad's `CSearch`, so late results can route to the right tab. Out of scope here.

## Test plan

- [x] amuled / amule with EC enabled.
- [x] amuleweb (or amulegui): ed2k Global search "foo" → wait for initial server reply → start Kad search "bar" → result list contains only Kad results from "bar", no late ed2k results from "foo".
- [x] Reverse direction (Kad → ed2k) — already covered by #36, sanity-check it still works.

Discovered while verifying #36 on the test VM. Was about to reply on #31 when the contamination appeared in the reverse direction.