### PR TITLE
feat(amulegui): populate Server Info tab from amuled via EC

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -218,6 +218,17 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent&)
 			|| amuledlg->m_serverwnd->IsShown()) {
 			// update downloads, shared files and servers
 			knownfiles->DoRequery(EC_OP_GET_UPDATE, EC_TAG_KNOWNFILE);
+			// Server-message log mirror: pull the cumulative
+			// server_msg buffer while the Network tab is up so the
+			// "Server Info" sub-panel reaches feature parity with
+			// the monolithic build. ed2k server messages are bursty
+			// (one-off on connect, the occasional ID-change notice,
+			// disconnect) so the natural ~3 s cadence of step 2 is
+			// plenty.
+			if (amuledlg->m_serverwnd->IsShown()) {
+				CECPacket srvinfo_req(EC_OP_GET_SERVERINFO);
+				m_connect->SendRequest(&m_serverinfo_handler, &srvinfo_req);
+			}
 		} else if (amuledlg->m_transferwnd->IsShown()) {
 			// update both downloads and shared files
 			knownfiles->DoRequery(EC_OP_GET_UPDATE, EC_TAG_KNOWNFILE);
@@ -663,9 +674,63 @@ wxString CamuleRemoteGuiApp::GetLog(bool reset)
 }
 
 
-wxString CamuleRemoteGuiApp::GetServerLog(bool)
+wxString CamuleRemoteGuiApp::GetServerLog(bool reset)
 {
+	if (reset) {
+		// Mirror the GetLog reset path: clear the remote buffer, the
+		// local snapshot we diff against, and the on-screen text ctrl.
+		CECPacket req(EC_OP_CLEAR_SERVERINFO);
+		m_connect->SendPacket(&req);
+		m_serverinfo_handler.m_seenSoFar.clear();
+		amuledlg->ResetLog(ID_SERVERINFO);
+	}
 	return "";
+}
+
+
+void CamuleRemoteGuiApp::AddServerMessageLine(wxString &msg)
+{
+	// Drives the same CamuleDlg::AddServerMessageLine the monolithic
+	// build calls -- ID_SERVERINFO text ctrl + 500-char truncation +
+	// auto-scroll. Cumulative-log diffing happens in
+	// CServerInfoHandlerRem::HandlePacket; by the time we land here
+	// `msg` is a single new line, ready to append.
+	amuledlg->AddServerMessageLine(msg);
+}
+
+
+void CServerInfoHandlerRem::HandlePacket(const CECPacket *packet)
+{
+	// amuled answers EC_OP_GET_SERVERINFO with one EC_TAG_STRING
+	// carrying the full cumulative server_msg buffer. Diff against
+	// what we've already shown so the text ctrl receives only new
+	// lines (preserves scroll position and avoids re-rendering tens
+	// of KB on every poll).
+	const CECTag *tag = packet->GetFirstTagSafe();
+	if (!tag || !tag->IsString()) {
+		return;
+	}
+	const wxString fullLog = tag->GetStringData();
+
+	wxString delta;
+	if (fullLog.StartsWith(m_seenSoFar)) {
+		delta = fullLog.Mid(m_seenSoFar.length());
+	} else {
+		// amuled was restarted, or someone else issued a clear, so the
+		// remote cumulative buffer is shorter or unrelated. Wipe the
+		// local view and start fresh from the current snapshot.
+		theApp->amuledlg->ResetLog(ID_SERVERINFO);
+		delta = fullLog;
+	}
+	m_seenSoFar = fullLog;
+
+	while (!delta.IsEmpty()) {
+		wxString line = delta.BeforeFirst('\n');
+		delta = delta.AfterFirst('\n');
+		if (!line.IsEmpty()) {
+			theApp->AddServerMessageLine(line);
+		}
+	}
 }
 
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -643,6 +643,19 @@ public:
 	CStatsUpdaterRem() {}
 };
 
+// Server-message log mirror. amuled accumulates ed2k server messages in
+// CamuleApp::server_msg and serves them as one EC_TAG_STRING tag on
+// EC_OP_GET_SERVERINFO. We poll periodically while the network/servers
+// tab is visible, keep the last-seen snapshot in m_seenSoFar, and feed
+// only the new tail through CamuleDlg::AddServerMessageLine so the GUI
+// text control behaves the same as the monolithic build (append-only,
+// no scroll reset). EC_OP_CLEAR_SERVERINFO is used on the Reset button.
+class CServerInfoHandlerRem : public CECPacketHandlerBase {
+public:
+	wxString m_seenSoFar;
+	virtual void HandlePacket(const CECPacket *);
+};
+
 class CStatTreeRem : public CECPacketHandlerBase {
 	virtual void HandlePacket(const CECPacket *);
 	CRemoteConnect *m_conn;
@@ -719,6 +732,7 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 	void OnFinishedHTTPDownload(CMuleInternalEvent& event);
 
 	CStatsUpdaterRem m_stats_updater;
+	CServerInfoHandlerRem m_serverinfo_handler;
 public:
 
 	void Startup();

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -1579,9 +1579,12 @@ void CamuleDlg::DoNetworkRearrange()
 	}
 
 	if (thePrefs::GetNetworkED2K()) {
-#ifndef CLIENT_GUI
+		// "Server Info" sub-panel. Previously CLIENT_GUI-gated because
+		// amulegui had no way to populate ID_SERVERINFO from amuled;
+		// the EC_OP_GET_SERVERINFO / EC_OP_CLEAR_SERVERINFO polling
+		// in CamuleRemoteGuiApp now mirrors the server_msg buffer, so
+		// the tab is shown unconditionally as in the monolithic build.
 		logs_notebook->AddPage(m_logpages[1].page, m_logpages[1].name);
-#endif
 		logs_notebook->AddPage(m_logpages[2].page, m_logpages[2].name);
 	}
 


### PR DESCRIPTION
## Summary

Addresses the first item in #54 — the **"Server Info"** sub-tab on the Network panel was present in `amule` (monolithic) but missing in `amulegui`. The tab UI has actually been generated by `serverListDlgDown` for years, but [amuleDlg.cpp:1581-1586](src/amuleDlg.cpp#L1581-L1586) gated its `AddPage` behind `#ifndef CLIENT_GUI`, because no one had wired the EC plumbing to populate it. This PR wires the plumbing and drops the gate. The other items in #54 (directory tree behaviour and the broader preferences enable/disable audit) are intentionally left for follow-ups; the issue stays open.

## What was already there

- amuled tracks every ed2k server message in `CamuleApp::server_msg` ([amule.cpp:1841](src/amule.cpp#L1841)) and exposes it on EC as `EC_OP_GET_SERVERINFO` / `EC_OP_SERVERINFO` / `EC_OP_CLEAR_SERVERINFO` ([ExternalConn.cpp:2230-2237](src/ExternalConn.cpp#L2230-L2237)). amuleweb has consumed these for years ([php_amule_lib.cpp:705-715](src/webserver/src/php_amule_lib.cpp#L705-L715)).
- `CRemoteConnect::GetServerInfo` / `ClearServerInfo` ([RemoteConnect.h:293,302](src/libs/ec/cpp/RemoteConnect.h#L293-L302)) were *declared* back in 2009 (sturedman's "Implement directory preferences in remote gui" commit) but never implemented, never called, and the declarations have been dead weight ever since.

## What this PR adds

- **`CServerInfoHandlerRem`** in [amule-remote-gui.h](src/amule-remote-gui.h) — an `EC_OP_GET_SERVERINFO` response handler that keeps the last-seen snapshot in `m_seenSoFar`, computes a delta against the fresh response, and only feeds the new tail to the GUI. Diff-based update preserves scroll position and avoids re-rendering the full log on every poll. On a non-monotonic delta (e.g. amuled restarted, or another client called `EC_OP_CLEAR_SERVERINFO`), the handler resets `ID_SERVERINFO` and refills from the current snapshot.
- **Polling hook** in `CamuleRemoteGuiApp::OnPollTimer` step 2 — fires the EC request only while the Network tab is visible. Step 2's natural ~3 s cadence is plenty for the bursty traffic pattern (welcome on connect, ID change, disconnect) and doesn't wake amuled when the user isn't looking.
- **`CamuleRemoteGuiApp::AddServerMessageLine`** — dispatches to `CamuleDlg::AddServerMessageLine`, the same code path the monolithic build calls, so `ID_SERVERINFO` (500-char truncation + auto-scroll) behaves identically.
- **`CamuleRemoteGuiApp::GetServerLog(true)`** — was a stub that returned `""`; now issues `EC_OP_CLEAR_SERVERINFO`, resets `m_seenSoFar`, and clears `ID_SERVERINFO` so the existing "Reset" button on the Server Info panel (wired via [ServerWnd.cpp:171](src/ServerWnd.cpp#L171)) works the same as in monolithic.
- Drops the `#ifndef CLIENT_GUI` gate at [amuleDlg.cpp:1582](src/amuleDlg.cpp#L1582) so the tab is shown unconditionally.

## What's deliberately *not* in this PR (left for the rest of #54)

- The directory-tree behaviour when amulegui is on remote vs localhost (item 2 in the issue) — separate, larger discussion about how the tree should source data and whether dirpickers should be only-Browse-disabled vs fully disabled (item 3).
- A broader audit of which preferences panels should be local-only vs amuled-driven vs shared via EC. That deserves its own thread with @ngosang per-tab.

## Test plan

- [x] Local: built clean on macOS Release (`cmake --build build-macos --target amulegui`).
- [x] Live: ran the rebuilt `aMuleGUI.app` against an `amuled` on a remote ARM64 Ubuntu VM. After amuled connected to an ed2k server, the welcome message appeared in the Server Info sub-tab within ~3 s, and "Reset" both cleared the on-screen log and emptied amuled's `server_msg` buffer (verified by the next poll arriving empty).
- [x] CI green on Ubuntu / macOS / mingw-w64.