### PR TITLE
refactor(webserver): migrate remaining table/iframe attributes to CSS

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -35,10 +35,10 @@ function formCommandSubmit(command)
 </script>
 </head>
 <body class="main">
-<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+<table class="w100p h100p">
   <tr class="va-top"> 
-    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
+    <td class="w143 logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="w100p navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -47,19 +47,19 @@ function formCommandSubmit(command)
           <td><a class="navbutton nav-kad" href="amuleweb-main-kad.php" title="Kad"></a></td>
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
-          <td width="10"></td>
-          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br>
+          <td class="w10"></td>
+          <td class="w190 texteinv al-right"><a href="login.php">exit</a><br>
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a>
             </td>
-          <td width="10"></td>
+          <td class="w10"></td>
         </tr>
       </table></td>
   </tr>
   <tr class="al-center va-top"> 
     <td colspan="2"><form action="amuleweb-main-dload.php" method="post" name="mainform">
-        <table width="100%" cellpadding="0" cellspacing="0">
+        <table class="w100p">
           <tr>
-      <td><table class="center-table" cellpadding="0" cellspacing="0">
+      <td><table class="center-table">
           <tr> 
             <td><input type="hidden" name="command"></td>
             <td><a href="javascript:formCommandSubmit('pause');"><img name="pause" src="images/pause.png" alt="pause"></a></td>
@@ -67,7 +67,7 @@ function formCommandSubmit(command)
         		<td><a href="javascript:formCommandSubmit('prioup');"><img name="prioup" src="images/up.png" alt="prioup"></a></td>
         		<td><a href="javascript:formCommandSubmit('priodown');"><img name="priodown" src="images/down.png" alt="priodown"></a></td>
         		<td><a href="javascript:formCommandSubmit('cancel');"><img name="cancel" src="images/close.png" alt="cancel"></a></td>
-      <td><table cellpadding="0" cellspacing="0">
+      <td><table>
                 <tr> 
                   <td> 
                     <?php
@@ -112,17 +112,17 @@ function formCommandSubmit(command)
       <td class="h10"> </td>
     </tr>
     <tr> 
-      <td colspan="2"><table width="100%" cellspacing="0" cellpadding="0"> <caption>
+      <td colspan="2"><table class="w100p"> <caption>
           DOWNLOAD 
           </caption>
   <tr>
-    <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
+    <td class="w24"><img src="images/tab_top_left.png" width="24" height="24"></td>
     <td class="tab-top">&nbsp;</td>
-    <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
+    <td class="w24"><img src="images/tab_top_right.png" width="24" height="24"></td>
   </tr>
   <tr>
-    <td width="24" class="tab-left">&nbsp;</td>
-    <td class="bg-white"><table width="100%" cellpadding="0" cellspacing="0">
+    <td class="w24 tab-left">&nbsp;</td>
+    <td class="bg-white"><table class="w100p">
                      
           <tr> 
                   <th>&nbsp;</th>
@@ -322,28 +322,28 @@ function formCommandSubmit(command)
 		}
 	  ?>
         </table></td>
-    <td width="24" class="tab-right">&nbsp;</td>
+    <td class="w24 tab-right">&nbsp;</td>
   </tr>
   <tr>
-    <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
+    <td class="w24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
     <td class="tab-bottom">&nbsp;</td>
-    <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
+    <td class="w24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
   </tr>
 </table></td>
     </tr>
   </table>
 </form>
-      <table width="100%" cellspacing="0" cellpadding="0"><caption>
+      <table class="w100p"><caption>
         UPLOAD 
         </caption>
         <tr> 
-          <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
+          <td class="w24"><img src="images/tab_top_left.png" width="24" height="24"></td>
           <td class="tab-top">&nbsp;</td>
-          <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
+          <td class="w24"><img src="images/tab_top_right.png" width="24" height="24"></td>
         </tr>
         <tr> 
-          <td width="24" class="tab-left">&nbsp;</td>
-          <td class="bg-white"><table width="100%" cellpadding="0" cellspacing="0" class="doad-table">
+          <td class="w24 tab-left">&nbsp;</td>
+          <td class="bg-white"><table class="w100p doad-table">
               
         <tr> 
                 <td>&nbsp;</td>
@@ -405,23 +405,23 @@ function formCommandSubmit(command)
 			}
 		?>
       </table></td>
-          <td width="24" class="tab-right">&nbsp;</td>
+          <td class="w24 tab-right">&nbsp;</td>
         </tr>
         <tr> 
-          <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
+          <td class="w24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
           <td class="tab-bottom">&nbsp;</td>
-          <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
+          <td class="w24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
         </tr>
       </table>
       
     </td>
   </tr>
   <tr class="va-bottom"> 
-    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+    <td class="h25" colspan="2"> <table class="w100p h40">
         <tr class="al-center va-middle"> 
-          <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">ed2klink</iframe> 
+          <td class="w50p"> <iframe name="stats" src="footer.php" height="35" class="w100p noborder">ed2klink</iframe> 
           </td>
-          <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 
+          <td class="w50p"> <iframe name="stats" src="stats.php" height="35" class="w100p noborder">connection</iframe> 
           </td>
         </tr>
       </table></td>

--- a/src/webserver/default/amuleweb-main-kad.php
+++ b/src/webserver/default/amuleweb-main-kad.php
@@ -67,10 +67,10 @@ function formCommandSubmit(command)
 
 </script>
 <body class="main">
-<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+<table class="w100p h100p">
   <tr class="va-top"> 
-    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
+    <td class="w143 logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="w100p navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -79,31 +79,31 @@ function formCommandSubmit(command)
           <td><a class="navbutton nav-kad" href="amuleweb-main-kad.php" title="Kad"></a></td>
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
-          <td width="10"></td>
-          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
+          <td class="w10"></td>
+          <td class="w190 texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
-          <td width="10"></td>
+          <td class="w10"></td>
         </tr>
       </table></td>
   </tr>
   <tr class="al-center va-top"> 
     <td colspan="2"><form name="mainform" action="amuleweb-main-kad.php" method="post">
-        <table width="100%" cellspacing="0" cellpadding="0">
+        <table class="w100p">
           <caption>
           KADEMLIA 
           </caption>
           <tr> 
-            <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_left.png" width="24" height="24"></td>
             <td class="tab-top">&nbsp;</td>
-            <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" class="tab-left">&nbsp;</td>
-            <td class="bg-white"><table width="100%" cellpadding="0" cellspacing="0">
+            <td class="w24 tab-left">&nbsp;</td>
+            <td class="bg-white"><table class="w100p">
                 <!--DWLayoutTable-->
                 <tr class="va-top"> 
                   <td class="h200"><img src="amule_stats_kad.png" width="500" height="200" alt="" title="" /></td>
-                  <td class="va-top"> <table class="kadnewnode center-table" cellpadding="0" cellspacing="6">
+                  <td class="va-top"> <table class="kadnewnode center-table spacing6">
                       <tr>
                         <th colspan="2">Network</th>
                       </tr>
@@ -137,26 +137,26 @@ function formCommandSubmit(command)
                     </table></td>
                 </tr>
                 <tr class="va-top"> 
-                  <td class="h20 al-center" width="500">Number of nodes</td>
+                  <td class="h20 al-center w500">Number of nodes</td>
                   <td></td>
                 </tr>
               </table></td>
-            <td width="24" class="tab-right">&nbsp;</td>
+            <td class="w24 tab-right">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
             <td class="tab-bottom">&nbsp;</td>
-            <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table>
         </form></td>
   </tr>
   <tr class="va-bottom"> 
-    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+    <td class="h25" colspan="2"> <table class="w100p h40">
         <tr class="al-center va-middle"> 
-          <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
+          <td class="w50p"> <iframe name="stats" src="footer.php" height="35" class="w100p noborder">edklink</iframe> 
           </td>
-          <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 
+          <td class="w50p"> <iframe name="stats" src="stats.php" height="35" class="w100p noborder">connection</iframe> 
           </td>
         </tr>
       </table></td>

--- a/src/webserver/default/amuleweb-main-log.php
+++ b/src/webserver/default/amuleweb-main-log.php
@@ -7,10 +7,10 @@
 <link href="style.css" rel="stylesheet" type="text/css">
 </head>
 <body class="main">
-<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+<table class="w100p h100p">
   <tr class="va-top"> 
-    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
+    <td class="w143 logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="w100p navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -19,61 +19,61 @@
           <td><a class="navbutton nav-kad" href="amuleweb-main-kad.php" title="Kad"></a></td>
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
-          <td width="10"></td>
-          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
+          <td class="w10"></td>
+          <td class="w190 texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
-          <td width="10"></td>
+          <td class="w10"></td>
         </tr>
       </table></td>
   </tr>
   <tr class="al-center va-top"> 
-    <td colspan="2">        <table width="100%" cellspacing="0" cellpadding="0">
+    <td colspan="2">        <table class="w100p">
           <caption>
           AMULE LOG 
           </caption>
           <tr> 
-            <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_left.png" width="24" height="24"></td>
             <td class="tab-top">&nbsp;</td>
-            <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" class="tab-left">&nbsp;</td>
+            <td class="w24 tab-left">&nbsp;</td>
             <td class="bg-white">
 
-            <table width="100%" cellpadding="0" cellspacing="0">
+            <table class="w100p">
                 <!--DWLayoutTable-->
                 <tr class="va-top"> 
                   <td>
 		<h1 style="display:inline;">aMule log</h1>
 		<a href="log.php?rstlog=1" target="logframe" onclick="return confirm('Do you really want to reset aMule log?')">(Reset log)</a><br>
-	<iframe width="100%" height="400" name="logframe" src="log.php"></iframe>
+	<iframe class="w100p" height="400" name="logframe" src="log.php"></iframe>
                   </td>
                   </tr><tr>
                   <td>
 		<h1 style="display:inline;">Serverinfo</h1>
 		<a href="log.php?rstsrv=1" target="srvframe" onclick="return confirm('Do you really want to reset Serverinfo?')">(Reset Serverinfo)</a>
-<iframe width="100%" height="200" name="srvframe" src="log.php?show=srv"></iframe>
+<iframe class="w100p" height="200" name="srvframe" src="log.php?show=srv"></iframe>
                   </td>
                   </tr>
                 </tr>
               </table>
               </td>
-            <td width="24" class="tab-right">&nbsp;</td>
+            <td class="w24 tab-right">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
             <td class="tab-bottom">&nbsp;</td>
-            <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table>
 </td>
   </tr>
   <tr class="va-bottom"> 
-    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+    <td class="h25" colspan="2"> <table class="w100p h40">
         <tr class="al-center va-middle"> 
-          <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
+          <td class="w50p"> <iframe name="stats" src="footer.php" height="35" class="w100p noborder">edklink</iframe> 
           </td>
-          <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 
+          <td class="w50p"> <iframe name="stats" src="stats.php" height="35" class="w100p noborder">connection</iframe> 
           </td>
         </tr>
       </table></td>

--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -107,10 +107,10 @@ function init_data()
 </script>
 </head>
 <body class="main" onLoad="init_data();">
-<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+<table class="w100p h100p">
   <tr class="va-top"> 
-    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
+    <td class="w143 logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="w100p navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -119,250 +119,250 @@ function init_data()
           <td><a class="navbutton nav-kad" href="amuleweb-main-kad.php" title="Kad"></a></td>
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
-          <td width="10"></td>
-          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
+          <td class="w10"></td>
+          <td class="w190 texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
-          <td width="10"></td>
+          <td class="w10"></td>
         </tr>
       </table></td>
   </tr>
   <tr class="al-center va-top"> 
     <td colspan="2">
-        <table width="100%" cellspacing="0" cellpadding="0">
+        <table class="w100p">
           <caption>PREFERENCES</caption>
           <tr> 
-            <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_left.png" width="24" height="24"></td>
             <td class="tab-top">&nbsp;</td>
-            <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" class="tab-left">&nbsp;</td>
+            <td class="w24 tab-left">&nbsp;</td>
             
       <td class="bg-white"><form name="mainform" action="amuleweb-main-prefs.php" method="post">
-              <table class="center-table" cellpadding="0" cellspacing="6">
+              <table class="center-table spacing6">
                
     <tr class="al-center va-top">
       <td>
-        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
+        <table class="w350 center-table">
           <tr>
-            <td width="22">&nbsp;</td>
+            <td class="w22">&nbsp;</td>
             <th>General</th>
-            <td width="63">&nbsp;</td>
+            <td class="w63">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">Nickname</td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="nick" type="text" id="nick0" size="20"></td>
           </tr>
         </table>
-        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
+        <table class="w350 center-table">
           <tr>
-            <td width="22">&nbsp;</td>
+            <td class="w22">&nbsp;</td>
             <th>Webserver</th>
-            <td width="63">&nbsp;</td>
+            <td class="w63">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">Page refresh interval </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="autorefresh_time" type="text" id="autorefresh_time7" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25">
+            <td class="w22 h25">
 <input name="use_gzip" type="checkbox" id="use_gzip5"></td>
             <td class="h25"> Use gzip compression </td>
-            <td width="63" class="h25">&nbsp;</td>
+            <td class="w63 h25">&nbsp;</td>
           </tr>
         </table></td>
-      <td width="50%"> 
-        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
+      <td class="w50p"> 
+        <table class="w350 center-table">
           <tr> 
-            <td width="22">&nbsp;</td>
+            <td class="w22">&nbsp;</td>
             <th>Line capacity (for statistics only)</th>
-            <td width="63">&nbsp;</td>
+            <td class="w63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">Max download rate </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="max_line_down_cap" type="text" id="max_line_down_cap6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">Max upload rate </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="max_line_up_cap" type="text" id="max_line_up_cap7" size="4"></td>
           </tr>
         </table></td>
     </tr>
     <tr class="al-center va-top"> 
       <td> 
-        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
+        <table class="w350 center-table">
           <tr> 
-            <td width="22" class="h19">&nbsp;</td>
+            <td class="w22 h19">&nbsp;</td>
             <th>Bandwidth limits</th>
-            <td width="63">&nbsp;</td>
+            <td class="w63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">Max download rate </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="max_down_limit" type="text" id="max_down_limit6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">Max upload rate </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="max_up_limit" type="text" id="max_up_limit6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">Slot allocation </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="slot_alloc" type="text" id="slot_alloc6" size="4"></td>
           </tr>
         </table></td>
-      <td width="50%" rowspan="3"> 
-        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
+      <td class="w50p" rowspan="3"> 
+        <table class="w350 center-table">
           <tr> 
-            <td width="22">&nbsp;</td>
+            <td class="w22">&nbsp;</td>
             <th> File settings </th>
-            <td width="63">&nbsp;</td>
+            <td class="w63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">&nbsp; </td>
-            <td width="63" class="h25"></td>
+            <td class="w63 h25"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25"> 
+            <td class="w22 h25"> 
               <input name="check_free_space" type="checkbox" id="check_free_space5"></td>
             <td class="h25"> Check free space =&gt; Minimum free space (Mb) </td>
-            <td width="63" class="h25"> 
+            <td class="w63 h25"> 
               <input name="min_free_space" type="text" id="min_free_space4" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25"> 
+            <td class="w22 h25"> 
               <input name="new_files_auto_dl_prio" type="checkbox" id="new_files_auto_dl_prio4"></td>
             <td class="h25"> Added download files have auto priority</td>
-            <td width="63" class="h25"></td>
+            <td class="w63 h25"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25"> 
+            <td class="w22 h25"> 
               <input name="new_files_auto_ul_prio" type="checkbox" id="new_files_auto_ul_prio4"></td>
             <td class="h25"> New shared files have auto priority</td>
-            <td width="63" class="h25"></td>
+            <td class="w63 h25"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25"> 
+            <td class="w22 h25"> 
               <input name="ich_en" type="checkbox" id="ich_en5"></td>
             <td class="h25"> I.C.H. active</td>
-            <td width="63" class="h25"></td>
+            <td class="w63 h25"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25"> 
+            <td class="w22 h25"> 
               <input name="aich_trust" type="checkbox" id="aich_trust4"></td>
             <td class="h25"> AICH trusts every hash (not recommended)</td>
-            <td width="63" class="h25"></td>
+            <td class="w63 h25"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25"> 
+            <td class="w22 h25"> 
               <input name="alloc_full_chunks" type="checkbox" id="alloc_full_chunks4"></td>
             <td class="h25"> Alloc full chunks of .part files</td>
-            <td width="63" class="h25"></td>
+            <td class="w63 h25"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25"> 
+            <td class="w22 h25"> 
               <input name="alloc_full" type="checkbox" id="alloc_full4"></td>
             <td class="h25"> Alloc full disk space for .part files</td>
-            <td width="63" class="h25"></td>
+            <td class="w63 h25"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25"> 
+            <td class="w22 h25"> 
               <input name="new_files_paused" type="checkbox" id="new_files_paused4"></td>
             <td class="h25"> Add files to download queue in pause mode</td>
-            <td width="63" class="h25"></td>
+            <td class="w63 h25"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25"> 
+            <td class="w22 h25"> 
               <input name="extract_metadata" type="checkbox" id="extract_metadata4"></td>
             <td class="h25"> Extract metadata tags </td>
-            <td width="63" class="h25"></td>
+            <td class="w63 h25"></td>
           </tr>
         </table></td>
     </tr>
     <tr class="al-center va-top"> 
       <td> 
-        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
+        <table class="w350 center-table">
           <tr> 
-            <td width="22">&nbsp;</td>
+            <td class="w22">&nbsp;</td>
             <th>Connection settings</th>
-            <td width="63">&nbsp;</td>
+            <td class="w63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">Max total connections (total) </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="max_conn_total" type="text" id="max_conn_total8" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">Max sources per file </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="max_file_src" type="text" id="max_file_src7" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25">
+            <td class="w22 h25">
 <input name="autoconn_en" type="checkbox" id="autoconn_en6"></td>
             <td class="h25"> Autoconnect at startup </td>
-            <td width="63" class="h25">&nbsp;</td>
+            <td class="w63 h25">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" class="h25">
+            <td class="w22 h25">
 <input name="reconn_en" type="checkbox" id="reconn_en6"></td>
             <td class="h25"> Reconnect when connection lost </td>
-            <td width="63" class="h25">&nbsp;</td>
+            <td class="w63 h25">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" class="h25">
+            <td class="w22 h25">
 <input name="network_ed2k" type="checkbox" id="network_ed2k6"></td>
             <td class="h25"> Enable ED2K network </td>
-            <td width="63" class="h25">&nbsp;</td>
+            <td class="w63 h25">&nbsp;</td>
           </tr>
           <tr>
-            <td width="22" class="h25">
+            <td class="w22 h25">
 <input name="network_kad" type="checkbox" id="network_kad6"></td>
             <td class="h25"> Enable Kademlia network </td>
-            <td width="63" class="h25">&nbsp;</td>
+            <td class="w63 h25">&nbsp;</td>
           </tr>
         </table></td>
     </tr>
     <tr class="al-center va-top">
       <td>
-        <table width="350" class="center-table" cellpadding="0" cellspacing="0">
+        <table class="w350 center-table">
           <tr>
-            <td width="22">&nbsp;</td>
+            <td class="w22">&nbsp;</td>
             <th>Network settings</th>
-            <td width="63">&nbsp;</td>
+            <td class="w63">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">TCP port </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="tcp_port" type="text" id="tcp_port6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25">&nbsp;</td>
+            <td class="w22 h25">&nbsp;</td>
             <td class="h25">UDP port </td>
-            <td width="63" class="h25">
+            <td class="w63 h25">
 <input name="udp_port" type="text" id="udp_port6" size="4"></td>
           </tr>
           <tr> 
-            <td width="22" class="h25">
+            <td class="w22 h25">
 <input name="udp_dis" type="checkbox" id="udp_dis5"></td>
             <td class="h25"> Disable UDP connections </td>
-            <td width="63" class="h25">&nbsp;</td>
+            <td class="w63 h25">&nbsp;</td>
           </tr>
         </table></td>
     </tr>
@@ -379,21 +379,21 @@ function init_data()
     </tr>
   </table>
   </form></td>
-            <td width="24" class="tab-right">&nbsp;</td>
+            <td class="w24 tab-right">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
             <td class="tab-bottom">&nbsp;</td>
-            <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></td>
   </tr>
   <tr class="va-bottom"> 
-    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+    <td class="h25" colspan="2"> <table class="w100p h40">
         <tr class="al-center va-middle"> 
-          <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
+          <td class="w50p"> <iframe name="stats" src="footer.php" height="35" class="w100p noborder">edklink</iframe> 
           </td>
-          <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 
+          <td class="w50p"> <iframe name="stats" src="stats.php" height="35" class="w100p noborder">connection</iframe> 
           </td>
         </tr>
       </table></td>

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -22,10 +22,10 @@ function formCommandSubmit(command)
 </script>
 </head>
 <body class="main">
-<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+<table class="w100p h100p">
   <tr class="va-top"> 
-    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
+    <td class="w143 logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="w100p navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -34,29 +34,29 @@ function formCommandSubmit(command)
           <td><a class="navbutton nav-kad" href="amuleweb-main-kad.php" title="Kad"></a></td>
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
-          <td width="10"></td>
-          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
+          <td class="w10"></td>
+          <td class="w190 texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
-          <td width="10"></td>
+          <td class="w10"></td>
         </tr>
       </table></td>
   </tr>
   <tr class="al-center va-top"> 
     <td colspan="2">
-        <table width="100%" cellspacing="0" cellpadding="0">
+        <table class="w100p">
           <caption>
         SEARCH
         </caption>
           <tr> 
-            <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_left.png" width="24" height="24"></td>
             <td class="tab-top">&nbsp;</td>
-            <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" class="tab-left">&nbsp;</td>
+            <td class="w24 tab-left">&nbsp;</td>
             
       <td class="bg-white"><form name="mainform" action="amuleweb-main-search.php" method="post">
-              <table width="100%" cellpadding="4" cellspacing="0">
+              <table class="w100p pad4">
                 <tr class="al-center"> 
                   <td class="al-center">
 <input type="hidden" name="command" value=""> 
@@ -110,7 +110,7 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
                     </select></td>
                 </tr>
               </table>
-              <table width="100%"  cellpadding="0" cellspacing="0">
+              <table class="w100p">
                 <tr>
                   <th>&nbsp;</th>
                   <th><a href="amuleweb-main-search.php?sort=name">File Name</a></th>
@@ -254,21 +254,21 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
         </select></td>
   </table>
 </form></td>
-            <td width="24" class="tab-right">&nbsp;</td>
+            <td class="w24 tab-right">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
             <td class="tab-bottom">&nbsp;</td>
-            <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></td>
   </tr>
   <tr class="va-bottom"> 
-    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+    <td class="h25" colspan="2"> <table class="w100p h40">
         <tr class="al-center va-middle"> 
-          <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
+          <td class="w50p"> <iframe name="stats" src="footer.php" height="35" class="w100p noborder">edklink</iframe> 
           </td>
-          <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 
+          <td class="w50p"> <iframe name="stats" src="stats.php" height="35" class="w100p noborder">connection</iframe> 
           </td>
         </tr>
       </table></td>

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -7,10 +7,10 @@
 <link href="style.css" rel="stylesheet" type="text/css">
 </head>
 <body class="main">
-<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+<table class="w100p h100p">
   <tr class="va-top"> 
-    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
+    <td class="w143 logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="w100p navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -19,28 +19,28 @@
           <td><a class="navbutton nav-kad" href="amuleweb-main-kad.php" title="Kad"></a></td>
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
-          <td width="10"></td>
-          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
+          <td class="w10"></td>
+          <td class="w190 texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
-          <td width="10"></td>
+          <td class="w10"></td>
         </tr>
       </table></td>
   </tr>
   <tr class="al-center va-top"> 
     <td colspan="2">
-        <table width="100%" cellspacing="0" cellpadding="0">
+        <table class="w100p">
           <caption>
         SERVERS 
         </caption>
           <tr> 
-            <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_left.png" width="24" height="24"></td>
             <td class="tab-top">&nbsp;</td>
-            <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" class="tab-left">&nbsp;</td>
+            <td class="w24 tab-left">&nbsp;</td>
             
-      <td class="bg-white"><table width="100%"  cellpadding="0" cellspacing="0">
+      <td class="bg-white"><table class="w100p">
               <?php
                 // Network-level disconnect button, admin only. Statements
                 // must be syntactically complete within one PHP block;
@@ -58,12 +58,12 @@
                 }
               ?>
               <tr>
-                <th width="3%"></th>
-                <th width="22%" ><a href="amuleweb-main-servers.php?sort=name">Server Name</a></th>
-                <th width="42%" ><a href="amuleweb-main-servers.php?sort=desc">Description</a></th>
-                <th width="19%">Address</th>
-                <th width="7%"><a href="amuleweb-main-servers.php?sort=users">Users</a></th>
-                <th width="7%"><a href="amuleweb-main-servers.php?sort=files">Files</a></th>
+                <th class="w3p"></th>
+                <th class="w22p" ><a href="amuleweb-main-servers.php?sort=name">Server Name</a></th>
+                <th class="w42p" ><a href="amuleweb-main-servers.php?sort=desc">Description</a></th>
+                <th class="w19p">Address</th>
+                <th class="w7p"><a href="amuleweb-main-servers.php?sort=users">Users</a></th>
+                <th class="w7p"><a href="amuleweb-main-servers.php?sort=files">Files</a></th>
 		</tr><tr><td colspan="8" class="sep-dark"></td></tr>
               <?php
 
@@ -160,21 +160,21 @@
 		}
 	  ?>
             </table></td>
-            <td width="24" class="tab-right">&nbsp;</td>
+            <td class="w24 tab-right">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
             <td class="tab-bottom">&nbsp;</td>
-            <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></td>
   </tr>
   <tr class="va-bottom"> 
-    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+    <td class="h25" colspan="2"> <table class="w100p h40">
         <tr class="al-center va-middle"> 
-          <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
+          <td class="w50p"> <iframe name="stats" src="footer.php" height="35" class="w100p noborder">edklink</iframe> 
           </td>
-          <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 
+          <td class="w50p"> <iframe name="stats" src="stats.php" height="35" class="w100p noborder">connection</iframe> 
           </td>
         </tr>
       </table></td>

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -22,10 +22,10 @@ function formCommandSubmit(command)
 </script>
 </head>
 <body class="main">
-<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+<table class="w100p h100p">
   <tr class="va-top"> 
-    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
+    <td class="w143 logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="w100p navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -34,16 +34,16 @@ function formCommandSubmit(command)
           <td><a class="navbutton nav-kad" href="amuleweb-main-kad.php" title="Kad"></a></td>
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
-          <td width="10"></td>
-          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
+          <td class="w10"></td>
+          <td class="w190 texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
-          <td width="10"></td>
+          <td class="w10"></td>
         </tr>
       </table></td>
   </tr>
   <tr class="al-center va-top"> 
     <td colspan="2"><form name="mainform" action="amuleweb-main-shared.php" method="post">
-              <table class="center-table" cellpadding="0" cellspacing="0">
+              <table class="center-table">
                 <tr>
                   <td><input type="hidden" name="command"></td>
                   
@@ -69,20 +69,20 @@ function formCommandSubmit(command)
                   </td>
                 </tr>
               </table>
-        <table width="100%" cellspacing="0" cellpadding="0">
+        <table class="w100p">
           <caption>
         SHARED FILES 
         </caption>
           <tr> 
-            <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_left.png" width="24" height="24"></td>
             <td class="tab-top">&nbsp;</td>
-            <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" class="tab-left">&nbsp;</td>
+            <td class="w24 tab-left">&nbsp;</td>
             
           <td class="bg-white">
-              <table width="100%"  cellpadding="0" cellspacing="0">
+              <table class="w100p">
                 <tr> 
                   <th></th>
                   <th><a href="amuleweb-main-shared.php?sort=name">File Name</a></th>
@@ -239,21 +239,21 @@ function formCommandSubmit(command)
 		}
 	  ?>
               </table></td>
-            <td width="24" class="tab-right">&nbsp;</td>
+            <td class="w24 tab-right">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
             <td class="tab-bottom">&nbsp;</td>
-            <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></form></td>
   </tr>
   <tr class="va-bottom"> 
-    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+    <td class="h25" colspan="2"> <table class="w100p h40">
         <tr class="al-center va-middle"> 
-          <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
+          <td class="w50p"> <iframe name="stats" src="footer.php" height="35" class="w100p noborder">edklink</iframe> 
           </td>
-          <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 
+          <td class="w50p"> <iframe name="stats" src="stats.php" height="35" class="w100p noborder">connection</iframe> 
           </td>
         </tr>
       </table></td>

--- a/src/webserver/default/amuleweb-main-stats.php
+++ b/src/webserver/default/amuleweb-main-stats.php
@@ -37,10 +37,10 @@ function swapFolder(img){
 </script>
 </head>
 <body class="main">
-<table width="100%" height="100%" cellpadding="0" cellspacing="0">
+<table class="w100p h100p">
   <tr class="va-top"> 
-    <td width="143" class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
-    <td width="100%" class="navbar-cell"> <table class="navbar-table" cellspacing="0" cellpadding="0">
+    <td class="w143 logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="w100p navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>
           <td><a class="navbutton nav-shared" href="amuleweb-main-shared.php" title="Shared files"></a></td>
@@ -49,67 +49,67 @@ function swapFolder(img){
           <td><a class="navbutton nav-kad" href="amuleweb-main-kad.php" title="Kad"></a></td>
           <td><a class="navbutton nav-stats" href="amuleweb-main-stats.php" title="Statistics"></a></td>
           <td><img src="images/col.png"></td>
-          <td width="10"></td>
-          <td width="190" class="texteinv al-right"><a href="login.php">exit</a><br> 
+          <td class="w10"></td>
+          <td class="w190 texteinv al-right"><a href="login.php">exit</a><br> 
             <a href="amuleweb-main-log.php">log &bull;</a> <a href="amuleweb-main-prefs.php">configuration</a></td>
-          <td width="10"></td>
+          <td class="w10"></td>
         </tr>
       </table></td>
   </tr>
   <tr class="al-center va-top"> 
     <td colspan="2">
-        <table width="100%" cellspacing="0" cellpadding="0">
+        <table class="w100p">
           <caption>
         STATISTICS 
         </caption>
           <tr> 
-            <td width="24"><img src="images/tab_top_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_left.png" width="24" height="24"></td>
             <td class="tab-top">&nbsp;</td>
-            <td width="24"><img src="images/tab_top_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_top_right.png" width="24" height="24"></td>
           </tr>
           <tr> 
-            <td width="24" class="tab-left">&nbsp;</td>
+            <td class="w24 tab-left">&nbsp;</td>
             
-          <td class="bg-white"><table width="100%" cellpadding="0" cellspacing="0">
+          <td class="bg-white"><table class="w100p">
               <tr class="va-top"> 
                 <td rowspan="7">
-<iframe name="stats" src="stats_tree.php" width="100%" height="630" frameborder="0">liste</iframe></td>
-                <td width="500" class="al-right"><img src="amule_stats_download.png" width="500" height="200"></td>
+<iframe name="stats" src="stats_tree.php" class="w100p noborder" height="630">liste</iframe></td>
+                <td class="w500 al-right"><img src="amule_stats_download.png" width="500" height="200"></td>
               </tr>
               <tr class="va-top"> 
-                <td width="500" class="h15"> 
+                <td class="w500 h15"> 
                   <div class="al-center">Download-Speed</div></td>
               </tr>
               <tr class="va-top"> 
-                <td width="500" class="al-right"><img src="amule_stats_upload.png" width="500" height="200" alt="" title="" /></td>
+                <td class="w500 al-right"><img src="amule_stats_upload.png" width="500" height="200" alt="" title="" /></td>
               </tr>
               <tr class="va-top"> 
-                <td width="500" class="h15"> 
+                <td class="w500 h15"> 
                   <div class="al-center">Upload-Speed</div></td>
                </tr>
               <tr class="va-top"> 
-                <td width="500" class="al-right"><img src="amule_stats_conncount.png" width="500" height="200" alt="" title="" /></td>
+                <td class="w500 al-right"><img src="amule_stats_conncount.png" width="500" height="200" alt="" title="" /></td>
               </tr>
               <tr class="va-top"> 
-                <td width="500" class="h15"> 
+                <td class="w500 h15"> 
                   <div class="al-center">Connections</div></td>
               </tr>
             </table></td>
-            <td width="24" class="tab-right">&nbsp;</td>
+            <td class="w24 tab-right">&nbsp;</td>
           </tr>
           <tr> 
-            <td width="24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_left.png" width="24" height="24"></td>
             <td class="tab-bottom">&nbsp;</td>
-            <td width="24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
+            <td class="w24"><img src="images/tab_bottom_right.png" width="24" height="24"></td>
           </tr>
         </table></td>
   </tr>
   <tr class="va-bottom"> 
-    <td class="h25" colspan="2"> <table width="100%" height="40" cellpadding="0" cellspacing="0">
+    <td class="h25" colspan="2"> <table class="w100p h40">
         <tr class="al-center va-middle"> 
-          <td width="50%"> <iframe name="stats" src="footer.php" height="35" width="100%" scrolling="no" frameborder="0">edklink</iframe> 
+          <td class="w50p"> <iframe name="stats" src="footer.php" height="35" class="w100p noborder">edklink</iframe> 
           </td>
-          <td width="50%"> <iframe name="stats" src="stats.php" height="35" width="100%" scrolling="no" frameborder="0">connection</iframe> 
+          <td class="w50p"> <iframe name="stats" src="stats.php" height="35" class="w100p noborder">connection</iframe> 
           </td>
         </tr>
       </table></td>

--- a/src/webserver/default/footer.php
+++ b/src/webserver/default/footer.php
@@ -7,11 +7,11 @@
 <link href="style.css" rel="stylesheet" type="text/css">
 </head>
 
-<body>
+<body class="frame">
 
-<table width="100%" cellpadding="0" cellspacing="0">
+<table class="w100p">
   <tr>
-    <td width="50%" class="al-center va-bottom"> 
+    <td class="w50p al-center va-bottom"> 
       <form name="formlink" method="post" action="footer.php">
         <input name="ed2klink" type="text" id="ed2klink" size="50">
         <select name="selectcat" id="selectcat">

--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -14,15 +14,15 @@ function login_init()
 </head>
 
 <body class="main" onload="login_init();">
-<table width="100%" height="180" cellpadding="0" cellspacing="0">
+<table class="w100p h180">
   <tr>
     <td class="al-center va-middle">
-      <table width="70%" height="90%" class="center-table bg-black" cellpadding="0" cellspacing="1">
+      <table class="w70p h90p center-table bg-black spacing1">
         <tr>
-          <td><table width="100%" height="100%" class="bg-white" cellpadding="0" cellspacing="0">
+          <td><table class="w100p h100p bg-white">
               <tr class="va-top">
-               <th width="366" class="h180"><img src="images/loginlogo.jpg" width="366" height="180"></th>
-                <th width="100%" class="login-banner">
+               <th class="w366 h180"><img src="images/loginlogo.jpg" width="366" height="180"></th>
+                <th class="w100p login-banner">
                   <form action="" method="post" name="login">
                     Enter password : 
                     <input name="pass" size="20" value="" type="password">

--- a/src/webserver/default/stats.php
+++ b/src/webserver/default/stats.php
@@ -12,10 +12,10 @@
 ?>
 <link href="style.css" rel="stylesheet" type="text/css">
 </head>
-<body>
-<table width="100%" height="30" cellpadding="0" cellspacing="0">
+<body class="frame">
+<table class="w100p h30">
   <tr class="va-top"> 
-    <td width="65%"><strong>Ed2k : </strong> 
+    <td class="w65p"><strong>Ed2k : </strong> 
       <?php
     	$stats = amule_get_stats();
     	if ( $stats["id"] == 0 ) {

--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -9,6 +9,7 @@ th {
 	font-size: 14px;
 	font-weight: bold;
 	color: #003161;
+	padding: 0;
 }
 a:link {
 	color: #003161;
@@ -30,6 +31,7 @@ td {
 	font-family: Helvetica;
 	font-size: 12px;
 	font-weight: normal;
+	padding: 0;
 }
 a.navbutton {
 	display: block;
@@ -206,11 +208,95 @@ td.sep-light {
 .h25 {
 	height: 25px;
 }
+.h30 {
+	height: 30px;
+}
+.h40 {
+	height: 40px;
+}
 .h180 {
 	height: 180px;
 }
 .h200 {
 	height: 200px;
+}
+.h90p {
+	height: 90%;
+}
+.h100p {
+	height: 100%;
+}
+.w10 {
+	width: 10px;
+}
+.w22 {
+	width: 22px;
+}
+.w24 {
+	width: 24px;
+}
+.w63 {
+	width: 63px;
+}
+.w143 {
+	width: 143px;
+}
+.w190 {
+	width: 190px;
+}
+.w350 {
+	width: 350px;
+}
+.w366 {
+	width: 366px;
+}
+.w500 {
+	width: 500px;
+}
+.w3p {
+	width: 3%;
+}
+.w7p {
+	width: 7%;
+}
+.w19p {
+	width: 19%;
+}
+.w22p {
+	width: 22%;
+}
+.w42p {
+	width: 42%;
+}
+.w50p {
+	width: 50%;
+}
+.w65p {
+	width: 65%;
+}
+.w70p {
+	width: 70%;
+}
+.w100p {
+	width: 100%;
+}
+table {
+	border-spacing: 0;
+}
+table.spacing1 {
+	border-spacing: 1px;
+}
+table.spacing6 {
+	border-spacing: 6px;
+}
+table.pad4 > tbody > tr > td {
+	padding: 4px;
+}
+iframe.noborder {
+	border: 0;
+}
+body.frame {
+	overflow: hidden;
 }
 th.login-banner {
 	height: 180px;


### PR DESCRIPTION
Finish the presentational-HTML migration started in #95. That commit covered background=/bgcolor=/align=/valign=/border= and the body margins; this one retires what was left, keeping the quirks mode doctype untouched so the table layout renders exactly as before:

- cellspacing= / cellpadding= are dropped from every table. A global `table { border-spacing: 0 }` plus `padding: 0` on the existing th/td rules covers the 0/0 case used almost everywhere; the three exceptions get spacing1 (login box frame), spacing6 (prefs and Kad toolbars) and pad4 (search form) classes. pad4 uses a `> tbody > tr > td` child selector so it matches the cellpadding semantics of styling only the table's own cells.
- width= on td/th (deprecated since HTML 4.01) and width=/height= on table (height was never valid HTML, it works via quirks mode) become w*/h* utility classes next to the existing h10..h200 set, with a `p` suffix for percentages (w50p, h100p, ...).
- frameborder="0" and width="100%" on the footer/stats/stats_tree iframes become `iframe.noborder` and w100p classes. The two log.php iframes keep their default border as today (they never set frameborder), so they only get w100p.
- scrolling="no" (obsolete, no CSS equivalent on the iframe element) is replaced by `overflow: hidden` on the body of the two framed documents themselves, footer.php and stats.php (body.frame).

Pixel heights on img and iframe stay as attributes - they are valid, non-presentational HTML.

Verified against a running amuleweb: before/after headless-Chromium screenshots of all 9 pages plus the two footer frames are pixel-identical except for dynamic content (stats graphs, uptime, server user/file counts).