### PR TITLE
AICH: rate-limit OP_AICHREQUEST + O(1) LoadHashSet via offset cache

### DIFF
--- a/src/ClientTCPSocket.cpp
+++ b/src/ClientTCPSocket.cpp
@@ -1548,6 +1548,16 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t* buffer, uint32 size, uint
 		case OP_AICHREQUEST: {
 			AddDebugLogLineN( logRemoteClient, "Remote Client: OP_AICHREQUEST from " + m_client->GetFullIP()  );
 			theStats::AddDownOverheadOther(size);
+			// Each OP_AICHREQUEST triggers an O(N) walk of known2.met
+			// via ProcessAICHRequest -> CreatePartRecoveryData ->
+			// LoadHashSet. Without rate-limiting, a hostile peer can
+			// hammer this with 16-byte packets and force the seeder to
+			// burn disk + CPU on each one. Treat repeated requests the
+			// same way the file-request paths do.
+			m_client->CheckForAggressive();
+			if ( m_client->IsBanned() ) {
+				break;
+			}
 			m_client->ProcessAICHRequest(buffer, size);
 			break;
 		}

--- a/src/SHAHashSet.cpp
+++ b/src/SHAHashSet.cpp
@@ -47,9 +47,11 @@
 
 CAICHRequestedDataList CAICHHashSet::m_liRequestedData;
 
-// Lazily-built dedup index over known2.met. See SaveHashSet for usage.
+// Lazily-built index mapping root hash → file offset in known2.met.
+// See SaveHashSet (dedup-on-append) and LoadHashSet (O(1) lookup for
+// incoming AICH requests) for usage.
 wxMutex CAICHHashSet::s_rootHashCacheMutex;
-std::unordered_set<CAICHHash> CAICHHashSet::s_rootHashCache;
+std::unordered_map<CAICHHash, uint64> CAICHHashSet::s_rootHashCache;
 bool CAICHHashSet::s_rootHashCacheLoaded = false;
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -668,6 +670,10 @@ void CAICHHashSet::LoadRootHashCacheLocked()
 			return;
 		}
 		while (file.GetPosition() < nFileSize) {
+			// Remember the byte offset of the root-hash position so
+			// LoadHashSet can seek straight here later instead of
+			// rewalking the file.
+			const uint64 entryOffset = file.GetPosition();
 			CAICHHash rootHash;
 			rootHash.Read(&file);
 			const uint32 nHashCount = file.ReadUInt32();
@@ -681,7 +687,7 @@ void CAICHHashSet::LoadRootHashCacheLocked()
 				break;
 			}
 			file.Seek(static_cast<wxFileOffset>(skipBytes), wxFromCurrent);
-			s_rootHashCache.insert(rootHash);
+			s_rootHashCache.emplace(rootHash, entryOffset);
 		}
 	} catch (const CSafeIOException& e) {
 		AddDebugLogLineC(logSHAHashSet,
@@ -715,6 +721,11 @@ bool CAICHHashSet::SaveHashSet()
 		return true;
 	}
 
+	// Byte offset at which the new entry's root hash will be appended.
+	// Captured inside the try block and used after it to update the
+	// cache once the write has succeeded.
+	uint64 newEntryOffset = 0;
+
 	try {
 		const wxString fullpath = thePrefs::GetConfigDir() + KNOWN2_MET_FILENAME;
 		const bool exists = wxFile::Exists(fullpath);
@@ -741,6 +752,11 @@ bool CAICHHashSet::SaveHashSet()
 			nExistingSize += 1;
 		}
 
+		// This is the byte offset at which the new entry's root hash
+		// will land — capture it for the cache so LoadHashSet can
+		// seek straight here later.
+		newEntryOffset = nExistingSize;
+
 		// write hashset
 		m_pHashTree.m_Hash.Write(&file);
 		uint32 nHashCount = (PARTSIZE/EMBLOCKSIZE + ((PARTSIZE % EMBLOCKSIZE != 0)? 1 : 0)) * (m_pHashTree.m_nDataSize/PARTSIZE);
@@ -766,9 +782,10 @@ bool CAICHHashSet::SaveHashSet()
 		return false;
 	}
 
-	// Append succeeded — record in the cache so the next SaveHashSet for
-	// the same root hash dedups in O(1).
-	s_rootHashCache.insert(m_pHashTree.m_Hash);
+	// Append succeeded — record offset in the cache so the next
+	// SaveHashSet for this root hash dedups in O(1), and LoadHashSet
+	// can seek straight to it.
+	s_rootHashCache.emplace(m_pHashTree.m_Hash, newEntryOffset);
 	return true;
 }
 
@@ -783,6 +800,31 @@ bool CAICHHashSet::LoadHashSet()
 		wxFAIL;
 		return false;
 	}
+
+	// O(1) cache lookup: ask the offset index where this root hash
+	// lives in known2.met. The cache was the dedup-on-write index
+	// before; here we reuse it to skip the linear scan that used to
+	// happen on every incoming OP_AICHREQUEST (issue #166). If the
+	// cache miss-and-cold-load path is taken we still pay the one-shot
+	// walk, but only once across all subsequent calls.
+	uint64 cachedOffset = 0;
+	bool haveCachedOffset = false;
+	{
+		wxMutexLocker lock(s_rootHashCacheMutex);
+		if (!s_rootHashCacheLoaded) {
+			LoadRootHashCacheLocked();
+		}
+		auto it = s_rootHashCache.find(m_pHashTree.m_Hash);
+		if (it != s_rootHashCache.end()) {
+			cachedOffset = it->second;
+			haveCachedOffset = true;
+		} else if (s_rootHashCacheLoaded) {
+			// Cache is authoritative and the hash isn't there.
+			// known2.met genuinely doesn't contain it; skip the I/O.
+			return false;
+		}
+	}
+
 	wxString fullpath = thePrefs::GetConfigDir() + KNOWN2_MET_FILENAME;
 	CFile file(fullpath, CFile::read);
 	if (!file.IsOpened()) {
@@ -798,6 +840,13 @@ bool CAICHHashSet::LoadHashSet()
 		if (header != KNOWN2_MET_VERSION) {
 			AddDebugLogLineC(logSHAHashSet, "Loading failed: Current file is not a met-file!");
 			return false;
+		}
+
+		// Fast path: seek straight to the cached entry. If the hash at
+		// that offset doesn't match, the cache is stale -- fall through
+		// to the linear scan from the start as a defensive recovery.
+		if (haveCachedOffset) {
+			file.Seek(static_cast<wxFileOffset>(cachedOffset), wxFromStart);
 		}
 
 		CAICHHash CurrentHash;

--- a/src/SHAHashSet.h
+++ b/src/SHAHashSet.h
@@ -74,7 +74,7 @@ Version 2 of AICH also supports 32bit identifiers to support large files, check 
 
 #include <deque>
 #include <set>
-#include <unordered_set>
+#include <unordered_map>
 
 #include <wx/thread.h>		// Needed for wxMutex
 
@@ -305,12 +305,22 @@ public:
 	static void InvalidateRootHashCache();
 
 private:
-	// Cache of every root hash currently stored in known2.met. Populated
-	// lazily on first SaveHashSet call (or refilled after invalidation).
-	// Replaces the per-call linear file walk that made SaveHashSet O(N)
-	// per call / O(N^2) over a bulk-hash batch.
+	// Cache mapping every root hash currently stored in known2.met to
+	// the byte offset of its entry's root-hash position in the file.
+	// Populated lazily on first SaveHashSet or LoadHashSet call (or
+	// refilled after invalidation).
+	//
+	// - For SaveHashSet: replaces the per-call linear file walk that
+	//   made the dedup check O(N) per call / O(N^2) over a bulk-hash
+	//   batch.
+	// - For LoadHashSet (and the AICH request path that calls it):
+	//   replaces the per-call linear file walk that turned each
+	//   incoming OP_AICHREQUEST into an O(N) disk-backed scan. The
+	//   cached offset lets LoadHashSet seek straight to the matching
+	//   entry, making the AICH request path O(1) and closing the DoS
+	//   amplification noted in #166.
 	static wxMutex			s_rootHashCacheMutex;
-	static std::unordered_set<CAICHHash> s_rootHashCache;
+	static std::unordered_map<CAICHHash, uint64> s_rootHashCache;
 	static bool			s_rootHashCacheLoaded;
 
 	// Caller must hold s_rootHashCacheMutex.


### PR DESCRIPTION
## Summary

Addresses both mitigations identified by @danim7 in #166 ([analysis](https://github.com/amule-org/amule/issues/166#issuecomment-4723989476)).

Two independent commits — they can be reviewed and bisected separately.

### Commit 1 — rate-limit OP_AICHREQUEST

[`ClientTCPSocket.cpp:1548`](https://github.com/amule-org/amule/blob/master/src/ClientTCPSocket.cpp#L1548) was the only file-request-shaped opcode in the TCP dispatch that bypassed `CheckForAggressive()`. A hostile peer could send 16-byte `OP_AICHREQUEST` packets at it and each one chained through `ProcessAICHRequest` → `CreatePartRecoveryData` → `LoadHashSet`, forcing an O(N) walk of `known2.met` per packet. On a busy seeder (~120 MiB `known2.met` per TiB shared) the amplification is real.

Match the `OP_STARTUPLOADREQ` pattern at [`:539`](https://github.com/amule-org/amule/blob/master/src/ClientTCPSocket.cpp#L539): tick the per-client request counter and bail if `Ban()` already fired this round.

The other ungated AICH opcodes don't have the same disk-amplification shape (`OP_AICHANSWER` is inbound response data; `OP_AICHFILEHASHREQ` only does an in-memory `GetFileByID` lookup) and stay as-is.

### Commit 2 — O(1) LoadHashSet via offset cache

`s_rootHashCache` already existed for dedup-on-write (introduced in #579) as `unordered_set<CAICHHash>`. Extend it to `unordered_map<CAICHHash, uint64>` where the value is the byte offset of the entry's root-hash position in `known2.met`.

- `LoadRootHashCacheLocked` records `file.GetPosition()` before reading each `rootHash` during the one-shot walk.
- `SaveHashSet` records the offset of the new entry's root hash immediately after the append succeeds.
- `LoadHashSet` looks up the cached offset under the existing mutex, seeks straight there, and validates — O(1) on a hit. On a cold cache it pays the one-shot `LoadRootHashCacheLocked` walk once and is O(1) for every subsequent call.

Two follow-on wins fall out:

- When the cache is loaded and the requested root hash isn't present, `LoadHashSet` returns false immediately without opening `known2.met` — the cache is authoritative once warm.
- The dedup-on-write fast path in `SaveHashSet` keeps its O(1) behaviour unchanged (`set` vs. `map` lookup cost is identical).

**Memory cost:** ~8 bytes per `known2.met` entry beyond the existing set. A 1 TiB library at ~5500 files averages ~44 KiB extra RAM. Negligible.

**Defensive fallback:** if the cached offset's hash doesn't match (stale cache from external `known2.met` mutation), `LoadHashSet` falls through to the existing linear-scan loop from the post-header position. False negatives are non-fatal — the caller sends an empty AICH answer and the peer re-requests.

## Test plan

- [x] CI build matrix green (9/9: Ubuntu Debug+Release, macOS Debug+Release, mingw-w64 Debug+Release, App catalogs, Manpage catalogs, Translation checks).
- [x] Configure + build clean on macOS arm64 (Release **and** Debug, the latter to exercise the `__DEBUG__`-gated log paths).
- [x] End-to-end verification harness drives both code paths against an isolated patched `amuled` (no production touch). Setup boots a throwaway daemon under `/tmp/amule-aich-test/` with one shared 500 KB test file and enables the `ED2k Client` / `Remote Client Protocol` / `AICH-Transfer` / `SHAHashSet` debug categories so the dispatch and ban paths are observable in the logfile.

  **Test 1 — offset cache returns valid AICH recovery data.** Send a legitimate `OP_AICHREQUEST` referencing the test file's MD4 (computed in-script via `hashlib.md4`) and AICH master hash (parsed from `known2_64.met` offset 1, the first entry's 20-byte root). Receive `OP_AICHANSWER` with 108 bytes of recovery payload — proving `LoadHashSet` resolved the cached offset, seeked to the right entry, and emitted correct output.

  **Test 2 — flood triggers Ban() at exactly the expected request.** Restart amuled (so the per-IP client-tracker state from test 1 doesn't pre-load `m_LastFileRequest`), then send 8 rapid `OP_AICHREQUEST` packets with 300 ms inter-send delay. Result mirrors `CheckForAggressive`'s math exactly: requests 1-4 receive a 108-byte answer (score 0→3→6→9, all below the threshold of 10); request 5 silenced because the in-handler `Ban()` fires at score 12; requests 6-8 hit the new `IsBanned()` short-circuit before `ProcessAICHRequest`. The amuled debug log confirms with "Aggressive client banned (score: 12): amule-bench".

- [x] Harness output and log excerpt posted as a PR comment for visibility.