### PR TITLE
feat(webserver): add select-all checkbox to file tables in default template

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -32,6 +32,14 @@ function formCommandSubmit(command)
 	frm.submit()
 }
 
+function selectAll(check)
+{
+	var checkboxes = document.querySelectorAll('input[type="checkbox"]');
+	checkboxes.forEach(function(checkbox) {
+		checkbox.checked = check.checked;
+	});
+}
+
 </script>
 </head>
 <body class="main">
@@ -128,8 +136,8 @@ function formCommandSubmit(command)
     <td>&nbsp;</td>
     <td><table class="w100p">
                      
-          <tr> 
-                  <th>&nbsp;</th>
+          <tr>
+                  <th class="al-left"><input type="checkbox" name="selectAllFiles" onclick="selectAll(this)"></th>
                   <th><a href="amuleweb-main-dload.php?sort=name">File name</a></th>
                   <th><a href="amuleweb-main-dload.php?sort=size">Size</a></th>
                   <th><a href="amuleweb-main-dload.php?sort=size_done">Completed</a></th>

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -19,6 +19,14 @@ function formCommandSubmit(command)
 	frm.submit()
 }
 
+function selectAll(check)
+{
+	var checkboxes = document.querySelectorAll('input[type="checkbox"]');
+	checkboxes.forEach(function(checkbox) {
+		checkbox.checked = check.checked;
+	});
+}
+
 </script>
 </head>
 <body class="main">
@@ -111,7 +119,7 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
               </table>
               <table class="w100p">
                 <tr>
-                  <th>&nbsp;</th>
+                  <th class="al-left"><input type="checkbox" name="selectAllFiles" onclick="selectAll(this)"></th>
                   <th><a href="amuleweb-main-search.php?sort=name">File Name</a></th>
                   <th><a href="amuleweb-main-search.php?sort=size">Size</a></th>
                   <th><a href="amuleweb-main-search.php?sort=sources">Sources</a></th>

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -19,6 +19,14 @@ function formCommandSubmit(command)
 	frm.submit()
 }
 
+function selectAll(check)
+{
+	var checkboxes = document.querySelectorAll('input[type="checkbox"]');
+	checkboxes.forEach(function(checkbox) {
+		checkbox.checked = check.checked;
+	});
+}
+
 </script>
 </head>
 <body class="main">
@@ -88,8 +96,8 @@ function formCommandSubmit(command)
             
           <td>
               <table class="w100p">
-                <tr> 
-                  <th></th>
+                <tr>
+                  <th class="al-left"><input type="checkbox" name="selectAllFiles" onclick="selectAll(this)"></th>
                   <th><a href="amuleweb-main-shared.php?sort=name">File Name</a></th>
                   <th><a href="amuleweb-main-shared.php?sort=xfer">Transferred</a> 
                     (<a href="amuleweb-main-shared.php?sort=xfer_all">Total</a>)</th>


### PR DESCRIPTION
Add a master checkbox in the table header of the Downloads, Search and Shared pages that toggles every row checkbox at once, instead of having to tick files one by one.

- Add a JS selectAll(check) helper to each page that walks all input[type=checkbox] in the document and sets them to check.checked.
- Replace the empty header cell with <th class="al-left"> containing the master checkbox (onclick="selectAll(this)"). The al-left class matches the left alignment of the row checkbox cells, which <th> would otherwise center.
- Name the master checkbox selectAllFiles (not a 32-char hash) so the command-processing loop, which only acts on 32-char file-hash names, ignores it automatically.