### PR TITLE
feat(webserver): pause auto-refresh while checkboxes are selected

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -3,8 +3,17 @@
 <head>
 <title>aMule control panel</title>
 <?php
+	// Auto-refresh: reload on a timer, but skip while any checkbox is
+	// checked so the user's selection isn't wiped.
 	if ( $_SESSION["auto_refresh"] > 0 ) {
-		echo "<meta http-equiv=\"refresh\" content=\"", $_SESSION["auto_refresh"], '">';
+		echo "<script type=\"text/JavaScript\">
+	setInterval(function() {
+		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
+			return;
+		}
+		location.reload();
+	}, 1000 * ", $_SESSION["auto_refresh"], ");
+</script>";
 	}
 ?><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 

--- a/src/webserver/default/amuleweb-main-kad.php
+++ b/src/webserver/default/amuleweb-main-kad.php
@@ -4,8 +4,17 @@
 <title>aMule control panel</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <?php
+	// Auto-refresh: reload on a timer, but skip while any checkbox is
+	// checked so the user's selection isn't wiped.
 	if ( $_SESSION["auto_refresh"] > 0 ) {
-		echo "<meta http-equiv=\"refresh\" content=\"", $_SESSION["auto_refresh"], '">';
+		echo "<script type=\"text/JavaScript\">
+	setInterval(function() {
+		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
+			return;
+		}
+		location.reload();
+	}, 1000 * ", $_SESSION["auto_refresh"], ");
+</script>";
 	}
 
 	// Kad network controls. Dispatch before stats are rendered so the

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -3,6 +3,20 @@
 <head>
 <title>aMule control panel</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<?php
+	// Auto-refresh: reload on a timer, but skip while any checkbox is
+	// checked so the user's selection isn't wiped.
+	if ( $_SESSION["auto_refresh"] > 0 ) {
+		echo "<script type=\"text/JavaScript\">
+	setInterval(function() {
+		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
+			return;
+		}
+		location.reload();
+	}, 1000 * ", $_SESSION["auto_refresh"], ");
+</script>";
+	}
+?>
 
 <link href="style.css" rel="stylesheet" type="text/css">
 <script language="JavaScript" type="text/JavaScript">

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -3,6 +3,20 @@
 <head>
 <title>aMule control panel</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<?php
+	// Auto-refresh: reload on a timer, but skip while any checkbox is
+	// checked so the user's selection isn't wiped.
+	if ( $_SESSION["auto_refresh"] > 0 ) {
+		echo "<script type=\"text/JavaScript\">
+	setInterval(function() {
+		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
+			return;
+		}
+		location.reload();
+	}, 1000 * ", $_SESSION["auto_refresh"], ");
+</script>";
+	}
+?>
 
 <link href="style.css" rel="stylesheet" type="text/css">
 </head>

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -3,6 +3,20 @@
 <head>
 <title>aMule control panel</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<?php
+	// Auto-refresh: reload on a timer, but skip while any checkbox is
+	// checked so the user's selection isn't wiped.
+	if ( $_SESSION["auto_refresh"] > 0 ) {
+		echo "<script type=\"text/JavaScript\">
+	setInterval(function() {
+		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
+			return;
+		}
+		location.reload();
+	}, 1000 * ", $_SESSION["auto_refresh"], ");
+</script>";
+	}
+?>
 
 <link href="style.css" rel="stylesheet" type="text/css">
 <script language="JavaScript" type="text/JavaScript">

--- a/src/webserver/default/amuleweb-main-stats.php
+++ b/src/webserver/default/amuleweb-main-stats.php
@@ -4,8 +4,17 @@
 <title>aMule control panel</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <?php
+	// Auto-refresh: reload on a timer, but skip while any checkbox is
+	// checked so the user's selection isn't wiped.
 	if ( $_SESSION["auto_refresh"] > 0 ) {
-		echo "<meta http-equiv=\"refresh\" content=\"", $_SESSION["auto_refresh"], '">';
+		echo "<script type=\"text/JavaScript\">
+	setInterval(function() {
+		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
+			return;
+		}
+		location.reload();
+	}, 1000 * ", $_SESSION["auto_refresh"], ");
+</script>";
 	}
 
 	amule_load_vars("stats_graph");


### PR DESCRIPTION
Replace the unconditional <meta http-equiv="refresh"> in the default template with a JS setInterval that reloads on the same cadence but skips the reload whenever any checkbox is checked, so the user's in-progress selection is never wiped out from under them.

The mechanism is now applied uniformly across all main pages:
- dload, kad, stats: replaced the old <meta refresh> with the JS guard.
- search, shared, servers: gained the auto-refresh (none before), each reusing the same guarded block for consistency.

The log pages are intentionally left unchanged: the container has no checkboxes and its log content already self-refreshes inside its iframes, so a full-page reload would only reset iframe scroll for no benefit.