### PR TITLE
fix(SharedDirWatcher): close inotify race window on new subdirectory

### DIFF
--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -326,8 +326,17 @@ void CSharedDirWatcher::OnFileSystemEvent(wxFileSystemWatcherEvent & event)
 	// without having to revisit the prefs dialog. Existing subdirs that
 	// were originally excluded (non-recursive share) are not
 	// retroactively scanned — only newly-created ones get added.
+	//
+	// Early-return after registration: a directory CREATE is fully
+	// handled inside RegisterNewSubdirectory (add to shareddir_list,
+	// install a watch, race-scan the contents). Falling through to the
+	// file-add accumulator below would enqueue the directory path as if
+	// it were a file, and AddPathToShares's FileExists() check would
+	// reject it with a misleading "Shared file does not exist (possibly
+	// a broken link)" debug line on every new subdir.
 	if ((changeType & wxFSW_EVENT_CREATE) && path.IsOk() && path.DirExists()) {
 		RegisterNewSubdirectory(path.GetFullPath());
+		return;
 	}
 
 	// Per-path event accumulation. Coalesces a CREATE → MODIFY × N →
@@ -399,6 +408,62 @@ void CSharedDirWatcher::RegisterNewSubdirectory(const wxString & path)
 
 	// Persist the new entry so the change survives a restart.
 	theApp->glob_prefs->SaveSharedFolders();
+
+	// Close the inotify race window. Between the kernel mkdir() that
+	// fired this CREATE event and our wxFileSystemWatcher::Add() above,
+	// any file or subdir created inside `path` fires on a watch that
+	// doesn't exist yet, so the event is silently dropped. Common with
+	// tools that batch a mkdir + a content-drop within microseconds
+	// (Sonarr "mkdir /tv/$show; symlink $episode" being the canonical
+	// case). Walk the new dir now and feed any pre-existing entries
+	// through the same NotifyPathAdded / RegisterNewSubdirectory
+	// pipeline they would have gone through if events had been
+	// observed. Idempotent: NotifyPathAdded short-circuits on the
+	// shared-file path index if the file is already known (covers
+	// macOS, where FSEvents may still deliver the same events later),
+	// and RegisterNewSubdirectory short-circuits on the shareddir_list
+	// dedup check.
+	ScanNewSubdirRace(p);
+}
+
+
+void CSharedDirWatcher::ScanNewSubdirRace(const CPath & parent)
+{
+	if (!parent.IsOk() || !parent.DirExists()) {
+		return;
+	}
+
+	const int dirFlags = thePrefs::FollowSymlinksInShares() ? 0 : wxDIR_NO_FOLLOW;
+
+	// Files first: each is routed through NotifyPathAdded, which dedups
+	// against the shared-file path index and queues a CHashingTask for
+	// genuinely new entries.
+	{
+		CDirIterator files(parent);
+		for (CPath f = files.GetFirstFile(CDirIterator::File, wxEmptyString, dirFlags);
+			f.IsOk();
+			f = files.GetNextFile())
+		{
+			CPath fullFile = parent.JoinPaths(f);
+			m_parent->NotifyPathAdded(fullFile.GetRaw());
+		}
+	}
+
+	// Subdirs: recurse via RegisterNewSubdirectory so each gets added
+	// to shareddir_list, picks up its own watch on Linux/BSD/Windows,
+	// and runs its own race-scan. Handles arbitrary nesting created
+	// inside the original race window (e.g. mkdir /tv/show; mkdir
+	// /tv/show/season; ln -s /downloads/ep /tv/show/season/ep.mkv).
+	{
+		CDirIterator subdirs(parent);
+		for (CPath sub = subdirs.GetFirstFile(CDirIterator::Dir, wxEmptyString, dirFlags);
+			sub.IsOk();
+			sub = subdirs.GetNextFile())
+		{
+			CPath fullSub = parent.JoinPaths(sub);
+			RegisterNewSubdirectory(fullSub.GetRaw());
+		}
+	}
 }
 
 

--- a/src/SharedDirWatcher.h
+++ b/src/SharedDirWatcher.h
@@ -112,6 +112,16 @@ private:
 	// "auto-share new subdirs of watched parents" behaviour.
 	void RegisterNewSubdirectory(const wxString & path);
 
+	// Closes the inotify/kqueue race window inside RegisterNewSubdirectory:
+	// between the kernel mkdir and our wxFileSystemWatcher::Add(), any
+	// files or subdirs created inside the new directory fire on a watch
+	// that doesn't exist yet and get silently dropped. Walks `parent`
+	// after the watch is in place and feeds existing entries through
+	// NotifyPathAdded (files) and RegisterNewSubdirectory (subdirs,
+	// recursively) so the catch-up is symmetric with what the live
+	// event path would have done. Idempotent on second observation.
+	void ScanNewSubdirRace(const CPath & parent);
+
 	// Recursively walk each path in shareddir_list and add any subdir
 	// not already listed. The "cold" twin of RegisterNewSubdirectory:
 	// without this, subdirs created while aMule was offline are never


### PR DESCRIPTION
## Bug

A program that creates a new subdirectory under a recursive shared root and immediately drops content inside it can lose the inner file events. The canonical case observed on a user's `/tv` recursive share:

1. Sonarr runs `mkdir /tv/MyShow` → kernel emits IN_CREATE on `/tv`.
2. Sonarr immediately symlinks `/tv/MyShow/Episode.mkv` → kernel emits IN_CREATE on `/tv/MyShow`, **but `/tv/MyShow` has no inotify watch yet**, so the event is silently dropped.
3. The first IN_CREATE finally drains through the kernel → wx event loop → `OnFileSystemEvent` calls `RegisterNewSubdirectory` and installs the watch on `/tv/MyShow` — too late.

Net result: the symlinked episode never reaches the shared file list until something else nudges it (touch, manual reshare, restart). The user also saw a misleading log line on every new subdir:

```
2026-06-22 06:46:13: [diag] Shared file does not exist (possibly a broken link): /tv/MyShow
```

That's because `OnFileSystemEvent` was both handing the directory to `RegisterNewSubdirectory` **and** falling through to the file-add accumulator. `AddPathToShares`'s `FileExists()` check rejects directories with the "broken link" message.

Equivalent races exist on macOS (FSEvents 1-2 s delivery latency) and BSD/Windows backends, just with different timing budgets.

## Fix

In `RegisterNewSubdirectory`, after the watch is in place, walk the new directory contents and feed them through the same path handlers the live event flow would have used:

- Files → `NotifyPathAdded` (queues a hashing task).
- Subdirectories → recursive `RegisterNewSubdirectory` (each gets its own entry in `shareddir_list`, its own watch, and its own race-scan). Handles arbitrary nesting like `mkdir /tv/MyShow; mkdir /tv/MyShow/Season1; ln -s ep.mkv /tv/MyShow/Season1/ep.mkv`.

Also early-return from `OnFileSystemEvent` after dispatching a directory CREATE, so the directory path doesn't also get enqueued as a file-add. Kills the "Shared file does not exist" log noise.

Idempotent on second observation — `NotifyPathAdded` short-circuits against the shared-file path index, and `RegisterNewSubdirectory` short-circuits against the `shareddir_list` dedup — so macOS doesn't double-process when FSEvents delivers the same events on its own schedule.

## Persistence

No change to `shareddir-recursive.dat` or `shareddir-explicit.dat`. Only `shareddir.dat` (the runtime union) gains the auto-discovered subdir entries, exactly as today. Existing stale-pruning logic in [`ReloadSharedFolders`](https://github.com/amule-org/amule/blob/master/src/Preferences.cpp#L2186-L2192) already drops deleted entries at restart via the `DirExists()` gate.
