### PR TITLE
fix(serverinfo): clear stale messages on ed2k disconnect

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -707,6 +707,18 @@ void CamuleRemoteGuiApp::AddServerMessageLine(wxString &msg)
 }
 
 
+void CamuleRemoteGuiApp::ClearServerInfo()
+{
+	// Data-only clear, symmetric with CamuleApp::ClearServerInfo: wipe
+	// the daemon's cumulative buffer + the local diff snapshot. The
+	// on-screen text ctrl is wiped from the dialog side
+	// (CamuleDlg::ShowConnectionState).
+	CECPacket req(EC_OP_CLEAR_SERVERINFO);
+	m_connect->SendPacket(&req);
+	m_serverinfo_handler.m_seenSoFar.clear();
+}
+
+
 void CServerInfoHandlerRem::HandlePacket(const CECPacket *packet)
 {
 	// amuled answers EC_OP_GET_SERVERINFO with one EC_TAG_STRING

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -784,6 +784,10 @@ public:
 	wxString GetServerLog(bool reset = false);
 
 	void AddServerMessageLine(wxString &msg);
+	// Wipe the daemon's cumulative buffer, the local diff snapshot, and
+	// the on-screen log. Called on ed2k disconnect so the Server Info
+	// tab doesn't keep showing messages from the disconnected server.
+	void ClearServerInfo();
 	void AddRemoteLogLine(const wxString& line);
 
 	void SetOSFiles(wxString ) { /* onlinesig is created on remote side */ }

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1864,6 +1864,15 @@ void CamuleApp::AddServerMessageLine(wxString &msg)
 }
 
 
+void CamuleApp::ClearServerInfo()
+{
+	// Data-only clear; the on-screen ID_SERVERINFO text ctrl is wiped
+	// from the dialog side (CamuleDlg::ShowConnectionState) so this
+	// stays compilable in the daemon build too.
+	server_msg.Clear();
+}
+
+
 
 void CamuleApp::OnFinishedHTTPDownload(CMuleInternalEvent& event)
 {

--- a/src/amule.h
+++ b/src/amule.h
@@ -308,6 +308,10 @@ public:
 
 	bool AddServer(CServer *srv, bool fromUser = false);
 	void AddServerMessageLine(wxString &msg);
+	// Wipe the cumulative server-message buffer + the on-screen log.
+	// Called on ed2k disconnect so the Server Info tab doesn't keep
+	// showing messages from the disconnected server.
+	void ClearServerInfo();
 #ifdef __DEBUG__
 	void AddSocketDeleteDebug(uint32 socket_pointer, uint32 creation_time);
 #endif

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -714,6 +714,21 @@ void CamuleDlg::ShowConnectionState(bool skinChanged)
 		}
 	}
 
+	// Detect ed2k connected -> disconnected transition and wipe the
+	// Server Info tab so it doesn't keep displaying messages from the
+	// server we just dropped. ClearServerInfo() clears the data side
+	// (server_msg on monolithic, EC_OP_CLEAR_SERVERINFO + the diff
+	// snapshot on amulegui); the on-screen text ctrl gets wiped here
+	// via ResetLog so it works in both builds without having to make
+	// amuledlg accessible from CamuleApp.
+	static bool s_wasConnectedED2K = false;
+	bool nowConnectedED2K = theApp->IsConnectedED2K();
+	if (s_wasConnectedED2K && !nowConnectedED2K) {
+		theApp->ClearServerInfo();
+		ResetLog(ID_SERVERINFO);
+	}
+	s_wasConnectedED2K = nowConnectedED2K;
+
 	m_serverwnd->UpdateED2KInfo();
 	m_serverwnd->UpdateKadInfo();
 


### PR DESCRIPTION
Fixes #162.

The Server Info tab in the Network panel kept displaying messages from the disconnected server because there was no clear-on-disconnect path — the cumulative `server_msg` buffer (monolithic) and the diff-snapshot / on-screen text ctrl (amulegui post-#120) just kept accumulating.

## What this PR does

Adds a small `ClearServerInfo()` on each app variant:

- `CamuleApp::ClearServerInfo()` — clears `server_msg`.
- `CamuleRemoteGuiApp::ClearServerInfo()` — sends `EC_OP_CLEAR_SERVERINFO` to `amuled` and clears `m_serverinfo_handler.m_seenSoFar`.

`CamuleDlg::ShowConnectionState` tracks the previous ed2k state via a static bool and on a connected → disconnected transition calls both `theApp->ClearServerInfo()` (data) and `ResetLog(ID_SERVERINFO)` (UI). Putting the UI clear on the dialog side keeps the data-side method compilable in the daemon build (`amuledlg` lives on `CamuleGuiBase`, which `CamuleApp` doesn't inherit).

## Test plan

- [x] macOS local build (monolithic + amulegui) clean.
- [x] Manual: connect to a server, observe messages, disconnect → tab clears. Reconnect → fresh messages appear, no stale tail.