### PR TITLE
ui: theme-aware list-control colours (drop hardcoded *wxBLACK/BLUE/RED)

### DIFF
--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -1001,11 +1001,14 @@ void CGenericClientListCtrl::DrawClientItem(wxDC* dc, int nColumn, const wxRect&
 
 					dc->GetTextExtent(buffer, &txtwidth, &txtheight);
 
-					dc->SetTextForeground(*wxBLACK);
+					// Theme-aware text + border colour (was *wxBLACK / *wxBLACK_PEN
+					// which was invisible on dark themes -- the badge sits on
+					// the row stripe, not on a known light background).
+					const wxColour badgeColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+					dc->SetTextForeground(badgeColour);
 					dc->DrawText(buffer, wxMax(rect.GetX() + 2, mid_x - (txtwidth >> 1)), mid_y - (txtheight >> 1));
 
-					// Draw black border
-					dc->SetPen( *wxBLACK_PEN );
+					dc->SetPen(wxPen(badgeColour));
 					dc->SetBrush( *wxTRANSPARENT_BRUSH );
 					dc->DrawRectangle( rect.GetX(), rect.GetY() + 1, iWidth, iHeight );
 				}
@@ -1038,11 +1041,15 @@ void CGenericClientListCtrl::DrawClientItem(wxDC* dc, int nColumn, const wxRect&
 						if (qrDiff == rank) {
 							qrDiff = 0;
 						}
+						// Queue rank change cue: down (good) = blue, up (bad) = red.
+						// Pure *wxBLUE / *wxRED were unreadable on dark themes;
+						// swap to a hand-tuned palette that contrasts on both.
+						const bool isDark = wxSystemSettings::GetAppearance().IsDark();
 						if ( qrDiff < 0 ) {
-							dc->SetTextForeground(*wxBLUE);
+							dc->SetTextForeground(isDark ? wxColour(120, 170, 255) : wxColour(0, 80, 200));
 						}
 						if ( qrDiff > 0 ) {
-							dc->SetTextForeground(*wxRED);
+							dc->SetTextForeground(isDark ? wxColour(255, 100, 100) : wxColour(220, 0, 0));
 						}
 						buffer = CFormat(_("On Queue: %u (%i)")) % rank % qrDiff;
 					} else {
@@ -1127,7 +1134,11 @@ void CGenericClientListCtrl::DrawClientItem(wxDC* dc, int nColumn, const wxRect&
 				const CPartFile * pf = client.GetRequestFile();
 				if (pf && (pf->GetFileName().GetPrintable().CmpNoCase(buffer) != 0)) {
 					nameMismatch = true;
-					dc->SetTextForeground(*wxRED);
+					// "watch out: peer is advertising a different name for
+					// this hash" warning cue. Pure *wxRED was unreadable on
+					// dark themes.
+					const bool isDark = wxSystemSettings::GetAppearance().IsDark();
+					dc->SetTextForeground(isDark ? wxColour(255, 100, 100) : wxColour(220, 0, 0));
 				}
 			}
 			dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -350,43 +350,46 @@ void CSearchListCtrl::UpdateItemColor(long index)
 		wxLIST_MASK_FORMAT);
 
 	if (GetItem(item)) {
-		CMuleColour newcol(wxSYS_COLOUR_WINDOWTEXT);
-
 		CSearchFile* file = reinterpret_cast<CSearchFile*>(GetItemData(index));
 
-		int red		= newcol.Red();
-		int green	= newcol.Green();
-		int blue	= newcol.Blue();
+		// Theme-aware state palette. The previous logic started from
+		// wxSYS_COLOUR_WINDOWTEXT and overlaid per-channel tints
+		// (`green = 255`, `red = 255` etc.). On light themes the base
+		// is black so the tints produce green / red / magenta; on dark
+		// themes the base is white-ish, so setting a channel that is
+		// already 255 is a no-op and every state collapses to the same
+		// colour -- the cue was invisible. Two hand-tuned palettes
+		// instead, chosen at draw time via IsDark().
+		const bool isDark = wxSystemSettings::GetAppearance().IsDark();
+		wxColour colour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
 
 		switch (file->GetDownloadStatus()) {
 		case CSearchFile::DOWNLOADED:
-			// File has already been downloaded. Mark as green.
-			green = 255;
+			// Already downloaded -- green.
+			colour = isDark ? wxColour( 80, 220,  80) : wxColour(  0, 160,   0);
 			break;
 		case CSearchFile::QUEUED:
-			// File is downloading.
 		case CSearchFile::QUEUEDCANCELED:
-			// File is downloading and has been canceled before.
-			// Mark as red
-			red = 255;
+			// Currently downloading (or was, then cancelled) -- red.
+			colour = isDark ? wxColour(255, 100, 100) : wxColour(220,   0,   0);
 			break;
 		case CSearchFile::CANCELED:
-			// File has been canceled. Mark as magenta.
-			red = 255;
-			blue = 255;
+			// Cancelled -- magenta.
+			colour = isDark ? wxColour(255, 120, 200) : wxColour(180,   0, 180);
 			break;
-		default:
-			// File is new, colour after number of files
-			blue += file->GetSourceCount() * 5;
-			if ( blue > 255 ) {
-				blue = 255;
-			}
+		default: {
+			// New result -- blue-tinted gradient by source count.
+			const int shift = std::min((int)file->GetSourceCount() * 5, 255);
+			colour = isDark ? wxColour(255 - shift, 255 - shift, 255)
+			                : wxColour(0,           0,           shift);
+			break;
+		}
 		}
 
 		// don't forget to set the item data back...
 		wxListItem newitem;
 		newitem.SetId( index );
-		newitem.SetTextColour( wxColour( red, green, blue ) );
+		newitem.SetTextColour( colour );
 		SetItem( newitem );
 	}
 }


### PR DESCRIPTION
## Summary

Closes #177.

PR #128's `*wxBLUE` sweep covered `muuli_wdr.cpp`'s dialog stat labels but didn't touch the custom DC drawing inside the list controls. Two classes of bug remained:

1. **Hardcoded text / pen colours** that render fine on the default light theme but are unreadable on Adwaita-dark / macOS dark / KDE Breeze Dark.
2. **SearchListCtrl's state palette** overlays per-channel tints (`green = 255`, `red = 255`, ...) on a base initialised from `wxSYS_COLOUR_WINDOWTEXT`. On light themes the base is black so the tints produce green / red / magenta. On dark themes the base is white-ish, so setting a channel that's already 255 is a no-op and **every state collapses to the same colour** — the semantic cue disappears entirely.

## Sites fixed

| Site | Was | Now |
|---|---|---|
| `GenericClientListCtrl.cpp:1004` + `:1008` (A4AF badge text + border) | `*wxBLACK`, `*wxBLACK_PEN` | `wxSYS_COLOUR_WINDOWTEXT` |
| `GenericClientListCtrl.cpp:1042` (queue rank ↓) | `*wxBLUE` | `(120,170,255)` dark / `(0,80,200)` light |
| `GenericClientListCtrl.cpp:1045` (queue rank ↑) | `*wxRED` | `(255,100,100)` dark / `(220,0,0)` light |
| `GenericClientListCtrl.cpp:1130` (filename mismatch) | `*wxRED` | `(255,100,100)` dark / `(220,0,0)` light |
| `SearchListCtrl.cpp:362-389` (state palette) | channel-tweak on `WINDOWTEXT` base | explicit per-state palette branching on `IsDark()` |

## Primitive

```cpp
const bool isDark = wxSystemSettings::GetAppearance().IsDark();
```

Called per-paint (not cached at startup), so a runtime theme toggle takes effect on the next list refresh. Available since wxWidgets 3.1.3 — safely in our 3.2 minimum.

## Sites intentionally not touched

- `CaptchaGenerator.cpp:53` — drawing onto a `*wxWHITE_BRUSH` bitmap; theme is irrelevant.
- `DownloadListCtrl.cpp:1035` / `:1037` — contrast keyed off the progress bar's own hardcoded fill, not the system background.

## Test plan

- [x] macOS arm64 dark mode + light mode: all five sites readable.
- [x] @Stoatwblr — would you test against your environment before this merges? The two original sites you reported plus the three adjacent ones I caught while sweeping: queue rank decrease + increase pair, the filename-mismatch highlight, and the search-result list state colours (which had the additional bug of being completely indistinguishable on dark themes). Please paste a quick visual or log confirmation when you've had a look.
- [x] CI build matrix.