### PR TITLE
fix(webserver): php_syntree various fixes

### DIFF
--- a/src/webserver/src/php_syntree.cpp
+++ b/src/webserver/src/php_syntree.cpp
@@ -984,7 +984,7 @@ void cast_value_array(PHP_VALUE_NODE *val)
 		case PHP_VAL_BOOL:
 		case PHP_VAL_INT:
 		case PHP_VAL_FLOAT: break;
-		case PHP_VAL_STRING: free(val->str_val);
+		case PHP_VAL_STRING: free(val->str_val); break;
 		case PHP_VAL_ARRAY: return;
 		case PHP_VAL_OBJECT: ;/* must call to free_obj() */
 		case PHP_VAL_VAR_NODE:

--- a/src/webserver/src/php_syntree.cpp
+++ b/src/webserver/src/php_syntree.cpp
@@ -962,7 +962,7 @@ void cast_value_str(PHP_VALUE_NODE *val)
 	switch(val->type) {
 		case PHP_VAL_NONE: buff[0] = 0; break;
 		case PHP_VAL_BOOL:
-		case PHP_VAL_INT: snprintf(buff, sizeof(buff), "%" PRIu64, val->int_val); break;
+		case PHP_VAL_INT: snprintf(buff, sizeof(buff), "%" PRId64, val->int_val); break;
 		case PHP_VAL_FLOAT: snprintf(buff, sizeof(buff), "%.02f", val->float_val); break;
 		case PHP_VAL_STRING: return;
 		case PHP_VAL_ARRAY: {


### PR DESCRIPTION
# Fixes

- Added missing `break` for `type == PHP_VAL_STRING` in `cast_value_array()` — without it, the function exits at the `PHP_VAL_ARRAY` branch before actually allocating the array.
- Replaced `PRIu64` with `PRId64` in `cast_value_str()` — `PHP_VAL_INT` holds a signed integer.
