### PR TITLE
refactor(webserver): migrate presentational HTML attributes to CSS

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -34,11 +34,11 @@ function formCommandSubmit(command)
 
 </script>
 </head>
-<body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-<table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr valign="top"> 
-    <td width="143" height="64"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" height="64" align="right" background="images/fond_haut.png"> <table border="0" cellspacing="0" cellpadding="0">
+<body class="main">
+<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+  <tr class="va-top"> 
+    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -48,26 +48,26 @@ function formCommandSubmit(command)
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
           <td width="10"></td>
-          <td width="190" align="right" class="texteinv"><a href="login.php">exit</a><br>
+          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br>
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a>
             </td>
           <td width="10"></td>
         </tr>
       </table></td>
   </tr>
-  <tr align="center" valign="top"> 
+  <tr class="al-center va-top"> 
     <td colspan="2"><form action="amuleweb-main-dload.php" method="post" name="mainform">
-        <table width="100%" border="0" cellpadding="0" cellspacing="0">
+        <table width="100%" cellpadding="0" cellspacing="0">
           <tr>
-      <td align="center"><table border="0" cellpadding="0" cellspacing="0">
+      <td><table class="center-table" cellpadding="0" cellspacing="0">
           <tr> 
             <td><input type="hidden" name="command"></td>
-            <td><a href="javascript:formCommandSubmit('pause');"><img name="pause" src="images/pause.png" alt="pause" border="0"></a></td>
-            <td><a href="javascript:formCommandSubmit('resume');"><img name="resume" src="images/play.png" alt="resume" border="0"></a></td>
-        		<td><a href="javascript:formCommandSubmit('prioup');"><img name="prioup" src="images/up.png" alt="prioup" border="0"></a></td>
-        		<td><a href="javascript:formCommandSubmit('priodown');"><img name="priodown" src="images/down.png" alt="priodown" border="0"></a></td>
-        		<td><a href="javascript:formCommandSubmit('cancel');"><img name="cancel" src="images/close.png" alt="cancel" border="0"></a></td>
-      <td><table border="0" cellpadding="0" cellspacing="0">
+            <td><a href="javascript:formCommandSubmit('pause');"><img name="pause" src="images/pause.png" alt="pause"></a></td>
+            <td><a href="javascript:formCommandSubmit('resume');"><img name="resume" src="images/play.png" alt="resume"></a></td>
+        		<td><a href="javascript:formCommandSubmit('prioup');"><img name="prioup" src="images/up.png" alt="prioup"></a></td>
+        		<td><a href="javascript:formCommandSubmit('priodown');"><img name="priodown" src="images/down.png" alt="priodown"></a></td>
+        		<td><a href="javascript:formCommandSubmit('cancel');"><img name="cancel" src="images/close.png" alt="cancel"></a></td>
+      <td><table cellpadding="0" cellspacing="0">
                 <tr> 
                   <td> 
                     <?php
@@ -93,7 +93,7 @@ function formCommandSubmit(command)
 			echo '</select>';
         ?>
                   </td>
-                  			<td><a href="javascript:formCommandSubmit('filter');"><img src="images/filter.png" border="0" alt="Apply" name="resume"></a></td>
+                  			<td><a href="javascript:formCommandSubmit('filter');"><img src="images/filter.png" alt="Apply" name="resume"></a></td>
                   <td>&nbsp;</td>
                   <td>&nbsp;</td>
                   <td> 
@@ -109,20 +109,20 @@ function formCommandSubmit(command)
         </table></td>
     </tr>
     <tr> 
-      <td height="10" align="center"> </td>
+      <td class="h10"> </td>
     </tr>
     <tr> 
-      <td colspan="2"><table width="100%" border="0" cellspacing="0" cellpadding="0"> <caption>
+      <td colspan="2"><table width="100%" cellspacing="0" cellpadding="0"> <caption>
           DOWNLOAD 
           </caption>
   <tr>
     <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
-    <td background="images/tab_top.png">&nbsp;</td>
+    <td class="tab-top">&nbsp;</td>
     <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
   </tr>
   <tr>
-    <td width="24" background="images/tab_left.png">&nbsp;</td>
-    <td bgcolor="#FFFFFF"><table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+    <td width="24" class="tab-left">&nbsp;</td>
+    <td class="bg-white"><table width="100%" cellpadding="0" cellspacing="0">
                      
           <tr> 
                   <th>&nbsp;</th>
@@ -134,7 +134,7 @@ function formCommandSubmit(command)
                   <th><a href="amuleweb-main-dload.php?sort=srccount">Sources</a></th>
                   <th><a href="amuleweb-main-dload.php?sort=status">Status</a></th>
                   <th><a href="amuleweb-main-dload.php?sort=prio">Priority</a></th>
-          </tr><tr><td colspan="9" height="1" bgcolor="#000000"></td></tr>
+          </tr><tr><td colspan="9" class="sep-dark"></td></tr>
           <?php
 		function CastToXBytes($size, &$count) {
 			$count += $size;
@@ -263,20 +263,20 @@ function formCommandSubmit(command)
 			if ( $filter_status_result and $filter_cat_result) {
 				print "<tr>";
 	
-				echo "<td class='texte' height='22'>", '<input type="checkbox" name="', $file->hash, '" >', "</td>";
+				echo "<td class='texte h22'>", '<input type="checkbox" name="', $file->hash, '" >', "</td>";
 	
-				echo "<td class='texte texte-full-name' height='22'>", $file->name, "</td>";
+				echo "<td class='texte texte-full-name h22'>", $file->name, "</td>";
 				
-				echo "<td class='texte' height='22' align='center'>", CastToXBytes($file->size, $countSize), "</td>";
+				echo "<td class='texte h22 al-center'>", CastToXBytes($file->size, $countSize), "</td>";
 
-				echo "<td class='texte' height='22' align='center'>", CastToXBytes($file->size_done, $countCompleted), "&nbsp;(",
+				echo "<td class='texte h22 al-center'>", CastToXBytes($file->size_done, $countCompleted), "&nbsp;(",
 					($file->size > 0) ? (((float)$file->size_done*100)/((float)$file->size)) : 0, "%)</td>";
 
-				echo "<td class='texte' height='22' align='center'>", ($file->speed > 0) ? (CastToXBytes($file->speed, $countSpeed) . "/s") : "-", "</td>";
+				echo "<td class='texte h22 al-center'>", ($file->speed > 0) ? (CastToXBytes($file->speed, $countSpeed) . "/s") : "-", "</td>";
 
-				echo "<td class='texte' height='22' align='center' align='center'>", $file->progress, "</td>";
+				echo "<td class='texte h22 al-center'>", $file->progress, "</td>";
 	
-				echo "<td class='texte' height='22' align='center'>";
+				echo "<td class='texte h22 al-center'>";
 				if ( $file->src_count_not_curr != 0 ) {
 					echo $file->src_count - $file->src_count_not_curr, " / ";
 				}
@@ -286,21 +286,21 @@ function formCommandSubmit(command)
 				}
 				echo "</td>";
 	
-				echo "<td class='texte' height='22' align='center'>", StatusString($file), "</td>";
+				echo "<td class='texte h22 al-center'>", StatusString($file), "</td>";
 				
-				echo "<td class='texte' height='22' align='center'>", PrioString($file), "</td>";
+				echo "<td class='texte h22 al-center'>", PrioString($file), "</td>";
 				
-				print "</tr><tr><td colspan='9' height='1' bgcolor='#c0c0c0'></td></tr>";
+				print "</tr><tr><td colspan='9' class='sep-light'></td></tr>";
 			}
 		}
 		if (count($downloads)>0) {
 			echo "<tr>";
 			echo "<td style='padding-bottom:0;'></td>";
-			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;text-align: right;padding-right: 20px;' height='22' align='center'>Total</td>";
-			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' height='22' align='center'>", CastToXBytes($countSize, $fakevar), "</td>";
-			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' height='22' align='center'>", CastToXBytes($countCompleted, $fakevar), "&nbsp;(",
+			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;text-align: right;padding-right: 20px;' class='h22 al-center'>Total</td>";
+			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' class='h22 al-center'>", CastToXBytes($countSize, $fakevar), "</td>";
+			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' class='h22 al-center'>", CastToXBytes($countCompleted, $fakevar), "&nbsp;(",
 				($countSize > 0) ? (((float)$countCompleted*100)/((float)$countSize)) : 0, "%)</td>";
-			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' height='22' align='center'>", ($countSpeed > 0) ? (CastToXBytes($countSpeed, $fakevar) . "/s" ) : "", "</td>";
+			echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' class='h22 al-center'>", ($countSpeed > 0) ? (CastToXBytes($countSpeed, $fakevar) . "/s" ) : "", "</td>";
 			echo "<td style='padding-bottom:0;'></td>";
 			echo "<td style='padding-bottom:0;'></td>";
 			echo "<td style='padding-bottom:0;'></td>";
@@ -309,28 +309,28 @@ function formCommandSubmit(command)
 		}
 	  ?>
         </table></td>
-    <td width="24" background="images/tab_right.png">&nbsp;</td>
+    <td width="24" class="tab-right">&nbsp;</td>
   </tr>
   <tr>
     <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
-    <td background="images/tab_bottom.png">&nbsp;</td>
+    <td class="tab-bottom">&nbsp;</td>
     <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
   </tr>
 </table></td>
     </tr>
   </table>
 </form>
-      <table width="100%" border="0" cellspacing="0" cellpadding="0"><caption>
+      <table width="100%" cellspacing="0" cellpadding="0"><caption>
         UPLOAD 
         </caption>
         <tr> 
           <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
-          <td background="images/tab_top.png">&nbsp;</td>
+          <td class="tab-top">&nbsp;</td>
           <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
         </tr>
         <tr> 
-          <td width="24" background="images/tab_left.png">&nbsp;</td>
-          <td bgcolor="#FFFFFF"><table width="100%" border="0" align="center" cellpadding="0" cellspacing="0" class="doad-table">
+          <td width="24" class="tab-left">&nbsp;</td>
+          <td class="bg-white"><table width="100%" cellpadding="0" cellspacing="0" class="doad-table">
               
         <tr> 
                 <td>&nbsp;</td>
@@ -342,7 +342,7 @@ function formCommandSubmit(command)
                 <th>&nbsp;</th>
                 <th>Speed</th>
                 <td>&nbsp;</td>
-        </tr><tr><td colspan="9" height="1" bgcolor="#000000"></td></tr>
+        </tr><tr><td colspan="9" class="sep-dark"></td></tr>
         <?php
 			function CastToXBytes($size, &$count) {
 				$count += $size;
@@ -365,47 +365,47 @@ function formCommandSubmit(command)
 			foreach ($uploads as $file) {
 				echo "<tr>";
 	
-				echo "<td class='texte' height='22' align='center'>", "</td>";
+				echo "<td class='texte h22 al-center'>", "</td>";
 				
-				echo "<td class='texte texte-full-name texte-full-name-upload' height='22'>", $file->name, "</td>";
+				echo "<td class='texte texte-full-name texte-full-name-upload h22'>", $file->name, "</td>";
 
-				echo "<td class='texte' height='22' align='center'>", $file->user_name, "</td>";
+				echo "<td class='texte h22 al-center'>", $file->user_name, "</td>";
 	
-				echo "<td class='texte' height='22' align='center'>", CastToXBytes($file->xfer_up, $countUploadDimension), "</td>";
-				echo "<td class='texte' height='22' align='center'>", CastToXBytes($file->xfer_down, $countDownloadDimension), "</td>";
-				echo "<td class='texte' height='22' align='center'>", "</td>";
-				echo "<td class='texte' height='22' align='center'>", "</td>";
-				echo "<td class='texte' height='22' align='center'>", ($file->xfer_speed > 0) ? (CastToXBytes($file->xfer_speed, $countSpeed) . "/s") : "-", "</td>";
-				echo "<td class='texte' height='22' align='center'>", "</td>";
-				echo "</tr><tr><td colspan='9' height='1' bgcolor='#c0c0c0'></td></tr>";
+				echo "<td class='texte h22 al-center'>", CastToXBytes($file->xfer_up, $countUploadDimension), "</td>";
+				echo "<td class='texte h22 al-center'>", CastToXBytes($file->xfer_down, $countDownloadDimension), "</td>";
+				echo "<td class='texte h22 al-center'>", "</td>";
+				echo "<td class='texte h22 al-center'>", "</td>";
+				echo "<td class='texte h22 al-center'>", ($file->xfer_speed > 0) ? (CastToXBytes($file->xfer_speed, $countSpeed) . "/s") : "-", "</td>";
+				echo "<td class='texte h22 al-center'>", "</td>";
+				echo "</tr><tr><td colspan='9' class='sep-light'></td></tr>";
 			}
 			if (count($uploads)>0) {
 				echo "<tr>";
 				echo "<td style='padding-bottom:0;'></td>";
 				echo "<td style='padding-bottom:0;'></td>";
-				echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;text-align: right;padding-right: 20px;' height='22' align='center'>Total</td>";
-				echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' height='22' align='center'>", CastToXBytes($countUploadDimension, $fakevar), "</td>";
-				echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' height='22' align='center'>", CastToXBytes($countDownloadDimension, $fakevar), "</td>";
+				echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;text-align: right;padding-right: 20px;' class='h22 al-center'>Total</td>";
+				echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' class='h22 al-center'>", CastToXBytes($countUploadDimension, $fakevar), "</td>";
+				echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' class='h22 al-center'>", CastToXBytes($countDownloadDimension, $fakevar), "</td>";
 				echo "<td style='padding-bottom:0;'></td>";
 				echo "<td style='padding-bottom:0;'></td>";
-				echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' height='22' align='center'>", CastToXBytes($countSpeed, $fakevar) . "/s", "</td>";
+				echo "<td style='font-size:12px;color:#908c8c;padding-bottom:0;' class='h22 al-center'>", CastToXBytes($countSpeed, $fakevar) . "/s", "</td>";
 			}
 		?>
       </table></td>
-          <td width="24" background="images/tab_right.png">&nbsp;</td>
+          <td width="24" class="tab-right">&nbsp;</td>
         </tr>
         <tr> 
           <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
-          <td background="images/tab_bottom.png">&nbsp;</td>
+          <td class="tab-bottom">&nbsp;</td>
           <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
         </tr>
       </table>
       
     </td>
   </tr>
-  <tr valign="bottom"> 
-    <td height="25" colspan="2"> <table width="100%" height="40" border="0" cellpadding="0" cellspacing="0">
-        <tr align="center" valign="middle"> 
+  <tr class="va-bottom"> 
+    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+        <tr class="al-center va-middle"> 
           <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">ed2klink</iframe> 
           </td>
           <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 

--- a/src/webserver/default/amuleweb-main-kad.php
+++ b/src/webserver/default/amuleweb-main-kad.php
@@ -66,11 +66,11 @@ function formCommandSubmit(command)
 }
 
 </script>
-<body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-<table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr valign="top"> 
-    <td width="143" height="64"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" height="64" align="right" background="images/fond_haut.png"> <table border="0" cellspacing="0" cellpadding="0">
+<body class="main">
+<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+  <tr class="va-top"> 
+    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -80,35 +80,35 @@ function formCommandSubmit(command)
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
           <td width="10"></td>
-          <td width="190" align="right" class="texteinv"><a href="login.php">exit</a><br> 
+          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
           <td width="10"></td>
         </tr>
       </table></td>
   </tr>
-  <tr align="center" valign="top"> 
+  <tr class="al-center va-top"> 
     <td colspan="2"><form name="mainform" action="amuleweb-main-kad.php" method="post">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <table width="100%" cellspacing="0" cellpadding="0">
           <caption>
           KADEMLIA 
           </caption>
           <tr> 
             <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
-            <td background="images/tab_top.png">&nbsp;</td>
+            <td class="tab-top">&nbsp;</td>
             <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" background="images/tab_left.png">&nbsp;</td>
-            <td bgcolor="#FFFFFF"><table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+            <td width="24" class="tab-left">&nbsp;</td>
+            <td class="bg-white"><table width="100%" cellpadding="0" cellspacing="0">
                 <!--DWLayoutTable-->
-                <tr valign="top"> 
-                  <td height="200"><img src="amule_stats_kad.png" width="500" height="200" border="0" alt="" title="" /></td>
-                  <td valign="top"> <table  border="0" align="center" cellpadding="0" cellspacing="6" class="kadnewnode">
+                <tr class="va-top"> 
+                  <td class="h200"><img src="amule_stats_kad.png" width="500" height="200" alt="" title="" /></td>
+                  <td class="va-top"> <table class="kadnewnode center-table" cellpadding="0" cellspacing="6">
                       <tr>
                         <th colspan="2">Network</th>
                       </tr>
                       <tr>
-                        <td colspan="2" align="center">
+                        <td colspan="2" class="al-center">
                           <button type="submit" name="kad_action" value="connect_known">Connect from known peers</button>
                           &nbsp;
                           <button type="submit" name="kad_action" value="disconnect">Disconnect</button>
@@ -118,42 +118,42 @@ function formCommandSubmit(command)
                         <th colspan="2">Bootstrap from node</th>
                       </tr>
                       <tr>
-                        <td align="right">IP :</td><td align="left"><input name="ip3" type="text" id="ip32" size="3" maxlength="3">
+                        <td class="al-right">IP :</td><td class="al-left"><input name="ip3" type="text" id="ip32" size="3" maxlength="3">
                           &nbsp; <input name="ip2" type="text" id="ip23" size="3" maxlength="3">
                           &nbsp; <input name="ip1" type="text" id="ip13" size="3" maxlength="3">
                           &nbsp; <input name="ip0" type="text" id="ip03" size="3" maxlength="3"></td>
                       </tr>
                       <tr>
-                        <td align="right">Port :</td><td align="left"><input name="port" type="text" id="port3" size="4" maxlength="5">
+                        <td class="al-right">Port :</td><td class="al-left"><input name="port" type="text" id="port3" size="4" maxlength="5">
                           &nbsp; <button type="submit" name="kad_action" value="connect_ip">Connect</button></td>
                       </tr>
                       <tr>
                         <th colspan="2">Update bootstrap from URL</th>
                       </tr>
                       <tr>
-                        <td align="right">URL :</td><td align="left"><input name="nodes_url" type="text" id="nodes_url" size="32">
+                        <td class="al-right">URL :</td><td class="al-left"><input name="nodes_url" type="text" id="nodes_url" size="32">
                           &nbsp; <button type="submit" name="kad_action" value="update_url">Update</button></td>
                       </tr>
                     </table></td>
                 </tr>
-                <tr valign="top"> 
-                  <td height="20" width="500" align="center">Number of nodes</td>
+                <tr class="va-top"> 
+                  <td class="h20 al-center" width="500">Number of nodes</td>
                   <td></td>
                 </tr>
               </table></td>
-            <td width="24" background="images/tab_right.png">&nbsp;</td>
+            <td width="24" class="tab-right">&nbsp;</td>
           </tr>
           <tr> 
             <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
-            <td background="images/tab_bottom.png">&nbsp;</td>
+            <td class="tab-bottom">&nbsp;</td>
             <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table>
         </form></td>
   </tr>
-  <tr valign="bottom"> 
-    <td height="25" colspan="2"> <table width="100%" height="40" border="0" cellpadding="0" cellspacing="0">
-        <tr align="center" valign="middle"> 
+  <tr class="va-bottom"> 
+    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+        <tr class="al-center va-middle"> 
           <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
           </td>
           <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 

--- a/src/webserver/default/amuleweb-main-log.php
+++ b/src/webserver/default/amuleweb-main-log.php
@@ -6,11 +6,11 @@
 
 <link href="style.css" rel="stylesheet" type="text/css">
 </head>
-<body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-<table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr valign="top"> 
-    <td width="143" height="64"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" height="64" align="right" background="images/fond_haut.png"> <table border="0" cellspacing="0" cellpadding="0">
+<body class="main">
+<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+  <tr class="va-top"> 
+    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -20,29 +20,29 @@
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
           <td width="10"></td>
-          <td width="190" align="right" class="texteinv"><a href="login.php">exit</a><br> 
+          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
           <td width="10"></td>
         </tr>
       </table></td>
   </tr>
-  <tr align="center" valign="top"> 
-    <td colspan="2">        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+  <tr class="al-center va-top"> 
+    <td colspan="2">        <table width="100%" cellspacing="0" cellpadding="0">
           <caption>
           AMULE LOG 
           </caption>
           <tr> 
             <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
-            <td background="images/tab_top.png">&nbsp;</td>
+            <td class="tab-top">&nbsp;</td>
             <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" background="images/tab_left.png">&nbsp;</td>
-            <td bgcolor="#FFFFFF">
+            <td width="24" class="tab-left">&nbsp;</td>
+            <td class="bg-white">
 
-            <table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+            <table width="100%" cellpadding="0" cellspacing="0">
                 <!--DWLayoutTable-->
-                <tr valign="top"> 
+                <tr class="va-top"> 
                   <td>
 		<h1 style="display:inline;">aMule log</h1>
 		<a href="log.php?rstlog=1" target="logframe" onclick="return confirm('Do you really want to reset aMule log?')">(Reset log)</a><br>
@@ -58,19 +58,19 @@
                 </tr>
               </table>
               </td>
-            <td width="24" background="images/tab_right.png">&nbsp;</td>
+            <td width="24" class="tab-right">&nbsp;</td>
           </tr>
           <tr> 
             <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
-            <td background="images/tab_bottom.png">&nbsp;</td>
+            <td class="tab-bottom">&nbsp;</td>
             <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table>
 </td>
   </tr>
-  <tr valign="bottom"> 
-    <td height="25" colspan="2"> <table width="100%" height="40" border="0" cellpadding="0" cellspacing="0">
-        <tr align="center" valign="middle"> 
+  <tr class="va-bottom"> 
+    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+        <tr class="al-center va-middle"> 
           <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
           </td>
           <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 

--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -106,11 +106,11 @@ function init_data()
 
 </script>
 </head>
-<body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onLoad="init_data();">
-<table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr valign="top"> 
-    <td width="143" height="64"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" height="64" align="right" background="images/fond_haut.png"> <table border="0" cellspacing="0" cellpadding="0">
+<body class="main" onLoad="init_data();">
+<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+  <tr class="va-top"> 
+    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -120,253 +120,253 @@ function init_data()
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
           <td width="10"></td>
-          <td width="190" align="right" class="texteinv"><a href="login.php">exit</a><br> 
+          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
           <td width="10"></td>
         </tr>
       </table></td>
   </tr>
-  <tr align="center" valign="top"> 
+  <tr class="al-center va-top"> 
     <td colspan="2">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <table width="100%" cellspacing="0" cellpadding="0">
           <caption>PREFERENCES</caption>
           <tr> 
             <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
-            <td background="images/tab_top.png">&nbsp;</td>
+            <td class="tab-top">&nbsp;</td>
             <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" background="images/tab_left.png">&nbsp;</td>
+            <td width="24" class="tab-left">&nbsp;</td>
             
-      <td bgcolor="#FFFFFF"><form name="mainform" action="amuleweb-main-prefs.php" method="post">
-              <table border="0" align="center" cellpadding="0" cellspacing="6">
+      <td class="bg-white"><form name="mainform" action="amuleweb-main-prefs.php" method="post">
+              <table class="center-table" cellpadding="0" cellspacing="6">
                
-    <tr align="center" valign="top">
+    <tr class="al-center va-top">
       <td>
-        <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
+        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
           <tr>
             <td width="22">&nbsp;</td>
             <th>General</th>
             <td width="63">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">Nickname</td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">Nickname</td>
+            <td width="63" class="h25">
 <input name="nick" type="text" id="nick0" size="20"></td>
           </tr>
         </table>
-        <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
+        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
           <tr>
             <td width="22">&nbsp;</td>
             <th>Webserver</th>
             <td width="63">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">Page refresh interval </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">Page refresh interval </td>
+            <td width="63" class="h25">
 <input name="autorefresh_time" type="text" id="autorefresh_time7" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" height="25">
+            <td width="22" class="h25">
 <input name="use_gzip" type="checkbox" id="use_gzip5"></td>
-            <td height="25"> Use gzip compression </td>
-            <td width="63" height="25">&nbsp;</td>
+            <td class="h25"> Use gzip compression </td>
+            <td width="63" class="h25">&nbsp;</td>
           </tr>
         </table></td>
       <td width="50%"> 
-        <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
+        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
           <tr> 
             <td width="22">&nbsp;</td>
             <th>Line capacity (for statistics only)</th>
             <td width="63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">Max download rate </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">Max download rate </td>
+            <td width="63" class="h25">
 <input name="max_line_down_cap" type="text" id="max_line_down_cap6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">Max upload rate </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">Max upload rate </td>
+            <td width="63" class="h25">
 <input name="max_line_up_cap" type="text" id="max_line_up_cap7" size="4"></td>
           </tr>
         </table></td>
     </tr>
-    <tr align="center" valign="top"> 
+    <tr class="al-center va-top"> 
       <td> 
-        <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
+        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
           <tr> 
-            <td width="22" height="19">&nbsp;</td>
+            <td width="22" class="h19">&nbsp;</td>
             <th>Bandwidth limits</th>
             <td width="63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">Max download rate </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">Max download rate </td>
+            <td width="63" class="h25">
 <input name="max_down_limit" type="text" id="max_down_limit6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">Max upload rate </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">Max upload rate </td>
+            <td width="63" class="h25">
 <input name="max_up_limit" type="text" id="max_up_limit6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">Slot allocation </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">Slot allocation </td>
+            <td width="63" class="h25">
 <input name="slot_alloc" type="text" id="slot_alloc6" size="4"></td>
           </tr>
         </table></td>
       <td width="50%" rowspan="3"> 
-        <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
+        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
           <tr> 
             <td width="22">&nbsp;</td>
             <th> File settings </th>
             <td width="63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">&nbsp; </td>
-            <td width="63" height="25"></td>
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">&nbsp; </td>
+            <td width="63" class="h25"></td>
           </tr>
           <tr> 
-            <td width="22" height="25"> 
+            <td width="22" class="h25"> 
               <input name="check_free_space" type="checkbox" id="check_free_space5"></td>
-            <td height="25"> Check free space =&gt; Minimum free space (Mb) </td>
-            <td width="63" height="25"> 
+            <td class="h25"> Check free space =&gt; Minimum free space (Mb) </td>
+            <td width="63" class="h25"> 
               <input name="min_free_space" type="text" id="min_free_space4" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" height="25"> 
+            <td width="22" class="h25"> 
               <input name="new_files_auto_dl_prio" type="checkbox" id="new_files_auto_dl_prio4"></td>
-            <td height="25"> Added download files have auto priority</td>
-            <td width="63" height="25"></td>
+            <td class="h25"> Added download files have auto priority</td>
+            <td width="63" class="h25"></td>
           </tr>
           <tr> 
-            <td width="22" height="25"> 
+            <td width="22" class="h25"> 
               <input name="new_files_auto_ul_prio" type="checkbox" id="new_files_auto_ul_prio4"></td>
-            <td height="25"> New shared files have auto priority</td>
-            <td width="63" height="25"></td>
+            <td class="h25"> New shared files have auto priority</td>
+            <td width="63" class="h25"></td>
           </tr>
           <tr> 
-            <td width="22" height="25"> 
+            <td width="22" class="h25"> 
               <input name="ich_en" type="checkbox" id="ich_en5"></td>
-            <td height="25"> I.C.H. active</td>
-            <td width="63" height="25"></td>
+            <td class="h25"> I.C.H. active</td>
+            <td width="63" class="h25"></td>
           </tr>
           <tr> 
-            <td width="22" height="25"> 
+            <td width="22" class="h25"> 
               <input name="aich_trust" type="checkbox" id="aich_trust4"></td>
-            <td height="25"> AICH trusts every hash (not recommended)</td>
-            <td width="63" height="25"></td>
+            <td class="h25"> AICH trusts every hash (not recommended)</td>
+            <td width="63" class="h25"></td>
           </tr>
           <tr> 
-            <td width="22" height="25"> 
+            <td width="22" class="h25"> 
               <input name="alloc_full_chunks" type="checkbox" id="alloc_full_chunks4"></td>
-            <td height="25"> Alloc full chunks of .part files</td>
-            <td width="63" height="25"></td>
+            <td class="h25"> Alloc full chunks of .part files</td>
+            <td width="63" class="h25"></td>
           </tr>
           <tr> 
-            <td width="22" height="25"> 
+            <td width="22" class="h25"> 
               <input name="alloc_full" type="checkbox" id="alloc_full4"></td>
-            <td height="25"> Alloc full disk space for .part files</td>
-            <td width="63" height="25"></td>
+            <td class="h25"> Alloc full disk space for .part files</td>
+            <td width="63" class="h25"></td>
           </tr>
           <tr> 
-            <td width="22" height="25"> 
+            <td width="22" class="h25"> 
               <input name="new_files_paused" type="checkbox" id="new_files_paused4"></td>
-            <td height="25"> Add files to download queue in pause mode</td>
-            <td width="63" height="25"></td>
+            <td class="h25"> Add files to download queue in pause mode</td>
+            <td width="63" class="h25"></td>
           </tr>
           <tr> 
-            <td width="22" height="25"> 
+            <td width="22" class="h25"> 
               <input name="extract_metadata" type="checkbox" id="extract_metadata4"></td>
-            <td height="25"> Extract metadata tags </td>
-            <td width="63" height="25"></td>
+            <td class="h25"> Extract metadata tags </td>
+            <td width="63" class="h25"></td>
           </tr>
         </table></td>
     </tr>
-    <tr align="center" valign="top"> 
+    <tr class="al-center va-top"> 
       <td> 
-        <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
+        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
           <tr> 
             <td width="22">&nbsp;</td>
             <th>Connection settings</th>
             <td width="63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">Max total connections (total) </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">Max total connections (total) </td>
+            <td width="63" class="h25">
 <input name="max_conn_total" type="text" id="max_conn_total8" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">Max sources per file </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">Max sources per file </td>
+            <td width="63" class="h25">
 <input name="max_file_src" type="text" id="max_file_src7" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" height="25">
+            <td width="22" class="h25">
 <input name="autoconn_en" type="checkbox" id="autoconn_en6"></td>
-            <td height="25"> Autoconnect at startup </td>
-            <td width="63" height="25">&nbsp;</td>
+            <td class="h25"> Autoconnect at startup </td>
+            <td width="63" class="h25">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" height="25">
+            <td width="22" class="h25">
 <input name="reconn_en" type="checkbox" id="reconn_en6"></td>
-            <td height="25"> Reconnect when connection lost </td>
-            <td width="63" height="25">&nbsp;</td>
+            <td class="h25"> Reconnect when connection lost </td>
+            <td width="63" class="h25">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" height="25">
+            <td width="22" class="h25">
 <input name="network_ed2k" type="checkbox" id="network_ed2k6"></td>
-            <td height="25"> Enable ED2K network </td>
-            <td width="63" height="25">&nbsp;</td>
+            <td class="h25"> Enable ED2K network </td>
+            <td width="63" class="h25">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" height="25">
+            <td width="22" class="h25">
 <input name="network_kad" type="checkbox" id="network_kad6"></td>
-            <td height="25"> Enable Kademlia network </td>
-            <td width="63" height="25">&nbsp;</td>
+            <td class="h25"> Enable Kademlia network </td>
+            <td width="63" class="h25">&nbsp;</td>
           </tr>
         </table></td>
     </tr>
-    <tr align="center" valign="top">
+    <tr class="al-center va-top">
       <td>
-        <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
+        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
           <tr>
             <td width="22">&nbsp;</td>
             <th>Network settings</th>
             <td width="63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">TCP port </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">TCP port </td>
+            <td width="63" class="h25">
 <input name="tcp_port" type="text" id="tcp_port6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" height="25">&nbsp;</td>
-            <td height="25">UDP port </td>
-            <td width="63" height="25">
+            <td width="22" class="h25">&nbsp;</td>
+            <td class="h25">UDP port </td>
+            <td width="63" class="h25">
 <input name="udp_port" type="text" id="udp_port6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" height="25">
+            <td width="22" class="h25">
 <input name="udp_dis" type="checkbox" id="udp_dis5"></td>
-            <td height="25"> Disable UDP connections </td>
-            <td width="63" height="25">&nbsp;</td>
+            <td class="h25"> Disable UDP connections </td>
+            <td width="63" class="h25">&nbsp;</td>
           </tr>
         </table></td>
     </tr>
-    <tr align="center"> 
+    <tr class="al-center"> 
       <td colspan="2"> 
         <?php
 			if ($_SESSION["guest_login"] == 0) {
@@ -379,18 +379,18 @@ function init_data()
     </tr>
   </table>
   </form></td>
-            <td width="24" background="images/tab_right.png">&nbsp;</td>
+            <td width="24" class="tab-right">&nbsp;</td>
           </tr>
           <tr> 
             <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
-            <td background="images/tab_bottom.png">&nbsp;</td>
+            <td class="tab-bottom">&nbsp;</td>
             <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></td>
   </tr>
-  <tr valign="bottom"> 
-    <td height="25" colspan="2"> <table width="100%" height="40" border="0" cellpadding="0" cellspacing="0">
-        <tr align="center" valign="middle"> 
+  <tr class="va-bottom"> 
+    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+        <tr class="al-center va-middle"> 
           <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
           </td>
           <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -21,11 +21,11 @@ function formCommandSubmit(command)
 
 </script>
 </head>
-<body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-<table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr valign="top"> 
-    <td width="143" height="64"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" height="64" align="right" background="images/fond_haut.png"> <table border="0" cellspacing="0" cellpadding="0">
+<body class="main">
+<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+  <tr class="va-top"> 
+    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -35,38 +35,38 @@ function formCommandSubmit(command)
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
           <td width="10"></td>
-          <td width="190" align="right" class="texteinv"><a href="login.php">exit</a><br> 
+          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
           <td width="10"></td>
         </tr>
       </table></td>
   </tr>
-  <tr align="center" valign="top"> 
+  <tr class="al-center va-top"> 
     <td colspan="2">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <table width="100%" cellspacing="0" cellpadding="0">
           <caption>
         SEARCH
         </caption>
           <tr> 
             <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
-            <td background="images/tab_top.png">&nbsp;</td>
+            <td class="tab-top">&nbsp;</td>
             <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" background="images/tab_left.png">&nbsp;</td>
+            <td width="24" class="tab-left">&nbsp;</td>
             
-      <td bgcolor="#FFFFFF"><form name="mainform" action="amuleweb-main-search.php" method="post">
-              <table width="100%" border="0" align="center" cellpadding="4" cellspacing="0">
-                <tr align="center"> 
-                  <td align="center">
+      <td class="bg-white"><form name="mainform" action="amuleweb-main-search.php" method="post">
+              <table width="100%" cellpadding="4" cellspacing="0">
+                <tr class="al-center"> 
+                  <td class="al-center">
 <input type="hidden" name="command" value=""> 
                     <input name="searchval" type="text" id="searchval4" size="60"> 
                     <input name="Search" type="submit" id="Search4" value="Search" onClick="javascript:formCommandSubmit('search');"></td>
-                  <td align="right">Availability :</td>
-                  <td align="left"> 
+                  <td class="al-right">Availability :</td>
+                  <td class="al-left"> 
                     <input name="avail" type="text" id="avail13" size="6"></td>
-                  <td align="left">Min Size : </td>
-                  <td align="left">
+                  <td class="al-left">Min Size : </td>
+                  <td class="al-left">
 <input name="minsize" type="text" id="minsize2" size="5"> 
                     <select name="minsizeu" id="select8">
                       <option>Byte</option>
@@ -76,7 +76,7 @@ function formCommandSubmit(command)
                     </select></td>
                 </tr>
                 <tr> 
-                  <td align="center"><a href="amuleweb-main-search.php?search_sort=<?php
+                  <td class="al-center"><a href="amuleweb-main-search.php?search_sort=<?php
 // Whitelist against the column keys my_cmp() actually understands
 // (line 234-236 of this file). Anything else is dropped to empty,
 // which falls through to the "no sort change" branch below. This
@@ -92,7 +92,7 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
     echo($sort_raw);
 }
 ?>">Click here to update the search results</a> </td>
-                  <td align="right">Search type :</td>
+                  <td class="al-right">Search type :</td>
                   <td> 
                     <select name="searchtype" id="select">
                       <option selected>Local</option>
@@ -110,13 +110,13 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
                     </select></td>
                 </tr>
               </table>
-              <table width="100%"  border="0" align="center" cellpadding="0" cellspacing="0">
+              <table width="100%"  cellpadding="0" cellspacing="0">
                 <tr>
                   <th>&nbsp;</th>
                   <th><a href="amuleweb-main-search.php?sort=name">File Name</a></th>
                   <th><a href="amuleweb-main-search.php?sort=size">Size</a></th>
                   <th><a href="amuleweb-main-search.php?sort=sources">Sources</a></th>
-    </tr><tr><td colspan="9" height="1" bgcolor="#000000"></td></tr>
+    </tr><tr><td colspan="9" class="sep-dark"></td></tr>
     <?php
 		function CastToXBytes($size)
 		{
@@ -233,15 +233,15 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
 
 			echo "<td class='texte texte-full-name texte-full-name-search'>", $file->name, "</td>";
 			
-			echo "<td class='texte' align='center'>", CastToXBytes($file->size), "</td>";
+			echo "<td class='texte al-center'>", CastToXBytes($file->size), "</td>";
 
-			echo "<td class='texte' align='center'>", $file->sources, "</td>";
+			echo "<td class='texte al-center'>", $file->sources, "</td>";
 
-			print "</tr><tr><td colspan='9' height='1' bgcolor='#c0c0c0'></td></tr>";
+			print "</tr><tr><td colspan='9' class='sep-light'></td></tr>";
 		}
 
 	  ?>
-    <tr align="right"> 
+    <tr class="al-right"> 
       <td colspan="4" scope="col">
         <input name="Download" type="submit" id="Download6" value="Download" onClick="javascript:formCommandSubmit('download');" >
         <select name="targetcat" id="select32">
@@ -254,18 +254,18 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
         </select></td>
   </table>
 </form></td>
-            <td width="24" background="images/tab_right.png">&nbsp;</td>
+            <td width="24" class="tab-right">&nbsp;</td>
           </tr>
           <tr> 
             <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
-            <td background="images/tab_bottom.png">&nbsp;</td>
+            <td class="tab-bottom">&nbsp;</td>
             <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></td>
   </tr>
-  <tr valign="bottom"> 
-    <td height="25" colspan="2"> <table width="100%" height="40" border="0" cellpadding="0" cellspacing="0">
-        <tr align="center" valign="middle"> 
+  <tr class="va-bottom"> 
+    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+        <tr class="al-center va-middle"> 
           <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
           </td>
           <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -6,11 +6,11 @@
 
 <link href="style.css" rel="stylesheet" type="text/css">
 </head>
-<body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-<table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr valign="top"> 
-    <td width="143" height="64"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" height="64" align="right" background="images/fond_haut.png"> <table border="0" cellspacing="0" cellpadding="0">
+<body class="main">
+<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+  <tr class="va-top"> 
+    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -20,27 +20,27 @@
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
           <td width="10"></td>
-          <td width="190" align="right" class="texteinv"><a href="login.php">exit</a><br> 
+          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
           <td width="10"></td>
         </tr>
       </table></td>
   </tr>
-  <tr align="center" valign="top"> 
+  <tr class="al-center va-top"> 
     <td colspan="2">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <table width="100%" cellspacing="0" cellpadding="0">
           <caption>
         SERVERS 
         </caption>
           <tr> 
             <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
-            <td background="images/tab_top.png">&nbsp;</td>
+            <td class="tab-top">&nbsp;</td>
             <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" background="images/tab_left.png">&nbsp;</td>
+            <td width="24" class="tab-left">&nbsp;</td>
             
-      <td bgcolor="#FFFFFF"><table width="100%"  border="0" align="center" cellpadding="0" cellspacing="0">
+      <td class="bg-white"><table width="100%"  cellpadding="0" cellspacing="0">
               <?php
                 // Network-level disconnect button, admin only. Statements
                 // must be syntactically complete within one PHP block;
@@ -49,7 +49,7 @@
                 // Kad page styling and give a proper clickable button
                 // rather than a plain text link.
                 if ($_SESSION["guest_login"] == 0) {
-                    echo '<tr><td colspan="6" align="right" style="padding:4px 8px;">',
+                    echo '<tr><td colspan="6" class="al-right" style="padding:4px 8px;">',
                          '<form action="amuleweb-main-servers.php" method="get" style="display:inline;">',
                          '<input type="hidden" name="server_action" value="disconnect">',
                          '<button type="submit">Disconnect from current ed2k server</button>',
@@ -64,7 +64,7 @@
                 <th width="19%">Address</th>
                 <th width="7%"><a href="amuleweb-main-servers.php?sort=users">Users</a></th>
                 <th width="7%"><a href="amuleweb-main-servers.php?sort=files">Files</a></th>
-		</tr><tr><td colspan="8" height="1" bgcolor="#000000"></td></tr>
+		</tr><tr><td colspan="8" class="sep-dark"></td></tr>
               <?php
 
 
@@ -129,40 +129,40 @@
 			echo "<tr>";
 			
 			if ($_SESSION["guest_login"] != 0) {
-				echo "<td class='texte' align='center'></td>";
+				echo "<td class='texte al-center'></td>";
 			} else {
-				echo "<td class='texte' align='center'>",
+				echo "<td class='texte al-center'>",
 					'<a href="amuleweb-main-servers.php?cmd=connect&ip=', $srv->ip,
 					'&port=', $srv->port, '">',
-					'<img src="images/connect.gif" width="16" height="16" border="0">','</a>',
+					'<img src="images/connect.gif" width="16" height="16">','</a>',
 					'<a href="amuleweb-main-servers.php?cmd=remove&ip=', $srv->ip,
 					'&port=', $srv->port, '">',
-					'<img src="images/cancel.gif" width="16" height="16" border="0">','</a>',
+					'<img src="images/cancel.gif" width="16" height="16">','</a>',
 					"</td>";
 			}
 
 			echo "<td class='texte'>", $srv->name, "</td>";
 			echo "<td class='texte'>", $srv->desc, "</td>";
-			echo "<td class='texte' align='center'>", $srv->addr, "</td>";
-			echo "<td class='texte' align='center'>", $srv->users, "</td>";
-			echo "<td class='texte' align='center'>", $srv->files, "</td>";
+			echo "<td class='texte al-center'>", $srv->addr, "</td>";
+			echo "<td class='texte al-center'>", $srv->users, "</td>";
+			echo "<td class='texte al-center'>", $srv->files, "</td>";
 
-			echo "</tr><tr><td colspan='9' height='1' bgcolor='#c0c0c0'></td></tr>";
+			echo "</tr><tr><td colspan='9' class='sep-light'></td></tr>";
 		}
 	  ?>
             </table></td>
-            <td width="24" background="images/tab_right.png">&nbsp;</td>
+            <td width="24" class="tab-right">&nbsp;</td>
           </tr>
           <tr> 
             <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
-            <td background="images/tab_bottom.png">&nbsp;</td>
+            <td class="tab-bottom">&nbsp;</td>
             <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></td>
   </tr>
-  <tr valign="bottom"> 
-    <td height="25" colspan="2"> <table width="100%" height="40" border="0" cellpadding="0" cellspacing="0">
-        <tr align="center" valign="middle"> 
+  <tr class="va-bottom"> 
+    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+        <tr class="al-center va-middle"> 
           <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
           </td>
           <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -21,11 +21,11 @@ function formCommandSubmit(command)
 
 </script>
 </head>
-<body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-<table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr valign="top"> 
-    <td width="143" height="64"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" height="64" align="right" background="images/fond_haut.png"> <table border="0" cellspacing="0" cellpadding="0">
+<body class="main">
+<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+  <tr class="va-top"> 
+    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -35,22 +35,22 @@ function formCommandSubmit(command)
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
           <td width="10"></td>
-          <td width="190" align="right" class="texteinv"><a href="login.php">exit</a><br> 
+          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
           <td width="10"></td>
         </tr>
       </table></td>
   </tr>
-  <tr align="center" valign="top"> 
+  <tr class="al-center va-top"> 
     <td colspan="2"><form name="mainform" action="amuleweb-main-shared.php" method="post">
-              <table border="0" align="center" cellpadding="0" cellspacing="0">
+              <table class="center-table" cellpadding="0" cellspacing="0">
                 <tr>
                   <td><input type="hidden" name="command"></td>
                   
-            <td><a href="javascript:formCommandSubmit('reload');"><img src="images/refresh.png" alt="Reload shared files" name="reload" border="0" onload=""></a></td>
-				  <td><a href="javascript:formCommandSubmit('prioup');"><img name="up" src="images/up.png" border="0" alt="Raise priority" onLoad=""></a></td>
+            <td><a href="javascript:formCommandSubmit('reload');"><img src="images/refresh.png" alt="Reload shared files" name="reload" onload=""></a></td>
+				  <td><a href="javascript:formCommandSubmit('prioup');"><img name="up" src="images/up.png" alt="Raise priority" onLoad=""></a></td>
                   
-            <td><a href="javascript:formCommandSubmit('priodown');"><img src="images/down.png" alt="Lower priority" name="down" border="0" onload=""></a></td>
+            <td><a href="javascript:formCommandSubmit('priodown');"><img src="images/down.png" alt="Lower priority" name="down" onload=""></a></td>
                   <td><select name="select">
                       <option selected>Select prio</option>
                       <option>Low</option>
@@ -58,7 +58,7 @@ function formCommandSubmit(command)
                       <option>High</option>
                     </select> </td>
                   
-            <td><a href="javascript:formCommandSubmit('setprio');"><img src="images/ok.png" alt="Set priority" name="resume" border="0" onload=""></a></td>
+            <td><a href="javascript:formCommandSubmit('setprio');"><img src="images/ok.png" alt="Set priority" name="resume" onload=""></a></td>
               
                   <td> 
                     <?php
@@ -69,20 +69,20 @@ function formCommandSubmit(command)
                   </td>
                 </tr>
               </table>
-        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <table width="100%" cellspacing="0" cellpadding="0">
           <caption>
         SHARED FILES 
         </caption>
           <tr> 
             <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
-            <td background="images/tab_top.png">&nbsp;</td>
+            <td class="tab-top">&nbsp;</td>
             <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" background="images/tab_left.png">&nbsp;</td>
+            <td width="24" class="tab-left">&nbsp;</td>
             
-          <td bgcolor="#FFFFFF">
-              <table width="100%"  border="0" align="center" cellpadding="0" cellspacing="0">
+          <td class="bg-white">
+              <table width="100%"  cellpadding="0" cellspacing="0">
                 <tr> 
                   <th></th>
                   <th><a href="amuleweb-main-shared.php?sort=name">File Name</a></th>
@@ -94,7 +94,7 @@ function formCommandSubmit(command)
                     (<a href="amuleweb-main-shared.php?sort=acc_all">Total</a>)</th>
                   <th><a href="amuleweb-main-shared.php?sort=size">Size</a></th>
                   <th><a href="amuleweb-main-shared.php?sort=prio">Priority</a></th>
-                </tr><tr><td colspan="9" height="1" bgcolor="#000000"></td></tr>
+                </tr><tr><td colspan="9" class="sep-dark"></td></tr>
                 <?php
 		function CastToXBytes($size)
 		{
@@ -211,31 +211,31 @@ function formCommandSubmit(command)
 			echo "<td class='texte'>", '<input type="checkbox" name="', $file->hash, '" >', "</td>";
 
 			echo "<td class='texte texte-full-name'>", $file->name, "</td>";
-			echo "<td class='texte' align='center'>", CastToXBytes($file->xfer), " (", CastToXBytes($file->xfer_all),")</td>";
+			echo "<td class='texte al-center'>", CastToXBytes($file->xfer), " (", CastToXBytes($file->xfer_all),")</td>";
 
-			echo "<td class='texte' align='center'>", $file->req, " (", $file->req_all, ")</td>";
-			echo "<td class='texte' align='center'>", $file->accept, " (", $file->accept_all, ")</td>";
+			echo "<td class='texte al-center'>", $file->req, " (", $file->req_all, ")</td>";
+			echo "<td class='texte al-center'>", $file->accept, " (", $file->accept_all, ")</td>";
 			
-			echo "<td class='texte' align='center'>", CastToXBytes($file->size), "</td>";
+			echo "<td class='texte al-center'>", CastToXBytes($file->size), "</td>";
 
-			echo "<td class='texte' align='center'>", PrioString($file), "</td>";;
+			echo "<td class='texte al-center'>", PrioString($file), "</td>";;
 
-			print "</tr><tr><td colspan='9' height='1' bgcolor='#c0c0c0'></td></tr>";
+			print "</tr><tr><td colspan='9' class='sep-light'></td></tr>";
 		}
 	  ?>
               </table></td>
-            <td width="24" background="images/tab_right.png">&nbsp;</td>
+            <td width="24" class="tab-right">&nbsp;</td>
           </tr>
           <tr> 
             <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
-            <td background="images/tab_bottom.png">&nbsp;</td>
+            <td class="tab-bottom">&nbsp;</td>
             <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></form></td>
   </tr>
-  <tr valign="bottom"> 
-    <td height="25" colspan="2"> <table width="100%" height="40" border="0" cellpadding="0" cellspacing="0">
-        <tr align="center" valign="middle"> 
+  <tr class="va-bottom"> 
+    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+        <tr class="al-center va-middle"> 
           <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
           </td>
           <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 

--- a/src/webserver/default/amuleweb-main-stats.php
+++ b/src/webserver/default/amuleweb-main-stats.php
@@ -36,11 +36,11 @@ function swapFolder(img){
 
 </script>
 </head>
-<body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-<table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0">
-  <tr valign="top"> 
-    <td width="143" height="64"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" height="64" align="right" background="images/fond_haut.png"> <table border="0" cellspacing="0" cellpadding="0">
+<body class="main">
+<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+  <tr class="va-top"> 
+    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -50,63 +50,63 @@ function swapFolder(img){
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
           <td width="10"></td>
-          <td width="190" align="right" class="texteinv"><a href="login.php">exit</a><br> 
+          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
           <td width="10"></td>
         </tr>
       </table></td>
   </tr>
-  <tr align="center" valign="top"> 
+  <tr class="al-center va-top"> 
     <td colspan="2">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <table width="100%" cellspacing="0" cellpadding="0">
           <caption>
         STATISTICS 
         </caption>
           <tr> 
             <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
-            <td background="images/tab_top.png">&nbsp;</td>
+            <td class="tab-top">&nbsp;</td>
             <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" background="images/tab_left.png">&nbsp;</td>
+            <td width="24" class="tab-left">&nbsp;</td>
             
-          <td bgcolor="#FFFFFF"><table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
-              <tr valign="top"> 
+          <td class="bg-white"><table width="100%" cellpadding="0" cellspacing="0">
+              <tr class="va-top"> 
                 <td rowspan="7">
 <iframe name="stats" src="stats_tree.php" width="100%" height="630" frameborder="0">liste</iframe></td>
-                <td width="500" align="right"><img src="amule_stats_download.png" width="500" height="200" border="0"></td>
+                <td width="500" class="al-right"><img src="amule_stats_download.png" width="500" height="200"></td>
               </tr>
-              <tr valign="top"> 
-                <td width="500" height="15"> 
-                  <div align="center">Download-Speed</div></td>
+              <tr class="va-top"> 
+                <td width="500" class="h15"> 
+                  <div class="al-center">Download-Speed</div></td>
               </tr>
-              <tr valign="top"> 
-                <td width="500" align="right"><img src="amule_stats_upload.png" width="500" height="200" border="0" alt="" title="" /></td>
+              <tr class="va-top"> 
+                <td width="500" class="al-right"><img src="amule_stats_upload.png" width="500" height="200" alt="" title="" /></td>
               </tr>
-              <tr valign="top"> 
-                <td width="500" height="15"> 
-                  <div align="center">Upload-Speed</div></td>
+              <tr class="va-top"> 
+                <td width="500" class="h15"> 
+                  <div class="al-center">Upload-Speed</div></td>
                </tr>
-              <tr valign="top"> 
-                <td width="500" align="right"><img src="amule_stats_conncount.png" width="500" height="200" border="0" alt="" title="" /></td>
+              <tr class="va-top"> 
+                <td width="500" class="al-right"><img src="amule_stats_conncount.png" width="500" height="200" alt="" title="" /></td>
               </tr>
-              <tr valign="top"> 
-                <td width="500" height="15"> 
-                  <div align="center">Connections</div></td>
+              <tr class="va-top"> 
+                <td width="500" class="h15"> 
+                  <div class="al-center">Connections</div></td>
               </tr>
             </table></td>
-            <td width="24" background="images/tab_right.png">&nbsp;</td>
+            <td width="24" class="tab-right">&nbsp;</td>
           </tr>
           <tr> 
             <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
-            <td background="images/tab_bottom.png">&nbsp;</td>
+            <td class="tab-bottom">&nbsp;</td>
             <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></td>
   </tr>
-  <tr valign="bottom"> 
-    <td height="25" colspan="2"> <table width="100%" height="40" border="0" cellpadding="0" cellspacing="0">
-        <tr align="center" valign="middle"> 
+  <tr class="va-bottom"> 
+    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+        <tr class="al-center va-middle"> 
           <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
           </td>
           <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 

--- a/src/webserver/default/footer.php
+++ b/src/webserver/default/footer.php
@@ -9,9 +9,9 @@
 
 <body>
 
-<table width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+<table width="100%" cellpadding="0" cellspacing="0">
   <tr>
-    <td width="50%" align="center" valign="bottom"> 
+    <td width="50%" class="al-center va-bottom"> 
       <form name="formlink" method="post" action="footer.php">
         <input name="ed2klink" type="text" id="ed2klink" size="50">
         <select name="selectcat" id="selectcat">

--- a/src/webserver/default/index.html
+++ b/src/webserver/default/index.html
@@ -4,7 +4,7 @@
 <title>aMule control panel</title>
 
 <META http-EQUIV="Refresh" CONTENT="0; url=amuleweb-main-dload.php">
-<body background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
+<body style="margin: 0; background-image: url(images/fond.gif);">
 
 </body>
 </html>

--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -11,18 +11,59 @@ function login_init()
 </script>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <link href="style.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+/* This page is shown to unauthenticated clients, and the webserver only
+   serves style.css to a logged-in session (anything else gets the login
+   page HTML instead) -- so every rule this page needs must live inline
+   here. The class names match style.css on purpose. */
+body.main {
+	margin: 0;
+	background-image: url(images/fond.gif);
+}
+img {
+	border: 0;
+}
+.al-center {
+	text-align: center;
+}
+.va-middle {
+	vertical-align: middle;
+}
+.va-top {
+	vertical-align: top;
+}
+.center-table {
+	margin-left: auto;
+	margin-right: auto;
+}
+.bg-white {
+	background-color: #FFFFFF;
+}
+.bg-black {
+	background-color: #000000;
+}
+.h180 {
+	height: 180px;
+}
+th.login-banner {
+	height: 180px;
+	text-align: right;
+	vertical-align: middle;
+	background-image: url(images/loginfond_haut.png);
+}
+</style>
 </head>
 
-<body  onload="login_init();" background="images/fond.gif" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-<table width="100%" height="180" border="0" cellpadding="0" cellspacing="0" valign="middle">
+<body class="main" onload="login_init();">
+<table width="100%" height="180" cellpadding="0" cellspacing="0">
   <tr>
-    <td align="center" valign="middle"> 
-      <table width="70%" height="90%" border="0" align="center" cellpadding="0" cellspacing="1" bgcolor="#000000">
-        <tr> 
-          <td><table width="100%" height="100%" border="0" align="center" cellpadding="0" cellspacing="0" bgcolor="#FFFFFF">
-              <tr valign="top"> 
-               <th width="366" height="180"><img src="images/loginlogo.jpg" width="366" height="180" border="0"></th>
-                <th width="100% "height="180" align="right" valign="middle" background="images/loginfond_haut.png"> 
+    <td class="al-center va-middle">
+      <table width="70%" height="90%" class="center-table bg-black" cellpadding="0" cellspacing="1">
+        <tr>
+          <td><table width="100%" height="100%" class="bg-white" cellpadding="0" cellspacing="0">
+              <tr class="va-top">
+               <th width="366" class="h180"><img src="images/loginlogo.jpg" width="366" height="180"></th>
+                <th width="100%" class="login-banner">
                   <form action="" method="post" name="login">
                     Enter password : 
                     <input name="pass" size="20" value="" type="password">

--- a/src/webserver/default/stats.php
+++ b/src/webserver/default/stats.php
@@ -13,8 +13,8 @@
 <link href="style.css" rel="stylesheet" type="text/css">
 </head>
 <body>
-<table width="100%" height="30" border="0" align="center" cellpadding="0" cellspacing="0">
-  <tr valign="top"> 
+<table width="100%" height="30" cellpadding="0" cellspacing="0">
+  <tr class="va-top"> 
     <td width="65%"><strong>Ed2k : </strong> 
       <?php
     	$stats = amule_get_stats();

--- a/src/webserver/default/stats_tree.php
+++ b/src/webserver/default/stats_tree.php
@@ -80,7 +80,7 @@ function print_folder($key, &$arr, $ident)
 	echo "<span class=\"trigger\" onClick=\"showBranch('br_",
 		$key, "');swapFolder('fl_", $key, "')\">\n";
 	print_ident($ident+1);
-	echo "<img src=\"tree-open.gif\" border=\"0\" id=\"fl_", $key, "\">\n";
+	echo "<img src=\"tree-open.gif\" id=\"fl_", $key, "\">\n";
 	print_ident($ident+1);
 	echo $key, "<br>\n";
 	print_ident($ident);

--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -123,3 +123,98 @@ textarea {
 	font-size: 12px;
 	color: white;
 }
+body.main {
+	margin: 0;
+	background-image: url(images/fond.gif);
+}
+img {
+	border: 0;
+}
+.al-left {
+	text-align: left;
+}
+.al-center {
+	text-align: center;
+}
+.al-right {
+	text-align: right;
+}
+.va-top {
+	vertical-align: top;
+}
+.va-middle {
+	vertical-align: middle;
+}
+.va-bottom {
+	vertical-align: bottom;
+}
+.center-table {
+	margin-left: auto;
+	margin-right: auto;
+}
+td.logo-cell {
+	height: 64px;
+}
+td.navbar-cell {
+	height: 64px;
+	background-image: url(images/fond_haut.png);
+}
+table.navbar-table {
+	margin-left: auto;
+}
+td.tab-top {
+	background-image: url(images/tab_top.png);
+}
+td.tab-left {
+	background-image: url(images/tab_left.png);
+}
+td.tab-right {
+	background-image: url(images/tab_right.png);
+}
+td.tab-bottom {
+	background-image: url(images/tab_bottom.png);
+}
+.bg-white {
+	background-color: #FFFFFF;
+}
+.bg-black {
+	background-color: #000000;
+}
+td.sep-dark {
+	height: 1px;
+	background-color: #000000;
+}
+td.sep-light {
+	height: 1px;
+	background-color: #c0c0c0;
+}
+.h10 {
+	height: 10px;
+}
+.h15 {
+	height: 15px;
+}
+.h19 {
+	height: 19px;
+}
+.h20 {
+	height: 20px;
+}
+.h22 {
+	height: 22px;
+}
+.h25 {
+	height: 25px;
+}
+.h180 {
+	height: 180px;
+}
+.h200 {
+	height: 200px;
+}
+th.login-banner {
+	height: 180px;
+	text-align: right;
+	vertical-align: middle;
+	background-image: url(images/loginfond_haut.png);
+}


### PR DESCRIPTION
Replace the HTML 3.2-era presentational attributes across the default template with equivalent CSS classes in style.css, keeping the quirks mode doctype untouched so the table layout renders exactly as before:

- body background= / leftmargin= / topmargin= / marginwidth= / marginheight= become `body.main { margin: 0; background-image: ... }`.
- background= on the header bar and the tab-frame cells become the navbar-cell and tab-top/left/right/bottom classes.
- bgcolor= becomes bg-white / bg-black / sep-dark / sep-light (the 1px black and grey separator rows in the file listings).
- align= / valign= on rows and cells become al-* / va-* classes. Tables that relied on the legacy block-alignment behaviour of align="center" / align="right" (nav bar, toolbars, prefs panes, login box) get margin-based center-table / navbar-table classes instead, since CSS text-align only moves inline content.
- height= on td/th becomes h10..h200 utility classes.
- border="0" is dropped everywhere; a global `img { border: 0 }` rule covers linked images.

login.php keeps a private inline <style> copy of the rules it uses: the webserver only serves style.css to a logged-in session (any other request gets the login page HTML instead), and login.php is precisely the page unauthenticated clients see. It previously survived this only because the legacy attributes needed no stylesheet. index.html links no stylesheet either, so its body uses an inline style.

Also fixes the malformed `width="100% "height="180"` attribute pair in login.php and the stray valign= on its outer table.

Verified against a running amuleweb: before/after headless-Chromium screenshots of all 9 pages are pixel-identical except for dynamic content (stats graphs, server user/file counts).