### PR TITLE
fix(macos): bundle webserver templates into aMule.app

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -351,6 +351,37 @@ if (BUILD_MONOLITHIC)
 				)
 			endforeach()
 		endif()
+
+		# Bundle the default webserver template into the .app at
+		# Contents/Resources/webserver/default/. amuleweb's macOS
+		# template lookup in WebInterface.cpp::GetTemplateDir uses
+		# LSCopyApplicationURLsForBundleIdentifier("org.amule.aMule")
+		# to find the bundle, then expects login.php and friends under
+		# Contents/Resources/webserver/<templateName>/. The unix-style
+		# INSTALL rule in src/webserver/default/CMakeLists.txt writes
+		# to ${PKGDATADIR}/webserver/default which is outside the .app
+		# bundle scope, so without this bundling step every macOS user
+		# enabling the web server gets a fatal "Cannot find template:
+		# default" at amuleweb startup. The file list is the one set
+		# in src/webserver/default/CMakeLists.txt so the bundle stays
+		# in sync with the unix INSTALL rule automatically.
+		if (BUILD_WEBSERVER AND WEBSERVER_DEFAULT_TEMPLATE_FILES)
+			set (_tmpl_src "${CMAKE_SOURCE_DIR}/src/webserver/default")
+			set (_tmpl_dst
+				"$<TARGET_BUNDLE_CONTENT_DIR:amule>/Resources/webserver/default")
+			add_custom_command (TARGET amule POST_BUILD
+				COMMAND ${CMAKE_COMMAND} -E make_directory "${_tmpl_dst}"
+				COMMENT "Bundling default webserver template into aMule.app"
+				VERBATIM
+			)
+			foreach (_tmpl IN LISTS WEBSERVER_DEFAULT_TEMPLATE_FILES)
+				add_custom_command (TARGET amule POST_BUILD
+					COMMAND ${CMAKE_COMMAND} -E copy_if_different
+						"${_tmpl_src}/${_tmpl}" "${_tmpl_dst}/"
+					VERBATIM
+				)
+			endforeach()
+		endif()
 	endif()
 
 	install (TARGETS amule

--- a/src/webserver/default/CMakeLists.txt
+++ b/src/webserver/default/CMakeLists.txt
@@ -1,4 +1,8 @@
-INSTALL (FILES
+# Canonical list of files in the default web template. Cached so the
+# macOS .app bundle step in src/CMakeLists.txt can copy the same set
+# into aMule.app/Contents/Resources/webserver/default/ without
+# duplicating the list.
+set (WEBSERVER_DEFAULT_TEMPLATE_FILES
 		amuleweb-main-dload.php
 		amuleweb-main-kad.php
 		amuleweb-main-log.php
@@ -66,5 +70,10 @@ INSTALL (FILES
 		tree-open.gif
 		up.png
 		yellow.gif
+	CACHE INTERNAL "Default webserver template file list"
+)
+
+INSTALL (FILES
+		${WEBSERVER_DEFAULT_TEMPLATE_FILES}
 	DESTINATION "${PKGDATADIR}/webserver/default"
 )


### PR DESCRIPTION
## Summary

amuleweb on macOS fails immediately when users enable the web server in preferences. The lookup at [`WebInterface.cpp` `GetTemplateDir`](https://github.com/amule-org/amule/blob/master/src/webserver/src/WebInterface.cpp#L146-L194) uses `LSCopyApplicationURLsForBundleIdentifier("org.amule.aMule")` to find the installed `aMule.app`, then expects `Contents/Resources/webserver/<templateName>/login.php`. The unix-style `INSTALL` rule in `src/webserver/default/CMakeLists.txt` writes templates to `${PKGDATADIR}/webserver/default/` — outside any `.app` bundle scope — so the lookup always returns "not found" and amuleweb aborts with `FATAL ERROR: Cannot find template: default`. End-users see no logs that explain why.

Tracking #183 doesn't surface the template error because the user there gave up before getting that far, but it's the same root cause behind "enabled the web server, nothing happens".

## What this changes

Adds an `add_custom_command POST_BUILD` chain on the `amule` target that copies the canonical webserver template file list into `\$<TARGET_BUNDLE_CONTENT_DIR:amule>/Resources/webserver/default/`, mirroring the locale-catalog bundling pattern a few lines above. The file list lives in `src/webserver/default/CMakeLists.txt` and now drives both the unix `INSTALL` rule and the macOS bundle step via a `CACHE INTERNAL` variable — single source of truth, no risk of the two lists drifting apart when a template file is added.

Linux and Windows users are unaffected: `cmake --install` still writes templates to `\${PKGDATADIR}/webserver/default/` and amuleweb finds them via the `WEBSERVERDIR` compile-time fallback in `WebInterface.cpp:204`.

## Test plan

- [x] `cmake -B build -DBUILD_MONOLITHIC=YES -DBUILD_WEBSERVER=YES && cmake --build build --target amule` produces `build/src/aMule.app/Contents/Resources/webserver/default/` with all 67 template files.
- [x] Skipping `-DBUILD_WEBSERVER=YES` cleanly bypasses the bundling step (the `if (BUILD_WEBSERVER AND WEBSERVER_DEFAULT_TEMPLATE_FILES)` guard).
- [x] The unix `INSTALL` rule in `src/webserver/default/CMakeLists.txt` still resolves the same file list (CACHE INTERNAL variable is set before the rule consumes it).
- [x] End-to-end on the next macOS DMG build via CI: install `aMule.app` to `/Applications`, enable the web server with a password, restart, hit `http://localhost:4711/` and get the login page instead of the template-not-found death.