### PR TITLE
Use SHA1 and MD5 from Crypto++ instead of our own implementations

### DIFF
--- a/src/CryptoPP_Inc.h
+++ b/src/CryptoPP_Inc.h
@@ -37,7 +37,9 @@
 
 #include CRYPTO_HEADER(config.h)
 #include CRYPTO_HEADER(md4.h)
+#include CRYPTO_HEADER(md5.h)
 #include CRYPTO_HEADER(rsa.h)
+#include CRYPTO_HEADER(sha.h)
 #include CRYPTO_HEADER(base64.h)
 #include CRYPTO_HEADER(osrng.h)
 #include CRYPTO_HEADER(files.h)

--- a/src/SHA.cpp
+++ b/src/SHA.cpp
@@ -22,45 +22,6 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
-// Kry - Modified version of the original SHA.cpp to work on linux and
-// use wxWidgets. Original license follows.
-//
-
-/*
- ---------------------------------------------------------------------------
- Copyright (c) 2002-2011 Dr Brian Gladman ( brg@gladman.me.uk )
- All rights reserved.
-
- LICENSE TERMS
-
- The free distribution and use of this software in both source and binary
- form is allowed (with or without changes) provided that:
-
-   1. distributions of this source code include the above copyright
-      notice, this list of conditions and the following disclaimer;
-
-   2. distributions in binary form include the above copyright
-      notice, this list of conditions and the following disclaimer
-      in the documentation and/or other associated materials;
-
-   3. the copyright holder's name is not used to endorse products
-      built using this software without specific written permission.
-
- ALTERNATIVELY, provided that this notice is retained in full, this product
- may be distributed under the terms of the GNU General Public License (GPL),
- in which case the provisions of the GPL apply INSTEAD OF those given above.
-
- DISCLAIMER
-
- This software is provided 'as is' with no explicit or implied warranties
- in respect of its properties, including, but not limited to, correctness
- and/or fitness for purpose.
- ---------------------------------------------------------------------------
- Issue Date: 30/11/2002
-
- This is a byte oriented version of SHA1 that operates on arrays of bytes
- stored in memory. It runs at 22 cycles per byte on a Pentium P4 processor
-*/
 
 #include "SHA.h"
 
@@ -69,176 +30,37 @@ CSHA::CSHA()
 	Reset();
 }
 
-/*
-    To obtain the highest speed on processors with 32-bit words, this code
-    needs to determine the order in which bytes are packed into such words.
-    The following block of code is an attempt to capture the most obvious
-    ways in which various environments specify their endian definitions.
-    It may well fail, in which case the definitions will need to be set by
-    editing at the points marked **** EDIT HERE IF NECESSARY **** below.
-*/
-#define SHA_LITTLE_ENDIAN 1234 /* byte 0 is least significant (i386) */
-#define SHA_BIG_ENDIAN 4321    /* byte 0 is most significant (mc68k) */
-
-#define rotl32(x, n) (((x) << n) | ((x) >> (32 - n)))
-
-#if (wxBYTE_ORDER == wxBIG_ENDIAN)
-#define swap_b32(x) (x)
-#elif defined(bswap_32)
-#define swap_b32(x) bswap_32(x)
-#else
-#define swap_b32(x) ((rotl32((x), 8) & 0x00ff00ff) | (rotl32((x), 24) & 0xff00ff00))
-#endif
-
-#define SHA1_MASK (SHA1_BLOCK_SIZE - 1)
-
-/* reverse byte order in 32-bit words   */
-
-#define ch(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
-#define parity(x, y, z) ((x) ^ (y) ^ (z))
-#define maj(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
-
-/* A normal version as set out in the FIPS. This version uses   */
-/* partial loop unrolling and is optimised for the Pentium 4    */
-
-#define rnd(f, k) \
-	t = a; \
-	a = rotl32(a, 5) + f(b, c, d) + e + k + w[i]; \
-	e = d; \
-	d = c; \
-	c = rotl32(b, 30); \
-	b = t
-
-void CSHA::Compile()
-{
-	uint32 w[80], i, a, b, c, d, e, t;
-
-	/* note that words are compiled from the buffer into 32-bit */
-	/* words in big-endian order so an order reversal is needed */
-	/* here on little endian machines                           */
-	for (i = 0; i < SHA1_BLOCK_SIZE / 4; ++i)
-		w[i] = swap_b32(m_nBuffer[i]);
-
-	for (i = SHA1_BLOCK_SIZE / 4; i < 80; ++i)
-		w[i] = rotl32(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1);
-
-	a = m_nHash[0];
-	b = m_nHash[1];
-	c = m_nHash[2];
-	d = m_nHash[3];
-	e = m_nHash[4];
-
-	for (i = 0; i < 20; ++i) {
-		rnd(ch, 0x5a827999);
-	}
-
-	for (i = 20; i < 40; ++i) {
-		rnd(parity, 0x6ed9eba1);
-	}
-
-	for (i = 40; i < 60; ++i) {
-		rnd(maj, 0x8f1bbcdc);
-	}
-
-	for (i = 60; i < 80; ++i) {
-		rnd(parity, 0xca62c1d6);
-	}
-
-	m_nHash[0] += a;
-	m_nHash[1] += b;
-	m_nHash[2] += c;
-	m_nHash[3] += d;
-	m_nHash[4] += e;
-}
-
 void CSHA::Reset()
 {
-	m_nCount[0] = m_nCount[1] = 0;
-	m_nHash[0] = 0x67452301;
-	m_nHash[1] = 0xefcdab89;
-	m_nHash[2] = 0x98badcfe;
-	m_nHash[3] = 0x10325476;
-	m_nHash[4] = 0xc3d2e1f0;
+	m_hash = SHA1Digest();
+	m_sha.Restart();
 }
 
-void CSHA::GetHash(CAICHHash &Hash)
+void CSHA::GetHash(SHA1Digest *pHash) const
 {
-	/* extract the hash value as bytes in case the hash buffer is   */
-	/* misaligned for 32-bit words*/
-
-	wxASSERT(Hash.GetHashSize() == 20);
-	for (int i = 0; i < SHA1_DIGEST_SIZE; ++i)
-		Hash.GetRawHash()[i] = (unsigned char)(m_nHash[i >> 2] >> 8 * (~i & 3));
+	*pHash = m_hash;
 }
-
-/* SHA1 hash data in an array of bytes into hash buffer and call the        */
-/* hash_compile function as required.                                       */
 
 void CSHA::Add(const void *pData, uint32 nLength)
 {
-	const unsigned char *data = (const unsigned char *)pData;
-
-	uint32 pos = (uint32)(m_nCount[0] & SHA1_MASK), space = SHA1_BLOCK_SIZE - pos;
-	const unsigned char *sp = data;
-
-	if ((m_nCount[0] += nLength) < nLength)
-		++(m_nCount[1]);
-
-	while (nLength >= space) /* transfer whole blocks while possible  */
-	{
-		memcpy(((unsigned char *)m_nBuffer) + pos, sp, space);
-		sp += space;
-		nLength -= space;
-		space = SHA1_BLOCK_SIZE;
-		pos = 0;
-		Compile();
-	}
-
-	memcpy(((unsigned char *)m_nBuffer) + pos, sp, nLength);
+	m_sha.Update((const CryptoPP::byte *)pData, nLength);
 }
 
-/* SHA1 final padding and digest calculation  */
-
-#if (wxBYTE_ORDER == wxLITTLE_ENDIAN)
-static uint32 mask[4] = { 0x00000000, 0x000000ff, 0x0000ffff, 0x00ffffff };
-static uint32 bits[4] = { 0x00000080, 0x00008000, 0x00800000, 0x80000000 };
-#else
-static uint32 mask[4] = { 0x00000000, 0xff000000, 0xffff0000, 0xffffff00 };
-static uint32 bits[4] = { 0x80000000, 0x00800000, 0x00008000, 0x00000080 };
-#endif
-
-void CSHA::Finish(CAICHHash &Hash)
+void CSHA::Finish()
 {
-	uint32 i = (uint32)(m_nCount[0] & SHA1_MASK);
-
-	/* mask out the rest of any partial 32-bit word and then set    */
-	/* the next byte to 0x80. On big-endian machines any bytes in   */
-	/* the buffer will be at the top end of 32 bit words, on little */
-	/* endian machines they will be at the bottom. Hence the AND    */
-	/* and OR masks above are reversed for little endian systems    */
-	/* Note that we can always add the first padding byte at this	*/
-	/* because the buffer always contains at least one empty slot	*/
-	m_nBuffer[i >> 2] = (m_nBuffer[i >> 2] & mask[i & 3]) | bits[i & 3];
-
-	/* we need 9 or more empty positions, one for the padding byte  */
-	/* (above) and eight for the length count.  If there is not     */
-	/* enough space pad and empty the buffer                        */
-	if (i > SHA1_BLOCK_SIZE - 9) {
-		if (i < 60)
-			m_nBuffer[15] = 0;
-		Compile();
-		i = 0;
-	} else /* compute a word index for the empty buffer positions  */
-		i = (i >> 2) + 1;
-
-	while (i < 14) /* and zero pad all but last two positions      */
-		m_nBuffer[i++] = 0;
-
-	/* assemble the eight byte counter in in big-endian format		*/
-	m_nBuffer[14] = swap_b32((m_nCount[1] << 3) | (m_nCount[0] >> 29));
-	m_nBuffer[15] = swap_b32(m_nCount[0] << 3);
-
-	Compile();
-	GetHash(Hash);
+	m_sha.Final(m_hash.b);
 }
+
+void CSHA::GetHash(CAICHHash &rHash)
+{
+	wxASSERT(rHash.GetHashSize() == sizeof(SHA1Digest));
+	GetHash((SHA1Digest *)rHash.GetRawHash());
+}
+
+void CSHA::Finish(CAICHHash &rHash)
+{
+	Finish();
+	GetHash(rHash);
+}
+
 // File_checked_for_headers

--- a/src/SHA.h
+++ b/src/SHA.h
@@ -22,53 +22,23 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
-// Kry - Modified version of the original SHA.cpp to work on linux and
-// use wxWidgets. Original license follows.
-//
-
-/*
- ---------------------------------------------------------------------------
- Copyright (c) 2002-2011 Dr Brian Gladman ( brg@gladman.me.uk )
- All rights reserved.
-
- LICENSE TERMS
-
- The free distribution and use of this software in both source and binary
- form is allowed (with or without changes) provided that:
-
-   1. distributions of this source code include the above copyright
-      notice, this list of conditions and the following disclaimer;
-
-   2. distributions in binary form include the above copyright
-      notice, this list of conditions and the following disclaimer
-      in the documentation and/or other associated materials;
-
-   3. the copyright holder's name is not used to endorse products
-      built using this software without specific written permission.
-
- ALTERNATIVELY, provided that this notice is retained in full, this product
- may be distributed under the terms of the GNU General Public License (GPL),
- in which case the provisions of the GPL apply INSTEAD OF those given above.
-
- DISCLAIMER
-
- This software is provided 'as is' with no explicit or implied warranties
- in respect of its properties, including, but not limited to, correctness
- and/or fitness for purpose.
- ---------------------------------------------------------------------------
- Issue Date: 30/11/2002
-
- This is a byte oriented version of SHA1 that operates on arrays of bytes
- stored in memory. It runs at 22 cycles per byte on a Pentium P4 processor
-*/
 
 #ifndef __SHA_H__
 #define __SHA_H__
 
 #include "SHAHashSet.h"
+#include "CryptoPP_Inc.h"
+
+#define SHA1_DIGEST_SIZE 20
+
+typedef struct
+{
+	uint8 b[SHA1_DIGEST_SIZE];
+} SHA1Digest;
 
 class CSHA : public CAICHHashAlgo
 {
+
 	// Construction
 
 public:
@@ -81,18 +51,13 @@ public:
 	virtual void Add(const void *pData, uint32 nLength);
 	virtual void Finish(CAICHHash &Hash);
 	virtual void GetHash(CAICHHash &Hash);
-
-protected:
-	void Compile();
+	void GetHash(SHA1Digest *pHash) const;
+	void Finish();
 
 private:
-	uint32 m_nCount[2];
-	uint32 m_nHash[5];
-	uint32 m_nBuffer[16];
+	CryptoPP::SHA1 m_sha;
+	SHA1Digest m_hash;
 };
-
-#define SHA1_BLOCK_SIZE 64
-#define SHA1_DIGEST_SIZE 20
 
 #endif // __SHA_H__
 // File_checked_for_headers

--- a/src/libs/common/MD5Sum.cpp
+++ b/src/libs/common/MD5Sum.cpp
@@ -27,18 +27,10 @@
 
 #include "MD5Sum.h" // Interface declarations.
 
-typedef struct
+MD5Sum::MD5Sum()
+: m_hash()
 {
-	uint32_t state[4];
-	uint32_t count[2];
-	unsigned char buffer[64];
-} MD5_CTX;
-
-void MD5Init(MD5_CTX *);
-void MD5Update(MD5_CTX *, const unsigned char *, size_t);
-void MD5Final(unsigned char[16], MD5_CTX *);
-
-MD5Sum::MD5Sum() {}
+}
 
 MD5Sum::MD5Sum(const wxString &sSource)
 {
@@ -58,14 +50,10 @@ void MD5Sum::Calculate(const wxString &sSource)
 
 void MD5Sum::Calculate(const uint8 *buffer, size_t len)
 {
-	MD5_CTX context;
-	unsigned char digest[16];
-
-	MD5Init(&context);
-	MD5Update(&context, buffer, len);
-	MD5Final(digest, &context);
-
-	memcpy(m_rawhash, digest, 16);
+	CryptoPP::Weak::MD5 md5;
+	md5.Restart();
+	md5.Update(buffer, len);
+	md5.Final(m_hash.b);
 	m_sHash.Clear();
 }
 
@@ -73,286 +61,13 @@ wxString MD5Sum::GetHash()
 {
 	if (m_sHash.empty()) {
 		// That's still far from optimal, but called much less often.
-		for (int i = 0; i < 16; ++i) {
+		for (int i = 0; i < MD5_DIGEST_SIZE; ++i) {
 			wxString sT;
-			sT = CFormat("%02x") % m_rawhash[i];
+			sT = CFormat("%02x") % m_hash.b[i];
 			m_sHash += sT;
 		}
 	}
 	return m_sHash;
-}
-
-#define S11 7
-#define S12 12
-#define S13 17
-#define S14 22
-#define S21 5
-#define S22 9
-#define S23 14
-#define S24 20
-#define S31 4
-#define S32 11
-#define S33 16
-#define S34 23
-#define S41 6
-#define S42 10
-#define S43 15
-#define S44 21
-
-static void MD5Transform(uint32_t[4], const unsigned char[64]);
-static void Encode(unsigned char *, uint32_t *, size_t);
-static void Decode(uint32_t *, const unsigned char *, size_t);
-
-// clang-format off
-static const unsigned char PADDING[64] = {
-  0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-};
-// clang-format on
-
-/* F, G, H and I are basic MD5 functions.
- */
-#define F(x, y, z) (((x) & (y)) | ((~x) & (z)))
-#define G(x, y, z) (((x) & (z)) | ((y) & (~z)))
-#define H(x, y, z) ((x) ^ (y) ^ (z))
-#define I(x, y, z) ((y) ^ ((x) | (~z)))
-
-/* ROTATE_LEFT rotates x left n bits.
-	15-April-2003 Sony: use _MSC_VER intrinsic to save some cycles
- */
-#ifdef _MSC_VER
-#pragma intrinsic(_rotl)
-#define ROTATE_LEFT(x, n) _rotl((x), (n))
-#else
-#define ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
-#endif
-
-/* FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
-Rotation is separate from addition to prevent recomputation.
-*/
-/* Defines must be on one line to work with GCC-2.95.3 */
-#define FF(a, b, c, d, x, s, ac) \
-	{ \
-		(a) += F((b), (c), (d)) + (x) + (uint32_t)(ac); \
-		(a) = ROTATE_LEFT((a), (s)); \
-		(a) += (b); \
-	}
-#define GG(a, b, c, d, x, s, ac) \
-	{ \
-		(a) += G((b), (c), (d)) + (x) + (uint32_t)(ac); \
-		(a) = ROTATE_LEFT((a), (s)); \
-		(a) += (b); \
-	}
-#define HH(a, b, c, d, x, s, ac) \
-	{ \
-		(a) += H((b), (c), (d)) + (x) + (uint32_t)(ac); \
-		(a) = ROTATE_LEFT((a), (s)); \
-		(a) += (b); \
-	}
-#define II(a, b, c, d, x, s, ac) \
-	{ \
-		(a) += I((b), (c), (d)) + (x) + (uint32_t)(ac); \
-		(a) = ROTATE_LEFT((a), (s)); \
-		(a) += (b); \
-	}
-
-/* MD5 initialization. Begins an MD5 operation, writing a new context.
- */
-void MD5Init(MD5_CTX *context)
-{
-	context->count[0] = context->count[1] = 0;
-	/* Load magic initialization constants.
-	 */
-	context->state[0] = 0x67452301;
-	context->state[1] = 0xefcdab89;
-	context->state[2] = 0x98badcfe;
-	context->state[3] = 0x10325476;
-}
-
-/* MD5 block update operation. Continues an MD5 message-digest
-  operation, processing another message block, and updating the
-  context.
- */
-void MD5Update(MD5_CTX *context, const unsigned char *input, size_t inputLen)
-{
-	off_t index;
-	size_t i, partLen;
-
-	/* Compute number of bytes mod 64 */
-	index = (context->count[0] >> 3) & 0x3F;
-
-	/* Update number of bits */
-	if ((context->count[0] += ((uint32_t)inputLen << 3)) < ((uint32_t)inputLen << 3)) {
-		context->count[1]++;
-	}
-
-	context->count[1] += ((uint32_t)inputLen >> 29);
-	partLen = 64 - index;
-
-	/* Transform as many times as possible. */
-	if (inputLen >= partLen) {
-		memcpy((unsigned char *)&context->buffer[index], (unsigned char *)input, partLen);
-		MD5Transform(context->state, context->buffer);
-
-		for (i = partLen; i + 63 < inputLen; i += 64) {
-			MD5Transform(context->state, &input[i]);
-		}
-		index = 0;
-	} else {
-		i = 0;
-	}
-
-	/* Buffer remaining input */
-	memcpy((unsigned char *)&context->buffer[index], (unsigned char *)&input[i], inputLen - i);
-}
-
-/* MD5 finalization. Ends an MD5 message-digest operation, writing the
- * the message digest and zeroizing the context.
- */
-void MD5Final(unsigned char digest[16], MD5_CTX *context)
-{
-	unsigned char bits[8];
-	off_t index;
-	size_t padLen;
-
-	/* Save number of bits */
-	Encode(bits, context->count, 8);
-
-	/* Pad out to 56 mod 64. */
-	index = (context->count[0] >> 3) & 0x3f;
-
-	padLen = (index < 56) ? (56 - index) : (120 - index);
-
-	MD5Update(context, PADDING, padLen);
-
-	/* Append length (before padding) */
-	MD5Update(context, bits, 8);
-
-	/* Store state in digest */
-	Encode(digest, context->state, 16);
-
-	/* Zeroize sensitive information.*/
-	memset((unsigned char *)context, 0, sizeof(*context));
-}
-
-/* MD5 basic transformation. Transforms state based on block.
- */
-static void MD5Transform(uint32_t state[4], const unsigned char block[64])
-{
-	uint32_t a = state[0], b = state[1], c = state[2], d = state[3], x[16];
-
-	Decode(x, block, 64);
-
-	/* Round 1 */
-	FF(a, b, c, d, x[0], S11, 0xd76aa478);  /* 1 */
-	FF(d, a, b, c, x[1], S12, 0xe8c7b756);  /* 2 */
-	FF(c, d, a, b, x[2], S13, 0x242070db);  /* 3 */
-	FF(b, c, d, a, x[3], S14, 0xc1bdceee);  /* 4 */
-	FF(a, b, c, d, x[4], S11, 0xf57c0faf);  /* 5 */
-	FF(d, a, b, c, x[5], S12, 0x4787c62a);  /* 6 */
-	FF(c, d, a, b, x[6], S13, 0xa8304613);  /* 7 */
-	FF(b, c, d, a, x[7], S14, 0xfd469501);  /* 8 */
-	FF(a, b, c, d, x[8], S11, 0x698098d8);  /* 9 */
-	FF(d, a, b, c, x[9], S12, 0x8b44f7af);  /* 10 */
-	FF(c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
-	FF(b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
-	FF(a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
-	FF(d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
-	FF(c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
-	FF(b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
-
-	/* Round 2 */
-	GG(a, b, c, d, x[1], S21, 0xf61e2562);  /* 17 */
-	GG(d, a, b, c, x[6], S22, 0xc040b340);  /* 18 */
-	GG(c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
-	GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);  /* 20 */
-	GG(a, b, c, d, x[5], S21, 0xd62f105d);  /* 21 */
-	GG(d, a, b, c, x[10], S22, 0x2441453);  /* 22 */
-	GG(c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
-	GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);  /* 24 */
-	GG(a, b, c, d, x[9], S21, 0x21e1cde6);  /* 25 */
-	GG(d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
-	GG(c, d, a, b, x[3], S23, 0xf4d50d87);  /* 27 */
-	GG(b, c, d, a, x[8], S24, 0x455a14ed);  /* 28 */
-	GG(a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
-	GG(d, a, b, c, x[2], S22, 0xfcefa3f8);  /* 30 */
-	GG(c, d, a, b, x[7], S23, 0x676f02d9);  /* 31 */
-	GG(b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
-
-	/* Round 3 */
-	HH(a, b, c, d, x[5], S31, 0xfffa3942);  /* 33 */
-	HH(d, a, b, c, x[8], S32, 0x8771f681);  /* 34 */
-	HH(c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
-	HH(b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
-	HH(a, b, c, d, x[1], S31, 0xa4beea44);  /* 37 */
-	HH(d, a, b, c, x[4], S32, 0x4bdecfa9);  /* 38 */
-	HH(c, d, a, b, x[7], S33, 0xf6bb4b60);  /* 39 */
-	HH(b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
-	HH(a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
-	HH(d, a, b, c, x[0], S32, 0xeaa127fa);  /* 42 */
-	HH(c, d, a, b, x[3], S33, 0xd4ef3085);  /* 43 */
-	HH(b, c, d, a, x[6], S34, 0x4881d05);   /* 44 */
-	HH(a, b, c, d, x[9], S31, 0xd9d4d039);  /* 45 */
-	HH(d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
-	HH(c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
-	HH(b, c, d, a, x[2], S34, 0xc4ac5665);  /* 48 */
-
-	/* Round 4 */
-	II(a, b, c, d, x[0], S41, 0xf4292244);  /* 49 */
-	II(d, a, b, c, x[7], S42, 0x432aff97);  /* 50 */
-	II(c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
-	II(b, c, d, a, x[5], S44, 0xfc93a039);  /* 52 */
-	II(a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
-	II(d, a, b, c, x[3], S42, 0x8f0ccc92);  /* 54 */
-	II(c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
-	II(b, c, d, a, x[1], S44, 0x85845dd1);  /* 56 */
-	II(a, b, c, d, x[8], S41, 0x6fa87e4f);  /* 57 */
-	II(d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
-	II(c, d, a, b, x[6], S43, 0xa3014314);  /* 59 */
-	II(b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
-	II(a, b, c, d, x[4], S41, 0xf7537e82);  /* 61 */
-	II(d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
-	II(c, d, a, b, x[2], S43, 0x2ad7d2bb);  /* 63 */
-	II(b, c, d, a, x[9], S44, 0xeb86d391);  /* 64 */
-
-	state[0] += a;
-	state[1] += b;
-	state[2] += c;
-	state[3] += d;
-
-	/* Zeroize sensitive information.
-	 */
-	memset((unsigned char *)x, 0, sizeof(x));
-}
-
-/* Encodes input (uint32_t) into output (unsigned char). Assumes len is
-  a multiple of 4.
- */
-static void Encode(unsigned char *output, uint32_t *input, size_t len)
-{
-	size_t i, j;
-
-	for (i = 0, j = 0; j < len; i++, j += 4) {
-		output[j] = (unsigned char)(input[i] & 0xff);
-		output[j + 1] = (unsigned char)((input[i] >> 8) & 0xff);
-		output[j + 2] = (unsigned char)((input[i] >> 16) & 0xff);
-		output[j + 3] = (unsigned char)((input[i] >> 24) & 0xff);
-	}
-}
-
-/* Decodes input (unsigned char) into output (uint32_t). Assumes len is
-  a multiple of 4.
- */
-static void Decode(uint32_t *output, const unsigned char *input, size_t len)
-{
-	wxASSERT(!(len & 3));
-	size_t i, j;
-
-	for (i = 0, j = 0; j < len; i++, j += 4) {
-		output[i] = ((uint32_t)input[j]) | (((uint32_t)input[j + 1]) << 8) |
-			    (((uint32_t)input[j + 2]) << 16) | (((uint32_t)input[j + 3]) << 24);
-	}
 }
 
 // File_checked_for_headers

--- a/src/libs/common/MD5Sum.h
+++ b/src/libs/common/MD5Sum.h
@@ -26,6 +26,19 @@ documentation and/or software.
 #ifndef MD5SUM_H
 #define MD5SUM_H
 
+#include "../../CryptoPP_Inc.h"
+
+#define MD5_DIGEST_SIZE 16
+
+// Crypto::Weak::MD5 needs CRYPTOPP_ENABLE_NAMESPACE_WEAK which
+// has already been declared in CryptoPP_Inc.h header, where other
+// weak crypto algorithms (e.g. MD4) are also included
+
+typedef struct
+{
+	uint8 b[MD5_DIGEST_SIZE];
+} MD5Digest;
+
 class MD5Sum
 {
 public:
@@ -37,11 +50,11 @@ public:
 	void Calculate(const uint8 *buffer, size_t len);
 
 	wxString GetHash();
-	const uint8 *GetRawHash() const { return m_rawhash; }
+	const uint8 *GetRawHash() const { return m_hash.b; }
 
 private:
 	wxString m_sHash;
-	uint8 m_rawhash[16];
+	MD5Digest m_hash;
 };
 
 #endif // MD5SUM_H


### PR DESCRIPTION
Opening as a draft to be ready after 3.0.1 release

Closes #181

# What

Migrate MD5 and SHA1 hash algorithms from our own implementation to Crypto++'s.
We were already linking that library for MD4 and RSA, but the other crypto algorithms were directly implemented on aMule's source code.

The main goals of this migration are:
- security best-practice: do not re-implement crypto functions, use a library
- performance: using Crypto++ we get better performance: SHA CPU instructions where available, but also faster processing times on CPUs not having those instructions (check below)
- maintainability: reduced code size when delegating crypto functions to an external library


The RC4 algorithm migration to Crypto++'s version is out of scope. According to @Stoatwblr analysis here https://github.com/amule-org/amule/discussions/194#discussioncomment-17344524 , RC4 implementation in aMule is slightly broken vs Crypto++, and migrating to Crypto++'s version would actually inccur in a performance penalty because of the workarounds needed to make it work. We keep the existing implementation.
Also, credit to eMuleAI: SHA1 and MD5 migrations to Crypto++ are largely based on their code (SHA.* MD5Sum.*) here: https://github.com/eMuleAI/eMuleAI/tree/master/srchybrid

# Tests

- [x] Add new files to the shared folder. Compare known2_64.met files generated by the before-Crypto++ and after-Crypto++ versions. They shall be equal. Since entries in known2_64.met file do not follow any specific order, we need to delete the ~/.aMule folder for each version and add the shared files following the same order to generate identical known2_64.met files
- [x] Set-up configuration as "Accept only obfuscated connections", successfully connect to a Server, check in the log the connection is obfuscated
- [x] Set-up configuration as "Accept only obfuscated connections", successfully connect to Kad
- [x] Set-up configuration as "Accept only obfuscated connections", successfully download a file from other clients, check on Client Details the connection is obfuscated
- [x] Download a file, it shall hash correctly when the download is completed
- [x] Login to a remote amuled from amulecmd/amulegui by typing a password

# Performance

Performance comparison for SHA1 hash operations follows.
Since MD5 is only used to hash a few bytes (EC password, key agreement for RC4 encryption), the performance impact is assumed to be negligible. 

## Methodology
Before each test, remove ~/.aMule folder
Launch amule(d) to create the ~/.aMule folder, and close it.
Create three files in ~/.aMule/Incoming as follows and restart amule(d)
fallocate -l 300mb test-300mb
fallocate -l 2gb test-2gb
fallocate -l 5gb test-5gb
Measure start time from log line: SharedFileList.cpp(410): Found 0 known shared files, 3 unknown
Measure end time from known2_64.met modification time after all 3 files are hashed, since Release builds don't show any log line on hash completion. 

## Results:
### amule on a CPU with SHA instructions:
| type | time |
| ---------------------------------------- | -------------- |
| aMule using Crypto++ | 14s |
| aMule using its own implementation, release build | 44s |
| aMule using its own implementation, debug build | 52s |

### amuled on a CPU without SHA instructions (RPi 400):
| type | time |
| ---------------------------------------- | -------------- |
| aMule using Crypto++ | 1min 1s |
| aMule using its own implementation, release build | 1min 49s |
| aMule using its own implementation, debug build | 3min 37s |

