### PR TITLE
Fix: Apply security hardening to WebUI and WebServer backend

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -234,7 +234,7 @@ function formCommandSubmit(command)
 		// (#869 follow-up; same fix applied to shared and servers pages).
 		$sort_raw = isset($HTTP_GET_VARS["sort"]) ? $HTTP_GET_VARS["sort"] : "";
 		if ($sort_raw == "size" || $sort_raw == "size_done" || $sort_raw == "progress" ||
-		    $sort_raw == "name" || $sort_raw == "speed" || $sort_raw == "scrcount" ||
+		    $sort_raw == "name" || $sort_raw == "speed" || $sort_raw == "srccount" ||
 		    $sort_raw == "status" || $sort_raw == "prio") {
 			$sort_order = $sort_raw;
 		} else {

--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -226,7 +226,20 @@ function formCommandSubmit(command)
 		$countSpeed = 0;
 		$downloads = amule_load_vars("downloads");
 		$fakevar=0;
-		$sort_order = $HTTP_GET_VARS["sort"];
+		// Whitelist against the column keys my_cmp() actually understands
+		// (the switch() above). Anything not in the list is dropped to "",
+		// which falls through to the "no sort change" branch below.
+		// This prevents an attacker-controlled value from being stored in
+		// $_SESSION["download_sort"] and later reflected into rendered HTML
+		// (#869 follow-up; same fix applied to shared and servers pages).
+		$sort_raw = isset($HTTP_GET_VARS["sort"]) ? $HTTP_GET_VARS["sort"] : "";
+		if ($sort_raw == "size" || $sort_raw == "size_done" || $sort_raw == "progress" ||
+		    $sort_raw == "name" || $sort_raw == "speed" || $sort_raw == "scrcount" ||
+		    $sort_raw == "status" || $sort_raw == "prio") {
+			$sort_order = $sort_raw;
+		} else {
+			$sort_order = "";
+		}
 
 		if ( $sort_order == "" ) {
 			$sort_order = $_SESSION["download_sort"];

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -91,7 +91,16 @@
 
 		$servers = amule_load_vars("servers");
 
-		$sort_order = $HTTP_GET_VARS["sort"];
+		// Whitelist against the column keys my_cmp() actually understands
+		// (the switch() above). Anything not in the list is dropped to "",
+		// which falls through to the "no sort change" branch below (#869 follow-up).
+		$sort_raw = isset($HTTP_GET_VARS["sort"]) ? $HTTP_GET_VARS["sort"] : "";
+		if ($sort_raw == "name" || $sort_raw == "desc" ||
+		    $sort_raw == "users" || $sort_raw == "files") {
+			$sort_order = $sort_raw;
+		} else {
+			$sort_order = "";
+		}
 
 		//
 		// perform command before processing content

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -187,7 +187,22 @@ function formCommandSubmit(command)
 		}
 		$shared = amule_load_vars("shared");
 
-		$sort_order = $HTTP_GET_VARS["sort"];
+		// Whitelist against the column keys my_cmp() actually understands
+		// (the switch() above). Anything not in the list is dropped to "",
+		// which falls through to the "no sort change" branch below.
+		// This prevents an attacker-controlled value from being stored in
+		// $_SESSION["shared_sort"] and later reflected into rendered HTML
+		// if any future template change prints that variable (#869 follow-up).
+		// Plain string-equality chain is the only matching primitive the
+		// bundled PHP interpreter supports (no in_array(), no htmlspecialchars()).
+		$sort_raw = isset($HTTP_GET_VARS["sort"]) ? $HTTP_GET_VARS["sort"] : "";
+		if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "xfer" ||
+		    $sort_raw == "xfer_all" || $sort_raw == "acc" || $sort_raw == "acc_all" ||
+		    $sort_raw == "req" || $sort_raw == "req_all" || $sort_raw == "prio") {
+			$sort_order = $sort_raw;
+		} else {
+			$sort_order = "";
+		}
 
 		if ( $sort_order == "" ) {
 			$sort_order = $_SESSION["shared_sort"];

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -509,6 +509,12 @@ bool CWebServerBase::Send_DownloadEd2k_Cmd(wxString link, uint8 cat)
 	link_tag.AddTag(CECTag(EC_TAG_PARTFILE_CAT, cat));
 	req.AddTag(link_tag);
 	const CECPacket *response = webInterface->SendRecvMsg_v2(&req);
+	// SendRecvMsg_v2 returns null on EC connection failure.
+	// Treat a missing response as a failed command (same as EC_OP_FAILED)
+	// so the PHP caller gets a defined bool rather than a crash.
+	if (!response) {
+		return true;
+	}
 	bool result = (response->GetOpCode() == EC_OP_FAILED);
 	delete response;
 	return result;
@@ -1325,17 +1331,34 @@ void CStatsCollection::ReQuery()
 
 	const CECPacket *response = m_iface->SendRecvMsg_v2(&request);
 
+	// Guard against a lost EC connection: SendRecvMsg_v2 returns null
+	// on socket error. Without this the dereference below crashes amuleweb.
+	if (!response) {
+		return;
+	}
+
 	m_LastTimeStamp = response->GetTagByNameSafe(EC_TAG_STATSGRAPH_LAST)->GetDoubleData();
 
 	const CECTag *dataTag = response->GetTagByName(EC_TAG_STATSGRAPH_DATA);
+	// Guard against a well-formed response that simply omits the data tag
+	// (e.g. amuled returned EC_OP_FAILED or the daemon has no samples yet).
+	if (!dataTag) {
+		delete response;
+		return;
+	}
 	const uint32 *data = (const uint32 *)dataTag->GetTagData();
 	unsigned int count = dataTag->GetTagDataLen() / sizeof(uint32);
+	// Each sample group is exactly 4 uint32 values (down, up, conn, kad).
+	// A truncated or malformed tag could leave count % 4 != 0; clamp to
+	// the largest multiple of 4 that fits so we never read past the buffer.
+	count -= count % 4;
 	for (unsigned int i = 0; i < count; i += 4) {
 		m_down_speed->PushSample(ENDIAN_NTOHL(data[i+0]));
 		m_up_speed->PushSample(ENDIAN_NTOHL(data[i+1]));
 		m_conn_number->PushSample(ENDIAN_NTOHL(data[i+2]));
 		m_kad_count->PushSample(ENDIAN_NTOHL(data[i+3]));
 	}
+	delete response;
 }
 
 //
@@ -2004,7 +2027,13 @@ void CScriptWebServer::ProcessURL(ThreadData Data)
 
 	if (isUseGzip)	{
 		bool bOk = false;
-		uLongf destLen = httpOutLen + 1024;
+		// zlib's deflate worst-case expansion is sourceLen + (sourceLen/1000) + 12 bytes.
+		// GzipCompress adds an 18-byte gzip wrapper (10-byte header + 8-byte trailer).
+		// The previous fixed +1024 slack was technically correct for the template sizes
+		// amuleweb serves today, but violated zlib's documented contract for large or
+		// maximally-incompressible payloads. Use the formula from the zlib manual so
+		// the buffer is always sufficient regardless of content size.
+		uLongf destLen = httpOutLen + (httpOutLen / 1000) + 30;
 		char *gzipOut = new char[destLen];
 		if( GzipCompress((Bytef*)gzipOut, &destLen,
 		   (const Bytef*)httpOut, httpOutLen, Z_DEFAULT_COMPRESSION) == Z_OK) {


### PR DESCRIPTION
- PHP: Implement strict whitelist for $sort parameter to prevent reflected XSS (dload, servers, shared).
- C++: Add null pointer checks in Send_DownloadEd2k_Cmd and CStatsCollection::ReQuery to prevent crashes on EC failure.
- C++: Clamp stats data count to multiple of 4 to prevent Out-of-Bounds read.
- C++: Fix memory leak in ReQuery by ensuring delete response is called on all paths.
- C++: Fix potential heap buffer overflow in Gzip compression by using zlib's documented worst-case size formula.

## Summary

<!-- What does this PR do, and why? -->

## Test plan

<!-- How was this change verified? -->
