### PR TITLE
fix(serverinfo): clear log at the transition source (amuled side)

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -707,18 +707,6 @@ void CamuleRemoteGuiApp::AddServerMessageLine(wxString &msg)
 }
 
 
-void CamuleRemoteGuiApp::ClearServerInfo()
-{
-	// Data-only clear, symmetric with CamuleApp::ClearServerInfo: wipe
-	// the daemon's cumulative buffer + the local diff snapshot. The
-	// on-screen text ctrl is wiped from the dialog side
-	// (CamuleDlg::ShowConnectionState).
-	CECPacket req(EC_OP_CLEAR_SERVERINFO);
-	m_connect->SendPacket(&req);
-	m_serverinfo_handler.m_seenSoFar.clear();
-}
-
-
 void CServerInfoHandlerRem::HandlePacket(const CECPacket *packet)
 {
 	// amuled answers EC_OP_GET_SERVERINFO with one EC_TAG_STRING

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -784,10 +784,6 @@ public:
 	wxString GetServerLog(bool reset = false);
 
 	void AddServerMessageLine(wxString &msg);
-	// Wipe the daemon's cumulative buffer, the local diff snapshot, and
-	// the on-screen log. Called on ed2k disconnect so the Server Info
-	// tab doesn't keep showing messages from the disconnected server.
-	void ClearServerInfo();
 	void AddRemoteLogLine(const wxString& line);
 
 	void SetOSFiles(wxString ) { /* onlinesig is created on remote side */ }

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1864,15 +1864,6 @@ void CamuleApp::AddServerMessageLine(wxString &msg)
 }
 
 
-void CamuleApp::ClearServerInfo()
-{
-	// Data-only clear; the on-screen ID_SERVERINFO text ctrl is wiped
-	// from the dialog side (CamuleDlg::ShowConnectionState) so this
-	// stays compilable in the daemon build too.
-	server_msg.Clear();
-}
-
-
 
 void CamuleApp::OnFinishedHTTPDownload(CMuleInternalEvent& event)
 {
@@ -2241,6 +2232,32 @@ void CamuleApp::ShowConnectionState(bool forceUpdate)
 		} else {
 			state |= CONNECTED_KAD_NOT;
 		}
+	}
+
+	// Wipe the cumulative server-message buffer when the connected
+	// ed2k server changes (either disconnected, or switched A -> B).
+	// Without this the Server Info tab keeps showing messages from the
+	// server we just left. We do the data clear here so amulegui sees
+	// the cleared buffer on its next EC_OP_GET_SERVERINFO poll without
+	// any extra round trip — the existing else branch in
+	// CServerInfoHandlerRem::HandlePacket resets the local view when
+	// fullLog shortens. The on-screen text ctrl in monolithic builds
+	// is cleared from CamuleDlg::ShowConnectionState's matching
+	// detection.
+	static CServer* s_lastConnectedServer = NULL;
+	CServer* nowConnectedServer = (state & CONNECTED_ED2K)
+		? theApp->serverconnect->GetCurrentServer() : NULL;
+	if (s_lastConnectedServer != NULL
+		&& (!(state & CONNECTED_ED2K)
+			|| (nowConnectedServer && nowConnectedServer != s_lastConnectedServer))) {
+		server_msg.Clear();
+	}
+	if (nowConnectedServer) {
+		s_lastConnectedServer = nowConnectedServer;
+	} else if (!(state & CONNECTED_ED2K)) {
+		// Truly disconnected — drop the cached pointer so a reconnect
+		// to the same server doesn't spuriously clear next time.
+		s_lastConnectedServer = NULL;
 	}
 
 	if (old_state != state) {

--- a/src/amule.h
+++ b/src/amule.h
@@ -308,10 +308,6 @@ public:
 
 	bool AddServer(CServer *srv, bool fromUser = false);
 	void AddServerMessageLine(wxString &msg);
-	// Wipe the cumulative server-message buffer + the on-screen log.
-	// Called on ed2k disconnect so the Server Info tab doesn't keep
-	// showing messages from the disconnected server.
-	void ClearServerInfo();
 #ifdef __DEBUG__
 	void AddSocketDeleteDebug(uint32 socket_pointer, uint32 creation_time);
 #endif

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -714,20 +714,40 @@ void CamuleDlg::ShowConnectionState(bool skinChanged)
 		}
 	}
 
-	// Detect ed2k connected -> disconnected transition and wipe the
-	// Server Info tab so it doesn't keep displaying messages from the
-	// server we just dropped. ClearServerInfo() clears the data side
-	// (server_msg on monolithic, EC_OP_CLEAR_SERVERINFO + the diff
-	// snapshot on amulegui); the on-screen text ctrl gets wiped here
-	// via ResetLog so it works in both builds without having to make
-	// amuledlg accessible from CamuleApp.
+	// Wipe the Server Info text ctrl on any transition that leaves it
+	// showing messages from a server we're no longer talking to:
+	//   1) connected -> disconnected
+	//   2) connected to A -> connected to B (server switch)
+	// The data side (amuled's server_msg, shared with the monolithic
+	// build) is wiped in the matching block inside
+	// CamuleApp::ShowConnectionState; here we only ResetLog the text
+	// ctrl. We deliberately don't touch the amulegui side's
+	// CServerInfoHandlerRem::m_seenSoFar snapshot: if we cleared it
+	// locally and amuled's cleanup hadn't landed yet, the next poll
+	// would replay the stale buffer through the "fullLog starts with
+	// empty seenSoFar" path. Leaving the snapshot alone lets
+	// HandlePacket's existing StartsWith-vs-else logic handle the
+	// transition naturally -- once amuled's server_msg shortens
+	// after its own clear, the prefix mismatches and the else branch
+	// resets the local view properly.
 	static bool s_wasConnectedED2K = false;
+	static CServer* s_lastConnectedServer = NULL;
 	bool nowConnectedED2K = theApp->IsConnectedED2K();
-	if (s_wasConnectedED2K && !nowConnectedED2K) {
-		theApp->ClearServerInfo();
+	CServer* nowConnectedServer = nowConnectedED2K
+		? theApp->serverconnect->GetCurrentServer() : NULL;
+
+	if (s_wasConnectedED2K
+		&& (!nowConnectedED2K
+			|| (nowConnectedServer && s_lastConnectedServer
+				&& nowConnectedServer != s_lastConnectedServer))) {
 		ResetLog(ID_SERVERINFO);
 	}
 	s_wasConnectedED2K = nowConnectedED2K;
+	if (nowConnectedServer) {
+		s_lastConnectedServer = nowConnectedServer;
+	} else if (!nowConnectedED2K) {
+		s_lastConnectedServer = NULL;
+	}
 
 	m_serverwnd->UpdateED2KInfo();
 	m_serverwnd->UpdateKadInfo();


### PR DESCRIPTION
Supersedes the first attempt of this PR — the dialog-side `EC_OP_CLEAR_SERVERINFO` it sent on a server switch raced the new server's welcome message and silently wiped it on amulegui, leaving the Server Info tab empty until B happened to send a second message.

## New approach: clear at the source

**`CamuleApp::ShowConnectionState`** tracks the connected ed2k server pointer next to the existing `old_state` flag-bit tracking and clears `server_msg` on either:

1. Was connected, now disconnected, OR
2. Was connected to A, now connected to B (server switch — this transition doesn't flip `CONNECTED_ED2K` so it wouldn't fire the existing `old_state != state` branch).

This runs in the amuled process (or in the monolithic build's app), so the clear happens at the transition source — before any of B's messages can land in `server_msg`. No window for new server messages to be sandwich-cleared after the fact.

**`CamuleDlg::ShowConnectionState`** does the same detection but only handles the UI side: `ResetLog(ID_SERVERINFO)` for the text ctrl. It deliberately does NOT touch the amulegui side's `CServerInfoHandlerRem::m_seenSoFar` snapshot — clearing it locally before amuled's cleanup landed would let the next poll replay the stale buffer through the "fullLog starts with empty seenSoFar" path. Leaving the snapshot alone lets `HandlePacket`'s existing `StartsWith` / else-branch logic handle the transition naturally: once amuled's `server_msg` shortens after its own clear, the prefix mismatches and the else branch resets the local view correctly.

## Drops the `ClearServerInfo` methods added in #163

Both `CamuleApp::ClearServerInfo` and `CamuleRemoteGuiApp::ClearServerInfo` are removed — the amuled-side `ShowConnectionState` path replaces them, and nothing else called them.

## Test plan

- [x] macOS local build (monolithic + amulegui) clean.
- [x] Manual: connect to A, observe messages → switch to B → Server Info empties and then shows only B's messages once it sends them (no replay of A).
- [x] Manual: disconnect → text ctrl empties; reconnect → fresh content, no stale tail.
- [x] Manual: amulegui talking to amuled (both updated) → server switch shows the same behaviour as monolithic.