### PR TITLE
Drain the part-file worker threads on shutdown instead of dropping work

### DIFF
--- a/src/PartFileHashThread.cpp
+++ b/src/PartFileHashThread.cpp
@@ -89,11 +89,20 @@ void *CPartFileHashThread::Entry()
 
 	AddDebugLogLineN(logPartFile, wxT("Hash thread: started"));
 
-	while (m_bRun) {
+	// Loop until EndThread() clears m_bRun, then drain one final batch
+	// before returning. Dropping a queued job would skip its
+	// --m_pendingHashes (the only decrement), and ~CPartFile blocks on
+	// `while (m_pendingHashes > 0)` with no other decrementer — so a
+	// dropped job hangs shutdown. Draining also means the part is
+	// actually hashed rather than left unverified (its m_aChangedPart
+	// entry was already cleared at enqueue, so the sync-hash fallback
+	// won't catch it). Mirrors CPartFileWriteThread.
+	for (;;) {
 		// Move queued jobs to a local work list under the lock.
 		// Mirrors CPartFileWriteThread's pattern: minimise lock hold
 		// time so the main thread can keep enqueueing.
 		std::list<HashJob> workList;
+		bool keepRunning;
 		{
 			wxMutexLocker lock(m_mutex);
 			if (m_bRun && !m_bWorkPending) {
@@ -101,10 +110,15 @@ void *CPartFileHashThread::Entry()
 			}
 			m_bWorkPending = false;
 			workList.swap(m_jobList);
+			// Captured under the lock with the swap; the batch we just
+			// took is drained whatever m_bRun does next.
+			keepRunning = m_bRun;
 		}
 
-		for (std::list<HashJob>::iterator it = workList.begin(); it != workList.end() && m_bRun;
-			++it) {
+		// No m_bRun check in the loop condition: a batch, once taken, is
+		// always processed in full so a shutdown never abandons a job
+		// (which would leave m_pendingHashes stuck and hang ~CPartFile).
+		for (std::list<HashJob>::iterator it = workList.begin(); it != workList.end(); ++it) {
 			const uint64 startTick = GetTickCount64();
 
 			// CPartFile::m_pendingHashes was incremented before enqueue
@@ -148,6 +162,12 @@ void *CPartFileHashThread::Entry()
 			// AND event posted) so ~CPartFile's wait on the counter
 			// includes the event-post step.
 			--it->pFile->m_pendingHashes;
+		}
+
+		// Exit only after the batch above is fully processed, so every
+		// job's --m_pendingHashes runs and ~CPartFile's wait can complete.
+		if (!keepRunning) {
+			break;
 		}
 	}
 

--- a/src/PartFileHashThread.h
+++ b/src/PartFileHashThread.h
@@ -27,6 +27,7 @@
 #define PARTFILEHASHTHREAD_H
 
 #include <list>
+#include <atomic>
 #include <wx/event.h>
 #include <wx/thread.h>
 
@@ -72,7 +73,7 @@ public:
 private:
 	void *Entry() override;
 
-	volatile bool m_bRun;
+	std::atomic<bool> m_bRun{ false };
 	bool m_bWorkPending; // sticky wake flag
 
 	wxMutex m_mutex;

--- a/src/PartFileWriteThread.cpp
+++ b/src/PartFileWriteThread.cpp
@@ -105,11 +105,19 @@ void *CPartFileWriteThread::Entry()
 {
 	m_bRun = true;
 
-	while (m_bRun) {
+	// Loop until EndThread() clears m_bRun, then drain one final batch
+	// before returning. A shutdown signal must never drop queued writes:
+	// WriteToBuffer FillGap()s each range at queue time and the gaplist is
+	// persisted, so a dropped write would leave the .met claiming bytes
+	// that never reached disk — a silently corrupt part on the next
+	// launch. Each swapped batch is therefore drained in full, and the
+	// exit check happens only after that batch is on disk.
+	for (;;) {
 		// Move queued items to a local work list under the lock.
 		// This minimises lock hold time — main thread can keep queueing
 		// while we process the local list.
 		std::list<ToWrite> workList;
+		bool keepRunning;
 		{
 			wxMutexLocker lock(m_mutex);
 			if (m_bRun && !m_bWorkPending) {
@@ -117,12 +125,16 @@ void *CPartFileWriteThread::Entry()
 			}
 			m_bWorkPending = false;
 			workList.swap(m_flushList);
+			// Captured under the lock together with the swap, so the
+			// batch we just took is drained whatever m_bRun does next.
+			keepRunning = m_bRun;
 		}
 
-		// Process all queued writes synchronously.
+		// Process all queued writes synchronously. No m_bRun check in
+		// the loop condition: a batch, once taken, is always written in
+		// full so a shutdown never abandons it half-drained.
 		// eMule ref: WriteBuffers() — line 122
-		for (std::list<ToWrite>::iterator it = workList.begin(); it != workList.end() && m_bRun;
-			++it) {
+		for (std::list<ToWrite>::iterator it = workList.begin(); it != workList.end(); ++it) {
 			PartFileBufferedData *pBuffer = it->pBuffer;
 			uint32 lenData = (uint32)(pBuffer->end - pBuffer->start + 1);
 
@@ -169,6 +181,12 @@ void *CPartFileWriteThread::Entry()
 			// retry loops).
 			// eMule ref: WriteCompletionRoutine — line 182
 			pBuffer->flushed = writeOk ? PB_WRITTEN : PB_ERROR;
+		}
+
+		// Exit only after the batch above is on disk, so EndThread()
+		// genuinely drains rather than dropping in-flight writes.
+		if (!keepRunning) {
+			break;
 		}
 	}
 

--- a/src/PartFileWriteThread.h
+++ b/src/PartFileWriteThread.h
@@ -27,6 +27,7 @@
 #define PARTFILEWRITETHREAD_H
 
 #include <list>
+#include <atomic>
 
 #include <wx/thread.h>
 
@@ -76,7 +77,7 @@ public:
 private:
 	void *Entry() override;
 
-	volatile bool m_bRun;
+	std::atomic<bool> m_bRun{ false };
 	bool m_bWorkPending; // sticky wake flag
 
 	wxMutex m_mutex;

--- a/src/UploadDiskIOThread.h
+++ b/src/UploadDiskIOThread.h
@@ -27,6 +27,7 @@
 #define UPLOADDISKIOTHREAD_H
 
 #include <list>
+#include <atomic>
 #include <utility> // Needed for std::pair
 
 #include <wx/thread.h>
@@ -107,8 +108,8 @@ private:
 	void ReadCompletionRoutine(ReadRequest_Struct *req);     // eMule ref: line 369
 	bool ReleaseOpenFile(OpenFile_Struct *pFileStruct);      // eMule ref: line 498
 
-	volatile bool m_bRun;    // eMule ref: m_bRun (line 77)
-	bool m_bSignalThrottler; // eMule ref: m_bSignalThrottler (line 78)
+	std::atomic<bool> m_bRun{ false }; // eMule ref: m_bRun (line 77)
+	bool m_bSignalThrottler;           // eMule ref: m_bSignalThrottler (line 78)
 
 	wxMutex m_mutex;
 	wxCondition m_condition; // replaces m_eventNewBlockRequests + m_eventSocketNeedsData


### PR DESCRIPTION
## Problem

Two part-file worker threads shared a shutdown bug: their processing loop was `for (…; it != workList.end() && m_bRun; …)`, so when `EndThread()` cleared `m_bRun` the loop could stop **mid-batch**, abandoning queued work. `EndThread()` is documented to drain, but the `&& m_bRun` defeats it.

**Write thread → silent corruption.** Abandoned writes stay `PB_PENDING`; `~CPartFile`'s `FlushBuffer` then hits `case PB_PENDING: // still in flight — skip` even though the thread is gone, so the data is neither written nor harvested into `m_aChangedPart`, and the sync-hash loop skips the part. Because `WriteToBuffer` `FillGap()`s at queue time and the gaplist is persisted, the `.met` is saved claiming bytes that never reached disk → the part reloads trusted-but-corrupt, caught only later by the full-file completion re-hash.

**Hash thread → shutdown hang.** Abandoned hash jobs skip their `--m_pendingHashes` (the only decrement), and `~CPartFile` blocks on `while (m_pendingHashes > 0)` with no timeout and no other decrementer (the hash thread is already joined). So a dropped job hangs shutdown outright. Those parts also go unhashed — their `m_aChangedPart` was cleared at enqueue, so the sync-hash fallback skips them too.

Both are races that need queued-but-unfinished work at the instant of `EndThread` (quitting mid-download-burst); a part already flushed and hashed is unaffected. `CUploadDiskIOThread` shares the run-flag pattern but not the bug — its work loop has no `m_bRun` check, no blocking counter waits on it, and dropping an in-flight upload read is harmless.

## Fix

Same change to both `Entry()` loops (commits 1–2):
- Capture `m_bRun` under the same lock as the queue swap (`keepRunning`).
- Always process the taken batch **in full** — no `m_bRun` check in the loop condition.
- Exit only **after** that batch is done (`if (!keepRunning) break;`).

So a shutdown during active I/O now flushes every queued write and finishes every queued hash before the thread returns. The write thread's data is harvested + verified; the hash thread's `--m_pendingHashes` all run so `~CPartFile`'s wait completes.

Commit 3 also converts `m_bRun` on all three threads (`CPartFileWriteThread`, `CPartFileHashThread`, `CUploadDiskIOThread`) from `volatile bool` to `std::atomic<bool>`. `volatile` gives no cross-thread visibility or atomicity guarantee in C++, yet the flag is read unlocked via `IsRunning()` — a data race. This is a correctness hardening independent of the drain fix (the drain loops read the flag under the mutex regardless); `CUploadDiskIOThread` gets it too for consistency even though it isn't subject to the drop bug.

## Testing

Debug build clean. Both drain failures need a precisely-timed quit mid-work, so they're hard to reproduce deterministically in a unit test; the changes are small, self-contained, and identical in shape.

Both threads are `wxTHREAD_JOINABLE` and `EndThread()` already `Wait()`s on them, so the main thread blocks until `Entry()` returns — now that means until the drain completes (previously it returned early by dropping work). The waits are bounded: the write queue holds ~one flush cycle of buffered data (`m_nTotalBufferData` cap, a few MB), and the hash queue is the pending-parts backlog — so it's a brief, bounded flush on shutdown, not a large stall. Given these touch thread-shutdown timing, they warrant a careful maintainer read.
