### PR TITLE
fix(ip2country): default ENABLE_IP2COUNTRY=ON, hard-fail on missing dep

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -164,21 +164,7 @@ if (NEED_LIB_MULECOMMON)
 endif()
 
 if (NEED_LIB_MULEAPPCOMMON)
-	# Auto-default ENABLE_IP2COUNTRY based on whether libmaxminddb is
-	# discoverable. The probe also runs from cmake/ip2country.cmake when
-	# the feature is actually wired up, but this pre-check lets the
-	# option default to ON whenever the user has the library installed —
-	# avoiding the silent-no-feature surprise where a distro shipping
-	# libmaxminddb-dev still produced an aMule build with no country-
-	# flag UI because no one passed -DENABLE_IP2COUNTRY=YES. Users can
-	# still force the feature off with -DENABLE_IP2COUNTRY=NO.
-	find_path    (MAXMINDDB_INCLUDE_DIR maxminddb.h)
-	find_library (MAXMINDDB_LIB         maxminddb)
-	if (MAXMINDDB_INCLUDE_DIR AND MAXMINDDB_LIB)
-		option (ENABLE_IP2COUNTRY "compile with GeoIP IP2Country library" ON)
-	else()
-		option (ENABLE_IP2COUNTRY "compile with GeoIP IP2Country library" OFF)
-	endif()
+	option (ENABLE_IP2COUNTRY "compile with GeoIP IP2Country library" ON)
 	option (ENABLE_MMAP "enable using mapped memory if supported")
 	option (ENABLE_NLS "enable national language support" ON)
 	# Backtrace symbol resolution: ON => use libbfd for in-process

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -131,7 +131,7 @@ Common `-D` options (`YES` / `NO`):
 | `BUILD_FILEVIEW`     | NO      | console file viewer (experimental)                               |
 | `ENABLE_NLS`         | YES     | native-language support (gettext)                                |
 | `ENABLE_UPNP`        | YES     | UPnP port forwarding                                             |
-| `ENABLE_IP2COUNTRY`  | NO      | libmaxminddb country flags ([docs/IP2Country.md](IP2Country.md)) |
+| `ENABLE_IP2COUNTRY`  | YES     | libmaxminddb country flags ([docs/IP2Country.md](IP2Country.md)) |
 
 For the full list:
 

--- a/docs/IP2Country.md
+++ b/docs/IP2Country.md
@@ -13,9 +13,10 @@ auto-update from inside aMule — no `amule.conf` editing required.
 
 ## Build prerequisites
 
-`libmaxminddb` must be installed and discoverable by CMake's
-`find_path(maxminddb.h)` and `find_library(maxminddb)` for the
-IP2Country feature to be compiled in.
+`ENABLE_IP2COUNTRY` defaults to `ON`. `libmaxminddb` must be installed
+for the configure step to succeed; if it isn't, CMake emits a fatal
+error pointing to this page. Users who don't want the country-flag
+feature can opt out with `-DENABLE_IP2COUNTRY=NO`.
 
 | Platform               | Install                                                  |
 |------------------------|----------------------------------------------------------|
@@ -26,9 +27,8 @@ IP2Country feature to be compiled in.
 | MSYS2 (Windows clang)  | `pacman -S mingw-w64-clang-aarch64-libmaxminddb` (ARM64) |
 | MSYS2 (Windows MinGW)  | `pacman -S mingw-w64-x86_64-libmaxminddb` (x64)          |
 
-If the library is not present at configure time, `ENABLE_IP2COUNTRY` is
-set to `OFF`, the feature is omitted from the build with a status
-message, and the `IP2Country` preferences tab is hidden.
+This matches the pattern used by `ENABLE_NLS`, `ENABLE_BFD`, and
+`ENABLE_UPNP` — defaulted on, hard-fail on missing dep, explicit opt-out.
 
 
 ## The IP2Country preferences tab


### PR DESCRIPTION
## Summary

Follow-up to #113 review feedback from @Vollstrecker. Drops the probe-driven default in `cmake/options.cmake` that flipped `ENABLE_IP2COUNTRY` based on whether `libmaxminddb` was discoverable. The probe was a "silent activation" that conflicted with the project's feature-gating policy.

## Fix

Switch to the same shape used by `ENABLE_NLS`, `ENABLE_BFD`, and `ENABLE_UPNP`: default the option `ON` unconditionally. `cmake/ip2country.cmake` already produces a `FATAL_ERROR` with an actionable hint ("install libmaxminddb-dev or pass `-DENABLE_IP2COUNTRY=NO`") when the dep is missing, so the missing-dep UX is preserved.

Net effect on the configure matrix:

| User has libmaxminddb? | User passes flag? | Before this PR | After this PR |
|---|---|---|---|
| yes | unset | auto-ON | ON (default) |
| yes | `=YES` | ON | ON |
| yes | `=NO` | OFF | OFF |
| no | unset | auto-OFF (silent) | **FATAL_ERROR** (actionable) |
| no | `=YES` | FATAL_ERROR | FATAL_ERROR |
| no | `=NO` | OFF | OFF |

The behavioural change is in row 4: a user on a system without `libmaxminddb` who never set the flag previously got a silent no-feature build; they now get a configure-time error pointing them at the right `apt`/`dnf`/`brew` install or the `-DENABLE_IP2COUNTRY=NO` opt-out — matching how NLS/UPnP handle missing deps today.

## Docs

- `docs/INSTALL.md` — table cell flipped `NO` → `YES`.
- `docs/IP2Country.md` — "Build prerequisites" paragraph rewritten to describe the hard-fail behaviour and the opt-out flag.

## Test plan

- [x] macOS arm64 with `libmaxminddb` installed, no flag: configures cleanly with `ENABLE_IP2COUNTRY=ON`, builds, binary links `libmaxminddb.0.dylib`.
- [x] macOS arm64 with `libmaxminddb` hidden via `CMAKE_IGNORE_PATH`: configure hard-fails at `cmake/ip2country.cmake:21` with the install/opt-out hint.
- [x] CI build matrix (Ubuntu / macOS / mingw-w64 × Debug / Release).