### PR TITLE
fix(webserver): remove small deprecated CSS/HTML leftovers from default template

### DIFF
--- a/src/webserver/default/amuleweb-main-kad.php
+++ b/src/webserver/default/amuleweb-main-kad.php
@@ -100,8 +100,7 @@ function formCommandSubmit(command)
           <tr> 
             <td>&nbsp;</td>
             <td><table class="w100p">
-                <!--DWLayoutTable-->
-                <tr class="va-top"> 
+                <tr class="va-top">
                   <td class="h200"><img src="amule_stats_kad.png" width="500" height="200" alt="" title="" /></td>
                   <td class="va-top"> <table class="kadnewnode">
                       <tr>

--- a/src/webserver/default/amuleweb-main-log.php
+++ b/src/webserver/default/amuleweb-main-log.php
@@ -41,8 +41,7 @@
             <td>
 
             <table class="w100p">
-                <!--DWLayoutTable-->
-                <tr class="va-top"> 
+                <tr class="va-top">
                   <td>
 		<h1 style="display:inline;">aMule log</h1>
 		<a href="log.php?rstlog=1" target="logframe" onclick="return confirm('Do you really want to reset aMule log?')">(Reset log)</a><br>

--- a/src/webserver/default/log.php
+++ b/src/webserver/default/log.php
@@ -10,7 +10,6 @@
 
 ?>
 <style type="text/css">
-<!--
 body {
 	margin-left: 0px;
 	margin-top: 0px;
@@ -18,10 +17,9 @@ body {
 	margin-bottom: 0px;
 	background-color: #FFFFFF;
 	font-size: small;
-	font-family: Fixed;
+	font-family: monospace;
 	color: #000000;
 }
--->
 </style>
 </head>
 <body>

--- a/src/webserver/default/stats_tree.php
+++ b/src/webserver/default/stats_tree.php
@@ -13,7 +13,6 @@
 <style type="text/css">
 .trigger{
 	cursor: pointer;
-	cursor: hand;
 	font-family: Tahoma;
 	font-size: small;
 }
@@ -23,7 +22,6 @@
 	font-family: Tahoma;
 	font-size: small;
 }
-<!--
 body {
 	margin-left: 0px;
 	margin-top: 0px;
@@ -31,7 +29,6 @@ body {
 	margin-bottom: 0px;
 	background-color: #ffffff;
 }
--->
 </style>
 </head>
 <script language="JavaScript" type="text/JavaScript">


### PR DESCRIPTION
Clean up deprecated constructs left over from the Dreamweaver-era templates (item 17 of the WebUI modernization roadmap):

- stats_tree.php: drop the IE-only `cursor: hand` fallback; `cursor: pointer` is universally supported.
- log.php: replace `font-family: Fixed` (not a real font family) with the generic `monospace` family, so the log actually renders in a fixed-width font.
- log.php, stats_tree.php: remove the Netscape-era `<!-- -->` script-hiding wrappers inside the `<style>` blocks (CDO/CDC tokens are ignored by CSS parsers, so this is a no-op visually; in stats_tree.php the wrapper confusingly enclosed only the body rules).
- amuleweb-main-log.php, amuleweb-main-kad.php: remove the `<!--DWLayoutTable-->` Dreamweaver design-time comments.

Verified against a running amuleweb: all four pages serve the cleaned markup and render completely.