### PR TITLE
fix(webserver): php_amule_lib_standalone various fixes

### DIFF
--- a/src/webserver/src/php_amule_lib_standalone.cpp
+++ b/src/webserver/src/php_amule_lib_standalone.cpp
@@ -375,7 +375,7 @@ void php_native_ed2k_download_cmd(PHP_VALUE_NODE *result)
 	cast_value_dnum(&si->var->value);
 	int cat = si->var->value.int_val;
 
-	printf("php_native_search_download_cmd: hash=%s category=%d\n", str_link, cat);
+	printf("php_native_ed2k_download_cmd: file_link=%s category=%d\n", str_link, cat);
 }
 
 

--- a/src/webserver/src/php_amule_lib_standalone.cpp
+++ b/src/webserver/src/php_amule_lib_standalone.cpp
@@ -35,7 +35,6 @@
 
 #define PACKAGE_VERSION "standalone"
 
-#include <map>
 #include <list>
 #include <stdarg.h>
 

--- a/src/webserver/src/php_amule_lib_standalone.cpp
+++ b/src/webserver/src/php_amule_lib_standalone.cpp
@@ -253,11 +253,10 @@ void php_native_search_download_cmd(PHP_VALUE_NODE *)
 	char *str_hash = si->var->value.str_val;
 
 	si = get_scope_item(g_current_scope, "__param_1");
-	if ( !si || (si->var->value.type != PHP_VAL_STRING)) {
+	if ( !si ) {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 2 (category)");
 		return;
 	}
-
 	cast_value_dnum(&si->var->value);
 	int cat = si->var->value.int_val;
 
@@ -367,11 +366,10 @@ void php_native_ed2k_download_cmd(PHP_VALUE_NODE *result)
 	char *str_link = si->var->value.str_val;
 
 	si = get_scope_item(g_current_scope, "__param_1");
-	if ( !si || (si->var->value.type != PHP_VAL_STRING)) {
+	if ( !si ) {
 		php_report_error(PHP_ERROR, "Invalid or missing argument 2 (category)");
 		return;
 	}
-
 	cast_value_dnum(&si->var->value);
 	int cat = si->var->value.int_val;
 


### PR DESCRIPTION
# Fixes

- Fixed `printf` in `php_native_ed2k_download_cmd` function (copy-paste issue)
- Removed string check from `php_native_search_download_cmd` and `php_native_ed2k_download_cmd` functions (useless as the value is cast to int, so an int parameter value can be accepted, as happens in other functions such as `php_native_server_cmd`)
- Removed duplicated `#include <map>`

# Doubts and Suggestions

- `php_native_search_start_cmd` argument 4 (search type) is parsed but not assigned to any variable → add `int search_type = si->var->value.int_val;` and replace `type=%s` with `file_type=%s\nsearch_type=%d` in `printf`

If you can help me clarify the doubts, I will apply the suggested changes in this PR.