### PR TITLE
fix(webserver): show login error message on failed login

### DIFF
--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -99,7 +99,13 @@ color: white;
                     <input name="pass" size="20" value="" type="password">
                     &nbsp; 
                     <input name="submit" type="submit" value="Submit">
-                    &nbsp;&nbsp; </form></th>
+                    &nbsp;&nbsp;
+<?php
+	if ( $_SESSION["login_error"] != "" ) {
+		echo "<br><span style=\"color: #c00000; font-weight: bold;\">", $_SESSION["login_error"], "</span>&nbsp;&nbsp;";
+	}
+?>
+                    </form></th>
               </tr>
             </table></td>
         </tr>


### PR DESCRIPTION
The webserver backend sets $_SESSION["login_error"] when a login attempt fails (wrong password, invalid hash, or no password configured), but login.php never printed it: a wrong password just re-rendered the login form with no feedback, leaving the user with no clue why they were not logged in.

Echo the session variable next to the login form, styled in red, when it is non-empty. The message is a static server-provided string (WebServer.cpp), so no escaping is needed. The error only shows on the response to the failed attempt itself, since the backend resets login_error at the start of every request.

Verified against a running amuleweb: a wrong password now renders "Password incorrect, please try again." under the form, a fresh visit shows no message, and the correct password still logs in.