### PR TITLE
fix(webserver): add htmlspecialchars + addslashes builtins and escape remote-controlled strings in the WebUI (XSS)

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -88,7 +88,7 @@ function formCommandSubmit(command)
         	echo '<select name="category" id="category">';
 			$cats = amule_get_categories();
 			foreach($cats as $c) {
-				echo (($c == $_SESSION["filter_cat"]) ? '<option selected>' : '<option>'), $c, '</option>';
+				echo (($c == $_SESSION["filter_cat"]) ? '<option selected>' : '<option>'), htmlspecialchars($c), '</option>';
 			}
 			echo '</select>';
         ?>
@@ -278,7 +278,7 @@ function formCommandSubmit(command)
 	
 				echo "<td class='texte h22'>", '<input type="checkbox" name="', $file->hash, '" >', "</td>";
 	
-				echo "<td class='texte texte-full-name h22'>", $file->name, "</td>";
+				echo "<td class='texte texte-full-name h22'>", htmlspecialchars($file->name), "</td>";
 				
 				echo "<td class='texte h22 al-center'>", CastToXBytes($file->size, $countSize), "</td>";
 
@@ -380,9 +380,9 @@ function formCommandSubmit(command)
 	
 				echo "<td class='texte h22 al-center'>", "</td>";
 				
-				echo "<td class='texte texte-full-name texte-full-name-upload h22'>", $file->name, "</td>";
+				echo "<td class='texte texte-full-name texte-full-name-upload h22'>", htmlspecialchars($file->name), "</td>";
 
-				echo "<td class='texte h22 al-center'>", $file->user_name, "</td>";
+				echo "<td class='texte h22 al-center'>", htmlspecialchars($file->user_name), "</td>";
 	
 				echo "<td class='texte h22 al-center'>", CastToXBytes($file->xfer_up, $countUploadDimension), "</td>";
 				echo "<td class='texte h22 al-center'>", CastToXBytes($file->xfer_down, $countDownloadDimension), "</td>";

--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -62,14 +62,17 @@ var initvals = new Object;
 	}
 	$opts = amule_get_options();
 	//var_dump($opts);
-	echo 'initvals["nick"] = "', $opts["nick"], '";';
+	// These values are emitted into double-quoted JS string literals inside
+	// the <script> block, so they are escaped with addslashes (JS-string
+	// context), not htmlspecialchars (which would show literal entities).
+	echo 'initvals["nick"] = "', addslashes($opts["nick"]), '";';
 	$opt_groups = array("connection", "files", "webserver");
 	//var_dump($opt_groups);
 	foreach ($opt_groups as $group) {
 		$curr_opts = $opts[$group];
 		//var_dump($curr_opts);
 		foreach ($curr_opts as $opt_name => $opt_val) {
-			echo 'initvals["', $opt_name, '"] = "', $opt_val, '";';
+			echo 'initvals["', addslashes($opt_name), '"] = "', addslashes($opt_val), '";';
 		}
 	}
 ?>

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -81,12 +81,11 @@ function formCommandSubmit(command)
 // (line 234-236 of this file). Anything else is dropped to empty,
 // which falls through to the "no sort change" branch below. This
 // avoids reflecting an attacker-controlled string into the rendered
-// HTML (#869). Plain string-equality chain is the only matching
-// primitive amuleweb's bundled PHP interpreter supports -- the
-// classic `in_array()` / `htmlspecialchars()` builtins aren't
-// registered (see src/webserver/src/php_core_lib.cpp), and array
-// short syntax `[...]` doesn't parse either. The three whitelisted
-// values are static alphanumeric column keys; no escaping needed.
+// HTML (#869). A whitelist is stricter than escaping here: only the
+// three known column keys are ever echoed, so the reflected value is
+// guaranteed safe regardless of context. The plain string-equality
+// chain is the only matching primitive the bundled interpreter offers
+// (no `in_array()`, and `[...]` short array syntax doesn't parse).
 $sort_raw = isset($HTTP_GET_VARS["sort"]) ? $HTTP_GET_VARS["sort"] : "";
 if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
     echo($sort_raw);
@@ -231,7 +230,7 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
 
 			echo "<td class='texte'>", '<input type="checkbox" name="', $file->hash, '" >', "</td>";
 
-			echo "<td class='texte texte-full-name texte-full-name-search'>", $file->name, "</td>";
+			echo "<td class='texte texte-full-name texte-full-name-search'>", htmlspecialchars($file->name), "</td>";
 			
 			echo "<td class='texte al-center'>", CastToXBytes($file->size), "</td>";
 
@@ -248,7 +247,7 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
           <?php
                 	$cats = amule_get_categories();
                 	foreach($cats as $c) {
-                		echo "<option>", $c, "</option>";
+                		echo "<option>", htmlspecialchars($c), "</option>";
                 	}
                 ?>
         </select></td>

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -150,9 +150,9 @@
 					"</td>";
 			}
 
-			echo "<td class='texte'>", $srv->name, "</td>";
-			echo "<td class='texte'>", $srv->desc, "</td>";
-			echo "<td class='texte al-center'>", $srv->addr, "</td>";
+			echo "<td class='texte'>", htmlspecialchars($srv->name), "</td>";
+			echo "<td class='texte'>", htmlspecialchars($srv->desc), "</td>";
+			echo "<td class='texte al-center'>", htmlspecialchars($srv->addr), "</td>";
 			echo "<td class='texte al-center'>", $srv->users, "</td>";
 			echo "<td class='texte al-center'>", $srv->files, "</td>";
 

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -225,7 +225,7 @@ function formCommandSubmit(command)
 
 			echo "<td class='texte'>", '<input type="checkbox" name="', $file->hash, '" >', "</td>";
 
-			echo "<td class='texte texte-full-name'>", $file->name, "</td>";
+			echo "<td class='texte texte-full-name'>", htmlspecialchars($file->name), "</td>";
 			echo "<td class='texte al-center'>", CastToXBytes($file->xfer), " (", CastToXBytes($file->xfer_all),")</td>";
 
 			echo "<td class='texte al-center'>", $file->req, " (", $file->req_all, ")</td>";

--- a/src/webserver/default/footer.php
+++ b/src/webserver/default/footer.php
@@ -35,7 +35,7 @@
 		}
 
 		foreach($cats as $c) {
-			echo  '<option>', $c, '</option>';
+			echo  '<option>', htmlspecialchars($c), '</option>';
 		}
 	?>
         </select>

--- a/src/webserver/default/log.php
+++ b/src/webserver/default/log.php
@@ -26,9 +26,9 @@ body {
 <pre>
 <?php
 	if ("srv" == $HTTP_GET_VARS['show'] || 1 == $HTTP_GET_VARS['rstsrv']) {
-		echo amule_get_serverinfo($HTTP_GET_VARS['rstsrv']);
+		echo htmlspecialchars(amule_get_serverinfo($HTTP_GET_VARS['rstsrv']));
 	 }else {
-		echo amule_get_log($HTTP_GET_VARS['rstlog']);
+		echo htmlspecialchars(amule_get_log($HTTP_GET_VARS['rstlog']));
 	}
 ?>
 </pre>

--- a/src/webserver/default/stats.php
+++ b/src/webserver/default/stats.php
@@ -24,7 +24,7 @@
     		echo "Connecting ...";
     	} else {
     		echo "Connected with ", (($stats["id"] < 16777216) ? "low" : "high"), " ID to ",
-    			$stats["serv_name"], "  ", $stats["serv_addr"];
+    			htmlspecialchars($stats["serv_name"]), "  ", htmlspecialchars($stats["serv_addr"]);
     	}
     ?>
     </td>

--- a/src/webserver/default/stats_tree.php
+++ b/src/webserver/default/stats_tree.php
@@ -68,22 +68,22 @@ function print_ident($i)
 function print_item($it, $ident)
 {
 	print_ident($ident);
-	echo "<img src=\"tree-leaf.gif\">", $it, "<br>\n";
+	echo "<img src=\"tree-leaf.gif\">", htmlspecialchars($it), "<br>\n";
 }
 
 function print_folder($key, &$arr, $ident)
 {
 	print_ident($ident);
 	echo "<span class=\"trigger\" onClick=\"showBranch('br_",
-		$key, "');swapFolder('fl_", $key, "')\">\n";
+		htmlspecialchars($key), "');swapFolder('fl_", htmlspecialchars($key), "')\">\n";
 	print_ident($ident+1);
-	echo "<img src=\"tree-open.gif\" id=\"fl_", $key, "\">\n";
+	echo "<img src=\"tree-open.gif\" id=\"fl_", htmlspecialchars($key), "\">\n";
 	print_ident($ident+1);
-	echo $key, "<br>\n";
+	echo htmlspecialchars($key), "<br>\n";
 	print_ident($ident);
 	echo "</span>\n";
 	print_ident($ident);
-	echo "<span class=\"branch\" id=\"br_", $key, "\">\n";
+	echo "<span class=\"branch\" id=\"br_", htmlspecialchars($key), "\">\n";
 
 	foreach ($arr as $k => $v) {
 		if ( count(&$v) ) {

--- a/src/webserver/src/php_core_lib.cpp
+++ b/src/webserver/src/php_core_lib.cpp
@@ -278,6 +278,33 @@ void php_native_substr(PHP_VALUE_NODE * /*result*/)
 
 }
 
+void php_native_htmlspecialchars(PHP_VALUE_NODE *result)
+{
+	PHP_SCOPE_ITEM *si_str = get_scope_item(g_current_scope, "__param_0");
+	if ( !si_str ) {
+		php_report_error(PHP_ERROR, "Invalid or missing argument 'string' for 'htmlspecialchars'");
+		return;
+	}
+	PHP_VALUE_NODE *str = &si_str->var->value;
+	cast_value_str(str);
+	if ( result ) {
+		cast_value_dnum(result);
+		std::string escaped;
+		for(const char *p = str->str_val; *p; p++) {
+			switch(*p) {
+				case '&': escaped += "&amp;"; break;
+				case '<': escaped += "&lt;"; break;
+				case '>': escaped += "&gt;"; break;
+				case '"': escaped += "&quot;"; break;
+				case '\'': escaped += "&#039;"; break;
+				default: escaped += *p;
+			}
+		}
+		result->type = PHP_VAL_STRING;
+		result->str_val = strdup(escaped.c_str());
+	}
+}
+
 
 void php_native_split(PHP_VALUE_NODE *result)
 {
@@ -480,6 +507,10 @@ PHP_BLTIN_FUNC_DEF core_lib_funcs[] = {
 		"split",
 		3,
 		php_native_split,
+	},
+	{
+		"htmlspecialchars",
+		1, php_native_htmlspecialchars,
 	},
 #ifdef ENABLE_NLS
 	{

--- a/src/webserver/src/php_core_lib.cpp
+++ b/src/webserver/src/php_core_lib.cpp
@@ -305,6 +305,42 @@ void php_native_htmlspecialchars(PHP_VALUE_NODE *result)
 	}
 }
 
+// Escape a string for safe inclusion inside a quoted JavaScript string
+// literal that lives in an HTML <script> element. On top of the classic PHP
+// addslashes() set (\ " ') this also escapes '<' as \x3C so an embedded
+// "</script>" cannot terminate the <script> block (the HTML parser scans
+// raw-text script content for that literal sequence regardless of JS
+// syntax), and CR/LF as \r/\n so a multi-line value can't break the literal.
+// Every escape decodes back to the original character in JS, so the value is
+// displayed verbatim when assigned to a form field.
+void php_native_addslashes(PHP_VALUE_NODE *result)
+{
+	PHP_SCOPE_ITEM *si_str = get_scope_item(g_current_scope, "__param_0");
+	if ( !si_str ) {
+		php_report_error(PHP_ERROR, "Invalid or missing argument 'string' for 'addslashes'");
+		return;
+	}
+	PHP_VALUE_NODE *str = &si_str->var->value;
+	cast_value_str(str);
+	if ( result ) {
+		cast_value_dnum(result);
+		std::string escaped;
+		for(const char *p = str->str_val; *p; p++) {
+			switch(*p) {
+				case '\\': escaped += "\\\\"; break;
+				case '"':  escaped += "\\\""; break;
+				case '\'': escaped += "\\'"; break;
+				case '<':  escaped += "\\x3C"; break;
+				case '\n': escaped += "\\n"; break;
+				case '\r': escaped += "\\r"; break;
+				default: escaped += *p;
+			}
+		}
+		result->type = PHP_VAL_STRING;
+		result->str_val = strdup(escaped.c_str());
+	}
+}
+
 
 void php_native_split(PHP_VALUE_NODE *result)
 {
@@ -511,6 +547,10 @@ PHP_BLTIN_FUNC_DEF core_lib_funcs[] = {
 	{
 		"htmlspecialchars",
 		1, php_native_htmlspecialchars,
+	},
+	{
+		"addslashes",
+		1, php_native_addslashes,
 	},
 #ifdef ENABLE_NLS
 	{


### PR DESCRIPTION
  ## What

  Fixes stored/reflected XSS in the amuleweb `default` template. Adds two
  escaping builtins to the embedded PHP interpreter and uses them to escape
  every echo of remote-controlled data in the right context.

  ## Why
  Several pages echoed attacker-influenced strings into HTML without escaping, so
  a shared file or server named `<script>…</script>` (or a malicious eD2K server
  name, or a remote client's reported version/OS string) executed JavaScript in
  the admin's authenticated session.
  
  The bundled mini-PHP interpreter had no escaping builtins (`htmlspecialchars`,
  `str_replace`, …), and `include()` is unusable (it resolves against the process
  cwd), so there was previously no clean way to escape from a template.
  
  ## Changes (3 commits)
  
  **1. `htmlspecialchars` builtin** (`php_core_lib.cpp`)
  - Escapes `& < > " '` (matching PHP ≥8.1 `htmlspecialchars` with `ENT_QUOTES`).
  - Byte-wise into a `std::string` — UTF-8 safe (metacharacters are ASCII and
    never appear inside multibyte sequences), no manual buffer sizing.
    
  **2. `addslashes` builtin** (`php_core_lib.cpp`)
  - Escapes a string for a double-quoted **JavaScript string literal inside a
    `<script>` block**. On top of the classic `\ " '` set, it escapes `<` as
    `\x3C` (so an embedded `</script>` cannot terminate the script element) and
    CR/LF as `\r`/`\n`.
  - Every escape decodes back to the original char in JS, so a value assigned to
    a form field is displayed verbatim — unlike `htmlspecialchars`, whose HTML
    entities are not decoded inside a raw-text `<script>`.

  **3. Audit + escape across all `.php` templates**
  - HTML text / attribute context → `htmlspecialchars`: file names, user names
    (dload, shared, search), server name/desc/addr (servers), raw log/serverinfo
    (`log.php`), connected server name/address in the iframe status bar
    (`stats.php`), stats-tree leaf labels (`stats_tree.php`), category names in
    `<option>` lists (dload, search, footer).
  - JS-string context → `addslashes`: the nickname (settable via `?nick=`) and
    option values emitted into the `<script> initvals` block in `prefs.php`.
  - Updated an obsolete comment in `amuleweb-main-search.php` (the `sort` param
    stays whitelisted — stricter than escaping for that reflected value). 

  ## Testing
  
  - `amuleweb` builds clean (no new warnings).
  - Built the standalone interpreter under **AddressSanitizer + UBSan** and ran,
    for both builtins:
    - Functional/edge-case batteries (all specials, empty, non-string types,
      nested calls, UTF-8, missing/extra args).
    - 10k–100k-call loops and multi-MB worst-case inputs — no per-call leaks
      (allocation count independent of iteration count), no overflow.
    - Differential fuzz (hundreds of random byte strings) vs reference escapers —
      exact match.
    - `addslashes`: real-JS (node) **round-trip** — every payload (incl.
      `</script>`, quotes, backslash, newlines, unicode) decodes back to the
      original and never produces a literal `</script>` that closes the block.
    - All 13 templates parse and run clean; crafted payloads render inert and
      display correctly.
  