### PR TITLE
style(webserver): make logo a home link to transfers in default template

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -37,7 +37,7 @@ function formCommandSubmit(command)
 <body class="main">
 <table class="page">
   <tr> 
-    <td class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="logo-cell"><a href="amuleweb-main-dload.php" title="Home"><img src="images/logo.png" width="143" height="64" alt="aMule"></a></td>
     <td class="navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>

--- a/src/webserver/default/amuleweb-main-kad.php
+++ b/src/webserver/default/amuleweb-main-kad.php
@@ -69,7 +69,7 @@ function formCommandSubmit(command)
 <body class="main">
 <table class="page">
   <tr> 
-    <td class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="logo-cell"><a href="amuleweb-main-dload.php" title="Home"><img src="images/logo.png" width="143" height="64" alt="aMule"></a></td>
     <td class="navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>

--- a/src/webserver/default/amuleweb-main-log.php
+++ b/src/webserver/default/amuleweb-main-log.php
@@ -9,7 +9,7 @@
 <body class="main">
 <table class="page">
   <tr> 
-    <td class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="logo-cell"><a href="amuleweb-main-dload.php" title="Home"><img src="images/logo.png" width="143" height="64" alt="aMule"></a></td>
     <td class="navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>

--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -112,7 +112,7 @@ function init_data()
 <body class="main" onLoad="init_data();">
 <table class="page">
   <tr> 
-    <td class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="logo-cell"><a href="amuleweb-main-dload.php" title="Home"><img src="images/logo.png" width="143" height="64" alt="aMule"></a></td>
     <td class="navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -24,7 +24,7 @@ function formCommandSubmit(command)
 <body class="main">
 <table class="page">
   <tr> 
-    <td class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="logo-cell"><a href="amuleweb-main-dload.php" title="Home"><img src="images/logo.png" width="143" height="64" alt="aMule"></a></td>
     <td class="navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -9,7 +9,7 @@
 <body class="main">
 <table class="page">
   <tr> 
-    <td class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="logo-cell"><a href="amuleweb-main-dload.php" title="Home"><img src="images/logo.png" width="143" height="64" alt="aMule"></a></td>
     <td class="navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -24,7 +24,7 @@ function formCommandSubmit(command)
 <body class="main">
 <table class="page">
   <tr> 
-    <td class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="logo-cell"><a href="amuleweb-main-dload.php" title="Home"><img src="images/logo.png" width="143" height="64" alt="aMule"></a></td>
     <td class="navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>

--- a/src/webserver/default/amuleweb-main-stats.php
+++ b/src/webserver/default/amuleweb-main-stats.php
@@ -39,7 +39,7 @@ function swapFolder(img){
 <body class="main">
 <table class="page">
   <tr> 
-    <td class="logo-cell"><img src="images/logo.png" width="143" height="64"></td>
+    <td class="logo-cell"><a href="amuleweb-main-dload.php" title="Home"><img src="images/logo.png" width="143" height="64" alt="aMule"></a></td>
     <td class="navbar-cell"> <table class="navbar-table">
         <tr> 
           <td><a class="navbutton nav-transfer" href="amuleweb-main-dload.php" title="Transfers"></a></td>

--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -174,7 +174,7 @@ td.logo-cell {
 	width: 143px;
 	height: 64px;
 }
-td.logo-cell > img {
+td.logo-cell img {
 	display: block;
 }
 td.navbar-cell {


### PR DESCRIPTION
Wrap the navbar logo image in an anchor pointing to amuleweb-main-dload.php across all default template pages, so clicking the aMule logo navigates to the Transfers/downloads page. An alt="aMule" and title="Home" are added for accessibility.

Update the CSS selector from 'td.logo-cell > img' to 'td.logo-cell img' so the 'display: block' rule still applies now that the image is nested inside the anchor. This removes the inline baseline gap that exposed the navbar's blue background as a stray bar below the navigation bar.