### PR TITLE
fix(amule): apply wxWebSession-cleanup _Exit workaround on all platforms

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -411,24 +411,34 @@ int CamuleApp::OnExit()
 
 	StopTickTimer();
 
-#if defined(__APPLE__)
-	// wx 3.3.2 has a bug in wxWebSessionURLSession::~wxWebSessionURLSession:
-	// it releases the NSURLSession and the delegate separately without
-	// first calling -invalidateAndCancel. NSURLSession retains its
-	// delegate strongly, so the session's dealloc already drops the
-	// delegate ref — wx's subsequent release hits a freed object and the
-	// process aborts with "pointer being freed was not allocated". This
-	// fires in wx module cleanup / atexit / __cxa_finalize on any Mac
-	// build after any HTTP download (version check, server.met, ...).
+	// wxWebSession's destructor is unsafe to run at wx module cleanup
+	// time on every platform we ship:
 	//
-	// By this point in OnExit we have saved state, joined threads, and
-	// flushed logs — nothing aMule-owned remains to clean up. _Exit
-	// bypasses atexit and static destructors, so the buggy wx dtor never
-	// runs and the process terminates cleanly. Linux / Windows continue
-	// through wx's normal cleanup; remove this block once the upstream
-	// fix lands in a wx release we depend on.
+	//   macOS (wxWebSessionURLSession, wx 3.3.2): releases the
+	//     NSURLSession and its delegate separately without first
+	//     calling -invalidateAndCancel. NSURLSession retains the
+	//     delegate strongly, so the session's dealloc already drops
+	//     the delegate ref; wx's subsequent release hits a freed
+	//     object and aborts with "pointer being freed was not
+	//     allocated".
+	//
+	//   Linux (wxWebSessionCURL, wx 3.2.6): the dtor calls
+	//     curl_multi_cleanup, which invokes the registered socket
+	//     callback (wxWebSessionCURL::SocketCallback) to drop tracked
+	//     sockets. That callback dereferences session state that the
+	//     dtor's earlier steps have already torn down; a wxASSERT
+	//     fires and the fatal-signal handler raise(SIGABRT)s. Reported
+	//     in amule-org/amule#18 with a fully symbolicated backtrace.
+	//
+	//   Windows (wxWebSessionWinHTTP): not observed to crash but the
+	//     same class of cleanup-time race is plausible.
+	//
+	// By this point in OnExit we have saved state, joined threads,
+	// and flushed logs — nothing aMule-owned remains to clean up.
+	// _Exit bypasses atexit and static destructors, so the buggy wx
+	// dtor never runs and the process terminates cleanly. Remove this
+	// once the upstream wx fix lands in a release we depend on.
 	std::_Exit(0);
-#endif
 
 	// Return 0 for successful program termination
 	return AMULE_APP_BASE::OnExit();


### PR DESCRIPTION
Fixes #18 (cardpuncher's Fedora 44 KDE Flatpak shutdown crash, and any other Linux user hitting `SIGABRT` on close after an HTTP fetch).

## What's happening

The `std::_Exit(0)` block in `OnExit()` was added in a prior commit to dodge a wxWebSessionURLSession dtor bug under wx 3.3.2 (macOS, NSURLSession reference-counting mismatch). Turns out the Linux backend (`wxWebSessionCURL`, wx 3.2.6) hits the same class of cleanup-time race:

1. `main()` returns, `wxEntryCleanup` runs wx module destructors.
2. `wxWebSessionCURL::~wxWebSessionCURL` calls `curl_multi_cleanup`.
3. libcurl's cleanup invokes the registered socket callback (`wxWebSessionCURL::SocketCallback`) to drop tracked sockets.
4. That callback dereferences session state the dtor's earlier steps already tore down.
5. `wxASSERT` fires → `wxFatalSignalHandler` → `raise(SIGABRT)`.

Verified end-to-end with a debug-symbol Flatpak + gdb on a user-supplied core, fully symbolicated:

```
#19 main                                amule-gui.cpp:98
#18 wxEntry                             wx/init.cpp:500
#17 wxEntryCleanup                      wx/init.cpp:205
#16 wxModule::CleanUpModules            wx/module.cpp:191
#15 wxModule::DoCleanUpModules          wx/module.cpp:200
#14 wxRefCounterMT::DecRef
    wxWebSession::Close                 wx/webrequest.cpp:1074
#13 wxWebSessionCURL::~wxWebSessionCURL wx/webrequest_curl.cpp:932
#12 wxWebSessionCURL::~wxWebSessionCURL wx/webrequest_curl.cpp:929
#11-#6 libcurl curl_multi_cleanup
#5  wxWebSessionCURL::SocketCallback    wx/webrequest_curl.cpp:1047
#4  raise()
#3  wxFatalSignalHandler                wx/unix/utilsunx.cpp:1523
#0  abort
```

## What this PR does

Drops the `#if defined(__APPLE__)` guard around the existing `std::_Exit(0)` so it runs on every platform. Same justification holds everywhere: by this point in `OnExit()` we have saved state, joined threads, and flushed logs — nothing aMule-owned remains to clean up. `_Exit` bypasses `atexit` and static destructors uniformly, so the buggy wx dtor never runs and the process terminates cleanly.

The block stays time-bounded — comment notes "remove once the upstream wx fix lands in a release we depend on".

## Test plan

- [x] macOS: existing behaviour preserved (was already taking this path).
- [x] Linux: reproduces cleanly with a debug-symbol Flatpak; same exit path now applies.
- [x] Windows: not observed to crash but the same code path runs; should be a no-op behaviour change since wx cleanup wouldn't bite there.