### PR TITLE
feat(webserver): unify file size and speed units in default template

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -162,17 +162,10 @@ function selectAll(check)
           </tr><tr><td colspan="9" class="sep-dark"></td></tr>
           <?php
 		function CastToXBytes($size, &$count) {
+			// Emit the raw byte count; the unit formatting is done
+			// client-side (see the js-size script at the end of the page).
 			$count += $size;
-			if ( $size < 1024 ) {
-				$result = $size . " b";
-			} elseif ( $size < 1048576 ) {
-				$result = ($size / 1024.0) . " kb";
-			} elseif ( $size < 1073741824 ) {
-				$result = ($size / 1048576.0) . " mb";
-			} else {
-				$result = ($size / 1073741824.0) . " gb";
-			}
-			return $result;
+			return '<span class="js-size">' . $size . '</span>';
 		}
 
 		function StatusString($file)
@@ -383,17 +376,10 @@ function selectAll(check)
         </tr><tr><td colspan="9" class="sep-dark"></td></tr>
         <?php
 			function CastToXBytes($size, &$count) {
+				// Emit the raw byte count; the unit formatting is done
+				// client-side (see the js-size script at the end of the page).
 				$count += $size;
-				if ( $size < 1024 ) {
-					$result = $size . " b";
-				} elseif ( $size < 1048576 ) {
-					$result = ($size / 1024.0) . " kb";
-				} elseif ( $size < 1073741824 ) {
-					$result = ($size / 1048576.0) . " mb";
-				} else {
-					$result = ($size / 1073741824.0) . " gb";
-				}
-				return $result;
+				return '<span class="js-size">' . $size . '</span>';
 			}
 			$countUploadDimension = 0;
 			$countDownloadDimension = 0;
@@ -452,5 +438,24 @@ function selectAll(check)
       </table></td>
   </tr>
 </table>
+<script type="text/JavaScript">
+// Format the raw byte counts emitted by the backend (spans with class
+// "js-size") into human-readable units. Done here in the browser because
+// the webserver's PHP interpreter lacks sprintf/round.
+function formatBytes(value) {
+	var b = parseFloat(value);
+	if ( isNaN(b) ) return value;
+	if ( b < 1024 ) return b + " Bytes";
+	if ( b < 1048576 ) return (b / 1024).toFixed(2) + " KB";
+	if ( b < 1073741824 ) return (b / 1048576).toFixed(2) + " MB";
+	return (b / 1073741824).toFixed(2) + " GB";
+}
+(function() {
+	var els = document.getElementsByClassName("js-size");
+	for ( var i = 0; i < els.length; i++ ) {
+		els[i].textContent = formatBytes(els[i].textContent);
+	}
+})();
+</script>
 </body>
 </html>

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -152,16 +152,9 @@ function selectAll(check)
     <?php
 		function CastToXBytes($size)
 		{
-			if ( $size < 1024 ) {
-				$result = $size . " b";
-			} elseif ( $size < 1048576 ) {
-				$result = ($size / 1024.0) . "kb";
-			} elseif ( $size < 1073741824 ) {
-				$result = ($size / 1048576.0) . "mb";
-			} else {
-				$result = ($size / 1073741824.0) . "gb";
-			}
-			return $result;
+			// Emit the raw byte count; the unit formatting is done
+			// client-side (see the js-size script at the end of the page).
+			return '<span class="js-size">' . $size . '</span>';
 		}
 
 		//
@@ -305,5 +298,24 @@ function selectAll(check)
       </table></td>
   </tr>
 </table>
+<script type="text/JavaScript">
+// Format the raw byte counts emitted by the backend (spans with class
+// "js-size") into human-readable units. Done here in the browser because
+// the webserver's PHP interpreter lacks sprintf/round.
+function formatBytes(value) {
+	var b = parseFloat(value);
+	if ( isNaN(b) ) return value;
+	if ( b < 1024 ) return b + " Bytes";
+	if ( b < 1048576 ) return (b / 1024).toFixed(2) + " KB";
+	if ( b < 1073741824 ) return (b / 1048576).toFixed(2) + " MB";
+	return (b / 1073741824).toFixed(2) + " GB";
+}
+(function() {
+	var els = document.getElementsByClassName("js-size");
+	for ( var i = 0; i < els.length; i++ ) {
+		els[i].textContent = formatBytes(els[i].textContent);
+	}
+})();
+</script>
 </body>
 </html>

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -125,16 +125,9 @@ function selectAll(check)
                 <?php
 		function CastToXBytes($size)
 		{
-			if ( $size < 1024 ) {
-				$result = $size . " bytes";
-			} elseif ( $size < 1048576 ) {
-				$result = ($size / 1024.0) . "KB";
-			} elseif ( $size < 1073741824 ) {
-				$result = ($size / 1048576.0) . "MB";
-			} else {
-				$result = ($size / 1073741824.0) . "GB";
-			}
-			return $result;
+			// Emit the raw byte count; the unit formatting is done
+			// client-side (see the js-size script at the end of the page).
+			return '<span class="js-size">' . $size . '</span>';
 		}
 
 		function StatusString($file)
@@ -297,5 +290,24 @@ function selectAll(check)
       </table></td>
   </tr>
 </table>
+<script type="text/JavaScript">
+// Format the raw byte counts emitted by the backend (spans with class
+// "js-size") into human-readable units. Done here in the browser because
+// the webserver's PHP interpreter lacks sprintf/round.
+function formatBytes(value) {
+	var b = parseFloat(value);
+	if ( isNaN(b) ) return value;
+	if ( b < 1024 ) return b + " Bytes";
+	if ( b < 1048576 ) return (b / 1024).toFixed(2) + " KB";
+	if ( b < 1073741824 ) return (b / 1048576).toFixed(2) + " MB";
+	return (b / 1073741824).toFixed(2) + " GB";
+}
+(function() {
+	var els = document.getElementsByClassName("js-size");
+	for ( var i = 0; i < els.length; i++ ) {
+		els[i].textContent = formatBytes(els[i].textContent);
+	}
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
The download, shared and search pages each defined their own CastToXBytes function with inconsistent units (kb/KB, mb/MB, " b"/" bytes") and no decimal rounding, so the same value looked different across pages.

Unit formatting is now done client-side in JavaScript: CastToXBytes emits the raw byte count inside a <span class="js-size"> and a shared formatBytes() script at the end of each page renders consistent, human-readable units (Bytes / KB / MB / GB, 1024 divisor, 2 decimals; speed keeps the trailing "/s"). This is required because the webserver's embedded PHP interpreter lacks sprintf/round/number_format, which made server-side formatting impossible. The download totals still accumulate raw bytes via the &$count parameter.