### PR TITLE
fix Global search when Kad is disabled

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -572,12 +572,11 @@ void CSearchDlg::StartNewSearch()
 
 	int selection = CastChild( ID_SEARCHTYPE, wxChoice )->GetSelection();
 
+	// In muuli_wdr.cpp, Search Choices are inserted in this order: Local, Global, Kad.
+	// If ED2K is disabled, the only choice in the menu is Kad,
+	// but the starting value is 0 and we need a 2 for the switch
 	if (!thePrefs::GetNetworkED2K()) {
 		selection += 2;
-	}
-
-	if (!thePrefs::GetNetworkKademlia()) {
-		selection += 1;
 	}
 
 	switch (selection) {


### PR DESCRIPTION
Fix Global search not working if Kad is disabled


Steps to reproduce:
1. Set-up Networks as:
- ED2K: Enabled
- Kad: Disabled
2. In the search Tab, select Type = Global and search something. You get this error message:


<img width="1038" height="768" alt="cap" src="https://github.com/user-attachments/assets/6199c82d-ddce-4b99-95f8-e8b3fd256bc3" />


Fix: Remove the wrong selection += 1 when Kad is disabled, which is just wrong. Also, add a comment explaining why do we modify the selection index.

Tests:
Tested the 4 combinations, all work as expected now:

Kad Enabled + ED2K Enabled
Kad Enabled + ED2K Disabled
Kad Disabled + ED2K Enabled
Kad Disabled + ED2K Disabled
