### PR TITLE
fix(webserver): move <script> blocks inside <head> in default template

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -154,7 +154,7 @@ color: white;
 }
 -->
 </style>
-</head><script language="JavaScript" type="text/JavaScript">
+<script language="JavaScript" type="text/JavaScript">
 function formCommandSubmit(command)
 {
 	if ( command == "cancel" ) {
@@ -177,6 +177,7 @@ function formCommandSubmit(command)
 }
 
 </script>
+</head>
 <body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onLoad="MM_preloadImages('images/transf_1.png','images/shared_1.png','images/search_1.png','images/edkserv_1.png','images/sheserv_1.png','images/stats_1.png')">
 <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
   <tr valign="top"> 

--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -102,7 +102,7 @@ color: white;
 }
 -->
 </style>
-</head><script language="JavaScript" type="text/JavaScript">
+<script language="JavaScript" type="text/JavaScript">
 function formCommandSubmit(command)
 {
 	var frm=document.forms.mainform
@@ -202,6 +202,7 @@ function init_data()
 }
 
 </script>
+</head>
 <body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onLoad="MM_preloadImages('images/transf_1.png','images/shared_1.png','images/search_1.png','images/edkserv_1.png','images/sheserv_1.png','images/stats_1.png');init_data();">
 <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
   <tr valign="top"> 

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -111,7 +111,7 @@ color: white;
 }
 -->
 </style>
-</head><script language="JavaScript" type="text/JavaScript">
+<script language="JavaScript" type="text/JavaScript">
 function formCommandSubmit(command)
 {
 	<?php
@@ -126,6 +126,7 @@ function formCommandSubmit(command)
 }
 
 </script>
+</head>
 <body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onLoad="MM_preloadImages('images/transf_1.png','images/shared_1.png','images/search_1.png','images/edkserv_1.png','images/sheserv_1.png','images/stats_1.png');">
 <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
   <tr valign="top"> 

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -145,7 +145,7 @@ color: white;
 }
 -->
 </style>
-</head><script language="JavaScript" type="text/JavaScript">
+<script language="JavaScript" type="text/JavaScript">
 function formCommandSubmit(command)
 {
 	<?php
@@ -160,6 +160,7 @@ function formCommandSubmit(command)
 }
 
 </script>
+</head>
 <body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onLoad="MM_preloadImages('images/transf_1.png','images/shared_1.png','images/search_1.png','images/edkserv_1.png','images/sheserv_1.png','images/stats_1.png');">
 <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
   <tr valign="top"> 

--- a/src/webserver/default/amuleweb-main-stats.php
+++ b/src/webserver/default/amuleweb-main-stats.php
@@ -109,7 +109,7 @@ color: white;
 }
 -->
 </style>
-</head><script language="JavaScript" type="text/JavaScript">
+<script language="JavaScript" type="text/JavaScript">
 var openImg = new Image();
 openImg.src = "tree-open.gif";
 var closedImg = new Image();
@@ -132,6 +132,7 @@ function swapFolder(img){
 }
 
 </script>
+</head>
 <body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onLoad="MM_preloadImages('images/transf_1.png','images/shared_1.png','images/search_1.png','images/edkserv_1.png','images/sheserv_1.png','images/stats_1.png');">
 <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
   <tr valign="top"> 


### PR DESCRIPTION
Seven pages of the default web template closed <head> and then emitted a <script> block before opening <body>, which is invalid HTML (no content is allowed between </head> and <body>). Browsers recover by reparenting the script, but it is a parse error and a trap for further markup work.

Move the closing </head> tag to after the script block so the scripts are declared inside <head>, in:

- amuleweb-main-dload.php
- amuleweb-main-search.php
- amuleweb-main-shared.php
- amuleweb-main-prefs.php
- amuleweb-main-log.php
- amuleweb-main-stats.php
- footer.php

No script content was changed; this is a purely structural fix. Verified
against a running amuleweb: every affected page now serves </head>
immediately before <body> and renders unchanged.