### PR TITLE
fix(webserver): guard division by zero in downloads page percentages

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -413,7 +413,7 @@ function formCommandSubmit(command)
 				echo "<td class='texte' height='22' align='center'>", CastToXBytes($file->size, $countSize), "</td>";
 
 				echo "<td class='texte' height='22' align='center'>", CastToXBytes($file->size_done, $countCompleted), "&nbsp;(",
-					((float)$file->size_done*100)/((float)$file->size), "%)</td>";
+					($file->size > 0) ? (((float)$file->size_done*100)/((float)$file->size)) : 0, "%)</td>";
 
 				echo "<td class='texte' height='22' align='center'>", ($file->speed > 0) ? (CastToXBytes($file->speed, $countSpeed) . "/s") : "-", "</td>";
 
@@ -442,7 +442,7 @@ function formCommandSubmit(command)
 			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;text-align: right;padding-right: 20px;' height='22' align='center'>Total</td>";
 			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' height='22' align='center'>", CastToXBytes($countSize, $fakevar), "</td>";
 			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' height='22' align='center'>", CastToXBytes($countCompleted, $fakevar), "&nbsp;(",
-				((float)$countCompleted*100)/((float)$countSize), "%)</td>";
+				($countSize > 0) ? (((float)$countCompleted*100)/((float)$countSize)) : 0, "%)</td>";
 			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' height='22' align='center'>", ($countSpeed > 0) ? (CastToXBytes($countSpeed, $fakevar) . "/s" ) : "", "</td>";
 			echo "<td style='padding-bottom:0;'></td>";
 			echo "<td style='padding-bottom:0;'></td>";


### PR DESCRIPTION
The downloads page of the default template computes two completion percentages with an unguarded division:

- the per-file column divides size_done by the file size, which is zero for 0-byte files;
- the totals row divides the completed sum by the accumulated total size, which stays at zero whenever the status/category filter matches no files (the row is printed as long as the unfiltered list is non-empty).

In the second case the page rendered "-nan%" in the Total row. Guard both expressions with a ternary that falls back to 0 when the divisor is zero, matching the style already used elsewhere in the template.

Verified against a running amuleweb: with downloads present the percentages are unchanged, and with a filter matching no files the totals row now shows "0 b (0%)" instead of "-nan%".