### PR TITLE
fix(prefs): don't wipe shareddir-*.dat on first-run userhash init

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -990,7 +990,24 @@ CPreferences::CPreferences()
 			RawPokeUInt16(s_userhash.GetHash() + (i * 2), rand());
 		}
 
-		Save();
+		// Persist only preferences.dat and amule.conf here. A full
+		// Save() would also call SaveSharedFolders() against
+		// still-empty in-memory lists (ReloadSharedFolders runs
+		// below), truncating any shareddir-*.dat files a pre-launch
+		// script may have populated.
+		CFile preffile;
+		if (!wxFileExists(fullpath)) {
+			preffile.Create(fullpath);
+		}
+		if (preffile.Open(fullpath, CFile::read_write)) {
+			try {
+				preffile.WriteUInt8(PREFFILE_VERSION);
+				preffile.WriteHash(s_userhash);
+			} catch (const CIOFailureException& e) {
+				AddDebugLogLineC(logGeneral, "IO failure while saving user-hash: " + e.what());
+			}
+		}
+		SavePreferences();
 	}
 
 	// Mark hash as an eMule-type hash


### PR DESCRIPTION
## Summary

On a clean install, `CPreferences::CPreferences()` generates a random userhash and calls `Save()` to persist it. `Save()` writes `preferences.dat`, `amule.conf`, **and** `shareddir-{explicit,recursive}.dat` + `shareddir.dat`. But at constructor time `ReloadSharedFolders()` has not yet run (it's called later in the same function), so the three in-memory shared-dir lists are still default-constructed empty. The result is that `Save()` truncates the three on-disk `shareddir-*.dat` files to zero bytes, wiping any content a pre-launch script (e.g. a Docker entrypoint) had populated. `ReloadSharedFolders()` then loads the now-empty files, and the runtime share set is silently empty.

Replace the construction-time `Save()` with an inline write of the userhash to `preferences.dat` plus a `SavePreferences()` for `amule.conf`, omitting the `SaveSharedFolders()` call. `ReloadSharedFolders()` further down re-persists the three `shareddir-*.dat` files later with the correctly loaded contents, so no functionality is lost.

Reported by ngosang on the [docker-amule entrypoint](https://github.com/ngosang/docker-amule/issues/91#issuecomment-4668628724), where the current workaround is `chmod 444 shareddir-recursive.dat` to make `fopen("w")` fail on the read-only file — at the cost of a spurious EACCES log line on every startup.

## Test plan

Executed on Ubuntu 26.04 ARM64 against this branch + master tip as baseline.

- [x] Pre-populate `~/.aMule/shareddir-recursive.dat` with one or more paths on a fresh config dir — populated with `/tmp/amule-shares-A` (root + `sub1/` + `sub2/`, each containing a 100 KiB marker file)
- [x] Start `amuled` for the first time
- [x] After the daemon starts, confirm `shareddir-recursive.dat` still contains the original paths — file preserved at 19 B with original content. Master-tip baseline reproduces the bug: file truncated from 20 B → 0 B
- [x] Confirm `shareddir.dat` is regenerated as the union of explicit + recursive expansion — 69 B containing `/tmp/amule-shares-A` + `sub1` + `sub2`
- [x] Confirm `amulecmd` → `show shared` lists the expected files — daemon log: `Found 0 known shared files, 3 unknown`; `known2_64.met` grew 1 B → 89 B confirming the hasher ingested the 3 marker files
- [x] Confirm normal first-run with no pre-populated files still works — empty `.aMule/` produced empty shared-dir files (0 B), `preferences.dat` + `amule.conf` written, no errors in log