### PR TITLE
fix debug message when AICH ReadRecoveryData fails

### DIFF
--- a/src/DownloadClient.cpp
+++ b/src/DownloadClient.cpp
@@ -1723,7 +1723,7 @@ void CUpDownClient::ProcessAICHAnswer(const uint8_t *packet, uint32 size)
 				return;
 			} else {
 				AddDebugLogLineN(logAICHTransfer,
-					"AICH Packet Answer: Succeeded to read and validate received "
+					"AICH Packet Answer: Failed to read and validate received "
 					"recoverydata");
 			}
 		} else {


### PR DESCRIPTION
Fix debug message when AICH ReadRecoveryData fails

Probably a wrong copypaste

The "if" path is for success, the "else" is for a fail