### PR TITLE
fix(aich): true linear-scan fallback when LoadHashSet cache offset is stale

### DIFF
--- a/src/SHAHashSet.cpp
+++ b/src/SHAHashSet.cpp
@@ -842,16 +842,25 @@ bool CAICHHashSet::LoadHashSet()
 			return false;
 		}
 
-		// Fast path: seek straight to the cached entry. If the hash at
-		// that offset doesn't match, the cache is stale -- fall through
-		// to the linear scan from the start as a defensive recovery.
+		uint64 nExistingSize = file.GetLength();
+
+		// Fast path: seek straight to the cached entry. If the offset
+		// turns out to be stale -- past EOF, or first read at that
+		// position doesn't match our root hash -- rewind once to just
+		// past the version header and fall through to a true linear
+		// scan from the top as defensive recovery against external
+		// modification of known2.met between cache load and now.
 		if (haveCachedOffset) {
-			file.Seek(static_cast<wxFileOffset>(cachedOffset), wxFromStart);
+			if (cachedOffset >= nExistingSize) {
+				haveCachedOffset = false;
+			} else {
+				file.Seek(static_cast<wxFileOffset>(cachedOffset), wxFromStart);
+			}
 		}
 
 		CAICHHash CurrentHash;
-		uint64 nExistingSize = file.GetLength();
 		uint32 nHashCount;
+		bool cacheFallbackTriggered = false;
 		while (file.GetPosition() < nExistingSize) {
 			CurrentHash.Read(&file);
 			if (m_pHashTree.m_Hash == CurrentHash) {
@@ -878,6 +887,17 @@ bool CAICHHashSet::LoadHashSet()
 					return false;
 				}
 				return true;
+			}
+			// First read after seeking to the cached offset didn't match
+			// our root hash. The cache must be stale -- known2.met was
+			// modified externally between cache load and now. Rewind once
+			// to just past the version header and restart as a true linear
+			// scan from the top.
+			if (haveCachedOffset && !cacheFallbackTriggered) {
+				cacheFallbackTriggered = true;
+				haveCachedOffset = false;
+				file.Seek(1, wxFromStart);
+				continue;
 			}
 			nHashCount = file.ReadUInt32();
 			if (file.GetPosition() + nHashCount*HASHSIZE > nExistingSize) {


### PR DESCRIPTION
## Summary

Follow-up to #186, addressing point 1 of @danim7's [post-merge review](https://github.com/amule-org/amule/pull/186#issuecomment-4730057741).

PR #186 added an offset cache so `LoadHashSet` seeks straight to the matching entry in `known2.met` instead of walking it linearly. The previous inline comment claimed that on a first-read mismatch we'd "fall through to the linear scan from the start as defensive recovery". @danim7 pointed out — correctly — that the loop actually keeps reading from the cached offset onward and just skips `nHashCount * HASHSIZE` bytes on each mismatch. If the cache is stale (`known2.met` modified externally between cache load and request), the offset could point into the middle of a hash blob; we'd misread `CurrentHash`, misread `nHashCount`, and the loop would walk off into garbage and ultimately return `false` even though the entry still exists somewhere in the file.

## What this changes

In `LoadHashSet`:
- On the first iteration after seeking to the cached offset, if `CurrentHash` doesn't match `m_pHashTree.m_Hash`, treat the cache as stale, rewind to byte 1 (just past the version header), and continue with a true linear scan from the top. Guarded by `cacheFallbackTriggered` so the rewind can fire at most once per call.
- If the cached offset is `>= file.GetLength()` (file was truncated externally), skip the seek entirely and fall straight to the linear scan.

In the happy path (cache correct), behaviour is unchanged: the first read matches and the existing match handler runs.

## Verification

- [x] Local Mac build clean.
- [x] PR #186's existing `verify-pr186-aich.py` still passes (single-file happy path).
- [x] New `verify-loadhashset-multi-file.py` (in `scripts/`, not part of this PR): boots amuled with **two** shared files of different sizes, waits for both AICH trees to land in `known2_64.met`, then sends two OP_AICHREQUESTs (one per file) on a single connection within the rate-limit budget. Both files resolve to non-empty `OP_AICHANSWER` payloads (152 B for file A, 306 B for file B), confirming the cache correctly returns distinct offsets per entry.

The stale-cache rewind path itself is not directly exercised by these tests — reaching it requires external modification of `known2.met` between cache load and request, which isn't reachable from a black-box harness without an instrumentation hook. The code path is small (~20 lines) and reviewable on inspection.

## Test plan

- [x] CI to verify the other targets.