### PR TITLE
fix(logger): write stdout/stderr via utf8_str instead of wxConvLibc (#40)

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -299,7 +299,13 @@ void CaMuleExternalConnector::OnInitCommandSet()
 void CaMuleExternalConnector::Show(const wxString &s)
 {
 	if( !m_KeepQuiet ) {
-		printf("%s", (const char *)unicode2char(s));
+		// `utf8_str()` instead of `unicode2char()` so non-ASCII output
+		// (server messages, file names) doesn't collapse to `?` /
+		// U+FFFD when the connector is invoked in a `C` locale (#40).
+		// Connectors do call `setlocale(LC_ALL, "")` below, but in
+		// minimal container environments without `LANG`/`LC_ALL`
+		// exported, the C locale still falls back to `C`.
+		printf("%s", (const char *)s.utf8_str());
 #ifdef __WINDOWS__
 		fflush(stdout);
 #endif
@@ -523,7 +529,7 @@ void CaMuleExternalConnector::OnInitCmdLine(wxCmdLineParser& parser, const char*
 bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser& parser)
 {
 	if (parser.Found("version")) {
-		printf("%s %s\n", m_appname, (const char *)unicode2char(GetMuleVersion()));
+		printf("%s %s\n", m_appname, (const char *)GetMuleVersion().utf8_str());
 		return false;
 	}
 
@@ -537,7 +543,7 @@ bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser& parser)
 	if (parser.Found("create-config-from", &aMuleConfigFile)) {
 		aMuleConfigFile = FinalizeFilename(aMuleConfigFile);
 		if (!::wxFileExists(aMuleConfigFile)) {
-			fprintf(stderr, "%s\n", (const char *)unicode2char("FATAL ERROR: File does not exist: " + aMuleConfigFile));
+			fprintf(stderr, "%s\n", (const char *)(wxString("FATAL ERROR: File does not exist: ") + aMuleConfigFile).utf8_str());
 			exit(1);
 		}
 		CECFileConfig aMuleConfig(aMuleConfigFile);

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -271,7 +271,18 @@ void CLogger::DoLine(const wxString & line, bool toStdout, bool GUI_ONLY(toGUI))
 
 		// write to Stdout
 		if (m_StdoutLog || toStdout) {
-			printf("%s", (const char*)unicode2char(line));
+			// `utf8_str()` instead of `unicode2char()` so non-ASCII
+			// log content (filenames, server messages, etc.) survives
+			// in stdout regardless of the process locale. `unicode2char`
+			// uses `wxConvLibc`, which collapses non-ASCII to `?` /
+			// U+FFFD when running in the default `C` locale -- common
+			// in headless / containerized deployments where amuled is
+			// invoked without `LANG`/`LC_ALL` set and never calls
+			// `setlocale(LC_ALL, "")` itself (#40). The on-disk log
+			// path already uses `wxConvUTF8` via `FlushApplog`, so
+			// switching the stdout sink to `utf8_str()` makes the two
+			// sinks consistently UTF-8.
+			printf("%s", (const char*)line.utf8_str());
 		}
 	}
 #ifndef AMULE_DAEMON
@@ -285,7 +296,8 @@ void CLogger::DoLine(const wxString & line, bool toStdout, bool GUI_ONLY(toGUI))
 
 void CLogger::EmergencyLog(const wxString &message, bool closeLog)
 {
-	fprintf(stderr, "%s", (const char*)unicode2char(message));
+	// Same UTF-8 sink as DoLine's stdout path (#40).
+	fprintf(stderr, "%s", (const char*)message.utf8_str());
 	m_ApplogBuf += message;
 	FlushApplog();
 	if (closeLog && applog) {


### PR DESCRIPTION
## Summary

Fixes #40 — `amuled -o` corrupts non-ASCII log lines on stdout when the process locale isn't UTF-8 capable (common in minimal containers without `LANG`/`LC_ALL` exported). The on-disk logfile path is unaffected because it writes UTF-8 explicitly via `wxConvUTF8`.

@ngosang did the full root-cause analysis in the issue body — `unicode2char()` uses `wxConvLibc` (C-library locale converter), which returns NULL in a `C` locale, after which the fallback path collapses each non-ASCII char to `?`. amuled never calls `setlocale(LC_ALL, "")` (only `CaMuleExternalConnector` does, for amulecmd / amuleweb).

## Fix

Switch the stdout/stderr log sinks to `wxString::utf8_str()`, which always returns UTF-8 regardless of locale. The two sinks (logfile, stdout) now both write UTF-8 by construction.

Five call sites:

- `CLogger::DoLine` stdout path (`Logger.cpp:274`) — the main reported bug
- `CLogger::EmergencyLog` stderr path (`Logger.cpp:288`) — same pattern
- `CaMuleExternalConnector::Show()` (`ExternalConnector.cpp:302`) — amulecmd / amuleweb interactive output. Connectors do call `setlocale(LC_ALL, "")` at startup, but that doesn't help in minimal containers where `LANG` / `LC_ALL` aren't exported (`setlocale("")` then falls back to `C`). Per @ngosang's follow-up comment ("Review also `src/ExternalConnector.cpp`, I don't trust Linux locales").
- `--version` banner (`ExternalConnector.cpp:532`)
- "FATAL ERROR: File does not exist" config-init message (`ExternalConnector.cpp:546`)

## Not addressed in this PR

- `ExternalConnector.cpp:243, 382` — libreadline integration; readline expects locale-encoded bytes, not UTF-8.
- `ExternalConnector.cpp:681, 682` — version / OS-description strings cached for HTTP User-Agent. Worth a follow-up but doesn't affect the immediate user-visible bug.

## Verification

Standalone wxString conversion test compiled against the same wxWidgets the build uses, with `setlocale(LC_ALL, "C")` to mimic amuled's runtime locale:

```
via wxConvLibc (unicode2char): [(null - conversion failed)]
via utf8_str():                [share: caf\xc3\xa9 / na\xc3\xafve / \xe2\x80\x9chello\xe2\x80\x9d / \xe2\x86\x92 / \xe6\x96\x87]
```

`wxConvLibc.cWX2MB()` returns NULL → runtime fallback in `unicode2char()` collapses to `?` (exactly the symptom @ngosang reported). `utf8_str()` returns clean UTF-8 bytes for accented chars, smart quotes, arrow, and CJK char.

## Backward compat

`wxString::utf8_str()` is locale-independent and produces the same UTF-8 bytes on every platform. No protocol change, no behavior change for users whose locale was already UTF-8 (they were getting UTF-8 either way — the bug was masked when `setlocale("")` happened to produce a UTF-8 locale).