### PR TITLE
hide macos build with gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ packaging/windows/installer_strings_generated.nsh
 .aider*
 
 .cache/
+
+build-macos/
+dist/


### PR DESCRIPTION
`./packaging/macos/build.sh` generates compilation files in `build-macos/` and `dist/`