### PR TITLE
fix(webserver): correct structural HTML errors in default template

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -206,11 +206,11 @@ function formCommandSubmit(command)
       <td align="center"><table border="0" cellpadding="0" cellspacing="0">
           <tr> 
             <td><input type="hidden" name="command"></td>
-            <td><a href="javascript:formCommandSubmit('pause');" onClick="MM_nbGroup('down','group1','pause','',1)" onMouseOver="MM_nbGroup('over','pause','','',1)" onMouseOut="MM_nbGroup('out')"><img name="pause" src="images/pause.png" alt="pause" border="0" onLoad=""></a></td>
-            <td><a href="javascript:formCommandSubmit('resume');" onClick="MM_nbGroup('down','group1','resume','',1)" onMouseOver="MM_nbGroup('over','resume','','',1)" onMouseOut="MM_nbGroup('out')"><img img name="resume" src="images/play.png" alt="resume" border="0" onLoad=""></a></td>
-        		<td><a href="javascript:formCommandSubmit('prioup');" onClick="MM_nbGroup('down','group1','up','',1)" onMouseOver="MM_nbGroup('over','up','','',1)" onMouseOut="MM_nbGroup('out')"><img img name="prioup" src="images/up.png" alt="prioup" border="0" onLoad=""></a></td>
-        		<td><a href="javascript:formCommandSubmit('priodown');" onClick="MM_nbGroup('down','group1','down','',1)" onMouseOver="MM_nbGroup('over','down','','',1)" onMouseOut="MM_nbGroup('out')"><img img name="priodown" src="images/down.png" alt="priodown" border="0" onLoad=""></a></td>
-        		<td><a href="javascript:formCommandSubmit('cancel');" onClick="MM_nbGroup('down','group1','cancel','',1)" onMouseOver="MM_nbGroup('over','delete','','',1)" onMouseOut="MM_nbGroup('out')"><img img name="cancel" src="images/close.png" alt="cancel" border="0" onLoad=""></a></td>
+            <td><a href="javascript:formCommandSubmit('pause');" onClick="MM_nbGroup('down','group1','pause','',1)" onMouseOver="MM_nbGroup('over','pause','','',1)" onMouseOut="MM_nbGroup('out')"><img name="pause" src="images/pause.png" alt="pause" border="0"></a></td>
+            <td><a href="javascript:formCommandSubmit('resume');" onClick="MM_nbGroup('down','group1','resume','',1)" onMouseOver="MM_nbGroup('over','resume','','',1)" onMouseOut="MM_nbGroup('out')"><img name="resume" src="images/play.png" alt="resume" border="0"></a></td>
+        		<td><a href="javascript:formCommandSubmit('prioup');" onClick="MM_nbGroup('down','group1','up','',1)" onMouseOver="MM_nbGroup('over','up','','',1)" onMouseOut="MM_nbGroup('out')"><img name="prioup" src="images/up.png" alt="prioup" border="0"></a></td>
+        		<td><a href="javascript:formCommandSubmit('priodown');" onClick="MM_nbGroup('down','group1','down','',1)" onMouseOver="MM_nbGroup('over','down','','',1)" onMouseOut="MM_nbGroup('out')"><img name="priodown" src="images/down.png" alt="priodown" border="0"></a></td>
+        		<td><a href="javascript:formCommandSubmit('cancel');" onClick="MM_nbGroup('down','group1','cancel','',1)" onMouseOver="MM_nbGroup('over','delete','','',1)" onMouseOut="MM_nbGroup('out')"><img name="cancel" src="images/close.png" alt="cancel" border="0"></a></td>
       <td><table border="0" cellpadding="0" cellspacing="0">
                 <tr> 
                   <td> 
@@ -237,7 +237,7 @@ function formCommandSubmit(command)
 			echo '</select>';
         ?>
                   </td>
-                  			<td><a href="javascript:formCommandSubmit('filter');" onClick="MM_nbGroup('down','group1','resume','',1)" onMouseOver="MM_nbGroup('over','resume','','',1)" onMouseOut="MM_nbGroup('out')"><img src="images/filter.png" border="0" alt="Apply" name="resume" border="0" onload=""></a></td>
+                  			<td><a href="javascript:formCommandSubmit('filter');" onClick="MM_nbGroup('down','group1','resume','',1)" onMouseOver="MM_nbGroup('over','resume','','',1)" onMouseOut="MM_nbGroup('out')"><img src="images/filter.png" border="0" alt="Apply" name="resume"></a></td>
                   <td>&nbsp;</td>
                   <td>&nbsp;</td>
                   <td> 

--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -259,6 +259,7 @@ function init_data()
             <th>Webserver</th>
             <td width="63">&nbsp;</td>
           </tr>
+          <tr>
             <td width="22" height="25">&nbsp;</td>
             <td height="25">Page refresh interval </td>
             <td width="63" height="25">

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -217,6 +217,7 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
                 </tr>
               </table>
               <table width="100%"  border="0" align="center" cellpadding="0" cellspacing="0">
+                <tr>
                   <th>&nbsp;</th>
                   <th><a href="amuleweb-main-search.php?sort=name">File Name</a></th>
                   <th><a href="amuleweb-main-search.php?sort=size">Size</a></th>
@@ -342,7 +343,7 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
 
 			echo "<td class='texte' align='center'>", $file->sources, "</td>";
 
-			print "</tr></tr><tr><td colspan='9' height='1' bgcolor='#c0c0c0'></td></tr>";
+			print "</tr><tr><td colspan='9' height='1' bgcolor='#c0c0c0'></td></tr>";
 		}
 
 	  ?>

--- a/src/webserver/default/footer.php
+++ b/src/webserver/default/footer.php
@@ -112,6 +112,7 @@ color: white;
         </select>
         <input type="submit" name="Submit" value="Download link">
       </form></td>
+  </tr>
 </table>
 <?php
 	if ( $HTTP_GET_VARS["Submit"] != "" ) {

--- a/src/webserver/default/log.php
+++ b/src/webserver/default/log.php
@@ -3,7 +3,6 @@
 <html><head>
 <title>aMule control panel</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta http-equiv="pragmas" content="no-cache">
 <?php
 	if ( $_SESSION["auto_refresh"] > 0 ) {
 		echo "<meta http-equiv=\"refresh\" content=\"", $_SESSION["auto_refresh"], '">';
@@ -26,7 +25,7 @@ body {
 </style>
 </head>
 <body>
-<code><pre>
+<pre>
 <?php
 	if ("srv" == $HTTP_GET_VARS['show'] || 1 == $HTTP_GET_VARS['rstsrv']) {
 		echo amule_get_serverinfo($HTTP_GET_VARS['rstsrv']);
@@ -34,6 +33,6 @@ body {
 		echo amule_get_log($HTTP_GET_VARS['rstlog']);
 	}
 ?>
-</pre></code>
+</pre>
 </body>
 </html>

--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -84,7 +84,7 @@ color: white;
 </style>
 </head>
 
-<body  onload="login_init();" background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" valign="middle">
+<body  onload="login_init();" background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
 <table width="100%" height="180" border="0" cellpadding="0" cellspacing="0" valign="middle">
   <tr>
     <td align="center" valign="middle"> 

--- a/src/webserver/default/stats.php
+++ b/src/webserver/default/stats.php
@@ -83,6 +83,7 @@ color: white;
 -->
 </style>
 </head>
+<body>
 <table width="100%" height="30" border="0" align="center" cellpadding="0" cellspacing="0">
   <tr valign="top"> 
     <td width="65%"><strong>Ed2k : </strong> 
@@ -115,4 +116,5 @@ color: white;
     </td>
   </tr>
 </table>
+</body>
 </html>


### PR DESCRIPTION
Fix several invalid-markup issues across the default template pages, with no visual or behavioral change intended:

```
- stats.php: the document went straight from </head> to <table> and ended at </html>; add the missing <body> and </body> tags.
- log.php: replace the invalid <code><pre> nesting with <pre> alone, and drop the <meta http-equiv="pragmas"> tag (a typo for "pragma", and redundant anyway since every response already carries Cache-Control: no-cache headers).
- amuleweb-main-search.php: the search results header <th> cells had no opening <tr>, and each result row was closed with a duplicated </tr></tr>.
- footer.php: add the missing </tr> before </table>.
- amuleweb-main-prefs.php: the "Page refresh interval" row content was missing its opening <tr>.
- amuleweb-main-dload.php: remove the duplicated attribute in the toolbar's <img img name=...> tags, a duplicated border="0" on the filter button image, and the empty onLoad=""/onload="" attributes.
- login.php: drop the stray valign="middle" from <body>, which is not a valid body attribute.
```