### PR TITLE
feat(webserver): add tooltips to buttons and clickable images in default template

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -83,11 +83,11 @@ function selectAll(check)
       <td><table class="center-table">
           <tr> 
             <td><input type="hidden" name="command"></td>
-            <td><a href="javascript:formCommandSubmit('pause');"><img name="pause" src="images/pause.png" alt="pause"></a></td>
-            <td><a href="javascript:formCommandSubmit('resume');"><img name="resume" src="images/play.png" alt="resume"></a></td>
-        		<td><a href="javascript:formCommandSubmit('prioup');"><img name="prioup" src="images/up.png" alt="prioup"></a></td>
-        		<td><a href="javascript:formCommandSubmit('priodown');"><img name="priodown" src="images/down.png" alt="priodown"></a></td>
-        		<td><a href="javascript:formCommandSubmit('cancel');"><img name="cancel" src="images/close.png" alt="cancel"></a></td>
+            <td><a href="javascript:formCommandSubmit('pause');" title="Pause selected downloads"><img name="pause" src="images/pause.png" alt="Pause"></a></td>
+            <td><a href="javascript:formCommandSubmit('resume');" title="Resume selected downloads"><img name="resume" src="images/play.png" alt="Resume"></a></td>
+        		<td><a href="javascript:formCommandSubmit('prioup');" title="Increase priority of selected downloads"><img name="prioup" src="images/up.png" alt="Increase priority"></a></td>
+        		<td><a href="javascript:formCommandSubmit('priodown');" title="Decrease priority of selected downloads"><img name="priodown" src="images/down.png" alt="Decrease priority"></a></td>
+        		<td><a href="javascript:formCommandSubmit('cancel');" title="Cancel/delete selected downloads"><img name="cancel" src="images/close.png" alt="Cancel"></a></td>
       <td><table>
                 <tr> 
                   <td> 
@@ -118,7 +118,7 @@ function selectAll(check)
 			echo '</select>';
         ?>
                   </td>
-                  			<td><a href="javascript:formCommandSubmit('filter');"><img src="images/filter.png" alt="Apply" name="resume"></a></td>
+                  			<td><a href="javascript:formCommandSubmit('filter');" title="Apply status and category filter"><img src="images/filter.png" alt="Apply filter" name="resume"></a></td>
                   <td>&nbsp;</td>
                   <td>&nbsp;</td>
                   <td> 

--- a/src/webserver/default/amuleweb-main-kad.php
+++ b/src/webserver/default/amuleweb-main-kad.php
@@ -117,9 +117,9 @@ function formCommandSubmit(command)
                       </tr>
                       <tr>
                         <td colspan="2" class="al-center">
-                          <button type="submit" name="kad_action" value="connect_known">Connect from known peers</button>
+                          <button type="submit" name="kad_action" value="connect_known" title="Bootstrap Kad from known peers">Connect from known peers</button>
                           &nbsp;
-                          <button type="submit" name="kad_action" value="disconnect">Disconnect</button>
+                          <button type="submit" name="kad_action" value="disconnect" title="Disconnect from the Kad network">Disconnect</button>
                         </td>
                       </tr>
                       <tr>
@@ -133,14 +133,14 @@ function formCommandSubmit(command)
                       </tr>
                       <tr>
                         <td class="al-right">Port :</td><td class="al-left"><input name="port" type="text" id="port3" size="4" maxlength="5">
-                          &nbsp; <button type="submit" name="kad_action" value="connect_ip">Connect</button></td>
+                          &nbsp; <button type="submit" name="kad_action" value="connect_ip" title="Bootstrap Kad from this node">Connect</button></td>
                       </tr>
                       <tr>
                         <th colspan="2">Update bootstrap from URL</th>
                       </tr>
                       <tr>
                         <td class="al-right">URL :</td><td class="al-left"><input name="nodes_url" type="text" id="nodes_url" size="32">
-                          &nbsp; <button type="submit" name="kad_action" value="update_url">Update</button></td>
+                          &nbsp; <button type="submit" name="kad_action" value="update_url" title="Update bootstrap nodes from this URL">Update</button></td>
                       </tr>
                     </table></td>
                 </tr>

--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -373,7 +373,7 @@ function init_data()
       <td colspan="2"> 
         <?php
 			if ($_SESSION["guest_login"] == 0) {
-				echo '<input type="submit" name="Submit" value="Apply">';
+				echo '<input type="submit" name="Submit" value="Apply" title="Save preferences">';
 			} else {
 				echo "<b>&nbsp;You can not change options - logged in as guest</b>";
 			}

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -93,7 +93,7 @@ function selectAll(check)
                   <td class="al-center">
 <input type="hidden" name="command" value=""> 
                     <input name="searchval" type="text" id="searchval4" size="60"> 
-                    <input name="Search" type="submit" id="Search4" value="Search" onClick="javascript:formCommandSubmit('search');"></td>
+                    <input name="Search" type="submit" id="Search4" value="Search" title="Start the search" onClick="javascript:formCommandSubmit('search');"></td>
                   <td class="al-right">Availability :</td>
                   <td class="al-left"> 
                     <input name="avail" type="text" id="avail13" size="6"></td>
@@ -130,7 +130,7 @@ function selectAll(check)
               <table class="w100p">
                 <tr class="al-right">
                   <td colspan="4" scope="col">
-                    <input name="Download" type="submit" id="Download6" value="Download" onClick="javascript:formCommandSubmit('download'); return false;" >
+                    <input name="Download" type="submit" id="Download6" value="Download" title="Download selected files" onClick="javascript:formCommandSubmit('download'); return false;" >
                     <select name="targetcat" id="select32">
                       <?php
                 	$cats = amule_get_categories();

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -66,7 +66,7 @@
                     echo '<tr><td colspan="6" class="al-right" style="padding:4px 8px;">',
                          '<form action="amuleweb-main-servers.php" method="get" style="display:inline;">',
                          '<input type="hidden" name="server_action" value="disconnect">',
-                         '<button type="submit">Disconnect from current ed2k server</button>',
+                         '<button type="submit" title="Disconnect from the current ed2k server">Disconnect from current ed2k server</button>',
                          '</form>',
                          '</td></tr>';
                 }
@@ -156,11 +156,11 @@
 			} else {
 				echo "<td class='texte al-center'>",
 					'<a href="amuleweb-main-servers.php?cmd=connect&ip=', $srv->ip,
-					'&port=', $srv->port, '">',
-					'<img src="images/connect.gif" width="16" height="16">','</a>',
+					'&port=', $srv->port, '" title="Connect to this server">',
+					'<img src="images/connect.gif" width="16" height="16" alt="Connect">','</a>',
 					'<a href="amuleweb-main-servers.php?cmd=remove&ip=', $srv->ip,
-					'&port=', $srv->port, '">',
-					'<img src="images/cancel.gif" width="16" height="16">','</a>',
+					'&port=', $srv->port, '" title="Remove this server">',
+					'<img src="images/cancel.gif" width="16" height="16" alt="Remove">','</a>',
 					"</td>";
 			}
 

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -69,10 +69,10 @@ function selectAll(check)
                 <tr>
                   <td><input type="hidden" name="command"></td>
                   
-            <td><a href="javascript:formCommandSubmit('reload');"><img src="images/refresh.png" alt="Reload shared files" name="reload" onload=""></a></td>
-				  <td><a href="javascript:formCommandSubmit('prioup');"><img name="up" src="images/up.png" alt="Raise priority" onLoad=""></a></td>
-                  
-            <td><a href="javascript:formCommandSubmit('priodown');"><img src="images/down.png" alt="Lower priority" name="down" onload=""></a></td>
+            <td><a href="javascript:formCommandSubmit('reload');" title="Reload shared files"><img src="images/refresh.png" alt="Reload shared files" name="reload" onload=""></a></td>
+				  <td><a href="javascript:formCommandSubmit('prioup');" title="Raise priority of selected files"><img name="up" src="images/up.png" alt="Raise priority" onLoad=""></a></td>
+
+            <td><a href="javascript:formCommandSubmit('priodown');" title="Lower priority of selected files"><img src="images/down.png" alt="Lower priority" name="down" onload=""></a></td>
                   <td><select name="select">
                       <option selected>Change priority</option>
                       <option>Auto</option>
@@ -84,7 +84,7 @@ function selectAll(check)
                       <option>Release</option>
                     </select> </td>
                   
-            <td><a href="javascript:formCommandSubmit('setprio');"><img src="images/ok.png" alt="Set priority" name="resume" onload=""></a></td>
+            <td><a href="javascript:formCommandSubmit('setprio');" title="Apply selected priority"><img src="images/ok.png" alt="Set priority" name="resume" onload=""></a></td>
               
                   <td> 
                     <?php

--- a/src/webserver/default/footer.php
+++ b/src/webserver/default/footer.php
@@ -39,7 +39,7 @@
 		}
 	?>
         </select>
-        <input type="submit" name="Submit" value="Download link">
+        <input type="submit" name="Submit" value="Download link" title="Add the ed2k link to downloads">
       </form></td>
   </tr>
 </table>

--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -28,7 +28,7 @@ function login_init()
                     &nbsp; 
                     <input name="pass" size="20" value="" type="password">
                     &nbsp; 
-                    <input name="submit" type="submit" value="Submit">
+                    <input name="submit" type="submit" value="Submit" title="Log in">
                     &nbsp;&nbsp;
 <?php
 	if ( $_SESSION["login_error"] != "" ) {


### PR DESCRIPTION
Add a descriptive title attribute to every button and clickable image in the default webserver templates so their purpose is shown on hover, and improve the alt text on action images for accessibility. All tooltips are in English to stay consistent with the rest of the (hardcoded) UI.

- dload: pause, resume, raise/lower priority, cancel and filter buttons
- shared: reload, raise/lower priority and apply-priority buttons
- search: Search and Download submit buttons
- servers: network Disconnect button and the per-server connect/remove image links (generated in PHP, now with title + alt)
- kad: connect from known peers, disconnect, connect IP and update URL
- login: log-in submit button
- footer: 'Download link' submit button
- prefs: Apply submit button

Only HTML attributes were added; no structural, JS, CSS or backend changes.