### PR TITLE
fix(macos): persist list-control settings on Dock → Quit

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -251,6 +251,17 @@ int CamuleApp::OnExit()
 		AddLogLineNS(_("Now, exiting main app..."));
 	}
 
+	// Flush wx's pending-delete queue before tearing down wxConfig:
+	// CamuleGuiApp::ShutDown calls amuledlg->Destroy(), which is lazy
+	// (it schedules deletion on the main-loop tail). On the CMD+Q path
+	// the event loop drains that queue naturally before OnExit runs;
+	// on the macOS Dock right-click → Quit path CamuleGuiApp::OnEndSession
+	// reaches OnExit directly, so without an explicit drain here the
+	// CamuleDlg destructor chain (and CMuleListCtrl::SaveSettings inside
+	// it) never runs against a live wxConfig, and column widths /
+	// sort orders silently fail to persist.
+	DeletePendingObjects();
+
 	// From wxWidgets docs, wxConfigBase:
 	// ...
 	// Note that you must delete this object (usually in wxApp::OnExit)


### PR DESCRIPTION
## Summary

On macOS, quitting aMule via the Dock right-click → **Quit** silently lost all list-control persisted state — column widths, sort orders, hidden-column choices on Downloads / Search / Server lists. CMD+Q and the red-X close button both worked. Reported in passing while testing column widths on the Downloads list.

## Root cause

`CMuleListCtrl::SaveSettings` is called from the destructor. The destructor chain only runs if the wx main loop drains its pending-delete queue (which is where `CamuleGuiApp::ShutDown` puts the main frame via `amuledlg->Destroy()` — that call is **lazy**, scheduling deletion on the loop tail rather than running it inline).

- **CMD+Q / red-X**: the main loop continues spinning after `OnClose` returns and naturally processes the pending-delete queue before `CamuleApp::OnExit` runs → `CamuleDlg` and its child list controls destruct with a live `wxConfig` → `SaveSettings` writes correctly.
- **Dock → Quit**: `CamuleGuiApp::OnEndSession` calls `OnExit()` directly. `CamuleApp::OnExit` at amule.cpp:263 deletes `wxConfig` immediately, then at amule.cpp:419 calls `std::_Exit(0)` which bypasses static destructors. The pending-delete queue is never processed → `CamuleDlg` destructor never runs → `CMuleListCtrl::SaveSettings` never fires.

## Fix

Drain the pending-delete queue (`DeletePendingObjects()`) at the top of `CamuleApp::OnExit`, before the `wxConfig` teardown. The frame + child destructor chain now runs with a live config on every quit path. CMD+Q and red-X are unaffected — the pending queue is already empty by the time `OnExit` runs on those paths, so `DeletePendingObjects()` is a no-op.

## Test plan

- [x] macOS arm64 build clean.
- [x] Manual: resize a column on the Downloads list → Dock right-click → Quit → relaunch → width persisted. Repeat with CMD+Q and red-X to confirm those still work.
- [x] CI build matrix.