### PR TITLE
fix(amule): persist Messages columns + minimized window geometry

### DIFF
--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -57,7 +57,13 @@ wxEND_EVENT_TABLE()
 CFriendListCtrl::CFriendListCtrl(wxWindow* parent, int id, const wxPoint& pos, wxSize siz, int flags)
 : CMuleListCtrl(parent, id, pos, siz, flags)
 {
-  InsertColumn(0, _("Username"), wxLIST_FORMAT_LEFT, siz.GetWidth() - 4);
+  // Column gets a one-letter name so CMuleListCtrl::SaveSettings has
+  // something to write under /eMule/TableWidthsFriend. Without it the
+  // base-class persistence path short-circuits at "if (!m_name.IsEmpty())"
+  // -- the dtor would never have a column to record.
+  InsertColumn(0, _("Username"), wxLIST_FORMAT_LEFT, siz.GetWidth() - 4, "N");
+  SetTableName("Friend");
+  LoadSettings();
 }
 
 CFriendListCtrl::~CFriendListCtrl()

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -145,6 +145,7 @@ wxBEGIN_EVENT_TABLE(CamuleDlg, wxFrame)
 	EVT_TIMER(ID_GUI_TIMER_EVENT, CamuleDlg::OnGUITimer)
 
 	EVT_SIZE(CamuleDlg::OnMainGUISizeChange)
+	EVT_MOVE(CamuleDlg::OnMainGUIMove)
 
 	EVT_KEY_UP(CamuleDlg::OnKeyPressed)
 
@@ -177,6 +178,10 @@ m_statisticswnd(NULL),
 m_kademliawnd(NULL),
 m_prefsDialog(NULL),
 m_srv_split_pos(0),
+m_lastShownPos(wxDefaultPosition),
+m_lastShownSize(wxDefaultSize),
+m_lastShownMaximized(false),
+m_lastShownValid(false),
 m_imagelist(16,16),
 m_tblist(32,32),
 m_prefsVisible(false),
@@ -1093,20 +1098,31 @@ bool CamuleDlg::SaveGUIPrefs()
 	// The section where to save in in file
 	wxString section = "/Razor_Preferences/";
 
+	// Prefer the live frame geometry; fall back to the last cached
+	// non-iconized snapshot when the user exits from a minimized
+	// window (iconized GetPosition() returns sentinel values on
+	// Windows that aren't safe to round-trip).
+	wxPoint pos;
+	wxSize size;
+	bool maximized;
+	bool haveGeom = false;
 	if (!IsIconized()) {
-		// Main window location and size
-		int x1, y1, x2, y2;
-		GetPosition(&x1, &y1);
-		GetSize(&x2, &y2);
-
-		// Saving window size and position
-		config->Write(section+"MAIN_X_POS", (long) x1);
-		config->Write(section+"MAIN_Y_POS", (long) y1);
-
-		config->Write(section+"MAIN_X_SIZE", (long) x2);
-		config->Write(section+"MAIN_Y_SIZE", (long) y2);
-
-		config->Write(section+"Maximized", (long) (IsMaximized() ? 1 : 0));
+		pos = GetPosition();
+		size = GetSize();
+		maximized = IsMaximized();
+		haveGeom = true;
+	} else if (m_lastShownValid) {
+		pos = m_lastShownPos;
+		size = m_lastShownSize;
+		maximized = m_lastShownMaximized;
+		haveGeom = true;
+	}
+	if (haveGeom) {
+		config->Write(section+"MAIN_X_POS", (long) pos.x);
+		config->Write(section+"MAIN_Y_POS", (long) pos.y);
+		config->Write(section+"MAIN_X_SIZE", (long) size.x);
+		config->Write(section+"MAIN_Y_SIZE", (long) size.y);
+		config->Write(section+"Maximized", (long) (maximized ? 1 : 0));
 	}
 
 	// Saving sash position of splitter in server window
@@ -1525,8 +1541,32 @@ void CamuleDlg::Create_Toolbar(bool orientation)
 }
 
 
+void CamuleDlg::CacheLastShownGeometry()
+{
+	// Iconized frames report sentinel positions (e.g. -32000,-32000 on
+	// Windows) and meaningless sizes; only snapshot real geometry. The
+	// snapshot lets SaveGUIPrefs persist a usable layout even when the
+	// user quits straight from the taskbar without restoring first.
+	if (IsIconized()) {
+		return;
+	}
+	m_lastShownPos = GetPosition();
+	m_lastShownSize = GetSize();
+	m_lastShownMaximized = IsMaximized();
+	m_lastShownValid = true;
+}
+
+
+void CamuleDlg::OnMainGUIMove(wxMoveEvent& evt)
+{
+	CacheLastShownGeometry();
+	evt.Skip();
+}
+
+
 void CamuleDlg::OnMainGUISizeChange(wxSizeEvent& evt)
 {
+	CacheLastShownGeometry();
 	wxFrame::OnSize(evt);
 	if (m_transferwnd && m_transferwnd->clientlistctrl) {
 		// Transfer window's splitter set again if it's hidden.

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -190,6 +190,15 @@ public:
 
 	int			m_srv_split_pos;
 
+	// Last frame geometry seen while NOT iconized. SaveGUIPrefs uses
+	// it as the fallback when the user exits from a minimized state
+	// (otherwise the iconized GetPosition() returns sentinel values
+	// like -32000,-32000 on Windows and the saved pos is unusable).
+	wxPoint		m_lastShownPos;
+	wxSize		m_lastShownSize;
+	bool		m_lastShownMaximized;
+	bool		m_lastShownValid;
+
 	wxImageList m_imagelist;
 	wxImageList m_tblist;
 
@@ -203,6 +212,11 @@ protected:
 	void OnBnClickedFast(wxCommandEvent& evt);
 	void OnGUITimer(wxTimerEvent& evt);
 	void OnMainGUISizeChange(wxSizeEvent& evt);
+	void OnMainGUIMove(wxMoveEvent& evt);
+	// Stash the current (non-iconized) pos / size / maximized state so
+	// SaveGUIPrefs can fall back to the last good geometry if the user
+	// exits from a minimized window.
+	void CacheLastShownGeometry();
 	void OnExit(wxCommandEvent& evt);
 
 private:


### PR DESCRIPTION
Refs #137 (Messages-tab columns + minimized-exit geometry parts).

The Downloads, Shared files, Networks, Searches and Messages tabs all use `CMuleListCtrl` for their lists, but only Messages had its `CFriendListCtrl` ctor calling neither `SetTableName()` nor naming the column it inserts. Result: `~CMuleListCtrl` short-circuited on the empty-name guard and nothing was ever written under `/eMule/TableWidthsFriend`. Column widths in Messages reset on every restart.

Separately, `CamuleDlg::SaveGUIPrefs` wraps the whole `MAIN_X_POS / MAIN_Y_POS / MAIN_X_SIZE / MAIN_Y_SIZE / Maximized` block in `if (!IsIconized())`, so a user who closes the app from a taskbar/dock minimized state has their last layout dropped — next launch falls back to wx defaults.

## Commits

1. **`fix(messages): persist column widths on the Friend list`** — Name the single column `"N"` (matching the other lists' single-char convention), call `SetTableName("Friend")` and `LoadSettings()` in the ctor.
2. **`fix(amule): preserve window geometry when exiting from a minimized state`** — Snapshot the frame's pos / size / Maximized into new `m_lastShown*` members on every `Move` / `Size` event while NOT iconized, and have `SaveGUIPrefs` fall back to that cache when the live frame is iconized. Iconized `GetPosition()` returns sentinel values on Windows (`-32000, -32000`) which aren't safe to round-trip, so it's still excluded from the live path.

## Out of scope

#137 also lists Downloads / Shared column widths as not persisting; code-side the wiring looks complete (`SetTableName("Download")` / `SetTableName("Shared")`, named columns, dtor `SaveSettings()`, splitter saves). Tested on a Windows VM against this branch and column widths + hidden columns + "Show clients for all files" all persist correctly. Leaving #137 open until the reporter can verify on a packaged build whether their experience changes.

## Test plan

Verified on Windows VM with the two-commit branch installed as portable:
- Resize Downloads + Shared columns → persist across restart.
- Hide a column in Downloads + Shared → persist.
- Change "Show clients for all files" in Shared → persist.
- Resize main window → persist.
- Minimize to tray → exit from tray menu → re-launch → geometry matches last shown size + position.
- Friend (Messages) column width → persist.

macOS + monolithic build verified clean (`BUILD_MONOLITHIC=YES BUILD_REMOTEGUI=YES BUILD_DAEMON=YES`).