### PR TITLE
fix(webserver): correct MByte/GByte multipliers in search size filters

### DIFF
--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -264,8 +264,8 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
 			switch($str) {
 				case "Byte":	$result = 1; break;
 				case "KByte":	$result = 1024; break;		
-				case "MByte":	$result = 1012*1024; break;
-				case "GByte":	$result = 1012*1024*1024; break;
+				case "MByte":	$result = 1024*1024; break;
+				case "GByte":	$result = 1024*1024*1024; break;
 			}
 			return $result;
 		}


### PR DESCRIPTION
str2mult() in the default template's search page converted the min/max size filter units using 1012*1024 for MByte and 1012*1024*1024 for GByte instead of 1024*1024 and 1024*1024*1024, a typo that made every size-filtered search off by ~1.2%. A search filtered to "min 700 MByte" actually asked the core for files >= 726,663,168 bytes instead of 734,003,200, silently excluding or including files near the boundary.

Use the correct power-of-two multipliers so the filter matches the units shown in the search form.