### PR TITLE
feat(webserver): add white background to footer bar in default template

### DIFF
--- a/src/webserver/default/stats.php
+++ b/src/webserver/default/stats.php
@@ -13,8 +13,8 @@
 </head>
 <body class="frame">
 <table class="w100p h30">
-  <tr class="va-top"> 
-    <td class="w65p"><strong>Ed2k : </strong> 
+  <tr class="va-top">
+    <td class="w65p"><strong>Ed2k : </strong>
       <?php
     	$stats = amule_get_stats();
     	if ( $stats["id"] == 0 ) {
@@ -27,7 +27,7 @@
     	}
     ?>
     </td>
-    <td><strong>Kad :</strong> 
+    <td><strong>Kad :</strong>
       <?php
     	$stats = amule_get_stats();
     	if ( $stats["kad_connected"] == 1 ) {

--- a/src/webserver/default/style.css
+++ b/src/webserver/default/style.css
@@ -236,6 +236,7 @@ table.prefs-pane > tbody > tr:not(:first-child) > td {
 table.footer-bar {
 	width: 100%;
 	height: 40px;
+	background-color: #FFFFFF;
 }
 table.footer-bar > tbody > tr {
 	text-align: center;
@@ -243,9 +244,12 @@ table.footer-bar > tbody > tr {
 }
 table.footer-bar > tbody > tr > td {
 	width: 50%;
+	background-color: #FFFFFF;
 }
 table.footer-bar iframe {
 	width: 100%;
+	height: 35px;
+	display: block;
 	border: 0;
 }
 table.tab {
@@ -371,6 +375,7 @@ select[name="status"] {
 }
 body.frame {
 	overflow: hidden;
+	background-color: #FFFFFF;
 }
 th.login-banner {
 	height: 180px;


### PR DESCRIPTION
The footer status bar (ed2k link form and Ed2k/Kad connection status) rendered its text directly over the metallic page background, making it hard to read.

- Add a white background to the footer bar table, its cells and the footer iframes (body.frame), so the whole footer is a continuous white strip with legible text.
- Make the footer iframes display:block with a fixed 35px height to remove the inline whitespace gap below them that exposed the page background, while keeping the original footer height.
- Trim trailing whitespace in stats.php.