### PR TITLE
fix(webserver): avoid form resubmission prompt on auto-refresh

### DIFF
--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -11,7 +11,7 @@
 		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
 			return;
 		}
-		location.reload();
+		window.location.href = window.location.href;
 	}, 1000 * ", $_SESSION["auto_refresh"], ");
 </script>";
 	}

--- a/src/webserver/default/amuleweb-main-kad.php
+++ b/src/webserver/default/amuleweb-main-kad.php
@@ -12,7 +12,7 @@
 		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
 			return;
 		}
-		location.reload();
+		window.location.href = window.location.href;
 	}, 1000 * ", $_SESSION["auto_refresh"], ");
 </script>";
 	}

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -12,7 +12,7 @@
 		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
 			return;
 		}
-		location.reload();
+		window.location.href = window.location.href;
 	}, 1000 * ", $_SESSION["auto_refresh"], ");
 </script>";
 	}

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -12,7 +12,7 @@
 		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
 			return;
 		}
-		location.reload();
+		window.location.href = window.location.href;
 	}, 1000 * ", $_SESSION["auto_refresh"], ");
 </script>";
 	}

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -12,7 +12,7 @@
 		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
 			return;
 		}
-		location.reload();
+		window.location.href = window.location.href;
 	}, 1000 * ", $_SESSION["auto_refresh"], ");
 </script>";
 	}

--- a/src/webserver/default/amuleweb-main-stats.php
+++ b/src/webserver/default/amuleweb-main-stats.php
@@ -12,7 +12,7 @@
 		if (document.querySelectorAll('input[type=\"checkbox\"]:checked').length > 0) {
 			return;
 		}
-		location.reload();
+		window.location.href = window.location.href;
 	}, 1000 * ", $_SESSION["auto_refresh"], ");
 </script>";
 	}


### PR DESCRIPTION
Fix for #226

The auto-refresh introduced in 2effbb2e used location.reload(), which repeats the original request. On pages whose forms POST (e.g. filtering downloads by category), each timed reload resubmitted the POST data, triggering the browser's "confirm form resubmission" dialog and breaking the page.

Replace location.reload() with window.location.href = window.location.href so the auto-refresh performs a plain GET navigation, matching the old <meta refresh> behavior. Filter/sort state is preserved because it is stored in $_SESSION. Applied uniformly to dload, kad, search, servers, shared and stats pages in the default template.