### PR TITLE
fix(webserver): remove stale onLoad tree calls in stats_tree.php

### DIFF
--- a/src/webserver/default/stats_tree.php
+++ b/src/webserver/default/stats_tree.php
@@ -53,7 +53,7 @@ function swapFolder(img){
 }
 
 </script>
-<body onLoad="showBranch('br_Stats');swapFolder('fl_Stats')">
+<body>
 <?php
 
 function print_ident($i)


### PR DESCRIPTION
The body onLoad ran showBranch('br_Stats') and swapFolder('fl_Stats'), written in 2008 when the stats tree had a single root node named "Stats". The daemon has emitted multiple top-level branches (Transfer, Connection, Clients, Servers, Shared Files) ever since, so document.getElementById('br_Stats') is null and the handler threw an uncaught TypeError on every page load without doing anything.

Remove the onLoad. The rendered state is unchanged (all branches start expanded, which is what the broken handler already produced) and the per-branch click-to-toggle handlers keep working; verified in headless Chromium that the statistics page now loads with a clean console and that collapsing/expanding a branch still works.