### PR TITLE
feat(webserver): unify button styles in default template

### DIFF
--- a/src/webserver/default/amuleweb-main-log.php
+++ b/src/webserver/default/amuleweb-main-log.php
@@ -43,14 +43,24 @@
             <table class="w100p">
                 <tr class="va-top">
                   <td>
-		<h1 style="display:inline;">aMule log</h1>
-		<a href="log.php?rstlog=1" target="logframe" onclick="return confirm('Do you really want to reset aMule log?')">(Reset log)</a><br>
+		<div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:14px;">
+			<h1 style="display:inline; margin:0;">aMule log</h1>
+			<form action="log.php" method="get" target="logframe" onsubmit="return confirm('Do you really want to reset aMule log?')">
+				<input type="hidden" name="rstlog" value="1">
+				<button type="submit" title="Reset aMule log">Reset log</button>
+			</form>
+		</div>
 	<iframe class="w100p" height="400" name="logframe" src="log.php"></iframe>
                   </td>
                   </tr><tr>
                   <td>
-		<h1 style="display:inline;">Serverinfo</h1>
-		<a href="log.php?rstsrv=1" target="srvframe" onclick="return confirm('Do you really want to reset Serverinfo?')">(Reset Serverinfo)</a>
+		<div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:14px;">
+			<h1 style="display:inline; margin:0;">Serverinfo</h1>
+			<form action="log.php" method="get" target="srvframe" onsubmit="return confirm('Do you really want to reset Serverinfo?')">
+				<input type="hidden" name="rstsrv" value="1">
+				<button type="submit" title="Reset Serverinfo">Reset Serverinfo</button>
+			</form>
+		</div>
 <iframe class="w100p" height="200" name="srvframe" src="log.php?show=srv"></iframe>
                   </td>
                   </tr>

--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -100,7 +100,7 @@ label {
 	font-size: 12px;
 	font-weight: bold;
 }
-input {
+input, button {
 	border: 1px solid #003161;
 	background-color: white;
 	font-family: Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Apply the input-field look of the Download button to all native buttons across the default template, and turn the log page reset links into proper buttons.

- style.css: extend the input styling rule to button elements so the native buttons on the Kad and Servers pages match the existing input[type=submit] buttons (blue border, white background).
- amuleweb-main-log.php: replace the (Reset log) and (Reset Serverinfo) text links with inline forms submitting a button (same pattern as the Servers page disconnect button), preserving the confirm() prompt and the target iframe. Each title and its reset button now sit on the same line via a flex row, with the button aligned right and extra vertical spacing before the iframe. The button text is kept short with a title attribute as alternative text.