### PR TITLE
fix(webserver): re-encode shared files page as UTF-8 with English alttexts

### DIFF
--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -186,10 +186,10 @@ function formCommandSubmit(command)
                 <tr>
                   <td><input type="hidden" name="command"></td>
                   
-            <td><a href="javascript:formCommandSubmit('reload');" onClick="MM_nbGroup('down','group1','reload','',1)" onMouseOver="MM_nbGroup('over','reload','','',1)" onMouseOut="MM_nbGroup('out')"><img src="images/refresh.png" alt="Ricarica Files Condivisi" name="reload" border="0" onload=""></a></td>
-				  <td><a href="javascript:formCommandSubmit('prioup');" onClick="MM_nbGroup('down','group1','up','',1)" onMouseOver="MM_nbGroup('over','up','','',1)" onMouseOut="MM_nbGroup('out')"><img name="up" src="images/up.png" border="0" alt="Alza Priorità" onLoad=""></a></td>
+            <td><a href="javascript:formCommandSubmit('reload');" onClick="MM_nbGroup('down','group1','reload','',1)" onMouseOver="MM_nbGroup('over','reload','','',1)" onMouseOut="MM_nbGroup('out')"><img src="images/refresh.png" alt="Reload shared files" name="reload" border="0" onload=""></a></td>
+				  <td><a href="javascript:formCommandSubmit('prioup');" onClick="MM_nbGroup('down','group1','up','',1)" onMouseOver="MM_nbGroup('over','up','','',1)" onMouseOut="MM_nbGroup('out')"><img name="up" src="images/up.png" border="0" alt="Raise priority" onLoad=""></a></td>
                   
-            <td><a href="javascript:formCommandSubmit('priodown');" onClick="MM_nbGroup('down','group1','down','',1)" onMouseOver="MM_nbGroup('over','down','','',1)" onMouseOut="MM_nbGroup('out')"><img src="images/down.png" alt="Abbassa Priorità" name="down" border="0" onload=""></a></td>
+            <td><a href="javascript:formCommandSubmit('priodown');" onClick="MM_nbGroup('down','group1','down','',1)" onMouseOver="MM_nbGroup('over','down','','',1)" onMouseOut="MM_nbGroup('out')"><img src="images/down.png" alt="Lower priority" name="down" border="0" onload=""></a></td>
                   <td><select name="select">
                       <option selected>Select prio</option>
                       <option>Low</option>
@@ -197,7 +197,7 @@ function formCommandSubmit(command)
                       <option>High</option>
                     </select> </td>
                   
-            <td><a href="javascript:formCommandSubmit('setprio');" onClick="MM_nbGroup('down','group1','resume','',1)" onMouseOver="MM_nbGroup('over','resume','','',1)" onMouseOut="MM_nbGroup('out')"><img src="images/ok.png" alt="Imposta Priorità" name="resume" border="0" onload=""></a></td>
+            <td><a href="javascript:formCommandSubmit('setprio');" onClick="MM_nbGroup('down','group1','resume','',1)" onMouseOver="MM_nbGroup('over','resume','','',1)" onMouseOut="MM_nbGroup('out')"><img src="images/ok.png" alt="Set priority" name="resume" border="0" onload=""></a></td>
               
                   <td> 
                     <?php


### PR DESCRIPTION
amuleweb-main-shared.php was the only template file encoded in ISO-8859-1 while every page declares a UTF-8 charset, so the toolbar tooltips rendered as mojibake ("Alza Priorit?"). On top of that, the four toolbar alt texts were in Italian on an otherwise English UI.

Translate the alt texts to English ("Reload shared files", "Raise priority", "Lower priority", "Set priority"), which also removes the only non-ASCII bytes in the file, making it plain ASCII / valid UTF-8 like the rest of the template.

Verified against a running amuleweb: the served page is valid UTF-8 and the tooltips render correctly.