### PR TITLE
fix(webserver): make footer's "Download link" refresh the main page

### DIFF
--- a/src/webserver/default/footer.php
+++ b/src/webserver/default/footer.php
@@ -77,15 +77,6 @@ color: white;
 -->
 </style>
 </head>
-<script language="JavaScript" type="text/JavaScript">
-
-function refreshFrames()
-{
-	location = "amuleweb-main-dload.php"
-	location.reload();
-}
-
-</script>
 
 <body>
 
@@ -119,8 +110,13 @@ function refreshFrames()
 		}
 	?>
         </select>
-        <input type="submit" name="Submit" value="Download link" onClick="refreshFrames()">
+        <input type="submit" name="Submit" value="Download link">
       </form></td>
 </table>
+<?php
+	if ( $HTTP_GET_VARS["Submit"] != "" ) {
+		echo '<script type="text/javascript">window.top.location = "amuleweb-main-dload.php";</script>';
+	}
+?>
 </body>
 </html>


### PR DESCRIPTION
refreshFrames() was broken in two ways: it assigned a new URL to 'location' and immediately called location.reload(), so the reload cancelled/duplicated the navigation; and since footer.php runs inside an iframe, 'location' only ever pointed at the iframe itself, never the main page. On top of that it ran from the submit button's onClick, i.e. before the form was actually submitted, racing the POST that adds the ed2k link.

Fix by navigating the top window once via window.top.location, and only after the form round-trip: the onClick handler and the refreshFrames() function are removed, and footer.php now emits a one-line script in its response only when the Submit parameter is present, i.e. after the server has already processed the ed2k link. The main page then reloads on amuleweb-main-dload.php and shows the new download.