### PR TITLE
feat(webserver): wire up priority selector on shared page

### DIFF
--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -53,9 +53,13 @@ function formCommandSubmit(command)
             <td><a href="javascript:formCommandSubmit('priodown');"><img src="images/down.png" alt="Lower priority" name="down" onload=""></a></td>
                   <td><select name="select">
                       <option selected>Change priority</option>
+                      <option>Auto</option>
+                      <option>Very low</option>
                       <option>Low</option>
                       <option>Normal</option>
                       <option>High</option>
+                      <option>Very high</option>
+                      <option>Release</option>
                     </select> </td>
                   
             <td><a href="javascript:formCommandSubmit('setprio');"><img src="images/ok.png" alt="Set priority" name="resume" onload=""></a></td>
@@ -175,14 +179,25 @@ function formCommandSubmit(command)
 		//var_dump($HTTP_GET_VARS);
 		if (($HTTP_GET_VARS["command"] != "") && ($_SESSION["guest_login"] == 0)) {
 			//amule_do_download_cmd($HTTP_GET_VARS["command"]);
+			$cmd = $HTTP_GET_VARS["command"];
+			// Dropdown label -> priority constant (src/Constants.h)
+			$prio_values = array("Low" => 0, "Normal" => 1, "High" => 2,
+				"Very high" => 3, "Very low" => 4, "Auto" => 5, "Release" => 6);
 			foreach ( $HTTP_GET_VARS as $name => $val) {
 				// this is file checkboxes
 				if ( (strlen($name) == 32) and ($val == "on") ) {
 					//var_dump($name);var_dump($val);
-					amule_do_shared_cmd($name, $HTTP_GET_VARS["command"]);
+					if ( $cmd == "setprio" ) {
+						$sel = $HTTP_GET_VARS["select"];
+						if ( isset($prio_values[$sel]) ) {
+							amule_do_shared_cmd($name, "prio", $prio_values[$sel]);
+						}
+					} else {
+						amule_do_shared_cmd($name, $cmd);
+					}
 				}
 			}
-			if ($HTTP_GET_VARS["command"] == "reload") {
+			if ($cmd == "reload") {
 				amule_do_reload_shared_cmd();
 			}
 		}

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -98,8 +98,11 @@ static uint8 GetHigherPrio(uint32 prio, bool auto_priority)
 
 static uint8 GetHigherPrioShared(uint32 prio, bool auto_priority)
 {
+	// The arrows walk the manual scale only; they never set or pass
+	// through Auto (that mode can only be chosen from the selector).
+	// Raising while in Auto leaves it for the manual scale at High.
 	if (auto_priority) {
-		return PR_VERY_LOW;
+		return PR_HIGH;
 	} else {
 		switch (prio) {
 			case PR_VERY_LOW: return PR_LOW;
@@ -107,9 +110,8 @@ static uint8 GetHigherPrioShared(uint32 prio, bool auto_priority)
 			case PR_NORMAL: return PR_HIGH;
 			case PR_HIGH: return PR_VERYHIGH;
 			case PR_VERYHIGH: return PR_POWERSHARE;
-			case PR_POWERSHARE: return PR_AUTO;
-			case PR_AUTO: return PR_VERY_LOW;
-			default: return PR_AUTO;
+			case PR_POWERSHARE: return PR_POWERSHARE;
+			default: return PR_NORMAL;
 		}
 	}
 }
@@ -132,18 +134,20 @@ static uint8 GetLowerPrio(uint32 prio, bool auto_priority)
 
 static uint8 GetLowerPrioShared(uint32 prio, bool auto_priority)
 {
+	// The arrows walk the manual scale only; they never set or pass
+	// through Auto (that mode can only be chosen from the selector).
+	// Lowering while in Auto leaves it for the manual scale at Low.
 	if (auto_priority) {
-		return PR_POWERSHARE;
+		return PR_LOW;
 	} else {
 		switch (prio) {
-			case PR_VERY_LOW: return PR_AUTO;
-			case PR_LOW: return PR_VERY_LOW;
-			case PR_NORMAL: return PR_LOW;
-			case PR_HIGH: return PR_NORMAL;
-			case PR_VERYHIGH: return PR_HIGH;
 			case PR_POWERSHARE: return PR_VERYHIGH;
-			case PR_AUTO: return PR_POWERSHARE;
-			default: return PR_AUTO;
+			case PR_VERYHIGH: return PR_HIGH;
+			case PR_HIGH: return PR_NORMAL;
+			case PR_NORMAL: return PR_LOW;
+			case PR_LOW: return PR_VERY_LOW;
+			case PR_VERY_LOW: return PR_VERY_LOW;
+			default: return PR_NORMAL;
 		}
 	}
 }


### PR DESCRIPTION
The priority dropdown on the shared files page of the default template was dead UI: it only offered Low/Normal/High and its OK button emitted a 'setprio' command that the backend never handled, so nothing was applied.

Template changes (amuleweb-main-shared.php):
- Expand the selector to the full set of priorities (Auto, Very low, Low, Normal, High, Very high, Release), with Auto as the first option.
- Wire the 'setprio' action: map the selected label to its priority constant (src/Constants.h) and dispatch the real 'prio' command via amule_do_shared_cmd($hash, 'prio', N).

Priority arrow logic (WebServer.cpp):
- GetHigherPrioShared/GetLowerPrioShared now walk only the manual scale (Very low <-> Low <-> Normal <-> High <-> Very high <-> Release) with clamped ends; the arrows no longer set or pass through Auto.
- Raising while in Auto leaves it at High, lowering leaves it at Low. Auto can now only be enabled from the selector, fixing the previous behavior where raising priority in Auto dropped the file to Very low.