### PR TITLE
style(webserver): clarify dropdown option labels in default template

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -81,14 +81,18 @@ function formCommandSubmit(command)
 
         	echo '<select name="status"> ';
         	foreach ($all_status as $s) {
-        		echo (($s == $_SESSION["filter_status"]) ? '<option selected>' : '<option>'), $s, '</option>';
+        		$label = ($s == 'all') ? 'All status' : $s;
+        		$sel = ($s == $_SESSION["filter_status"]) ? ' selected' : '';
+        		echo '<option value="', htmlspecialchars($s), '"', $sel, '>', htmlspecialchars($label), '</option>';
         	}
         	echo '</select>';
         	//var_dump($_SESSION["filter_cat"]);
         	echo '<select name="category" id="category">';
 			$cats = amule_get_categories();
 			foreach($cats as $c) {
-				echo (($c == $_SESSION["filter_cat"]) ? '<option selected>' : '<option>'), htmlspecialchars($c), '</option>';
+				$label = ($c == 'all') ? 'All categories' : $c;
+				$sel = ($c == $_SESSION["filter_cat"]) ? ' selected' : '';
+				echo '<option value="', htmlspecialchars($c), '"', $sel, '>', htmlspecialchars($label), '</option>';
 			}
 			echo '</select>';
         ?>

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -258,7 +258,8 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
           <?php
                 	$cats = amule_get_categories();
                 	foreach($cats as $c) {
-                		echo "<option>", htmlspecialchars($c), "</option>";
+                		$label = ($c == 'all') ? 'All categories' : $c;
+                		echo '<option value="', htmlspecialchars($c), '">', htmlspecialchars($label), '</option>';
                 	}
                 ?>
         </select></td>

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -52,7 +52,7 @@ function formCommandSubmit(command)
                   
             <td><a href="javascript:formCommandSubmit('priodown');"><img src="images/down.png" alt="Lower priority" name="down" onload=""></a></td>
                   <td><select name="select">
-                      <option selected>Select prio</option>
+                      <option selected>Change priority</option>
                       <option>Low</option>
                       <option>Normal</option>
                       <option>High</option>

--- a/src/webserver/default/footer.php
+++ b/src/webserver/default/footer.php
@@ -34,7 +34,8 @@
 		}
 
 		foreach($cats as $c) {
-			echo  '<option>', htmlspecialchars($c), '</option>';
+			$label = ($c == 'all') ? 'No category' : $c;
+			echo  '<option value="', htmlspecialchars($c), '">', htmlspecialchars($label), '</option>';
 		}
 	?>
         </select>


### PR DESCRIPTION
Make the purpose of several dropdowns clearer to users by relabeling their generic options, without changing any submitted values or backend behavior. Each option now carries an explicit value attribute holding the original value (e.g. "all"), so only the visible text changes.

- amuleweb-main-dload.php: status filter "all" -> "All status"; category filter "all" -> "All categories".
- amuleweb-main-search.php: target category "all" -> "All categories".
- footer.php: ed2k link target category "all" -> "No category".
- amuleweb-main-shared.php: priority selector placeholder "Select prio" -> "Change priority".