### PR TITLE
i18n: fix non-ASCII mangling under default C locale (#203)

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -24,8 +24,8 @@
 
 #include "ExternalConnector.h"
 #include "config.h"		// Needed for VERSION and readline detection
-#include <clocale>		// For setlocale()
 #include <common/Format.h>	// Needed for CFormat
+#include <common/LocaleInit.h>	// Needed for aMuleInitLocale()
 #include <wx/tokenzr.h>		// For wxStringTokenizer
 
 // For readline
@@ -678,7 +678,9 @@ bool CaMuleExternalConnector::OnInit()
 	// readline does its own setlocale on first read, so paths that go
 	// through readline appear to work; non-interactive paths (e.g.
 	// amulecmd -c "...") don't and need the explicit init here.
-	setlocale(LC_ALL, "");
+	// The helper also forces LC_NUMERIC back to "C" so libc printf/scanf
+	// decimal handling stays portable.
+	aMuleInitLocale();
 
 	// If we didn't know that OnInit is called only once when creating the
 	// object, it could cause a memory leak. The two pointers below should

--- a/src/amuled.cpp
+++ b/src/amuled.cpp
@@ -47,6 +47,7 @@
 
 #include <wx/utils.h>
 
+#include <common/LocaleInit.h>		// Needed for aMuleInitLocale()
 #include "Preferences.h"		// Needed for CPreferences
 #include "PartFile.h"			// Needed for CPartFile
 #include "PartFileHashThread.h"	// Needed for EVT_PARTFILE_HASH_RESULT
@@ -218,6 +219,11 @@ bool CamuleDaemonApp::Initialize(int& argc_, wxChar **argv_)
 	if ( !wxAppConsole::Initialize(argc_, argv_) ) {
 		return false;
 	}
+
+	// Pull LC_CTYPE etc. from the environment so unicode2char() emits
+	// real UTF-8 instead of mangling non-ASCII bytes under the default
+	// "C" locale (see #203).
+	aMuleInitLocale();
 
 #ifdef __UNIX__
 	wxString encName;

--- a/src/libs/common/CMakeLists.txt
+++ b/src/libs/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library (mulecommon STATIC
 	FileFunctions.cpp
 	Format.cpp
+	LocaleInit.cpp
 	MD5Sum.cpp
 	MuleDebug.cpp
 	Path.cpp

--- a/src/libs/common/LocaleInit.cpp
+++ b/src/libs/common/LocaleInit.cpp
@@ -1,0 +1,32 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program contributed by third-party developers are
+// copyrighted by their respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "LocaleInit.h"
+
+#include <clocale>
+
+void aMuleInitLocale()
+{
+	std::setlocale(LC_ALL, "");
+	std::setlocale(LC_NUMERIC, "C");
+}

--- a/src/libs/common/LocaleInit.h
+++ b/src/libs/common/LocaleInit.h
@@ -1,0 +1,47 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program contributed by third-party developers are
+// copyrighted by their respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef LOCALEINIT_H
+#define LOCALEINIT_H
+
+// Initialise the libc locale for an aMule binary.
+//
+// Picks `LC_CTYPE` (and related) up from the environment via
+// `setlocale(LC_ALL, "")` so the multibyte conversions used by wxConvLibc
+// (e.g. `unicode2char()` in StringFunctions.cpp) emit real UTF-8 instead
+// of mangling non-ASCII bytes the way they do under the default `C`
+// locale. Then forces `LC_NUMERIC` back to `C` so libc printf/scanf
+// decimal handling stays portable across locales (e.g. de_DE.UTF-8 would
+// otherwise turn `"%.2f"` of 3.14 into `"3,14"` and break any text-based
+// numeric serialisation that relies on libc).
+//
+// Call this once, as early as possible, from each binary's earliest
+// initialisation hook. Safe to call multiple times. Has no effect on
+// binaries that already drive their locale through `wxLocale`
+// (`amule` / `amule-remote-gui`); the inner setlocale calls are no-ops
+// when the resulting state matches.
+//
+// See amule-org/amule#203 for the original reported bug.
+void aMuleInitLocale();
+
+#endif // LOCALEINIT_H

--- a/src/utils/cas/cas.c
+++ b/src/utils/cas/cas.c
@@ -24,6 +24,7 @@
  *  Free Software Foundation, Inc.,
  *  51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
  */
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -152,6 +153,15 @@ return getopt(argc,argv,optstring);
 
 int main(int argc, char *argv[])
 {
+	/* Pull LC_CTYPE etc. from the environment so non-ASCII paths and
+	 * config values come through correctly under the default "C" locale
+	 * (see amule-org/amule#203). Force LC_NUMERIC back to "C" so
+	 * sprintf("%f") and friends stay portable across user locales. cas
+	 * is plain C, so we call libc setlocale directly rather than the
+	 * C++ aMuleInitLocale() helper used by the other binaries. */
+	setlocale(LC_ALL, "");
+	setlocale(LC_NUMERIC, "C");
+
 	/* Declaration of variables */
 	FILE *amulesig;
 	int use_page = 0;

--- a/src/utils/fileview/FileView.cpp
+++ b/src/utils/fileview/FileView.cpp
@@ -30,6 +30,7 @@
 #include "KadFiles.h"
 #include "Print.h"
 #include "../../CFile.h"
+#include <common/LocaleInit.h>
 
 #define VERSION_MAJOR	0
 #define VERSION_MINOR	10
@@ -78,6 +79,12 @@ IMPLEMENT_APP(CFileView);
 
 void CFileView::OnInitCmdLine(wxCmdLineParser& parser)
 {
+	// Pull LC_CTYPE etc. from the environment so unicode2char() emits
+	// real UTF-8 instead of mangling non-ASCII filenames under the
+	// default "C" locale (see #203). CFileView has no OnInit override,
+	// so this is the earliest hook wxApp calls after construction.
+	aMuleInitLocale();
+
 	parser.AddSwitch("h", "help", "Show help", wxCMD_LINE_OPTION_HELP);
 	parser.AddSwitch("v", "version", "Show program version", wxCMD_LINE_PARAM_OPTIONAL);
 	parser.AddOption("s", "strings", "String decoding mode: display (default), safe, utf8, none", wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL);


### PR DESCRIPTION
## Summary

Fix #203: `amuled` and several smaller binaries depend on the process locale for UTF-8 handling, and mangle non-ASCII text under the default `C`/`POSIX` locale common in headless Docker / systemd / cron deployments where `LANG`/`LC_ALL` is unset.

- New helper `aMuleInitLocale()` in `src/libs/common/`. Calls `setlocale(LC_ALL, "")` to pick the user's locale up from the environment, then forces `LC_NUMERIC` back to `C` so libc printf/scanf decimal handling stays portable (avoids the `de_DE.UTF-8` trap where `"%.2f"` of 3.14 silently becomes `"3,14"`).
- Wired into the binaries that had no locale init at all: `amuled` (the reported bug), `fileview`, and `cas` (plain C — inline setlocale pair rather than the C++ helper).
- Migrated `amulecmd` / `amuleweb` from the existing `setlocale(LC_ALL, "")` at `ExternalConnector.cpp:681` (added in #626) to the new helper. Behaviour change called out: `LC_NUMERIC` is now always `C` for the connectors regardless of the user's environment.

Left alone: `amule`, `amule-remote-gui`, `alc`, `alcc`, `wxcas` — they all drive locale through `wxLocale` (`m_locale.Init()` / `InitLocale()`), which calls `setlocale` internally and is not affected by this class of bug.

## Test plan

- [x] Configure + build everything on macOS APFS with `-DBUILD_EVERYTHING=YES`. Exit 0, zero new errors, zero new warnings, all touched targets (`amuled`, `amulecmd`, `amuleweb`, `fileview`, `cas`) build cleanly. `amule`, `amulegui`, `alc`, `alcc`, `wxcas` also build (unchanged behaviour confirmed).
- [x] CI matrix on Ubuntu Debug+Release, macOS Debug+Release, mingw-w64 Debug+Release, plus I18n CI.

## Notes for reviewers

Three commits, each separately revertable:
1. Introduce helper (pure addition, zero behaviour change).
2. Wire amuled + fileview + cas (the actual bugfix).
3. Migrate connectors from inline `setlocale` to the helper (small behaviour change: `LC_NUMERIC=C` for amulecmd/amuleweb).