### PR TITLE
fix(SearchDlg): replace FALSE macro with false, fix tab in function signature

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -242,8 +242,8 @@ void CSearchDlg::OnSearchClosing(wxBookCtrlEvent& evt)
 
 	// Do cleanups if this was the last tab
 	if ( m_notebook->GetPageCount() == 1 ) {
-		FindWindow(IDC_SDOWNLOAD)->Enable(FALSE);
-		FindWindow(IDC_CLEAR_RESULTS)->Enable(FALSE);
+		FindWindow(IDC_SDOWNLOAD)->Enable(false);
+		FindWindow(IDC_CLEAR_RESULTS)->Enable(false);
 	}
 }
 
@@ -498,9 +498,9 @@ void CSearchDlg::OnBnClickedClear(wxCommandEvent& WXUNUSED(ev))
 
 	m_notebook->DeleteAllPages();
 
-	FindWindow(IDC_CLEAR_RESULTS)->Enable(FALSE);
-	FindWindow(IDC_SDOWNLOAD)->Enable(FALSE);
-	FindWindow(IDC_SEARCHMORE)->Enable(FALSE);
+	FindWindow(IDC_CLEAR_RESULTS)->Enable(false);
+	FindWindow(IDC_SDOWNLOAD)->Enable(false);
+	FindWindow(IDC_SEARCHMORE)->Enable(false);
 }
 
 
@@ -650,7 +650,7 @@ void CSearchDlg::OnBnClickedReset(wxCommandEvent& WXUNUSED(evt))
 	CastChild( IDC_TypeSearch, wxChoice )->SetSelection(0);
 	CastChild( ID_AUTOCATASSIGN, wxChoice )->SetSelection(0);
 
-	FindWindow(IDC_SEARCH_RESET)->Enable(FALSE);
+	FindWindow(IDC_SEARCH_RESET)->Enable(false);
 }
 
 
@@ -668,7 +668,7 @@ void CSearchDlg::UpdateCatChoice()
 	c_cat->SetSelection( 0 );
 }
 
-void	CSearchDlg::UpdateProgress(uint32 new_value) {
+void CSearchDlg::UpdateProgress(uint32 new_value) {
 	m_progressbar->SetValue(new_value);
 }
 // File_checked_for_headers


### PR DESCRIPTION
## Summary

- Replace six occurrences of the `FALSE` preprocessor macro with the C++ keyword `false` in `Enable()` calls across three functions (`OnSearchClosing`, `OnBnClickedClear`, `OnBnClickedReset`).
- Fix a stray tab character between the return type and function name in `UpdateProgress`.

The `m_nSearchID` thread-safety finding was reviewed and intentionally skipped: `StartNewSearch()` is a UI event handler called exclusively from the main thread, so `std::atomic` would add complexity with no benefit.

## Test plan

- [x] Build passes without new warnings
- [x] Search dialog opens, runs a search, and closes tabs without regressions