### PR TITLE
Surface all bundled languages in Language picker on Flatpak

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -678,6 +678,47 @@ static LangInfo aMuleLanguages[] = {
 
 typedef Cfg_Int<int> Cfg_PureInt;
 
+// Returns true if aMule's translation catalog (PACKAGE.mo) exists on
+// disk for the given wxWidgets language id, using the same lookup
+// prefixes that InitLocale() registers. Used as an additional gate
+// in the language-picker probe below: the standard wxLocale::IsAvailable
+// / locale_to_check.IsOk() path depends on glibc-locale data being
+// present for each candidate language, which is *not* the case inside
+// Flatpak sandboxes — the GNOME runtime ships only the user's preferred
+// locale, so every other language fails the probe even when our .mo
+// files are reachable. Treating "catalog file is on disk" as also-OK
+// makes the picker show every language we actually ship a translation
+// for, regardless of sandbox glibc state.
+static bool HasAMuleCatalogForLanguage(int wxLanguageId)
+{
+	const wxLanguageInfo* info = wxLocale::GetLanguageInfo(wxLanguageId);
+	if (!info) {
+		return false;
+	}
+	const wxString canonical = info->CanonicalName;
+	if (canonical.IsEmpty()) {
+		return false;
+	}
+
+	// Same prefixes as InitLocale (OtherFunctions.cpp) — keep in sync.
+	wxArrayString prefixes;
+#if defined(__WXMAC__) || defined(__WINDOWS__)
+	prefixes.Add(JoinPaths(wxStandardPaths::Get().GetResourcesDir(), "locale"));
+#elif defined(__WXGTK__) || defined(__UNIX__)
+	prefixes.Add(JoinPaths(JoinPaths(wxStandardPaths::Get().GetInstallPrefix(), "share"), "locale"));
+#endif
+
+	const wxString catalog = wxString(PACKAGE) + ".mo";
+	for (size_t i = 0; i < prefixes.GetCount(); ++i) {
+		const wxString candidate = JoinPaths(JoinPaths(JoinPaths(prefixes[i], canonical), "LC_MESSAGES"), catalog);
+		if (wxFileExists(candidate)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
 class Cfg_Lang : public Cfg_PureInt, public Cfg_Lang_Base
 {
 public:
@@ -754,14 +795,29 @@ public:
 
 			// This suppresses error-messages about invalid locales
 			for (unsigned int i = 1; i < itemsof(aMuleLanguages); ++i) {
-				if ((aMuleLanguages[i].id > wxLANGUAGE_USER_DEFINED) || wxLocale::IsAvailable(aMuleLanguages[i].id)) {
+				// Outer gate: glibc-locale-data path OR aMule .mo catalog on
+				// disk. The catalog path is required for Flatpak sandboxes
+				// where the GNOME runtime ships only the user's preferred
+				// glibc locale, so wxLocale::IsAvailable returns false for
+				// every other language despite the .mo being present.
+				const bool hasCatalog = HasAMuleCatalogForLanguage(aMuleLanguages[i].id);
+				if ((aMuleLanguages[i].id > wxLANGUAGE_USER_DEFINED)
+				    || wxLocale::IsAvailable(aMuleLanguages[i].id)
+				    || hasCatalog) {
 					wxLogNull	logTarget;
 					wxLocale	locale_to_check;
 					InitLocale(locale_to_check, aMuleLanguages[i].id);
 					// English (U.S.) is the source language for the .pot catalog,
 					// so it is always available even though no en_US.mo is shipped.
 					const bool isSourceLanguage = aMuleLanguages[i].id == wxLANGUAGE_ENGLISH_US;
-					if (locale_to_check.IsOk() && (locale_to_check.IsLoaded(PACKAGE) || isSourceLanguage)) {
+					// Inner gate: same Flatpak rationale — InitLocale() can
+					// fail with IsOk()==false when glibc lacks the locale
+					// data for the candidate, but our .mo is still on disk
+					// and will be applied correctly when the user actually
+					// switches to this language. Accept `hasCatalog` here as
+					// well so those entries surface in the picker.
+					if ((locale_to_check.IsOk() && (locale_to_check.IsLoaded(PACKAGE) || isSourceLanguage))
+					    || hasCatalog) {
 						aMuleLanguages[i].displayname = wxString(wxGetTranslation(aMuleLanguages[i].name)) + " [" + aMuleLanguages[i].name + "]";
 						aMuleLanguages[i].available = true;
 #if 0


### PR DESCRIPTION
## Summary

Follow-up to [#18](https://github.com/amule-org/amule/issues/18). cardpuncher reported on the 3.0.0-151-g78f62c053 flatpak-x86_64 build that the Preferences → General → Language dropdown only listed their active glibc locale plus \`English (U.K.)\` / \`English (U.S.)\`, even though all 41 \`amule.mo\` catalogs are bundled into the Flatpak (verified via ostree on the \`.flatpak\`, and the GUI itself runs correctly translated once \`LANG=\` is set externally).

Root cause is in the picker probe in [Preferences.cpp](src/Preferences.cpp): each candidate language is gated behind \`wxLocale::IsAvailable()\` and a subsequent \`wxLocale::IsOk()\` check. Both require glibc locale data for that specific language inside the sandbox. The GNOME runtime ships locale data only for the user's preferred locale via \`org.freedesktop.Platform.Locale\`, so every other language fails the probe regardless of whether our translation catalog is present.

glibc locale data is only needed for \`LC_NUMERIC\` / \`LC_TIME\` formatting, not for translation lookup. \`wxLocale\` can apply our \`amule.mo\` catalog via the install-prefix path registered in \`InitLocale()\` (added in [#22](https://github.com/amule-org/amule/pull/22)) without locale data for the target language.

This adds a \`HasAMuleCatalogForLanguage()\` helper that probes for \`amule.mo\` under the same lookup prefixes \`InitLocale()\` registers (\`GetResourcesDir/locale\` on macOS/Windows, \`GetInstallPrefix/share/locale\` on Linux/*BSD) and accepts that as an additional positive signal in both gates of the picker probe. On system installs where glibc already has the locales, the existing checks pass first and the file-existence test is never reached, so there is no behaviour change on Mac, Windows, or native Linux packages.

## Test plan

- [x] Local macOS build: picker unchanged, same languages as before the patch
- [x] Flatpak build on aarch64 (amule-dev-vm, GNOME Platform 50, flatpak-builder against this branch): picker now shows the full bundled set (Slovenian, Spanish, Swedish, Turkish, Ukrainian, etc. visible at the tail of the dropdown)
- [x] Selecting a non-glibc language (Italian) loads the correct catalog and translates the UI