### PR TITLE
style(webserver): unify form controls in default template

### DIFF
--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -96,26 +96,28 @@ a.nav-stats:hover {
 	width: 75%;
 }
 label {
-	font-family: "trebuchet ms", sans-serif;
+	font-family: Helvetica, Arial, sans-serif;
 	font-size: 12px;
 	font-weight: bold;
 }
 input {
 	border: 1px solid #003161;
 	background-color: white;
-	font-family: "trebuchet ms", sans-serif;
+	font-family: Helvetica, Arial, sans-serif;
 	font-size: 12px;
 	color: #003161;
 }
 select, option {
+	border: 1px solid #003161;
 	background-color: white;
+	font-family: Helvetica, Arial, sans-serif;
 	font-size: 12px;
 	color: #003161;
 }
 textarea {
 	border: 1px solid #003161;
 	background-color: #90B6DB;
-	font-family: "trebuchet ms", sans-serif;
+	font-family: Helvetica, Arial, sans-serif;
 	font-size: 12px;
 	color: white;
 }
@@ -360,6 +362,12 @@ table.pad4 > tbody > tr > td {
 }
 iframe.noborder {
 	border: 0;
+}
+iframe[name="logframe"], iframe[name="srvframe"] {
+	border: 1px solid #003161;
+}
+select[name="status"] {
+	margin-right: 6px;
 }
 body.frame {
 	overflow: hidden;


### PR DESCRIPTION
Make the default web template form controls visually consistent:

- Add the same thin 1px solid #003161 border to select dropdowns so they match the text inputs instead of using the browser's native chunky border.
- Replace the 'trebuchet ms' font with a more common and robust stack (Helvetica, Arial, sans-serif) across all form controls (label, input, select, textarea), aligning with the rest of the stylesheet.
- Add the same thin border to the log boxes (logframe and srvframe iframes) on the log page.
- Add a small right margin to the status select on the downloads page to separate it from the adjacent category combo.