### PR TITLE
build(cmake): add pofiles dep to every NLS-aware executable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -816,3 +816,25 @@ if (WIN32 AND MINGW AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
 			"re-run cmake to populate this.")
 	endif()
 endif()
+
+# `gettext_process_po_files` puts the per-language `.gmo` builds in the
+# `all` target but adds no dependency to any specific binary target.
+# Building one binary in isolation (e.g. `cmake --build build --target
+# amuled`) therefore skips the `.gmo` step, and the subsequent `cmake
+# --install build` errors with "file INSTALL cannot find
+# /.../build/po/<lang>.gmo: No such file or directory" because the
+# `install (FILES ${gmo})` rules issued from `po/CMakeLists.txt` expect
+# them to exist.
+#
+# Make every NLS-aware executable take a hard dependency on the
+# CMake-internal `pofiles` aggregator that `gettext_process_po_files`
+# maintains. A partial-target build now transitively builds the catalogs
+# it would later install. Skipped under ENABLE_NLS=OFF because
+# `pofiles` is only created when `add_subdirectory(po)` runs.
+if (ENABLE_NLS AND TARGET pofiles)
+	foreach (_bin amule amuled amulecmd amulegui amuleweb ed2k alc alcc cas wxcas fileview)
+		if (TARGET ${_bin})
+			add_dependencies (${_bin} pofiles)
+		endif()
+	endforeach()
+endif()


### PR DESCRIPTION
Followup to #94 — found while exercising partial-target builds during VM testing of the manpage pipeline.

## Summary

`gettext_process_po_files` puts the per-language `.gmo` build in CMake's `all` target but adds **no dependency** to any specific binary target. So building one binary in isolation — e.g. `cmake --build build --target amuled` — silently skips the `.gmo` step entirely on Linux. The subsequent `cmake --install build` then errors with:

```
CMake Error at build/po/cmake_install.cmake:46 (file):
  file INSTALL cannot find ".../build/po/ar.gmo": No such file or directory.
```

because the `install (FILES ${gmo})` rules issued from `po/CMakeLists.txt` fire unconditionally for every enabled language. Reproduces against any partial-target build on Linux.

Add a single sweeping `add_dependencies(..., pofiles)` loop at the end of `src/CMakeLists.txt` covering every executable aMule ships:

`amule amuled amulecmd amulegui amuleweb ed2k alc alcc cas wxcas fileview`

`pofiles` is the aggregator target that `gettext_process_po_files` maintains internally — making each binary depend on it pulls the full catalog build into any partial-target invocation. Gated on `ENABLE_NLS AND TARGET pofiles`, which also covers the `ENABLE_NLS=YES`-but-`msgfmt`-missing edge case where `po/` isn't entered.

## Test plan

Run on Ubuntu 26.04 ARM64.

- [x] **Before fix (master tip)** — `cmake -B build -DBUILD_DAEMON=YES && cmake --build build --target amuled && cmake --install build` → `CMake Error … file INSTALL cannot find .../build/po/ar.gmo`
- [x] **After fix** — same sequence: 37 `.gmo` files built as a side effect of `--target amuled`, install completes cleanly, 37 `.mo` files land at `share/locale/<lang>/LC_MESSAGES/amule.mo`
- [x] `--target` for any other binary (verified `amulecmd`, `ed2k`) pulls in the same 37-file catalog build
- [x] `ENABLE_NLS=OFF` configure still works — the loop is a no-op since `TARGET pofiles` is false
- [x] macOS configure still works — the dependency lands the same way; the `.mo` install path is Mac-specific (POST_BUILD on the `.app` bundle, no `install(FILES ${gmo})` rule), so this fix is invisible there but not harmful
- [x] Full `cmake --build build` (ALL) behavior unchanged — `.gmo` was already in `all`, this just adds a redundant edge

## Scope

Only the catalog dependency. The orthogonal issue of `cmake --install build` failing on binaries you didn't build (e.g. `--target amuled` then trying to install `amulecmd`) is separate scope; it requires either making `install` depend on its target arguments or accepting the current "build everything, then install" contract. Not addressed here.