### PR TITLE
fix(webserver): free for() header expression lists in embedded PHP interpreter

### DIFF
--- a/src/webserver/src/php_syntree.cpp
+++ b/src/webserver/src/php_syntree.cpp
@@ -1129,6 +1129,21 @@ void php_exp_tree_free(PHP_EXP_NODE *tree)
                 }
 			}
 			break;
+		case PHP_OP_LIST: {
+				// Comma-separated expression list (e.g. the three clauses of
+				// a for() header). The payload of each node lives in exp_node,
+				// not in tree_node.left/right, so the default branch below would
+				// delete the list spine but leak every payload subtree. Walk the
+				// ->next chain and free both, like echo / switch do inline.
+				PHP_EXP_NODE *curr = tree;
+				while (curr) {
+					PHP_EXP_NODE *next = curr->next;
+					php_exp_tree_free(curr->exp_node);
+					delete curr;
+					curr = next;
+				}
+			}
+			return;
 		case PHP_OP_MUX:
 			php_exp_tree_free(tree->exp_node);
 		/* fall through */


### PR DESCRIPTION
The three clauses of a for() header are comma-separated expression lists (PHP_OP_LIST chains). php_exp_tree_free() had no PHP_OP_LIST case, so list nodes fell through to the default branch, which frees tree_node.left/right but never the exp_node payloads — leaking every init/cond/step subtree once per parsed for() loop (echo and switch avoided this by walking their lists inline). Add a PHP_OP_LIST case that walks the ->next chain and frees both the payloads and the list spine.