### PR TITLE
build: disable BUILD_TESTING by default

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -40,7 +40,7 @@ option (BUILD_MONOLITHIC "enable building of the monolithic aMule app" ON)
 option (BUILD_REMOTEGUI "compile aMule remote GUI")
 option (BUILD_WEBSERVER "compile aMule WebServer")
 option (BUILD_WXCAS "compile aMule GUI Statistics")
-option (BUILD_TESTING "Run Tests after compile" ON)
+option (BUILD_TESTING "Build unit tests" OFF)
 
 if (PREFIX)
 	set (CMAKE_INSTALL_PREFIX "${PREFIX}")


### PR DESCRIPTION
## Summary

- Changes `BUILD_TESTING` default from `ON` to `OFF` in `cmake/options.cmake`
- Fixes the misleading option description ("Run Tests after compile" → "Build unit tests"); the build compiles tests but does not execute them

## Why no CI changes needed

The CI workflow (`.github/workflows/ccpp.yml`) already passes `-DBUILD_TESTING=YES` explicitly in `cmake_common_config_flags`. This flag is unaffected by the default — the CI has always been self-contained in this regard. No workflow file needed to change.

## Test plan

- [x] Local cmake configure without flags: verify `unittests/` is not built
- [x] Local cmake configure with `-DBUILD_TESTING=ON`: verify tests build and `ctest` passes
- [x] CI passes on this PR (tests continue to run via the explicit flag)

Closes #46