### PR TITLE
fix(webserver): upgrade default template to the HTML5 doctype

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/amuleweb-main-kad.php
+++ b/src/webserver/default/amuleweb-main-kad.php
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/amuleweb-main-log.php
+++ b/src/webserver/default/amuleweb-main-log.php
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/amuleweb-main-stats.php
+++ b/src/webserver/default/amuleweb-main-stats.php
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/footer.php
+++ b/src/webserver/default/footer.php
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-"http://www.w3.org/TR/html4/loose.dtd">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/index.html
+++ b/src/webserver/default/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/log.php
+++ b/src/webserver/default/log.php
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-"http://www.w3.org/TR/html4/loose.dtd">
+<!doctype html>
 <html><head>
 <title>aMule control panel</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title><script language="JavaScript" type="text/javascript">

--- a/src/webserver/default/stats.php
+++ b/src/webserver/default/stats.php
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-"http://www.w3.org/TR/html4/loose.dtd">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/stats_tree.php
+++ b/src/webserver/default/stats_tree.php
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-"http://www.w3.org/TR/html4/loose.dtd">
+<!doctype html>
 <html>
 <head>
 <title>aMule control panel</title>

--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -119,6 +119,10 @@ textarea {
 	font-size: 12px;
 	color: white;
 }
+html,
+body.main {
+	height: 100%;
+}
 body.main {
 	margin: 0;
 	background-image: url(images/fond.gif);
@@ -156,7 +160,6 @@ table.page > tbody > tr:first-child {
 	vertical-align: top;
 }
 table.page > tbody > tr:nth-child(2) {
-	text-align: center;
 	vertical-align: top;
 }
 table.page > tbody > tr:last-child {
@@ -168,6 +171,9 @@ table.page > tbody > tr:last-child > td {
 td.logo-cell {
 	width: 143px;
 	height: 64px;
+}
+td.logo-cell > img {
+	display: block;
 }
 td.navbar-cell {
 	width: 100%;
@@ -199,7 +205,7 @@ table.prefs-grid {
 	margin-right: auto;
 	border-spacing: 6px;
 }
-table.prefs-grid > tbody > tr {
+table.prefs-grid > tbody > tr:last-child {
 	text-align: center;
 }
 table.prefs-grid > tbody > tr:not(:last-child) {
@@ -239,6 +245,10 @@ table.footer-bar iframe {
 }
 table.tab {
 	width: 100%;
+}
+table.tab > tbody > tr:first-child > td > img,
+table.tab > tbody > tr:last-child > td > img {
+	display: block;
 }
 table.tab > tbody > tr > td:first-child,
 table.tab > tbody > tr > td:last-child {


### PR DESCRIPTION
Replace the HTML 4.01 Transitional doctype with <!doctype html> in all 14 template files. The old doctype (without a system URI on most pages) made browsers render the UI in quirks mode; every page now renders in standards mode (document.compatMode == "CSS1Compat").

The mode switch changes three layout behaviours that the table-based layout relied on, compensated in style.css:

- Percentage heights now need an explicit ancestor height, so the height:100% on table.page no longer reached the viewport and the footer bar floated up right under the content. Give html and body.main height:100% to restore it.
- text-align now inherits into nested tables (quirks mode blocked that), so the centering rules on table.page row 2 and on table.prefs-grid rows leaked into the content tables, centering every file name and preference label. Drop the former (its children are full-width or self-centered) and scope the latter to the last row, which centers the Apply button.
- Inline images now sit on the text baseline, leaving a descender gap under them. This let the page background show through between the rounded tab corners and the content, and stretched the 64px header row to 67px, exposing a vertical tiling artifact of fond_haut.png below the navbar. Display the tab corner images and the header logo as blocks.

Verified with before/after headless-Chromium screenshots of every page (login, downloads, servers, shared, search, stats, kad, prefs, log and the footer/stats iframes): rendering is pixel-equivalent except for sub-3px text shifts, and no new console errors appear.