### PR TITLE
fix(socket): SO_REUSEADDR on UDP for post-suspend rebind

### DIFF
--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -1447,6 +1447,13 @@ private:
 			// without binding".
 			m_socket = new ip::udp::socket(s_io_service);
 			m_socket->open(endpoint.protocol());
+			// SO_REUSEADDR so a post-suspend rebind (DestroySocket +
+			// CreateSocket in CMuleUDPSocket::OnReceive when a read
+			// callback returns an error) doesn't hit EADDRINUSE while
+			// the kernel still considers the previous binding live.
+			// Without this Kad and the ed2k client UDP stay broken
+			// until the user restarts amule — see #103.
+			m_socket->set_option(socket_base::reuse_address(true));
 			SetCloexecOnSocket(m_socket->native_handle());
 			m_socket->bind(endpoint);
 			AddDebugLogLineN(logAsio, CFormat("Created UDP socket %s %d") % m_address.IPAddress() % m_address.Service());


### PR DESCRIPTION
## Summary

Refs #103. Fixes a Kad / ed2k-client-UDP wedge after suspend/resume on Linux (reported by @demanuel against the Flatpak prerelease).

## Root cause

`CMuleUDPSocket::OnReceive` drives a `DestroySocket()` + `CreateSocket()` self-recovery cycle whenever a read callback returns an error or `!IsOk()`. On Linux, after `systemd-suspend` returns, the first post-resume read sometimes delivers a transient error that hits this path. The destroy step closes the previous fd, but the kernel can still consider the binding live for a short window, so the immediate rebind fails:

```
Error creating UDP socket 0.0.0.0 4672 : Address already in use
MuleUDPSocket: Failed to create valid Client UDP-Socket
```

With the rebind failing, Kad never gets a working UDP socket back ("Kad: Connecting" forever) and ed2k client UDP is broken until the user fully restarts amule. demanuel's log + `ss -tan | grep :4661` (empty) at #103 ruled out the earlier TCP-stuck-dead hypothesis and pointed straight at the UDP rebind path.

## Fix

Set `SO_REUSEADDR` on the UDP socket between `open()` and `bind()` in `CAsioUDPSocketImpl::CreateSocket`. The TCP acceptor path at LibSocketAsio.cpp:995 already sets `reuse_address(true)` for the equivalent reason; this is the same fix applied to the UDP path.

No behavioural change for the cold-start case — the option only matters when there's a previous binding the kernel hasn't fully released yet.

## Status

**Draft.** Pending real-world confirmation from @demanuel that a suspend/resume cycle no longer wedges Kad. Packaging artifacts will be built from this branch on the fork (`got3nks/amule`) so demanuel can download a Flatpak/AppImage/Windows zip without building from source.

## Test plan

- [x] macOS build clean.
- [x] Linux suspend/resume reproduction by reporter.
- [x] CI build matrix on this PR.