### PR TITLE
fix(amuleweb): honor per-user template dir when spawned by the GUI

### DIFF
--- a/src/webserver/src/WebInterface.cpp
+++ b/src/webserver/src/WebInterface.cpp
@@ -327,6 +327,14 @@ bool CamulewebApp::OnCmdLineParsed(wxCmdLineParser& parser)
 		m_KeepQuiet = true;
 		m_LoadSettingsFromAmule = true;
 
+		// m_configDir is normally set by CaMuleExternalConnector::
+		// OnCmdLineParsed, which this early-return branch skips. Leaving
+		// it empty made GetTemplateDir look for "webserver" relative to
+		// the CWD, so the per-user template dir (<config>/webserver/) was
+		// never found when amuleweb was spawned by the aMule GUI. Derive
+		// it from the config file we were handed instead.
+		m_configDir = wxFileName(aMuleConfigFile).GetPathWithSep();
+
 		if (!(m_TemplateOk = GetTemplateDir(m_TemplateName, m_TemplateDir))) {
 			// no reason to run webserver without a template
 			fprintf(stderr, "FATAL ERROR: Cannot find template: %s\n",


### PR DESCRIPTION
In --amule-config-file mode (the mode aMule and aMuled use to spawn amuleweb automatically), CamulewebApp::OnCmdLineParsed returns early and never reaches CaMuleExternalConnector::OnCmdLineParsed, which is where m_configDir is normally initialized. With m_configDir empty, GetTemplateDir looked for "webserver" relative to the current working directory, so the per-user template directory (<config>/webserver/) was silently skipped and the lookup always fell through to the system-wide WEBSERVERDIR (/usr/share/amule/webserver/).

Derive m_configDir from the directory of the amule.conf file passed on the command line, so a GUI-spawned amuleweb resolves templates from the same config dir as the daemon that launched it. This also fixes the webserver locale lookup, which builds its path from m_configDir as well.

Verified by launching the rebuilt amuleweb with
--amule-config-file=~/.aMule/amule.conf and confirming it now serves templates from ~/.aMule/webserver/default/ instead of the installed copy.