### PR TITLE
fix(search): use wxUIntPtr for m_currentSearch to fix Windows EC search

### DIFF
--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -214,7 +214,7 @@ private:
 	bool		m_searchInProgress;
 
 	//! The ID of the current search.
-	long		m_currentSearch;
+	wxUIntPtr	m_currentSearch;
 
 	//! The current packet used for searches.
 	CPacket*	m_searchPacket;


### PR DESCRIPTION
## Summary

Fixes the Windows-specific 0-results bug @ngosang reported on #31 — EC clients (amuleweb / amulecmd) returned 0 ed2k Local/Global results on Windows even though the daemon side correctly received the server's reply.

## Root cause: LLP64 vs LP64

`CSearchList::m_currentSearch` is declared `long` ([SearchList.h:217](https://github.com/amule-org/amule/blob/master/src/SearchList.h#L217)) but every other place this value flows uses `wxUIntPtr` (`CSearchFile::m_searchID`, `std::map<wxUIntPtr, CSearchResultList> m_results`, `GetSearchResults`/`RemoveResults` parameters).

On Windows (LLP64), `long` is signed 32-bit and `wxUIntPtr` is unsigned 64-bit. The EC search-start path does:

1. `m_currentSearch = *searchID` where `*searchID = 0xffffffff` (uint32). Assignment to signed `long` overflows to `-1`.
2. `AddToList(new CSearchFile(..., m_currentSearch, ...))` — `m_currentSearch` (long = int32 = -1) implicitly converts to `wxUIntPtr` (uint64) via **sign extension** to `0xFFFFFFFFFFFFFFFF`.
3. So server-reply items end up in `m_results[0xFFFFFFFFFFFFFFFF]`.

But `Get_EC_Response_Search_Results` looks up `GetSearchResults(0xffffffff)` — the literal is `unsigned int`, which **zero-extends** to wxUIntPtr `0x00000000FFFFFFFF`. Different key. `m_results.find(...)` returns empty. amuleweb / amulecmd see 0 results.

Linux x64 (LP64): `long` is 64-bit, no overflow, the bit pattern matches the lookup. Bug invisible.

## Why Kad searches still worked on Windows

Kad results path bypasses `m_currentSearch`: `KademliaSearchKeyword(uint32_t searchID, ...)` writes the result via `CSearchFile`'s `wxUIntPtr searchID` ctor parameter directly, so the `uint32_t -> wxUIntPtr` zero-extension matches the lookup. The corrupted value of `m_currentSearch` is never read for Kad.

## Fix

One line — declare `m_currentSearch` as `wxUIntPtr` instead of `long`:

```diff
-    long        m_currentSearch;
+    wxUIntPtr   m_currentSearch;
```

This matches the type of every other place the value flows, eliminating the signed-vs-unsigned width mismatch.

## Verification on Windows ARM64 VM

Pre-fix `amulecmd search local ubuntu` → `results` reports 0 hits despite the daemon having received and parsed 153 results from the server (confirmed via diagnostic logging in `ProcessSearchAnswer`).

Post-fix: `search local ubuntu` → 151 results returned. `search global ubuntu` → 272 results. Both Local and Global now work via EC on Windows.

## Backward compat

Linux x64: unchanged. `long` was already 64-bit, the bit pattern was already correct. New type is the same bit width.

Windows: fixes the bug, no behavior change for any non-buggy case.

No protocol change, no client-side change.