### PR TITLE
cmake: accept versioned libatomic.so.1 in find_library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,10 +290,15 @@ endif()
 # require libatomic unconditionally on 32-bit builds.
 set (LIBATOMIC "")
 if (CMAKE_SIZEOF_VOID_P EQUAL 4)
-	find_library (LIBATOMIC_LIBRARY NAMES atomic)
+	# Accept either the unversioned `libatomic.so` (Debian / Fedora /
+	# Arch ship it via the -dev / -devel package) or the versioned-only
+	# `libatomic.so.1` (openSUSE ships only the latter -- there's no
+	# separate -devel package). Listing the unversioned name first keeps
+	# the canonical path preferred when both are present.
+	find_library (LIBATOMIC_LIBRARY NAMES atomic libatomic.so.1)
 	if (LIBATOMIC_LIBRARY)
 		set (LIBATOMIC atomic)
-		message (STATUS "32-bit target: linking libatomic for std::atomic<int64_t>")
+		message (STATUS "32-bit target: linking libatomic for std::atomic<int64_t> (${LIBATOMIC_LIBRARY})")
 	else()
 		message (FATAL_ERROR
 			"32-bit target detected (sizeof(void*) == 4). aMule's "


### PR DESCRIPTION
## Summary

Closes #171.

The 32-bit `find_library (NAMES atomic)` call only looks for the unversioned `libatomic.so` symlink, which on Debian / Fedora / Arch lives in the `-dev` / `-devel` package alongside the runtime library. openSUSE ships `libatomic1` with only the versioned `libatomic.so.1`; there's no separate `-devel` package, so the symlink is absent and `find_library` hard-fails the configure even when the linker would happily resolve `-latomic` against the versioned library at link time.

@gcomes reported this on #171 (openSUSE Tumbleweed packman maintainer, i586 32-bit build); his workaround was to manually create the missing `libatomic.so` symlink. @mrjimenez confirmed the openSUSE package names with `zypper search --provides 'libatomic.so'` output.

## Changes

**Widen `find_library` NAMES** to accept both forms:

```diff
-find_library (LIBATOMIC_LIBRARY NAMES atomic)
+find_library (LIBATOMIC_LIBRARY NAMES atomic libatomic.so.1)
```

Unversioned stays the preferred path; the versioned `.so.1` is the fallback for distros that don't ship the symlink. The STATUS line also logs the resolved path so the build log captures which form matched.

## Test plan

- [x] cmake configure clean on macOS arm64 (gate doesn't fire — 64-bit — but verifies the edits parse).
- [x] @gcomes — would you mind dropping the manual `libatomic.so` symlink, pulling this branch, and running `cmake -B build` on your openSUSE Tumbleweed i586 environment? The configure should now succeed without the symlink trick, and the STATUS line should print something like `32-bit target: linking libatomic for std::atomic<int64_t> (/usr/lib/libatomic.so.1)`. Please paste the configure output in code fences either way (success or failure).

## Background

The binary's runtime libatomic dependency stays empty regardless — GNU ld's `--as-needed` default drops the `DT_NEEDED` entry when the compiler inlines the lock-free expansion (CMPXCHG8B on i586+). That's why @gcomes observed `ldd` showing no libatomic dependency in the linked binary. The `-latomic` flag is link-time scaffolding for cross-TU `__atomic_*_8` references that the compiler can't inline, kept as a safety net per the rationale in [CMakeLists.txt:282-292](https://github.com/amule-org/amule/blob/master/CMakeLists.txt#L282-L292) (see also 22ba4f25 / closes #643).