### PR TITLE
DownloadQueue: log full path on ed2k-link duplicate

### DIFF
--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -390,7 +390,7 @@ bool CDownloadQueue::IsFileExisting( const CMD4Hash& fileid ) const
 				return false;
 			}
 
-			AddLogLineC(CFormat( _("You already have the file '%s'") ) % file->GetFileName());
+			AddLogLineC(CFormat( _("You already have the file '%s'") ) % fullpath);
 		}
 
 		return true;


### PR DESCRIPTION
## Summary

Closes #168.

The "You already have the file '%s'" log line printed only the bare filename when an `ed2k://` link resolved to a file already in the user's shared set. Stoatwblr's report on #168: when the local file has been renamed (or lives in a non-default shared root), the bare filename in the log doesn't tell the user where to actually find it on disk.

The full path is already computed two lines above the log site in `DownloadQueue.cpp:385` for the `FileExists()` existence check, so the fix is a one-liner — swap `file->GetFileName()` for `fullpath` in the `CFormat`:

```diff
-AddLogLineC(CFormat( _("You already have the file '%s'") ) % file->GetFileName());
+AddLogLineC(CFormat( _("You already have the file '%s'") ) % fullpath);
```

Output goes from `You already have the file 'XYZ.avi'` to `You already have the file '/home/user/Music/XYZ.avi'`. The basename is still in the formatted string (tail of the path), so existing log greps for the filename keep matching.

The msgid stays byte-identical, so `po/amule.pot` and the 40 `po/*.po` catalogs are untouched and translators don't get a fuzzy entry.

## Scope limit

`IsFileExisting` only receives the MD4 hash, not the ed2k-link filename the user clicked. Stoat's example showed both names (link name "as" local name); plumbing the link filename through every caller would be a much bigger change for a log-line tweak. Showing the on-disk path solves the "can't find the file" problem on its own.

## Test plan

- [x] Build clean on macOS arm64 (Homebrew, Release).
- [x] User confirmation: clicking an ed2k:// link for a file already in the shared set logs the absolute path of the on-disk copy.