### PR TITLE
fix(webserver): whitelist search sort param before storing it in the session

### DIFF
--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -207,7 +207,18 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
 		}		
 		$search = amule_load_vars("searchresult");
 
-		$sort_order = $HTTP_GET_VARS["sort"];
+		// Whitelist against the column keys my_cmp() understands, same
+		// pattern as the dload/shared/servers pages. This prevents an
+		// attacker-controlled value from being stored in
+		// $_SESSION["search_sort"] and later reflected into rendered
+		// HTML (#869 follow-up). Anything unknown drops to "", which
+		// falls through to the "keep current sort" branch below.
+		$sort_raw = isset($HTTP_GET_VARS["sort"]) ? $HTTP_GET_VARS["sort"] : "";
+		if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
+			$sort_order = $sort_raw;
+		} else {
+			$sort_order = "";
+		}
 
 		if ( $sort_order == "" ) {
 			$sort_order = $_SESSION["search_sort"];


### PR DESCRIPTION
The search page stored the raw ?sort= query parameter into $_SESSION["search_sort"], unlike the downloads, shared and servers pages, which already validate it against the column keys my_cmp() understands before persisting it (the #869 whitelist pattern).

Although the value stored in the session is not currently echoed back into HTML (the "update search results" link reflects only the already-whitelisted per-request value), keeping an attacker-controlled string in the session is a latent reflected-XSS hazard: any future template change printing that variable would become exploitable.

Apply the same string-equality whitelist (size|name|sources) used by the other three sortable pages. Unknown values drop to "", which falls through to the existing "keep current sort" branch, so behaviour for valid links is unchanged and garbage values no longer toggle the sort-reverse flag either.

Verified against a running amuleweb: ?sort=name and ?sort=sources still sort and are reflected in the update link; ?sort="><script>alert(1) </script> is not reflected anywhere in the response and the page renders normally.