### PR TITLE
Stream large file copies through a 1 MiB buffer (#11)

### DIFF
--- a/src/CFile.cpp
+++ b/src/CFile.cpp
@@ -28,6 +28,8 @@
 #include <common/Path.h> // Needed for CPath
 #include "config.h"      // Needed for HAVE_SYS_PARAM_H
 
+#include <vector> // Needed for the CopyFile stream buffer
+
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
@@ -541,5 +543,66 @@ bool CFile::SetLength(uint64 new_len)
 	syscall_check(result, m_filePath, "truncating file");
 
 	return result;
+}
+
+bool CFile::CloneFile(const CPath &src, const CPath &dst, bool overwrite)
+{
+	if (!overwrite && dst.FileExists()) {
+		return false;
+	}
+
+	CFile in;
+	if (!in.Open(src, CFile::read)) {
+		return false;
+	}
+
+	CFile out;
+	if (!out.Open(dst, CFile::write)) {
+		return false;
+	}
+
+	// Stream through a 1 MiB heap buffer. The previous implementation
+	// (wxCopyFile) used a hard-coded 4 KiB buffer, which throttled
+	// cross-filesystem copies over NFS / sshfs to a fraction of line speed
+	// (amule-org/amule#11). Heap-allocated, not a stack array: CopyFile can
+	// run on the completion worker thread, where musl caps the stack at
+	// 128 KiB.
+	const size_t bufferSize = 1u << 20;
+	std::vector<char> buffer(bufferSize);
+
+	try {
+		uint64 remaining = in.GetLength();
+		while (remaining) {
+			const size_t chunk =
+				(remaining < bufferSize) ? static_cast<size_t>(remaining) : bufferSize;
+			in.Read(buffer.data(), chunk);
+			out.Write(buffer.data(), chunk);
+			remaining -= chunk;
+		}
+		// Close (not just rely on the destructor): flushes the trailing
+		// sub-buffer write and surfaces any deferred error, e.g. an ENOSPC
+		// that only shows up when the write buffer drains.
+		if (!out.Close()) {
+			CPath::RemoveFile(dst);
+			return false;
+		}
+	} catch (const CSafeIOException &e) {
+		AddDebugLogLineC(
+			logCFile, CFormat(wxT("Failed to copy %s to %s: %s")) % src % dst % e.what());
+		// Close before unlinking: Windows can't remove an open file. Close
+		// may itself throw while draining, so guard it — we're already on
+		// the failure path.
+		try {
+			if (out.IsOpened()) {
+				out.Close();
+			}
+		} catch (const CSafeIOException &) {
+			// best-effort
+		}
+		CPath::RemoveFile(dst);
+		return false;
+	}
+
+	return true;
 }
 // File_checked_for_headers

--- a/src/CFile.h
+++ b/src/CFile.h
@@ -133,6 +133,24 @@ public:
 	bool Create(const wxString &path, bool overwrite = false, int accessMode = wxS_DEFAULT);
 
 	/**
+	 * Copies a file, streaming through a large buffer.
+	 *
+	 * Used for data-file copies that can cross filesystems (e.g. the
+	 * Temp -> Incoming move on download completion, when a rename fails
+	 * because the two directories live on different mounts). Unlike
+	 * wxCopyFile's hard-coded 4 KiB buffer, this streams through a 1 MiB
+	 * buffer, which is what lets cross-filesystem copies over NFS / sshfs
+	 * reach line speed. See amule-org/amule#11.
+	 *
+	 * The silly name (vs. CopyFile) avoids the CopyFile #define set on MSW.
+	 *
+	 * @param overwrite If false and the destination exists, fails.
+	 * @return true on success. On failure the (partial) destination is
+	 *         removed so a failed copy never leaves a corrupt file behind.
+	 */
+	static bool CloneFile(const CPath &src, const CPath &dst, bool overwrite = false);
+
+	/**
 	 * Closes the file.
 	 *
 	 * Note that calling Close on an closed file

--- a/src/ClientCreditsList.cpp
+++ b/src/ClientCreditsList.cpp
@@ -94,7 +94,11 @@ void CClientCreditsList::LoadList()
 		// else: the backup doesn't exist, create it
 		if (bCreateBackup) {
 			file.Close(); // close the file before copying
-			if (!CPath::CloneFile(fileName, bakFileName, true)) {
+			// Small same-directory config backup (clients.met ->
+			// clients.met.bak); the plain wxCopyFile path is the right
+			// fit, not the buffered CFile::CloneFile used for large,
+			// possibly cross-filesystem data-file copies.
+			if (!CPath::BackupFile(fileName, wxT(".bak"))) {
 				AddDebugLogLineC(
 					logCredits, CFormat("Could not create backup file '%s'") % fileName);
 			}

--- a/src/PartFileConvert.cpp
+++ b/src/PartFileConvert.cpp
@@ -414,7 +414,7 @@ ConvStatus CPartFileConvert::performConvertToeMule(const CPath &fileName)
 		} else if (s_pfconverting->removeSource) {
 			ret = CPath::RenameFile(oldfile, newfilename.RemoveExt());
 		} else {
-			ret = CPath::CloneFile(oldfile, newfilename.RemoveExt(), false);
+			ret = CFile::CloneFile(oldfile, newfilename.RemoveExt(), false);
 		}
 		if (!ret) {
 			file->Delete();
@@ -429,7 +429,7 @@ ConvStatus CPartFileConvert::performConvertToeMule(const CPath &fileName)
 	if (s_pfconverting->removeSource) {
 		CPath::RenameFile(folder.JoinPaths(partfile), newfilename);
 	} else {
-		CPath::CloneFile(folder.JoinPaths(partfile), newfilename, false);
+		CFile::CloneFile(folder.JoinPaths(partfile), newfilename, false);
 	}
 
 	file->m_hashlist.clear();

--- a/src/ThreadTasks.cpp
+++ b/src/ThreadTasks.cpp
@@ -31,6 +31,7 @@
 
 #include "ThreadTasks.h"      // Interface declarations
 #include "PartFile.h"         // Needed for CPartFile
+#include "CFile.h"            // Needed for CFile::CloneFile
 #include "Logger.h"           // Needed for Add(Debug)LogLine{C,N}
 #include <common/Format.h>    // Needed for CFormat
 #include "amule.h"            // Needed for theApp
@@ -563,7 +564,7 @@ void CCompletionTask::Entry()
 	// Move will handle dirs on the same partition, otherwise copy is needed.
 	CPath partfilename = m_metPath.RemoveExt();
 	if (!CPath::RenameFile(partfilename, newName)) {
-		if (!CPath::CloneFile(partfilename, newName, true)) {
+		if (!CFile::CloneFile(partfilename, newName, true)) {
 			m_error = true;
 			return;
 		}

--- a/src/libs/common/Path.cpp
+++ b/src/libs/common/Path.cpp
@@ -543,11 +543,6 @@ bool CPath::StartsWith(const CPath &other) const
 	return PATHNCMP(a.c_str(), b.c_str(), checkLen) == 0;
 }
 
-bool CPath::CloneFile(const CPath &src, const CPath &dst, bool overwrite)
-{
-	return ::wxCopyFile(src.m_filesystem, dst.m_filesystem, overwrite);
-}
-
 bool CPath::RemoveFile(const CPath &file)
 {
 	return ::wxRemoveFile(file.m_filesystem);
@@ -564,7 +559,11 @@ bool CPath::BackupFile(const CPath &src, const wxString &appendix)
 
 	CPath dst = CPath(src.m_filesystem + appendix);
 
-	if (CPath::CloneFile(src, dst, true)) {
+	// Small same-directory .met/config backup — wxCopyFile's 4 KiB buffer
+	// is fine here. Large data-file copies use CFile::CloneFile (higher
+	// layer) instead; see amule-org/amule#11. mulecommon deliberately has
+	// no dependency on the CFile layer, so this stays on wxCopyFile.
+	if (::wxCopyFile(src.m_filesystem, dst.m_filesystem, true)) {
 		// Try to ensure that the backup gets physically written
 #if defined __WINDOWS__ || defined __IRIX__
 		wxFFile backupFile;

--- a/src/libs/common/Path.h
+++ b/src/libs/common/Path.h
@@ -158,15 +158,9 @@ public:
 
 	/**
 	 * Renames the file 'src' to the file 'dst', overwriting if specified. Note that
-	 * renaming cannot be done across volumes. For that CopyFile is required.
+	 * renaming cannot be done across volumes. For that CFile::CloneFile is required.
 	 */
 	static bool RenameFile(const CPath &src, const CPath &dst, bool overwrite = false);
-	/**
-	 * Copies the file 'src' to the file 'dst', overwriting if specified.
-	 * The silly name is used to avoid conflicts with the #define CopyFile,
-	 * which is set on MSW.
-	 */
-	static bool CloneFile(const CPath &src, const CPath &dst, bool overwrite = false);
 
 	/** Makes a backup of a file, by copying the original file to 'src' + 'appendix' */
 	static bool BackupFile(const CPath &src, const wxString &appendix);

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -66,6 +66,32 @@ target_link_libraries (FileDataIOTest
 	muleunit
 )
 
+add_executable (CloneFileTest
+	CloneFileTest.cpp
+	${CMAKE_SOURCE_DIR}/src/SafeFile.cpp
+	${CMAKE_SOURCE_DIR}/src/CFile.cpp
+	${CMAKE_SOURCE_DIR}/src/MemFile.cpp
+	${CMAKE_SOURCE_DIR}/src/kademlia/utils/UInt128.cpp
+	${CMAKE_SOURCE_DIR}/src/Tag.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/Path.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+)
+
+add_test (NAME CloneFileTest
+	COMMAND CloneFileTest
+)
+
+target_include_directories (CloneFileTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (CloneFileTest
+	muleunit
+)
+
 add_executable (FormatTest
 	FormatTest.cpp
 	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp

--- a/unittests/tests/CloneFileTest.cpp
+++ b/unittests/tests/CloneFileTest.cpp
@@ -1,0 +1,284 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#include <muleunit/test.h>
+#include <CFile.h>
+#include <common/Path.h>
+#include <wx/filename.h>
+#include <vector>
+#include <cstdlib> // getenv / atoi for the opt-in huge-file test
+#include <cstring> // memcmp
+
+using namespace muleunit;
+
+namespace muleunit
+{
+//! Needed for ASSERT_* diagnostics involving CPath
+template <> wxString StringFrom<CPath>(const CPath &path)
+{
+	return path.GetPrintable();
+}
+} // namespace muleunit
+
+// Returns a path to a fresh, non-existent temp file. CreateTempFileName
+// creates the file empty, so remove it to hand back a clean slate.
+static CPath FreshTemp()
+{
+	CPath path(wxFileName::CreateTempFileName(wxT("amuleclone_")));
+	CPath::RemoveFile(path);
+	return path;
+}
+
+// Writes `length` bytes of deterministic, position-dependent data.
+static void WriteData(const CPath &path, size_t length)
+{
+	CFile file;
+	ASSERT_TRUE(file.Open(path, CFile::write));
+	std::vector<char> buffer(length);
+	for (size_t i = 0; i < length; ++i) {
+		buffer[i] = static_cast<char>((i * 31 + 7) & 0xff);
+	}
+	if (length) {
+		file.Write(buffer.data(), length);
+	}
+	file.Close();
+}
+
+static std::vector<char> ReadAll(const CPath &path)
+{
+	CFile file;
+	if (!file.Open(path, CFile::read)) {
+		return std::vector<char>();
+	}
+	const uint64 length = file.GetLength();
+	std::vector<char> buffer(static_cast<size_t>(length));
+	if (length) {
+		file.Read(buffer.data(), static_cast<size_t>(length));
+	}
+	file.Close();
+	return buffer;
+}
+
+static uint64 FileLength(const CPath &path)
+{
+	CFile file;
+	if (!file.Open(path, CFile::read)) {
+		return 0;
+	}
+	const uint64 length = file.GetLength();
+	file.Close();
+	return length;
+}
+
+// Writes `length` bytes of deterministic, position-dependent data in 1 MiB
+// blocks. Chunked (rather than a single buffer) so the huge-file test never
+// holds multiple GiB in memory. The pattern depends on absolute offset, so
+// the tail differs from the head — a high-offset copy bug can't hide.
+static void WriteDataChunked(const CPath &path, uint64 length)
+{
+	CFile file;
+	ASSERT_TRUE(file.Open(path, CFile::write));
+	const size_t block = 1u << 20;
+	std::vector<char> buffer(block);
+	uint64 written = 0;
+	while (written < length) {
+		const size_t chunk =
+			(length - written < block) ? static_cast<size_t>(length - written) : block;
+		for (size_t i = 0; i < chunk; ++i) {
+			buffer[i] = static_cast<char>(((written + i) * 31 + 7) & 0xff);
+		}
+		file.Write(buffer.data(), chunk);
+		written += chunk;
+	}
+	file.Close();
+}
+
+// Compares two files by streaming 1 MiB blocks, so it works on multi-GiB
+// files without loading them into memory.
+static bool SameContentStreaming(const CPath &a, const CPath &b)
+{
+	CFile fa, fb;
+	if (!fa.Open(a, CFile::read) || !fb.Open(b, CFile::read)) {
+		return false;
+	}
+	if (fa.GetLength() != fb.GetLength()) {
+		return false;
+	}
+	uint64 remaining = fa.GetLength();
+	const size_t block = 1u << 20;
+	std::vector<char> ba(block), bb(block);
+	while (remaining) {
+		const size_t chunk = (remaining < block) ? static_cast<size_t>(remaining) : block;
+		fa.Read(ba.data(), chunk);
+		fb.Read(bb.data(), chunk);
+		if (memcmp(ba.data(), bb.data(), chunk) != 0) {
+			return false;
+		}
+		remaining -= chunk;
+	}
+	return true;
+}
+
+// A size larger than the internal copy buffer, deliberately not a round
+// multiple of it, so the copy loop runs several full iterations plus a
+// short trailing chunk.
+static const size_t MULTI_CHUNK = 3 * 1024 * 1024 + 123;
+
+DECLARE_SIMPLE(CFileCloneFile)
+
+TEST(CFileCloneFile, ByteIdenticalMultiChunk)
+{
+	CPath src = FreshTemp();
+	WriteData(src, MULTI_CHUNK);
+	CPath dst = FreshTemp();
+
+	ASSERT_TRUE(CFile::CloneFile(src, dst, false));
+	ASSERT_TRUE(dst.FileExists());
+	ASSERT_TRUE(SameContentStreaming(src, dst));
+
+	CPath::RemoveFile(src);
+	CPath::RemoveFile(dst);
+}
+
+TEST(CFileCloneFile, EmptyFile)
+{
+	CPath src = FreshTemp();
+	WriteData(src, 0);
+	CPath dst = FreshTemp();
+
+	ASSERT_TRUE(CFile::CloneFile(src, dst, false));
+	ASSERT_TRUE(dst.FileExists());
+	ASSERT_TRUE(ReadAll(dst).empty());
+
+	CPath::RemoveFile(src);
+	CPath::RemoveFile(dst);
+}
+
+TEST(CFileCloneFile, NoOverwriteFailsAndPreservesDst)
+{
+	CPath src = FreshTemp();
+	WriteData(src, 4096);
+	CPath dst = FreshTemp();
+	WriteData(dst, 10); // distinct existing content
+	const std::vector<char> before = ReadAll(dst);
+
+	ASSERT_FALSE(CFile::CloneFile(src, dst, false));
+	ASSERT_TRUE(ReadAll(dst) == before); // untouched
+
+	CPath::RemoveFile(src);
+	CPath::RemoveFile(dst);
+}
+
+TEST(CFileCloneFile, OverwriteReplaces)
+{
+	CPath src = FreshTemp();
+	WriteData(src, 4096);
+	CPath dst = FreshTemp();
+	WriteData(dst, 10);
+
+	ASSERT_TRUE(CFile::CloneFile(src, dst, true));
+	ASSERT_TRUE(SameContentStreaming(src, dst));
+
+	CPath::RemoveFile(src);
+	CPath::RemoveFile(dst);
+}
+
+TEST(CFileCloneFile, MissingSourceFailsAndCreatesNoDst)
+{
+	CPath src = FreshTemp(); // never written -> does not exist
+	CPath dst = FreshTemp();
+
+	ASSERT_FALSE(CFile::CloneFile(src, dst, true));
+	ASSERT_FALSE(dst.FileExists()); // no partial destination left behind
+
+	CPath::RemoveFile(dst);
+}
+
+TEST(CFileCloneFile, UnwritableDestFails)
+{
+	CPath src = FreshTemp();
+	WriteData(src, 4096);
+	// Parent directory does not exist, so opening the destination fails.
+	CPath dst(wxT("amuleclone_missing_dir_xyz/dst.tmp"));
+
+	ASSERT_FALSE(CFile::CloneFile(src, dst, true));
+
+	CPath::RemoveFile(src);
+}
+
+// CPath::BackupFile is the small same-filesystem copy path that
+// ClientCreditsList's clients.met backup now uses. Verify it produces a
+// byte-identical copy at src + appendix and overwrites an existing backup.
+TEST(CFileCloneFile, BackupFileCreatesIdenticalCopy)
+{
+	const wxString base = wxFileName::CreateTempFileName(wxT("amuleclone_"));
+	CPath src(base);
+	CPath::RemoveFile(src);
+	WriteData(src, MULTI_CHUNK);
+
+	ASSERT_TRUE(CPath::BackupFile(src, wxT(".bak")));
+	CPath bak(base + wxT(".bak"));
+	ASSERT_TRUE(bak.FileExists());
+	ASSERT_TRUE(SameContentStreaming(src, bak));
+
+	// A second call overwrites the existing backup and stays identical.
+	ASSERT_TRUE(CPath::BackupFile(src, wxT(".bak")));
+	ASSERT_TRUE(SameContentStreaming(src, bak));
+
+	CPath::RemoveFile(src);
+	CPath::RemoveFile(bak);
+}
+
+// Opt-in: exercises a copy past the 4 GiB / 32-bit-offset boundary, which
+// would catch any length or offset truncation. Skipped unless
+// AMULE_CLONEFILE_HUGE_GB is set (writing multiple GiB is far too heavy for
+// the normal / CI test run). Example: AMULE_CLONEFILE_HUGE_GB=5 ./CloneFileTest
+TEST(CFileCloneFile, HugeFileOptIn)
+{
+	const char *env = getenv("AMULE_CLONEFILE_HUGE_GB");
+	if (!env) {
+		return; // not requested -> no-op pass
+	}
+	const uint64 gb = static_cast<uint64>(atoi(env));
+	if (!gb) {
+		return;
+	}
+	// gb GiB, plus a non-block-aligned tail so the final short chunk and a
+	// high absolute offset are both covered.
+	const uint64 length = gb * 1024ull * 1024ull * 1024ull + 4096ull;
+
+	CPath src = FreshTemp();
+	WriteDataChunked(src, length);
+	CPath dst = FreshTemp();
+
+	ASSERT_TRUE(CFile::CloneFile(src, dst, false));
+	ASSERT_TRUE(dst.FileExists());
+	// Length equality alone catches a 32-bit truncation (a truncated copy
+	// would land at length mod 4 GiB); streaming compare catches offset bugs.
+	ASSERT_TRUE(FileLength(dst) == length);
+	ASSERT_TRUE(SameContentStreaming(src, dst));
+
+	CPath::RemoveFile(src);
+	CPath::RemoveFile(dst);
+}


### PR DESCRIPTION
## Problem

`wxCopyFile` streams through a hard-coded 4 KiB buffer. On download completion aMule moves the finished file from Temp to Incoming; when those directories live on different filesystems the rename fails and it falls back to a copy — and that copy runs through the 4 KiB buffer. On network filesystems (NFS, sshfs) the tiny buffer defeats write coalescing and pays a round-trip per block, throttling completion to a fraction of line speed. Reported in #11 at ~13 MB/s on NFSv3.

## Fix

Add `CFile::CloneFile`, which streams through a 1 MiB heap buffer, and route the large data-file copies through it: the completion move (`ThreadTasks`) and the eMule part-file import (`PartFileConvert`), both of which can cross filesystems.

The helper lives on `CFile` rather than `CPath` for a layering reason: `CPath` is in the low-level `mulecommon` library, which must not depend on the `CFile` layer, and all four former `CPath::CloneFile` callers already sit in the `CFile` layer. `CPath::CloneFile` is therefore removed. Its two small, same-filesystem users stay on the plain `wxCopyFile` path: `CPath::BackupFile` inlines it, and the `clients.met` backup in `ClientCreditsList` switches to `CPath::BackupFile`.

The implementation is plain `CFile` read/write with no platform `#ifdef`s, so it behaves uniformly across macOS, Windows, Linux and BSD. The buffer is heap-allocated (not a stack array) because the copy can run on the completion worker thread, where musl caps the thread stack at 128 KiB. On any error the partial destination is removed, so a failed completion never leaves a corrupt file behind.

## Benchmark

Cold copy of a 2 GB file across an sshfs-to-localhost mount (cache dropped between runs), plus read/write syscall counts for a 256 MB copy:

| Buffer | Cross-filesystem throughput | read/write syscalls (256 MB) |
|---|---|---|
| 4 KiB (old `wxCopyFile`) | 16.7 MB/s | 131,075 |
| 1 MiB (new `CFile::CloneFile`) | 344.1 MB/s | 515 |

~20× faster on the cross-filesystem path (the 4 KiB figure matches the ~13 MB/s from the report), with 256× fewer syscalls.

## Testing

New `CloneFileTest` covers byte-identical multi-chunk copies, empty files, overwrite semantics, the failure paths (missing source, unwritable destination — no partial file left behind), and `CPath::BackupFile` (the small same-filesystem path the `clients.met` backup now uses). It also carries an env-gated case, `AMULE_CLONEFILE_HUGE_GB`, that copies a real >4 GiB file to exercise the 64-bit offset path; I ran it with a 5 GiB file (length + streaming content verified). Full unit suite green; clang-format clean.

Closes #11.
