### PR TITLE
fix(aich): self-heal LoadHashSet offset cache on successful rewind

### DIFF
--- a/src/SHAHashSet.cpp
+++ b/src/SHAHashSet.cpp
@@ -862,6 +862,10 @@ bool CAICHHashSet::LoadHashSet()
 		uint32 nHashCount;
 		bool cacheFallbackTriggered = false;
 		while (file.GetPosition() < nExistingSize) {
+			// Position of the root-hash at the start of the entry we're
+			// about to examine — captured pre-read so we can stamp it
+			// back into the cache when a stale-cache rewind succeeds.
+			const uint64 entryStartPos = file.GetPosition();
 			CurrentHash.Read(&file);
 			if (m_pHashTree.m_Hash == CurrentHash) {
 				// found Hashset
@@ -885,6 +889,14 @@ bool CAICHHashSet::LoadHashSet()
 				if (CurrentHash != m_pHashTree.m_Hash) {
 					AddDebugLogLineC(logSHAHashSet, "Failed to load HashSet: Calculated Masterhash differs from given Masterhash - hashset corrupt!");
 					return false;
+				}
+				// Self-heal: if we got here via the stale-cache rewind,
+				// update the cache so future lookups for this root hash
+				// go straight to the new correct offset instead of
+				// paying the linear-scan penalty every time.
+				if (cacheFallbackTriggered) {
+					wxMutexLocker lock(s_rootHashCacheMutex);
+					s_rootHashCache[m_pHashTree.m_Hash] = entryStartPos;
 				}
 				return true;
 			}


### PR DESCRIPTION
## Summary

Follow-up to #191.

#191 added a defensive rewind so `LoadHashSet` finds the right entry even when the cached offset is stale (`known2.met` modified externally between cache load and the request). The rewind worked, but it didn't update the cache after recovering — so every subsequent `LoadHashSet` for the same stale root hash kept paying the seek-miss + full linear scan instead of the O(1) cache hit the cache exists to provide.

The cache only self-cleared on daemon restart, on `CEOFException`-driven truncation, or after an orphan-prune rewrite in [`CAICHSyncTask::Entry()`](src/ThreadTasks.cpp#L410) — none of which fire just because a single entry's offset went stale.

## What this changes

In the match handler inside `LoadHashSet`:
- Capture the entry's start position pre-read (`entryStartPos`) so we know the exact offset of the root hash — matching the value `LoadRootHashCacheLocked` and `SaveHashSet` write into the cache.
- When the match happens AND we got there via the stale-cache rewind (`cacheFallbackTriggered == true`), stamp the new offset back into `s_rootHashCache`. Future lookups for the same hash go straight to the right offset.

Total diff is 12 lines added.

## Verification

- [x] Local Mac build clean.
- [x] CI for the other targets.

The fast-path (cache fresh, first read matches) is unchanged: `cacheFallbackTriggered` stays `false`, so the cache-update branch is skipped. Self-heal cost is one mutex lock + one map write, only on the rewind path, only on successful recovery.