### PR TITLE
fix(kad): refresh status bar after StopKad()

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -2301,6 +2301,12 @@ void CamuleApp::StopKad()
 	// Stop Kad if it's running
 	if (Kademlia::CKademlia::IsRunning()) {
 		Kademlia::CKademlia::Stop();
+		// Refresh the status-bar Kad indicator immediately; the
+		// symmetric BootstrapKad() path already does this after
+		// Start(). Without it the "Disconnect Kad" button in
+		// KadDlg leaves a stale "Connected to Kad" indicator
+		// until the next periodic refresh in the main timer.
+		ShowConnectionState();
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #131. The "Disconnect Kad" button in KadDlg stopped Kademlia but left the status-bar Kad indicator stuck on "Connected to Kad" until the next periodic refresh, as reported with screenshots.

## Root cause

`CamuleApp::StopKad()` at amule.cpp:2299 called `Kademlia::CKademlia::Stop()` but never `ShowConnectionState()`. The symmetric `BootstrapKad()` path at amule.cpp:2312 already calls `ShowConnectionState()` after `Start()` — the asymmetry was the bug.

## Fix

Add the matching `ShowConnectionState()` call after `Stop()` so the status-bar indicator refreshes immediately (`ShowConnectionState` is a local UI-side refresh — it computes the connection bitmask and calls `Notify_ShowConnState` to update the main window; no EC traffic).

## Scope

Visible to users via `KadDlg.cpp:206` (the "Disconnect Kad" button) — that path calls `theApp->StopKad()` directly with no follow-up refresh.

The EC handlers in `ExternalConn.cpp` (cases around lines 2267, 2274, 2294, 2328, 2345) already call `ShowConnectionState()` themselves after stopping Kad, so they were not affected. The internal `amule.cpp:1442` (lost-connection in the main timer loop) and `amule.cpp:1696` (shutdown) paths are also unaffected — the surrounding code in those frames already refreshes.

Putting the call inside `StopKad()` means future callers don't have to remember to refresh.

## Test plan

- [x] macOS arm64 build clean.
- [x] CI build matrix.
- [x] Manual: launch amule, ensure Kad shows "Connected", click "Disconnect Kad" in the Kad dialog, status bar should immediately flip to "Disconnected".