### PR TITLE
feat(shared): default "Show Clients for" to "All files"

### DIFF
--- a/src/SharedFilesWnd.cpp
+++ b/src/SharedFilesWnd.cpp
@@ -73,7 +73,7 @@ CSharedFilesWnd::CSharedFilesWnd( wxWindow* pParent )
 	peerslistctrl->SetShowing(show);
 	// Load the last used splitter position
 	m_splitter = config->Read( "/GUI/SharedWnd/Splitter", 463l );
-	m_clientShow = (EClientShow) config->Read("/GUI/SharedWnd/ClientShowMode", ClientShowSelected);
+	m_clientShow = (EClientShow) config->Read("/GUI/SharedWnd/ClientShowMode", ClientShowAll);
 	m_radioClientMode->SetSelection(m_clientShow);
 }
 


### PR DESCRIPTION
## Summary

Closes #114. The "Show Clients for" radio on the Shared Files tab defaulted to `ClientShowSelected`, which only populates the peer table once the user clicks on a specific file. First-time users land on the tab, see an empty list, and have no obvious cue that selecting a file is required. Flipping the default to `ClientShowAll` makes the tab self-explanatory.

## Change

One line in [`CSharedFilesWnd::CSharedFilesWnd`](src/SharedFilesWnd.cpp#L76):

```diff
- m_clientShow = (EClientShow) config->Read("/GUI/SharedWnd/ClientShowMode", ClientShowSelected);
+ m_clientShow = (EClientShow) config->Read("/GUI/SharedWnd/ClientShowMode", ClientShowAll);
```

The change is in core code shared between the monolithic `amule` and `amulegui` builds (the surrounding `#ifdef CLIENT_GUI` blocks are at lines 197 and 214; this line is outside both), so both targets pick up the new default.

## Behaviour for existing users

Unchanged. Anyone who has previously opened the Shared Files tab has the explicit selection persisted in `~/.aMule/amule.conf` under `[GUI/SharedWnd]` → `ClientShowMode=…`, so `wxConfigBase::Read` returns their saved value rather than the new fallback. Only fresh installs and users who've never opened that tab see the changed default.

## Test plan

- [x] Built clean on macOS for both `amule` and `amulegui` (`cmake --build build-macos --target amule amulegui`).
- [ ] CI green on Ubuntu / macOS / mingw-w64.
- [ ] Manual: fresh `~/.aMule/` → open Shared Files tab → "All files" pre-selected, peer list populated immediately.