### PR TITLE
fix(amulegui): keep stats + Kad graphs populated across tab switches

### DIFF
--- a/src/OScopeCtrl.cpp
+++ b/src/OScopeCtrl.cpp
@@ -433,7 +433,6 @@ void COScopeCtrl::DrawPoints(const std::vector<float *> &apf, unsigned cntPoints
 }
 
 
-#ifndef CLIENT_GUI
 void COScopeCtrl::PlotHistory(unsigned cntPoints, bool bShiftGraph, bool bRefresh)
 {
 	wxASSERT(graph_type != GRAPH_INVALID);
@@ -477,12 +476,6 @@ void COScopeCtrl::PlotHistory(unsigned cntPoints, bool bShiftGraph, bool bRefres
 		// No history (yet) for Kad.
 	}
 }
-#else
-//#warning CORE/GUI -- EC needed
-void COScopeCtrl::PlotHistory(unsigned, bool, bool)
-{
-}
-#endif
 
 
 void COScopeCtrl::RecreateGraph(bool bRefresh)

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -59,9 +59,10 @@
 #endif /* __BSD__ */
 
 
-#ifndef CLIENT_GUI
-
 /*----- CPreciseRateCounter -----*/
+// Shared with CLIENT_GUI: used by the runAvg trend ([1]) in
+// CStatistics::ComputeAverages, which both builds drive through
+// CStatistics::GetHistory.
 
 void CPreciseRateCounter::CalculateRate(uint64_t now)
 {
@@ -99,6 +100,8 @@ void CPreciseRateCounter::CalculateRate(uint64_t now)
 	}
 }
 
+
+#ifndef CLIENT_GUI
 
 /*----- CStatTreeItemRateCounter -----*/
 
@@ -420,6 +423,10 @@ void CStatistics::RecordHistory()
 }
 
 
+#endif // !CLIENT_GUI -- GetHistory + ComputeAverages are shared with
+       // CLIENT_GUI's CStatistics so COScopeCtrl::PlotHistory has a
+       // single implementation for both builds.
+
 unsigned CStatistics::GetHistory(	// Assemble arrays of sample points for a graph
 	unsigned cntPoints,		// number of sample points to assemble
 	double sStep,			// time difference between sample points
@@ -494,6 +501,7 @@ unsigned CStatistics::GetHistory(	// Assemble arrays of sample points for a grap
 	return cntFilled;
 }
 
+#ifndef CLIENT_GUI
 
 unsigned CStatistics::GetHistoryForWeb(  // Assemble arrays of sample points for the webserver
 	unsigned cntPoints,		// maximum number of sample points to assemble
@@ -645,6 +653,8 @@ unsigned CStatistics::GetHistoryForGui(
 }
 
 
+#endif // !CLIENT_GUI -- ComputeAverages is shared too.
+
 void CStatistics::ComputeAverages(
 	HR		**pphr,		// pointer to (end of) array of assembled history records
 	listRPOS	pos,		// position in history list from which to backtrack
@@ -733,6 +743,7 @@ void CStatistics::ComputeAverages(
 	}
 }
 
+#ifndef CLIENT_GUI
 
 GraphUpdateInfo CStatistics::GetPointsForUpdate()
 {
@@ -1065,9 +1076,18 @@ void CStatistics::RemoveKnownClient(uint32 clientSoft, uint32 clientVersion, con
 #else /* CLIENT_GUI */
 
 CStatistics::CStatistics(CRemoteConnect &conn)
-	: m_conn(conn)
+	: m_conn(conn),
+	  m_graphRunningAvgDown(thePrefs::GetStatsAverageMinutes() * 60 * 1000, true),
+	  m_graphRunningAvgUp(thePrefs::GetStatsAverageMinutes() * 60 * 1000, true),
+	  m_graphRunningAvgKad(thePrefs::GetStatsAverageMinutes() * 60 * 1000, true)
 {
 	s_start_time = GetTickCount64();
+	average_minutes = thePrefs::GetStatsAverageMinutes();
+
+	// Sentinel HR used by GetHistory when sTarget underflows past the
+	// beginning of listHR; matches the monolithic ctor's hrInit.
+	HR hr = {0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, 0};
+	hrInit = hr;
 
 	// Init Tree
 	s_statTree = new CStatTreeItemBase(_("Statistics"), 0);
@@ -1081,7 +1101,17 @@ CStatistics::CStatistics(CRemoteConnect &conn)
 
 CStatistics::~CStatistics()
 {
+	listHR.clear();
 	delete s_statTree;
+}
+
+
+void CStatistics::AddHistoryRecord(const HR& hr)
+{
+	listHR.push_back(hr);
+	while (listHR.size() > kHistoryCap) {
+		listHR.pop_front();
+	}
 }
 
 

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -29,6 +29,7 @@
 
 #include "Constants.h"		// Needed for StatsGraphType
 #include "StatTree.h"		// Needed for CStatTreeItem* classes
+#include "GetTickCount.h"	// Needed for GetTickCount64 in CPreciseRateCounter ctor
 
 #include <deque>		// Needed for std::deque
 
@@ -54,7 +55,10 @@ typedef struct HistoryRecord {
 } HR;
 
 
-#ifndef CLIENT_GUI
+// CPreciseRateCounter is the only history-bookkeeping primitive that
+// CLIENT_GUI needs (for the runAvg trend on remote stats graphs), so
+// it lives outside the #ifndef CLIENT_GUI gate even though the
+// CStatTree* derivatives below are monolithic-only.
 
 /**
  * Counts precise rate/average on added bytes/values.
@@ -139,6 +143,8 @@ class CPreciseRateCounter {
 	bool		m_count_average;
 };
 
+
+#ifndef CLIENT_GUI
 
 class CECTag;
 
@@ -531,9 +537,35 @@ private:
 	static uint64 s_statData[sdTotalItems];
 	uint8 average_minutes;
 
+	// History ring for the Statistics + Network->Kad graphs. Filled by
+	// CStatGraphRem::HandlePacket (one HR per decoded point) so the
+	// shared COScopeCtrl::PlotHistory path can replay across tab
+	// switches and auto-rescale events without a daemon round-trip.
+	std::list<HR>				listHR;
+	typedef std::list<HR>::iterator		listPOS;
+	typedef std::list<HR>::reverse_iterator	listRPOS;
+	HR					hrInit;
+	CPreciseRateCounter			m_graphRunningAvgDown;
+	CPreciseRateCounter			m_graphRunningAvgUp;
+	CPreciseRateCounter			m_graphRunningAvgKad;
+
  public:
 	CStatistics(CRemoteConnect &conn);
 	~CStatistics();
+
+	// Shared with the monolithic build (definitions outside any
+	// CLIENT_GUI gate in Statistics.cpp): assemble a contiguous arrays
+	// of sample points from listHR for the requested graph_type, and
+	// fold the per-trend running averages on top.
+	unsigned GetHistory(unsigned cntPoints, double sStep, double sFinal,
+		const std::vector<float *> &ppf, StatsGraphType which_graph);
+
+	// CLIENT_GUI-only producer (no analogue on monolithic, where
+	// RecordHistory() does the equivalent push from local counters).
+	// Appends one HR record to listHR and caps the ring at
+	// kHistoryCap so memory stays bounded across long sessions.
+	void AddHistoryRecord(const HR& hr);
+	static const size_t kHistoryCap = 1800;	// ~30 min @ 1 Hz
 
 	static	uint64	GetUptimeMillis();
 	static	uint64	GetUptimeSeconds();
@@ -576,6 +608,10 @@ private:
 
  private:
 	static	CStatTreeItemBase*	GetTreeRoot()		{ return s_statTree; }
+
+	// Helper for GetHistory(); shared with the monolithic build.
+	void ComputeAverages(HR **pphr, listRPOS pos, unsigned cntFilled,
+		double sStep, const std::vector<float *> &ppf, StatsGraphType which_graph);
 };
 
 #endif /* !CLIENT_GUI / CLIENT_GUI */

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -2828,6 +2828,34 @@ void CStatGraphRem::HandlePacket(const CECPacket * p)
 		theApp->amuledlg->m_statisticswnd->UpdateStatGraphs(
 			m_peakConnections, update);
 		theApp->amuledlg->m_kademliawnd->UpdateGraph(update);
+
+		// Mirror the decoded point into the client-side history ring
+		// so COScopeCtrl::PlotHistory (now shared with monolithic) can
+		// replay across tab switches and auto-rescale wipes without
+		// another daemon round-trip. Field mapping mirrors
+		// CStatistics::GetPointsForUpdate so the same GetHistory +
+		// ComputeAverages code paths read it back correctly:
+		//   kBytes{Received,Sent} / kadNodesTotal are stored as
+		//   (session rate * timestamp) so ComputeAverages's
+		//   "kValueRun / sTimestamp" recovers the session-avg trend.
+		// Per-point timestamps are reconstructed from the batch by
+		// stepping back from m_lastTimestamp at 1 s spacing (matches
+		// the scale we request in DoRequery).
+		const double sStep = 1.0;
+		const double pointTs = m_lastTimestamp - (double)(numPoints - 1 - i) * sStep;
+		HR hr = {
+			/* kBytesSent     */ (double)sessionUl  * pointTs,
+			/* kBytesReceived */ (double)sessionDl  * pointTs,
+			/* kBpsUpCur      */ ul_kbps,
+			/* kBpsDownCur    */ dl_kbps,
+			/* sTimestamp     */ pointTs,
+			/* cntDownloads   */ (uint16)cntDown,
+			/* cntUploads     */ (uint16)cntUp,
+			/* cntConnections */ (uint16)conn,
+			/* kadNodesCur    */ (uint16)kad,
+			/* kadNodesTotal  */ (uint64)((double)sessionKad * pointTs)
+		};
+		theApp->m_statistics->AddHistoryRecord(hr);
 	}
 }
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -236,17 +236,25 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent&)
 			if (searchlist->m_curr_search != -1) {
 				searchlist->DoRequery(EC_OP_SEARCH_RESULTS, EC_TAG_SEARCHFILE);
 			}
-		} else if (amuledlg->m_statisticswnd->IsShown()) {
+		}
+		// Stats polling is always on, even when the Statistics dialog
+		// isn't the active tab. statgraphs->HandlePacket() also feeds
+		// the Kad node-count graph on the Network -> Kad sub-tab via
+		// m_kademliawnd->UpdateGraph(); gating on m_statisticswnd left
+		// the Kad graph empty whenever the user wasn't sitting on
+		// Statistics, and produced a visible gap in the Statistics
+		// graph itself across any tab switch. Both requests are cheap
+		// deltas: the graph sends m_lastTimestamp and the daemon
+		// returns only points newer than that (or EC_OP_FAILED "No
+		// points for graph."); the tree request honors
+		// thePrefs::GetStatsInterval().
+		{
 			int sStatsUpdate = thePrefs::GetStatsInterval();
 			uint32 msCur = theStats::GetUptimeMillis();
 			if ((sStatsUpdate > 0) && ((int)(msCur - msPrevStats) > sStatsUpdate*1000)) {
 				msPrevStats = msCur;
 				stattree->DoRequery();
 			}
-			// Pull graph history every poll cycle while the dialog is
-			// visible. The handler asks only for points newer than the
-			// last timestamp the daemon reported, so the EC pipe carries
-			// just the delta even on a 1 Hz timer.
 			statgraphs->DoRequery();
 		}
 		// Back to the roots


### PR DESCRIPTION
Fixes #134 (stats + Kad parts).

Two visible regressions on amulegui's Statistics tab and the Network → Kad sub-tab, both rooted in the same gap: `COScopeCtrl::PlotHistory` was an empty stub under `CLIENT_GUI` because the monolithic implementation calls `theApp->m_statistics->GetHistory(...)` which had no analogue on the remote-GUI side. Two symptoms:

1. **Background starvation** — `CamuleRemoteGuiApp::OnPollTimer` only fired `statgraphs->DoRequery()` and `stattree->DoRequery()` when the Statistics dialog was visible. `CStatGraphRem::HandlePacket` also feeds `m_kademliawnd->UpdateGraph()`, so leaving Statistics hidden also starved the Kad node-count graph. Switch off Stats → both graphs froze.
2. **Whole-graph resets** — auto-rescale paths (`SetRanges` on Kad node count crossing a 50-step ceiling; `SetRange` on the Stats connection-scope `nScale` change) call `RecreateGraph`, which clears the bitmap and then calls `PlotHistory(width, false, ...)`. Under CLIENT_GUI that was a no-op, so the bitmap stayed cleared and the entire line vanished.

## What this PR does

**Commit 1 — polling-gate fix.** Both stats requests now run every step 2 cycle regardless of the active tab. Cost is unchanged in practice: the graph request is a delta (`m_lastTimestamp` lower bound; daemon returns only newer points or `EC_OP_FAILED "No points for graph."`) and the tree request is already throttled by `thePrefs::GetStatsInterval()`.

**Commit 2 — share `PlotHistory` with monolithic via a client-side history ring.** Rather than duplicate the monolithic machinery, `CPreciseRateCounter`, `CStatistics::GetHistory` and `CStatistics::ComputeAverages` are lifted out of the `#ifndef CLIENT_GUI` gate alongside the already-shared `HR` struct. The CLIENT_GUI `CStatistics` now also carries `listHR`, the three `m_graphRunningAvg*` counters and `hrInit`. A new CLIENT_GUI-only producer `AddHistoryRecord(const HR&)` is called once per decoded point from `CStatGraphRem::HandlePacket`. The ring is capped at `kHistoryCap = 1800` (~30 min @ 1 Hz, ≈150 KB across all four graphs). With `listHR` populated the shared `PlotHistory` body works under both builds and the CLIENT_GUI-specific empty stub is gone.

Field mapping in `HandlePacket` mirrors `CStatistics::GetPointsForUpdate` so the same `GetHistory` + `ComputeAverages` code reads it back correctly: `kBytes{Received,Sent}` and `kadNodesTotal` are stored as `session-rate * timestamp`, so `ComputeAverages`'s `kValueRun / sTimestamp` recovers the session-avg trend `[0]` verbatim. Per-point timestamps are reconstructed from the batch by stepping back from `m_lastTimestamp` at the 1 s scale we request in `DoRequery`.

## No EC protocol changes

The ring fills from the existing `EC_OP_GET_STATSGRAPHS` stream — no new tags, no version bump, fully backward compatible with old daemons.

## Test plan

- Statistics tab: graph stays continuous across Transfer / Search / Network switches; tree counters reflect current values on tab return.
- Network → Kad sub-tab: graph populates while sitting on Kad; no whole-graph blank when node count crosses a 50-step ceiling.
- Stats connection scope: no blank-out on `nScale` change.
- Monolithic `amule.app` builds cleanly with `BUILD_MONOLITHIC=YES BUILD_REMOTEGUI=YES BUILD_DAEMON=YES`; no regression in monolithic graph behavior (history machinery is the same code paths, just no longer `#ifdef`-gated).
- Long-session memory: `listHR` capped at 1800 records → bounded at ~150 KB total.