### PR TITLE
fix(prefs): don't promote stale shareddir.dat entries to explicit shares

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1998,8 +1998,20 @@ void CPreferences::ReloadSharedFolders()
 		// external writer intended them as recursive (they didn't
 		// touch shareddir-recursive.dat), so the safe default is
 		// explicit.
+		//
+		// DirExists() gate: skip on-disk entries whose directory no
+		// longer exists. Those are stale runtime-expansion remnants
+		// of recursive subdirs that have since been deleted (the
+		// watcher persisted them to shareddir.dat in a previous
+		// session). Without this gate they would be promoted to
+		// shareddir_explicit_list and re-attempted on every restart.
+		// The check is safe because shareddir-explicit/recursive.dat
+		// are loaded above without an existence filter (#703), so a
+		// temporarily-offline network share marked as explicit or
+		// recursive persists across restarts regardless.
 		for (size_t i = 0; i < onDisk.size(); ++i) {
-			if (expected.find(onDisk[i].GetRaw()) == expected.end()) {
+			if (expected.find(onDisk[i].GetRaw()) == expected.end()
+				&& onDisk[i].DirExists()) {
 				shareddir_explicit_list.push_back(onDisk[i]);
 				expected.insert(onDisk[i].GetRaw());
 			}


### PR DESCRIPTION
## Summary

`CPreferences::ReloadSharedFolders` reconciles the runtime union `shareddir.dat` against the persistent `shareddir-explicit.dat` and `shareddir-recursive.dat`. As part of that pass, any on-disk `shareddir.dat` entry not already in the explicit list or in the recursive expansion is **promoted to `shareddir_explicit_list`** — the intent being to absorb manual edits made by Docker entrypoints or downgraded older binaries.

But the same path also fires when:

1. User marks `/dir1/` as a recursive share.
2. The watcher discovers `/dir1/dir2/` at runtime and writes it to `shareddir.dat`.
3. User deletes `/dir1/dir2/` from disk.
4. Next start: `ExpandRecursiveRoot` walks `/dir1/` and produces only `[/dir1/]` (dir2 is gone). The reconciliation sees `/dir1/dir2/` in `shareddir.dat` but not in `expected` → **promotes it to `shareddir-explicit.dat`**.

From that point on the missing path is persistent user intent. Every subsequent restart re-imports it, and aMule keeps complaining the directory is unavailable.

Gate the promotion on `DirExists()`. The runtime union is treated as a disposable cache; stale watcher-expanded subdirs of deleted recursive descendants are dropped instead of being promoted. The persistent intent files (`shareddir-explicit.dat`, `shareddir-recursive.dat`) keep their [#703 protection](https://github.com/amule-org/amule/pull/703) — entries are loaded verbatim with no existence filter, so a temporarily-offline NAS or unmounted USB root marked by the user persists across restarts regardless.

## Test plan

Executed on Ubuntu 26.04 ARM64. `/tmp/amuled-master` built at the fix branch's parent commit (PR #79-inclusive baseline); `/tmp/amuled-fix` built from this branch.

- [x] **Bug repro on master tip** — `/tmp/t1-shares` recursive, after creating + deleting `/tmp/t1-shares/bar`, master-tip second-run promoted the deleted path into `shareddir-explicit.dat`: `/tmp/t1-shares/bar`
- [x] **Fix on this branch, same scenario** — `shareddir-explicit.dat` stays `<empty>`; `shareddir.dat` rewritten as just `/tmp/t2-shares`
- [x] **Offline-recursive root preserved** — `shareddir-recursive.dat` = `/mnt/offline-recursive` (non-existent) → restart preserved the entry verbatim
- [x] **Offline-explicit root preserved** — `shareddir-explicit.dat` = `/mnt/offline-explicit` (non-existent) → restart preserved the entry verbatim
- [x] **Legacy compat — Docker hand-write of existing path** — `shareddir.dat` = `/tmp/t5-data` (existing) → promoted into `shareddir-explicit.dat` as before
- [x] **Legacy compat — Docker hand-write of missing path** — `shareddir.dat` = `/tmp/does-not-exist` → `shareddir-explicit.dat` stays `<empty>` (the documented path is to write `shareddir-explicit.dat` directly)