### PR TITLE
feat(webserver): confirm download/delete with file count in default template

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -23,7 +23,11 @@
 function formCommandSubmit(command)
 {
 	if ( command == "cancel" ) {
-		var res = confirm("Delete selected files ?")
+		var boxchecked = document.querySelectorAll('input[type="checkbox"]:checked');
+		var selectedFiles = Object.values(boxchecked).filter(selected => selected.name != 'selectAllFiles').length;
+		if (selectedFiles == 0)
+			return;
+		var res = confirm("Delete selected " + (selectedFiles) + " files ?")
 		if ( res == false ) {
 			return;
 		}

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -28,6 +28,16 @@ function formCommandSubmit(command)
 				echo "return;";
 		}
 	?>
+	if ( command == "download" ) {
+		var boxchecked = document.querySelectorAll('input[type="checkbox"]:checked');
+		var selectedFiles = Object.values(boxchecked).filter(selected => selected.name != 'selectAllFiles').length;
+		if (selectedFiles == 0)
+			return;
+		var res = confirm("Download selected " + (selectedFiles) + " files ?")
+		if ( res == false ) {
+			return;
+		}
+	}
 	var frm=document.forms.mainform
 	frm.command.value=command
 	frm.submit()
@@ -275,7 +285,7 @@ if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
 	  ?>
     <tr class="al-right"> 
       <td colspan="4" scope="col">
-        <input name="Download" type="submit" id="Download6" value="Download" onClick="javascript:formCommandSubmit('download');" >
+        <input name="Download" type="submit" id="Download6" value="Download" onClick="javascript:formCommandSubmit('download'); return false;" >
         <select name="targetcat" id="select32">
           <?php
                 	$cats = amule_get_categories();


### PR DESCRIPTION
Show the number of selected files in the confirmation dialogs and avoid acting when nothing is selected, in the default web template.

- Search: extend formCommandSubmit's "download" path to count selected checkboxes (excluding the select-all master), return early when none are selected, and confirm "Download selected N files ?".
- Search: add "return false" to the Download submit button onClick so the native form submission no longer fires; formCommandSubmit submits the form itself. This fixes the page reloading even when the user pressed Cancel in the confirmation dialog.
- Downloads: replace the generic "Delete selected files ?" prompt with a count-aware "Delete selected N files ?", returning early when no rows are selected.