### PR TITLE
fix(webserver): ed2k links add via footer links form

### DIFF
--- a/src/webserver/default/footer.php
+++ b/src/webserver/default/footer.php
@@ -28,7 +28,7 @@
 			if ( strlen($link) > 0 ) {
 				$links = split("ed2k://", $link);
 				foreach($links as $linkn) {
-				    amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+				    if (strlen($linkn) > 0) amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Currently if any valid edk2 link is added via amuleweb links form in log two "adding link" lines appeared: the first is an error, the second the correct add.

This behavior occurs because splitting an ed2k link by its prefix ('ed2k://') yields a list with a minimum of two elements, where the first element is always an empty string.

Added length check before `amule_do_ed2k_download_cmd` call links form of `footer.php` to avoid this.

Bug already fixed by me in AmuleWebUI-Reloaded with this [PR](https://github.com/MatteoRagni/AmuleWebUI-Reloaded/pull/46).

NOTE: I'm unsure if PR should be opened here in amule-org repo or in old amule-project repo (please says me the correct place).

## Test plan

amuleweb logs when adding any single ed2k link before/after the fix.

Before:
```
!2026-06-12 16:01:00: ExternalConn: adding link 'ed2k://'.
!2026-06-12 16:01:00: Invalid eD2k link! ERROR: Not a valid ed2k-URI
!2026-06-12 16:01:00: ExternalConn: adding link 'ed2k://|file|<FILE_DATA>/ '.
!2026-06-12 16:01:00: <SUCCESS_MSG>
```
After:
```
!2026-06-12 16:09:00: ExternalConn: adding link 'ed2k://|file|<FILE_DATA>/ '.
!2026-06-12 16:09:00: <SUCCESS_MSG>
```
