### PR TITLE
chore: update .git-blame-ignore-revs with post-rebase SHA

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Bulk clang-format reformat — style only, no logic changes
-834ade35c7d0d7240de918bf8d22698c4d37c32a
+041a2fa3c78fdaef7e0a2ed37e895ffca63f5d8d


### PR DESCRIPTION
## Summary

- Updates the SHA in `.git-blame-ignore-revs` to reflect the actual commit hash of the bulk clang-format reformat after it was rebased onto master (PR #251).
- The pre-merge SHA (`834ade35c`) was from the PR branch; the post-rebase SHA is `041a2fa3c`.

## Test plan

- No code changes; no tests needed.