### PR TITLE
fix(manpages): pass --no-update to po4a so build doesn't dirty source tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,10 @@ jobs:
             -e 's|@CMAKE_SOURCE_DIR@|../..|g' \
             -e 's|@CMAKE_BINARY_DIR@|../..|g' \
             docs/man/po4a.config.in > "$TMP"
-          (cd docs/man && po4a --force "$TMP")
+          # --no-update: render translations but leave po/manpages.pot
+          # and po/manpages-*.po unchanged, so the tarred-up source tree
+          # matches git HEAD byte-for-byte (modulo the new rendered .lang.1.in).
+          (cd docs/man && po4a --no-update --force "$TMP")
           rm "$TMP"
           # Sanity-check that po4a actually produced the renders.
           count=$(find docs/man src/utils \

--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -108,9 +108,14 @@ if (TRANSLATED_MANPAGES)
 			"${CMAKE_CURRENT_SOURCE_DIR}/po/manpages.pot"
 		)
 
+		# --no-update: render translated manpages from the existing .po
+		# files but do NOT regenerate manpages.pot or msgmerge into
+		# manpages-*.po. Keeping these source-tree files unmodified is
+		# what scripts/update-manpages-po.sh is for; a plain `cmake
+		# --build` should never dirty the working tree.
 		add_custom_command (
 			OUTPUT ${PO4A_RAW_OUTPUTS}
-			COMMAND ${PO4A_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/po4a.config"
+			COMMAND ${PO4A_EXECUTABLE} --no-update "${CMAKE_CURRENT_BINARY_DIR}/po4a.config"
 			DEPENDS
 				${PO4A_PO_INPUTS}
 				"${CMAKE_CURRENT_BINARY_DIR}/po4a.config"


### PR DESCRIPTION
Followup to #94, reported by @ngosang in https://github.com/amule-org/amule/pull/94#issuecomment-4681341955.

## Problem

#94's `po4a` invocation runs with no flags, which means po4a does all **three** of its default operations on every `cmake --build`:

1. Regenerate `docs/man/po/manpages.pot` from English masters
2. Merge the new `.pot` into every `docs/man/po/manpages-*.po`
3. Render the translated `*.lang.1.in` into the build dir

Only (3) is the build's job. (1) and (2) belong to `scripts/update-manpages-po.sh`, which a translator/maintainer runs explicitly. The side effect: every plain `cmake --build` left `manpages.pot` + 10 × `manpages-*.po` showing as modified in `git status`, dirtying the working tree at minimum with a refreshed `POT-Creation-Date:` timestamp.

## Fix

Pass `--no-update` to po4a in both call sites:

- `docs/man/CMakeLists.txt`'s `add_custom_command` (the build path)
- `.github/workflows/release.yml`'s `source-bundle` job (so the tarred source bundle matches git HEAD byte-for-byte, modulo the new `.lang.1.in` files)

po4a then only renders translated manpages and leaves `.pot`/`.po` untouched.

## Test plan

Run on macOS ARM64.

- [x] **Before fix** — `cmake --build build` leaves 11 files modified in `docs/man/po/` (1 `.pot` + 10 `.po`)
- [x] **After fix** — same `cmake --build build` leaves `docs/man/po/` clean (`git status -s docs/man/po/` empty), but 102 rendered `*.lang.1` files still produced in `build/docs/man/` and `build/src/utils/`
- [x] `scripts/update-manpages-po.sh` still does its job (already uses `--no-translations --force`, unaffected)
- [x] CI `manpages-pot-sync` job still works (uses the script, unaffected)