### PR TITLE
fix: correct IDC_SPINSEARCHAVAIBILITY spelling to IDC_SPINSEARCHAVAILABILITY

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -323,7 +323,7 @@ void CSearchDlg::OnFieldChanged( wxEvent& WXUNUSED(evt) )
 	enable |= (CastChild(ID_AUTOCATASSIGN, wxChoice)->GetSelection() > 0);
 
 	// These are the IDs of the search-fields
-	int spinfields[] = { IDC_SPINSEARCHMIN, IDC_SPINSEARCHMAX, IDC_SPINSEARCHAVAIBILITY };
+	int spinfields[] = { IDC_SPINSEARCHMIN, IDC_SPINSEARCHMAX, IDC_SPINSEARCHAVAILABILITY };
 	for ( uint16 i = 0; i < itemsof(spinfields); i++ ) {
 		enable |= (CastChild( spinfields[i], wxSpinCtrl )->GetValue() > 0);
 	}
@@ -548,7 +548,7 @@ void CSearchDlg::StartNewSearch()
 		}
 
 		// Parameter Availability
-		params.availability = CastChild( IDC_SPINSEARCHAVAIBILITY, wxSpinCtrl )->GetValue();
+		params.availability = CastChild( IDC_SPINSEARCHAVAILABILITY, wxSpinCtrl )->GetValue();
 
 		switch ( CastChild( IDC_TypeSearch, wxChoice )->GetSelection() ) {
 		case 0:	params.typeText.Clear();	break;
@@ -646,7 +646,7 @@ void CSearchDlg::OnBnClickedReset(wxCommandEvent& WXUNUSED(evt))
 	CastChild( IDC_SEARCHMINSIZE, wxChoice )->SetSelection(2);
 	CastChild( IDC_SPINSEARCHMAX, wxSpinCtrl )->SetValue(0);
 	CastChild( IDC_SEARCHMAXSIZE, wxChoice )->SetSelection(2);
-	CastChild( IDC_SPINSEARCHAVAIBILITY, wxSpinCtrl )->SetValue(0);
+	CastChild( IDC_SPINSEARCHAVAILABILITY, wxSpinCtrl )->SetValue(0);
 	CastChild( IDC_TypeSearch, wxChoice )->SetSelection(0);
 	CastChild( ID_AUTOCATASSIGN, wxChoice )->SetSelection(0);
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -288,7 +288,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item13->Add( item31, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticText *item32 = new wxStaticText( parent, -1, _("Availability"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item32, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
-    wxSpinCtrl *item33 = new wxSpinCtrl( parent, IDC_SPINSEARCHAVAIBILITY, "0", wxDefaultPosition, wxDefaultSize, 0, 0, 1000, 0 );
+    wxSpinCtrl *item33 = new wxSpinCtrl( parent, IDC_SPINSEARCHAVAILABILITY, "0", wxDefaultPosition, wxDefaultSize, 0, 0, 1000, 0 );
     item13->Add( item33, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
     item1->Add( item13, 0, wxALIGN_CENTER, 5 );
 

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -75,7 +75,7 @@ extern wxSizer *s_extended_sizer;
 #define IDC_SEARCHMINSIZE 10010
 #define IDC_SPINSEARCHMAX 10011
 #define IDC_SEARCHMAXSIZE 10012
-#define IDC_SPINSEARCHAVAIBILITY 10013
+#define IDC_SPINSEARCHAVAILABILITY 10013
 extern wxSizer *s_filter_sizer;
 #define ID_FILTER_TEXT 10014
 #define ID_FILTER 10015


### PR DESCRIPTION
## Summary

Rename the misspelled constant `IDC_SPINSEARCHAVAIBILITY` → `IDC_SPINSEARCHAVAILABILITY` at its definition and all call sites:

- `src/muuli_wdr.h` — the `#define`
- `src/muuli_wdr.cpp` — the `wxSpinCtrl` constructor call
- `src/SearchDlg.cpp` — three usages (`spinfields` array, `params.availability` assignment, `SetValue` reset)

The fix is applied at the source rather than via a compatibility alias. The naming style (concatenated words, no underscores) was intentionally kept consistent with the sibling constants `IDC_SPINSEARCHMIN` and `IDC_SPINSEARCHMAX`.

## Test plan

- [x] Build passes without new warnings
- [x] Search dialog availability spin control functions correctly