### PR TITLE
fix(webserver): serve static .css/.js files to unauthenticated clients

### DIFF
--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -11,55 +11,6 @@ function login_init()
 </script>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <link href="style.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-/* This page is shown to unauthenticated clients, and the webserver only
-   serves style.css to a logged-in session (anything else gets the login
-   page HTML instead) -- so every rule this page needs must live inline
-   here. The class names match style.css on purpose. */
-body.main {
-	margin: 0;
-	background-image: url(images/fond.gif);
-}
-img {
-	border: 0;
-}
-.al-center {
-	text-align: center;
-}
-.va-middle {
-	vertical-align: middle;
-}
-.va-top {
-	vertical-align: top;
-}
-.center-table {
-	margin-left: auto;
-	margin-right: auto;
-}
-.bg-white {
-	background-color: #FFFFFF;
-}
-.bg-black {
-	background-color: #000000;
-}
-.h180 {
-	height: 180px;
-}
-th.login-banner {
-	height: 180px;
-	text-align: right;
-	vertical-align: middle;
-	background-image: url(images/loginfond_haut.png);
-}
-.login-error {
-	display: inline-block;
-	margin-top: 6px;
-	padding: 3px 10px;
-	background-color: #c00000;
-	color: white;
-	font-weight: bold;
-}
-</style>
 </head>
 
 <body class="main" onload="login_init();">

--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -218,3 +218,11 @@ th.login-banner {
 	vertical-align: middle;
 	background-image: url(images/loginfond_haut.png);
 }
+.login-error {
+	display: inline-block;
+	margin-top: 6px;
+	padding: 3px 10px;
+	background-color: #c00000;
+	color: white;
+	font-weight: bold;
+}

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -1901,7 +1901,12 @@ void CScriptWebServer::ProcessURL(ThreadData Data)
 	CSession *session = CheckLoggedin(Data);
 
 	session->m_vars["login_error"] = "";
-	if ( !session->m_logged_in ) {
+	// Stylesheets and scripts are public static assets, like the template
+	// images ProcessImgFileReq() already serves without a login. They are
+	// served statically from the template directory, never through the
+	// PHP interpreter.
+	bool public_asset = filename.EndsWith(wxT(".css")) || filename.EndsWith(wxT(".js"));
+	if ( !session->m_logged_in && !public_asset ) {
 		filename = "login.php";
 
 		// Refuse to consume `pass` if it's reachable via the original


### PR DESCRIPTION
ProcessURL() unconditionally rewrote every request from a session that is not logged in to login.php, so a logged-out browser asking for style.css got login-page HTML with the wrong Content-Type. The login page itself was therefore unable to use the shared stylesheet and had to carry an inline copy of every rule it needs.

Treat stylesheets and scripts as public static assets, exactly like the template images that ProcessImgFileReq() already serves without a login, and skip the login.php override for them. This is safe: path components are stripped from the request and resolved against the template root, only names ending in .css/.js take the new path, and they are served statically with the right Content-Type -- the PHP interpreter is never involved, so no template source can leak. Other extensions still get the login page, and a missing file still yields the 404 page.

With style.css reachable before login, drop the inline <style> block from login.php -- a forced duplicate of style.css rules -- and move the one rule that lived nowhere else (.login-error, the white-on-red failed-login badge) into style.css.

Verified against the rebuilt amuleweb: curl without a session gets style.css as text/css while .php pages still return the login page, and headless-Chromium screenshots of the unauthenticated login page and of the wrong-password error state are pixel-identical to before.