### PR TITLE
fix(packaging/windows): route SPANISHINTERNATIONAL to po/es.po

### DIFF
--- a/packaging/windows/po-to-nsh.py
+++ b/packaging/windows/po-to-nsh.py
@@ -101,6 +101,15 @@ NSIS_LANG_TO_LOCALE = {}
 for _loc, _nsis in LOCALE_TO_NSIS_LANG.items():
     NSIS_LANG_TO_LOCALE.setdefault(_nsis, _loc)
 
+# NSIS exposes two Spanish variants -- SPANISH (LCID 0x040a, "Spanish,
+# Traditional Sort") and SPANISHINTERNATIONAL (LCID 0x0c0a, "Spanish,
+# Modern Sort" / Latin America). Modern Windows and Wine both report
+# es_ES as the Modern variant, so the installer's MUI auto-detect
+# routes those users to SPANISHINTERNATIONAL. Without this alias the
+# generated block falls back to English (issue #55). aMule ships a
+# single es.po that serves both variants correctly.
+NSIS_LANG_TO_LOCALE.setdefault("SPANISHINTERNATIONAL", "es")
+
 # (NSIS LangString key, English msgid). Order matches the LangString
 # block in installer.nsi and the array in installer_strings.c. Update
 # all three together when adding or renaming an installer string. The


### PR DESCRIPTION
## Summary

Fixes #55. NSIS exposes two Spanish MUI variants — `SPANISH` (LCID `0x040a`, "Spanish, Traditional Sort") and `SPANISHINTERNATIONAL` (LCID `0x0c0a`, "Spanish, Modern Sort" / Latin America). Modern Windows and Wine both report `es_ES` as the Modern variant, so the installer's MUI auto-detect in [installer.nsi](packaging/windows/installer.nsi) routes those users to `SPANISHINTERNATIONAL`.

`po-to-nsh.py` only mapped `"es" → SPANISH`, leaving the `SPANISHINTERNATIONAL` `LangString` block at the English fallback. The hand-written `ENGLISH` baseline in `installer.nsi` then provided the displayed strings for every `es_ES` user — which is exactly the behaviour @cardpuncher and @ngosang reproduced (French and Turkish work, Spanish doesn't), and which silently neutralised the catalog work in 462b2e470.

## Fix

One alias added to `NSIS_LANG_TO_LOCALE` so the generated `.nsh` emits identical Spanish strings for both NSIS variants:

```python
NSIS_LANG_TO_LOCALE.setdefault("SPANISHINTERNATIONAL", "es")
```

After the fix, the generated `installer_strings_generated.nsh` contains a translated `${LANG_SPANISHINTERNATIONAL}` block byte-equivalent to the `${LANG_SPANISH}` block (verified locally by re-running `po-to-nsh.py`).

## Why other locales weren't affected

Each other NSIS language registered in [installer.nsi:118-184](packaging/windows/installer.nsi#L118-L184) maps 1:1 to a single aMule catalog. The other split NSIS pairs (`PORTUGUESE` / `PORTUGUESEBR`, `NORWEGIAN` / `NORWEGIANNYNORSK`, `SERBIAN` / `SERBIANLATIN`, `SIMPCHINESE` / `TRADCHINESE`) are already covered correctly because aMule ships distinct catalogs (`pt_PT` / `pt_BR`, `nn`, `zh_CN` / `zh_TW`) for the ones that have translations; the rest fall back to English as intended. Only Spanish has two NSIS variants serviced by a single aMule catalog.

## Test plan

- [ ] CI green on this branch.
- [ ] Manual: in the next nightly installer, run with `LANG=es_ES.UTF-8 wine aMule-...-Setup-x64.exe` and confirm section names + descriptions are Spanish (reproducing the issue #55 setup).