### PR TITLE
fix(upnp): pin LC_CTYPE = C around ASCII tolower() in UPnPBase

### DIFF
--- a/src/UPnPBase.cpp
+++ b/src/UPnPBase.cpp
@@ -54,6 +54,11 @@
 #include "UPnPBase.h"
 
 #include <algorithm>		// For transform()
+#include "CCtypeAsciiScope.h"	// Needed to pin LC_CTYPE = C around the
+				// ASCII-only tolower() comparisons below
+				// (Turkish-i: tolower('I') = U+0131 under
+				// tr_TR.UTF-8, breaks UPnP direction /
+				// device-type matching).
 
 #ifdef BROKEN_DEBIAN_LIBUPNP
   #define GET_UPNP_STRING(a) UpnpString_get_String(a)
@@ -81,6 +86,10 @@ const char s_deviceList[] = "deviceList";
  */
 static bool stdStringIsEqualCI(const std::string &s1, const std::string &s2)
 {
+	// Pin LC_CTYPE = C so tolower() is ASCII-deterministic regardless of
+	// the user's locale (tr_TR turns 'I' into U+0131, breaking this
+	// comparison's intended semantics).
+	CCtypeAsciiScope scope;
 	std::string ns1(s1);
 	std::string ns2(s2);
 	std::transform(ns1.begin(), ns1.end(), ns1.begin(), tolower);
@@ -94,6 +103,8 @@ static bool stdStringStartsWithCI(const std::string &s, const std::string &prefi
 	if (s.size() < prefix.size()) {
 		return false;
 	}
+	// Same reason as stdStringIsEqualCI: tolower() must be ASCII here.
+	CCtypeAsciiScope scope;
 	std::string head = s.substr(0, prefix.size());
 	std::string p = prefix;
 	std::transform(head.begin(), head.end(), head.begin(), tolower);
@@ -650,6 +661,9 @@ bool CUPnPService::Execute(
 			return false;
 		}
 		const CUPnPArgument &argument = *(itArg->second);
+		// Direction is "in" or "out" — ASCII-only. Pin LC_CTYPE = C so
+		// tolower() doesn't fold 'I' to U+0131 under tr_TR.
+		CCtypeAsciiScope direction_scope;
 		if (tolower(argument.GetDirection()[0]) != 'i' ||
 		    tolower(argument.GetDirection()[1]) != 'n') {
 			msg << "Invalid direction for argument '" <<
@@ -1379,7 +1393,13 @@ upnpDiscovery:
 #endif
 		// Check for an InternetGatewayDevice and removes it from the list
 
-		std::transform(devType.begin(), devType.end(), devType.begin(), tolower);
+		{
+			// devType is a UPnP URN ("urn:schemas-upnp-org:device:...")
+			// — ASCII-only. Pin LC_CTYPE = C around the tolower
+			// transform so 'I' stays 'i' under tr_TR.
+			CCtypeAsciiScope devtype_scope;
+			std::transform(devType.begin(), devType.end(), devType.begin(), tolower);
+		}
 
 		if (stdStringIsEqualCI(devType, UPnP::Device::IGW)) {
 #if UPNP_VERSION >= 10800


### PR DESCRIPTION
## Summary

Follow-up to #205. After that PR landed, `amuled` started picking `LC_CTYPE` up from the environment instead of staying on the C locale. That's the right behaviour for non-ASCII filenames, but it exposed a latent Turkish-i issue in `UPnPBase.cpp`: four `tolower()` call sites that rely on ASCII semantics and silently break under `tr_TR.UTF-8` (where `tolower('I')` returns `ı` / U+0131 instead of `i`).

Net effect for Turkish-locale users on `amuled` with UPnP enabled: auto-portforward silently fails because `CUPnPService::Execute` rejects every argument's direction string. `amule` (GUI) was already exposed to the same bug via `wxLocale::Init()` on Turkish-language installs; this also fixes it there as a side effect.

## Sites wrapped

All four use `CCtypeAsciiScope` (the existing RAII helper that pins `LC_CTYPE = "C"` for the duration of its scope and restores it on destruction — same pattern as `CamuleFileConfig.h` from #852 and `MaxMindDBDatabase.cpp` from the GeoIP flag fix):

- `stdStringIsEqualCI` — case-insensitive `std::string` helper used throughout the file.
- `stdStringStartsWithCI` — sibling helper, same shape.
- `CUPnPService::Execute` — direct `tolower(direction[0]) != 'i'` validation against "in"/"out".
- `CUPnPControlPoint::Callback` BYEBYE case — device-type URN lowercase before matching `UPnP::Device::IGW`.

## Test plan

- [x] Configure + build on macOS with `-DENABLE_UPNP=YES` (`amule`, `amuled`, `amulecmd`, `amuleweb` all build clean; zero new errors, zero new warnings).
- [ ] CI matrix: Ubuntu Debug+Release, macOS Debug+Release, mingw-w64 Debug+Release, I18n CI.