### PR TITLE
Don't assert on a Kad HELLO_REQ that requests an ACK (#267)

### DIFF
--- a/src/kademlia/net/KademliaUDPListener.cpp
+++ b/src/kademlia/net/KademliaUDPListener.cpp
@@ -449,7 +449,14 @@ bool CKademliaUDPListener::AddContact2(const uint8_t *data,
 							*outRequestsACK = true;
 						}
 					} else {
-						wxFAIL;
+						// The "requests ACK" bit is only meaningful in a
+						// KADEMLIA2_HELLO_RES; a HELLO_REQ carrying it is
+						// nonstandard. It is remote-controllable, though, so
+						// log and ignore rather than asserting (#267).
+						AddDebugLogLineN(logClientKadUDP,
+							"Ignoring unexpected 'requests ACK' bit in a Kad2 "
+							"HELLO_REQ (sender: " +
+								KadIPToString(ip) + ")");
 					}
 				}
 			}


### PR DESCRIPTION
## Problem

A `(Debugging)` build asserts in `AddContact2()` (reported in #267) when a Kad `HELLO_REQ` carries the `KADMISCOPTIONS` "requests ACK" bit.

## Cause

That bit (`0x04`) is only meaningful in a `KADEMLIA2_HELLO_RES`, where the responder challenges the initiator to prove it isn't a spoofed contact — that caller passes a real `outRequestsACK` pointer. The `KADEMLIA2_HELLO_REQ` caller passes `NULL`, and the code asserted (`wxFAIL`, "can never happen") if a REQ carried the bit. A remote peer can send exactly that — a nonstandard/older client, a MOD that sets the same misc-options in both packet types, or a crafted packet. `wxFAIL` is a no-op in release builds (the bit is simply ignored, which is correct), so only debug builds crash — but remote input should never be able to trip an assertion regardless.

## Fix

Replace the `wxFAIL` with a debug log line and keep ignoring the bit. Release behaviour is unchanged; debug builds log instead of asserting.

Closes #267.
