### PR TITLE
fix(udp): short-circuit UDP file-info handler when client is banned

### DIFF
--- a/src/ClientUDPSocket.cpp
+++ b/src/ClientUDPSocket.cpp
@@ -192,6 +192,14 @@ void CClientUDPSocket::ProcessPacket(uint8_t* packet, int16 size, int8 opcode, u
 
 			if (sender){
 				sender->CheckForAggressive();
+				if (sender->IsBanned()) {
+					// CheckForAggressive can call Ban() on score >= 10.
+					// Mirror the TCP file-request path at
+					// ClientTCPSocket.cpp:539 and short-circuit so a
+					// freshly-banned client cannot keep the seeder
+					// processing UDP file-info packets.
+					break;
+				}
 
 				//Make sure we are still thinking about the same file
 				if (reqfilehash == sender->GetUploadFileID()) {


### PR DESCRIPTION
## Summary

Follow-up to #186, addressing point 3 of @danim7's [post-merge review](https://github.com/amule-org/amule/pull/186#issuecomment-4730057741).

[`ClientUDPSocket.cpp:194`](src/ClientUDPSocket.cpp#L194) calls `CheckForAggressive()` on incoming UDP file-info packets but doesn't short-circuit on `IsBanned()` after, unlike the TCP file-request path at [`ClientTCPSocket.cpp:539`](src/ClientTCPSocket.cpp#L539) (and the TCP `OP_AICHREQUEST` path added in #186). `CheckForAggressive` can call `Ban()` when `m_Aggressiveness >= 10`, but the UDP handler then falls through and keeps processing the request anyway — `AddAskedCount()`, `SetUDPPort()`, `SetLastUpRequest()`, `ProcessExtendedInfo()`, and on through the rest of the case.

A freshly-banned client could keep the seeder doing work on each UDP file-info packet it sends. Small leak, same shape as the TCP gap that #186 closed.

## What this changes

Mirror the TCP guard: `break` out of the dispatch case if `IsBanned()` returns `true` immediately after `CheckForAggressive()`.

## Verification

- [x] Local Mac build clean (incremental on master + this change).
- [x] CI to verify the other targets.

This is the smallest possible diff that brings the UDP file-info handler in line with the rest of the aggressive-check paths in the codebase.