### PR TITLE
fix(webserver): remove stray leading brace in style.css and normalize formatting

### DIFF
--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -1,4 +1,3 @@
-}
 caption {
 	font-family: Helvetica;
 	font-size: 18px;
@@ -50,26 +49,26 @@ label {
 	color: white;
 }
 label {
-font-family:"trebuchet ms",sans-serif;
-font-size: 12px;
-font-weight:bold
+	font-family: "trebuchet ms", sans-serif;
+	font-size: 12px;
+	font-weight: bold;
 }
 input {
-border:1px solid #003161;
-background-color: white;
-font-family:"trebuchet ms",sans-serif;
-font-size: 12px;
-color: #003161;
+	border: 1px solid #003161;
+	background-color: white;
+	font-family: "trebuchet ms", sans-serif;
+	font-size: 12px;
+	color: #003161;
 }
 select, option {
-background-color: white;
-font-size: 12px;
-color: #003161;
+	background-color: white;
+	font-size: 12px;
+	color: #003161;
 }
 textarea {
-border:1px solid #003161;
-background-color: white;
-font-family:"trebuchet ms",sans-serif;
-font-size: 12px;
-color: #003161;
+	border: 1px solid #003161;
+	background-color: white;
+	font-family: "trebuchet ms", sans-serif;
+	font-size: 12px;
+	color: #003161;
 }


### PR DESCRIPTION
style.css started with an orphan closing brace on line 1, a remnant of a selector lost at some point. It is a CSS parse error: browsers recover by skipping it, so rendering was not affected, but it is a trap for future edits and trips up validators and tooling.

Remove the stray brace and normalize the formatting of the file (tab indentation, consistent "property: value;" spacing) without changing any selector or declaration, so the rendered result is identical.

Verified against a running amuleweb: the served style.css matches, parses with balanced braces, and the pages render unchanged.