### PR TITLE
fix(webserver): sorting downloads by sources never worked

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -330,7 +330,7 @@ function formCommandSubmit(command)
 				case "progress": $result = (((float)$a->size_done)/((float)$a->size)) > (((float)$b->size_done)/((float)$b->size)); break;
 				case "name": $result = $a->name > $b->name; break;
 				case "speed": $result = $a->speed > $b->speed; break;
-				case "scrcount": $result = $a->src_count > $b->src_count; break;
+				case "srccount": $result = $a->src_count > $b->src_count; break;
 				case "status": $result = StatusString($a) > StatusString($b); break;
 				case "prio": $result = $a->prio < $b->prio; break;
 			}


### PR DESCRIPTION
The "Sources" column header in the downloads page links to ?sort=srccount, but the my_cmp() comparator used by usort() matched the misspelled case label "scrcount". The switch therefore never matched, the comparison result stayed unset, and clicking the header only flipped the whole list via the session reverse flag instead of ordering rows by source count.

Fix the case label to "srccount" so it matches the value sent by the header link (and stored in the session), making the column sort by $file->src_count as intended.

Verified against a running amuleweb with three downloads having 0, 4 and 32 sources: before the fix ?sort=srccount returned them in daemon order (or its reverse); after the fix it returns them ordered 0/4/32 ascending and 32/4/0 on the second click.