### PR TITLE
AICH-recover parts found corrupt during the final completion re-hash

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -1269,7 +1269,18 @@ void CPartFile::PartFileHashFinished(CKnownFile *result)
 
 					AddGap(i);
 					errorfound = true;
-					corruptParts.push_back((uint16)i);
+					const uint16 part = (uint16)i;
+					// Mirror the mid-download corruption path: flag the
+					// part in m_corrupted_list. It is not needed for the
+					// AICH block recovery below, but it primes the ICH
+					// fallback for when no trusted AICH hashset is
+					// available, and — since m_corrupted_list is persisted
+					// to the .met — it keeps the corrupt state across a
+					// restart that happens mid-recovery.
+					if (!IsCorruptedPart(part)) {
+						m_corrupted_list.push_back(part);
+					}
+					corruptParts.push_back(part);
 				}
 			} else {
 				if (!IsComplete(i)) {

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -1225,6 +1225,12 @@ void CPartFile::PartFileHashFinished(CKnownFile *result)
 {
 	m_lastDateChanged = result->m_lastDateChanged;
 	bool errorfound = false;
+	// Parts that pass their per-part hash during download but fail this
+	// final full-file re-hash (e.g. a block rewritten after the part
+	// completed) are collected here so we can attempt AICH recovery once
+	// the file is back in a downloadable state, rather than only re-gapping
+	// the whole part.
+	std::vector<uint16> corruptParts;
 	if (GetED2KPartHashCount() == 0) {
 		if (IsComplete(0, GetFileSize() - 1)) {
 			if (result->GetFileHash() != GetFileHash()) {
@@ -1263,6 +1269,7 @@ void CPartFile::PartFileHashFinished(CKnownFile *result)
 
 					AddGap(i);
 					errorfound = true;
+					corruptParts.push_back((uint16)i);
 				}
 			} else {
 				if (!IsComplete(i)) {
@@ -1300,6 +1307,20 @@ void CPartFile::PartFileHashFinished(CKnownFile *result)
 	} else {
 		SetStatus(PS_READY);
 		SavePartFile();
+		// A part can pass its per-part hash during download yet fail this
+		// final full-file re-hash — e.g. a block rewritten after the part
+		// completed, as happens when endgame source rotation splices a
+		// block across two sources (amule-org/amule#225). AddGap() above
+		// re-opens the whole 9.28 MB part; when a trusted AICH hashset is
+		// available, recover it at 180 KB block granularity instead, so
+		// only the actually-corrupt blocks are re-downloaded (and the
+		// CorruptionBlackBox can pinpoint the bad block). RequestAICHRecovery
+		// is a no-op without a trusted hashset, so non-AICH files keep the
+		// existing whole-part re-download.
+		for (std::vector<uint16>::const_iterator it = corruptParts.begin(); it != corruptParts.end();
+			++it) {
+			RequestAICHRecovery(*it);
+		}
 		return;
 	}
 	SetStatus(PS_READY);


### PR DESCRIPTION
## Problem

When a completed file is re-hashed and a part fails, `PartFileHashFinished` re-opens the whole 9.28 MB part (`AddGap`) but — unlike the mid-download hash path — never requests AICH recovery. So a part that passed its per-part hash during download but was corrupted afterwards is fully re-downloaded, even when a trusted AICH hashset could recover just the bad 180 KB blocks.

This is what surfaces with endgame source rotation (#225): when a faster source evicts a slower one mid-block (`OP_CANCELTRANSFER`), the block ends up spliced across two sources and can fail the final full-file hash. In testing there, a 4.5 GB file at `AICH_TRUSTED` (10 sources) had 8 parts fail and re-downloaded them whole, because the completion path never asked AICH to narrow it down — the AICH quorum was reached but unused on this path.

## Fix

Collect the parts that fail the final re-hash and, once the file is back in `PS_READY`, call `RequestAICHRecovery()` for each.

`RequestAICHRecovery()` is self-guarded: it returns immediately unless the file has a valid trusted/verified AICH master hash and a source that can serve the recovery data. So the `AddGap()` whole-part re-open (unchanged and unconditional) is always the fallback, and this only adds an optional narrowing on top:

- Files without a trusted AICH hashset (quorum not reached, few sources) keep the existing whole-part re-download — no behaviour change, no new data-loss or stuck-state path.
- Files that reached `AICH_TRUSTED` / `AICH_VERIFIED` now recover at 180 KB block granularity, re-downloading only the corrupt blocks, and the `CorruptionBlackBox` can pinpoint the offending block.

## Testing

Debug build clean. The recovery path is best exercised live; this unblocks testing whether AICH recovers endgame split-block corruption on #225 (the motivating scenario), where it previously couldn't because the completion path never requested it.
