### PR TITLE
fix(webserver): correct default template layout glitches after HTML5 switch

### DIFF
--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -69,9 +69,10 @@ function formCommandSubmit(command)
                   </td>
                 </tr>
               </table>
+        <table class="w100p"><tr><td class="h10"></td></tr></table>
         <table class="tab">
           <caption>
-        SHARED FILES 
+        SHARED FILES
         </caption>
           <tr> 
             <td><img src="images/tab_top_left.png" width="24" height="24"></td>

--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -21,10 +21,11 @@ function login_init()
         <tr>
           <td><table class="w100p h100p bg-white">
               <tr class="va-top">
-               <th class="w366 h180"><img src="images/loginlogo.jpg" width="366" height="180"></th>
+               <th class="w366 h180 login-logo"><img src="images/loginlogo.jpg" width="366" height="180"></th>
                 <th class="w100p login-banner">
                   <form action="" method="post" name="login">
-                    Enter password : 
+                    Enter password
+                    &nbsp; 
                     <input name="pass" size="20" value="" type="password">
                     &nbsp; 
                     <input name="submit" type="submit" value="Submit">

--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -180,6 +180,9 @@ td.navbar-cell {
 	height: 64px;
 	background-image: url(images/fond_haut.png);
 }
+td.navbar-cell img {
+	display: block;
+}
 table.navbar-table {
 	margin-left: auto;
 }
@@ -366,6 +369,10 @@ th.login-banner {
 	text-align: right;
 	vertical-align: middle;
 	background-image: url(images/loginfond_haut.png);
+	color: #000000;
+}
+th.login-logo > img {
+	display: block;
 }
 .login-error {
 	display: inline-block;


### PR DESCRIPTION
The HTML5 doctype upgrade (standards mode) introduced inline-image descender gaps that were fixed for some images but missed two, and exposed a pre-existing layout inconsistency on the shared page:

- Login page: give the logo image display:block so its descender gap no longer makes the banner row taller than its background, which left a thin white line below the login box. Add a login-logo class to scope the rule.
- Navbar: give the col.png separator (the only inline <img> in the navbar) display:block, removing the ~2px descender gap that made the bar taller and pushed all page content down by 2px.
- Shared page: add the 10px spacer between the action toolbar and the content box that the downloads page already has, so both toolbar pages share the same header-to-content separation.
- Login page: make the "Enter password" label black instead of the inherited dark blue.