### PR TITLE
fix(webserver): php_core_lib various fixes

### DIFF
--- a/src/webserver/src/php_core_lib.cpp
+++ b/src/webserver/src/php_core_lib.cpp
@@ -69,7 +69,7 @@ void php_var_dump(PHP_VALUE_NODE *node, int ident, int ref)
 	if ( ref ) printf("&");
 	switch(node->type) {
 		case PHP_VAL_BOOL: printf("bool(%s)\n", node->int_val ? "true" : "false"); break;
-		case PHP_VAL_INT: printf("int(%" PRIu64 ")\n", node->int_val); break;
+		case PHP_VAL_INT: printf("int(%" PRId64 ")\n", node->int_val); break;
 		case PHP_VAL_FLOAT: printf("float(%f)\n", node->float_val); break;
 		case PHP_VAL_STRING: printf("string(%d) \"%s\"\n", (int)strlen(node->str_val), node->str_val); break;
 		case PHP_VAL_OBJECT: printf("Object(%s)\n", node->obj_val.class_name); break;

--- a/src/webserver/src/php_core_lib.cpp
+++ b/src/webserver/src/php_core_lib.cpp
@@ -702,7 +702,7 @@ CPhpFilter::CPhpFilter(CWebServerBase *server, CSession *sess,
 	fclose(f);
 	char *scan_ptr = buf;
 	char *curr_code_end = buf;
-	while ( strlen(scan_ptr) ) {
+	while ( *scan_ptr ) {
 		scan_ptr = strstr(scan_ptr, "<?php");
 		if ( !scan_ptr ) {
 			buff->Write(curr_code_end);

--- a/src/webserver/src/php_core_lib.cpp
+++ b/src/webserver/src/php_core_lib.cpp
@@ -440,8 +440,9 @@ void php_native_split(PHP_VALUE_NODE *result)
 void php_native_gettext(PHP_VALUE_NODE *result)
 {
 	PHP_SCOPE_ITEM *si_str = get_scope_item(g_current_scope, "__param_0");
-	PHP_VALUE_NODE *str = &si_str->var->value;
+	PHP_VALUE_NODE *str;
 	if ( si_str ) {
+		str = &si_str->var->value;
 		cast_value_str(str);
 	} else {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 'msgid' for 'gettext'");
@@ -457,8 +458,9 @@ void php_native_gettext(PHP_VALUE_NODE *result)
 void php_native_gettext_noop(PHP_VALUE_NODE *result)
 {
 	PHP_SCOPE_ITEM *si_str = get_scope_item(g_current_scope, "__param_0");
-	PHP_VALUE_NODE *str = &si_str->var->value;
+	PHP_VALUE_NODE *str;
 	if ( si_str ) {
+		str = &si_str->var->value;
 		cast_value_str(str);
 	} else {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 'msgid' for 'gettext_noop'");
@@ -474,24 +476,27 @@ void php_native_gettext_noop(PHP_VALUE_NODE *result)
 void php_native_ngettext(PHP_VALUE_NODE *result)
 {
 	PHP_SCOPE_ITEM *si_msgid = get_scope_item(g_current_scope, "__param_0");
-	PHP_VALUE_NODE *msgid = &si_msgid->var->value;
+	PHP_VALUE_NODE *msgid;
 	if ( si_msgid ) {
+		msgid = &si_msgid->var->value
 		cast_value_str(msgid);
 	} else {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 'msgid' for 'ngettext'");
 		return;
 	}
 	PHP_SCOPE_ITEM *si_msgid_plural = get_scope_item(g_current_scope, "__param_1");
-	PHP_VALUE_NODE *msgid_plural = &si_msgid_plural->var->value;
+	PHP_VALUE_NODE *msgid_plural;
 	if ( si_msgid_plural ) {
+		msgid_plural = &si_msgid_plural->var->value
 		cast_value_str(msgid_plural);
 	} else {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 'msgid_plural' for 'ngettext'");
 		return;
 	}
 	PHP_SCOPE_ITEM *si_count = get_scope_item(g_current_scope, "__param_2");
-	PHP_VALUE_NODE *count = &si_count->var->value;
+	PHP_VALUE_NODE *count;
 	if ( si_count ) {
+		count = &si_count->var->value
 		cast_value_dnum(count);
 	} else {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 'count' for 'ngettext'");

--- a/src/webserver/src/php_core_lib.cpp
+++ b/src/webserver/src/php_core_lib.cpp
@@ -249,35 +249,6 @@ void php_native_isset(PHP_VALUE_NODE *result)
 	}
 }
 
-void php_native_substr(PHP_VALUE_NODE * /*result*/)
-{
-	PHP_SCOPE_ITEM *si_str = get_scope_item(g_current_scope, "__param_0");
-	PHP_VALUE_NODE *str = &si_str->var->value;
-	if ( si_str ) {
-		cast_value_str(str);
-	} else {
-		php_report_error(PHP_ERROR, "Invalid or missing argument 'str' for 'substr'");
-		return;
-	}
-	PHP_SCOPE_ITEM *si_start = get_scope_item(g_current_scope, "__param_1");
-	PHP_VALUE_NODE *start = &si_start->var->value;
-	if ( si_start ) {
-		cast_value_dnum(start);
-	} else {
-		php_report_error(PHP_ERROR, "Invalid or missing argument 'start' for 'substr'");
-		return;
-	}
-	// 3-rd is optional
-	PHP_SCOPE_ITEM *si_end = get_scope_item(g_current_scope, "__param_2");
-	PHP_VALUE_NODE end = { PHP_VAL_INT, { 0 } };
-	if ( si_end ) {
-		end = si_end->var->value;
-	}
-	cast_value_dnum(&end);
-
-
-}
-
 void php_native_htmlspecialchars(PHP_VALUE_NODE *result)
 {
 	PHP_SCOPE_ITEM *si_str = get_scope_item(g_current_scope, "__param_0");

--- a/src/webserver/src/php_core_lib.cpp
+++ b/src/webserver/src/php_core_lib.cpp
@@ -478,7 +478,7 @@ void php_native_ngettext(PHP_VALUE_NODE *result)
 	PHP_SCOPE_ITEM *si_msgid = get_scope_item(g_current_scope, "__param_0");
 	PHP_VALUE_NODE *msgid;
 	if ( si_msgid ) {
-		msgid = &si_msgid->var->value
+		msgid = &si_msgid->var->value;
 		cast_value_str(msgid);
 	} else {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 'msgid' for 'ngettext'");
@@ -487,7 +487,7 @@ void php_native_ngettext(PHP_VALUE_NODE *result)
 	PHP_SCOPE_ITEM *si_msgid_plural = get_scope_item(g_current_scope, "__param_1");
 	PHP_VALUE_NODE *msgid_plural;
 	if ( si_msgid_plural ) {
-		msgid_plural = &si_msgid_plural->var->value
+		msgid_plural = &si_msgid_plural->var->value;
 		cast_value_str(msgid_plural);
 	} else {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 'msgid_plural' for 'ngettext'");
@@ -496,7 +496,7 @@ void php_native_ngettext(PHP_VALUE_NODE *result)
 	PHP_SCOPE_ITEM *si_count = get_scope_item(g_current_scope, "__param_2");
 	PHP_VALUE_NODE *count;
 	if ( si_count ) {
-		count = &si_count->var->value
+		count = &si_count->var->value;
 		cast_value_dnum(count);
 	} else {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 'count' for 'ngettext'");


### PR DESCRIPTION
**Fixes:**
- Removed `php_native_substr` as it contains several bugs and above all is never used
- Moved NULL check before params dereference in functions `php_native_substr`, `php_native_gettext`, `php_native_gettext_noop`, and `php_native_ngettext`
- Replaced `PRIu64` with `PRId64` in `php_var_dump` (`PHP_VAL_INT` can hold a signed integer)
- Replaced `while ( strlen(scan_ptr) )` with `while ( *scan_ptr )` in `CPhpFilter::CPhpFilter`, making the check O(1) instead of O(N)

**Doubts and suggestions:**
- `php_native_isset` calls `cast_value_str` on params without checking `param->str_val` (so it seems to do nothing useful); the only apparent reason is to trigger `assert(0)` when `type=PHP_VAL_INT_DATA`, but I don't see the advantage → two options: remove params and the `cast_value_str` call entirely, or also check whether `param->str_val` is not an empty string (but this seems unnecessary as the type check alone should be sufficient)
- `php_native_htmlspecialchars` calls `cast_value_dnum` on result without an apparent reason (`result->int_val` is never used); the only apparent reason seems to be triggering `assert(0)` when `type=PHP_VAL_INT_DATA`, but I don't see the advantage → remove the `cast_value_dnum` call
- `CWriteStrBuffer::Write`: in `if ( (len + 1) <= m_curr_buf_left )`, `len` is incremented by 1 to account for the string terminator, but `strncpy` does not actually add it → two options: explicitly add the null terminator (it is unclear whether the current behavior is intentional), or replace `(len + 1)` with `len` in the condition (also replacing `strncpy` with `memcpy` to make the intent clearer)

If you can help clarify these doubts, I will apply the suggested changes in this PR.