### PR TITLE
fix(webserver): make the login error message readable

### DIFF
--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -51,6 +51,14 @@ th.login-banner {
 	vertical-align: middle;
 	background-image: url(images/loginfond_haut.png);
 }
+.login-error {
+	display: inline-block;
+	margin-top: 6px;
+	padding: 3px 10px;
+	background-color: #c00000;
+	color: white;
+	font-weight: bold;
+}
 </style>
 </head>
 
@@ -72,7 +80,7 @@ th.login-banner {
                     &nbsp;&nbsp;
 <?php
 	if ( $_SESSION["login_error"] != "" ) {
-		echo "<br><span style=\"color: #c00000; font-weight: bold;\">", $_SESSION["login_error"], "</span>&nbsp;&nbsp;";
+		echo "<br><span class=\"login-error\">", $_SESSION["login_error"], "</span>&nbsp;&nbsp;";
 	}
 ?>
                     </form></th>


### PR DESCRIPTION
The failed-login message was dark red (#c00000) bold text sitting directly on the mid-blue gradient of the login banner image -- nearly illegible. Render it as white text on a solid red badge instead (inline-block span with padding), which reads clearly on the banner.

The rule lives in login.php's inline <style> block because style.css is not served to unauthenticated clients (see the modernization notes), and this message only ever renders on the login page.

Verified against the running webserver with a headless-Chromium screenshot of a wrong-password submit; the error-free login page is pixel-identical to before.