### PR TITLE
fix(SharedDirWatcher): file CREATEs no longer reach NotifyPathAdded after #227

### DIFF
--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -334,7 +334,19 @@ void CSharedDirWatcher::OnFileSystemEvent(wxFileSystemWatcherEvent & event)
 	// it were a file, and AddPathToShares's FileExists() check would
 	// reject it with a misleading "Shared file does not exist (possibly
 	// a broken link)" debug line on every new subdir.
-	if ((changeType & wxFSW_EVENT_CREATE) && path.IsOk() && path.DirExists()) {
+	//
+	// Use wxDirExists(GetFullPath()) — NOT the path.DirExists() instance
+	// method — because wxFileName::DirExists() checks GetPath() (the
+	// parent directory portion) for its truthiness, not the full path.
+	// Calling .DirExists() on a wxFileName built from
+	// /tv/Season 9/Episode.mkv returns true whenever /tv/Season 9 exists,
+	// which it always does inside a watched share. Without the static
+	// overload, every FILE CREATE would route through
+	// RegisterNewSubdirectory (which then no-ops on its own CPath
+	// directory check) and the early return below would suppress slot
+	// accumulation entirely — meaning no file ever reaches NotifyPathAdded.
+	if ((changeType & wxFSW_EVENT_CREATE) && path.IsOk() &&
+		wxFileName::DirExists(path.GetFullPath())) {
 		RegisterNewSubdirectory(path.GetFullPath());
 		return;
 	}


### PR DESCRIPTION
## Regression introduced by #227

#227 added an early `return;` after the directory-CREATE branch in `OnFileSystemEvent`. The branch condition uses `path.DirExists()` on the `wxFileName` returned by `wxFileSystemWatcherEvent::GetPath()`. The instance-method form of `wxFileName::DirExists()` checks `GetPath()` — the **parent-directory** portion of the wxFileName — not `GetFullPath()`. So for any file CREATE inside a watched dir:

```cpp
path.DirExists()                            // checks /tv/Season 9 → true
wxFileName::DirExists(path.GetFullPath())   // checks the full path → false
```

The wrong overload was selected, so every file CREATE under a watched directory satisfied the condition, was routed through `RegisterNewSubdirectory` (which then no-op'd on its own `CPath::DirExists()` check), and was eaten by the new early `return;` before slot accumulation. Net result: no file ever reached `NotifyPathAdded` and **shares stopped being added at all** as soon as #227 hit master.

The semantic mismatch was latent before #227 — the pre-existing code used `path.DirExists()` at the same site, but the fall-through to slot accumulation meant file CREATEs still got there even after a no-op trip through `RegisterNewSubdirectory`. Adding the `return;` exposed it.

## Fix

Switch to the static overload so the check actually matches its comment:

```diff
-if ((changeType & wxFSW_EVENT_CREATE) && path.IsOk() && path.DirExists()) {
+if ((changeType & wxFSW_EVENT_CREATE) && path.IsOk() &&
+    wxFileName::DirExists(path.GetFullPath())) {
     RegisterNewSubdirectory(path.GetFullPath());
     return;
 }
```

Only directory CREATEs short-circuit; file CREATEs fall through to the slot accumulator as before.
