### PR TITLE
fix(ec): bound the synchronous EC connect with a 15s timeout

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -452,6 +452,12 @@ void CaMuleExternalConnector::ConnectAndRun(const wxString &ProgName, const wxSt
 		m_ECClient = new CRemoteConnect(NULL);
 		m_ECClient->SetCapabilities(m_ZLIB, true, false); // ZLIB, UTF8 numbers, notification
 		m_ECClient->SetForceZlib(m_forceZLIB);
+		// Bound the blocking EC connect so a wrong or unreachable host
+		// fails fast instead of hanging on the OS TCP connect timeout
+		// (which can be minutes). The GUI clients have their own async
+		// connect watchdog; this covers the synchronous CLI/EC clients.
+		// 15s matches the amulegui watchdog budget.
+		m_ECClient->SetConnectTimeout(15000);
 
 		// ConnectToCore is blocking since m_ECClient was initialized with NULL
 		if (!m_ECClient->ConnectToCore(

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -76,6 +76,10 @@ public:
 	// wx Stuff
 	void Notify(bool);
 	bool Connect(const amuleIPV4Address &adr, bool wait);
+	// Bound the synchronous connect to `ms` milliseconds (0 = no bound,
+	// the default). Only affects the blocking connect path used by the
+	// synchronous EC clients (amulecmd); the async path is unaffected.
+	void SetConnectTimeout(int ms);
 	bool IsConnected() const;
 	bool IsOk() const;
 	void SetLocal(const amuleIPV4Address &local);

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -222,6 +222,7 @@ public:
 		m_sync = false;
 		m_IP = L"?";
 		m_IPint = 0;
+		m_connectTimeoutMs = 0;
 		m_socket = new ip::tcp::socket(s_io_service);
 
 		// Set socket to non blocking
@@ -244,6 +245,10 @@ public:
 
 	void Notify(bool notify) { m_notify = notify; }
 
+	// Bound the synchronous connect (0 = no bound, the default). Only
+	// honoured on the sync connect path — see Connect().
+	void SetConnectTimeout(int ms) { m_connectTimeoutMs = ms; }
+
 	bool Connect(const amuleIPV4Address &adr, bool wait)
 	{
 		if (!m_proxyState) {
@@ -257,9 +262,51 @@ public:
 
 		if (wait || m_sync) {
 			error_code ec;
-			m_socket->connect(adr.GetEndpoint(), ec);
+			if (m_connectTimeoutMs > 0) {
+				// Bounded synchronous connect: async_connect raced
+				// against a steady_timer, both driven here on the
+				// io_service. This path is only reached by the
+				// synchronous EC clients (amulecmd), which don't start
+				// the CAsioService thread pool, so the io_service is
+				// otherwise idle and safe to run locally. Portable
+				// across every platform through asio, with no per-OS
+				// socket-timeout handling — a wrong or unreachable host
+				// now fails in m_connectTimeoutMs instead of hanging on
+				// the OS TCP connect timeout (minutes).
+				ec = boost::asio::error::would_block;
+				m_socket->async_connect(
+					adr.GetEndpoint(), [&ec](const error_code &e) { ec = e; });
+				steady_timer timer(s_io_service);
+				timer.expires_after(std::chrono::milliseconds(m_connectTimeoutMs));
+				bool timedOut = false;
+				timer.async_wait([this, &timedOut](const error_code &e) {
+					// Fires only while the connect is still pending;
+					// closing the socket aborts it so run_one() returns.
+					if (e != boost::asio::error::operation_aborted) {
+						timedOut = true;
+						error_code ignore;
+						m_socket->close(ignore);
+					}
+				});
+				s_io_service.restart();
+				while (ec == boost::asio::error::would_block) {
+					if (s_io_service.run_one() == 0) {
+						break;
+					}
+				}
+				timer.cancel();
+				s_io_service.poll(); // drain the cancelled timer handler
+				if (timedOut) {
+					ec = boost::asio::error::timed_out;
+				}
+			} else {
+				m_socket->connect(adr.GetEndpoint(), ec);
+			}
 			m_OK = !ec;
 			m_connected = m_OK;
+			if (ec) {
+				m_ErrorCode = ec.value();
+			}
 			return m_OK;
 		} else {
 			auto self = shared_from_this();
@@ -761,8 +808,9 @@ private:
 	bool m_closed;
 	std::atomic<bool> m_destroying; // set once Destroy() has been called
 	bool m_proxyState;
-	bool m_notify; // set by Notify()
-	bool m_sync;   // copied from !m_notify on Connect()
+	bool m_notify;          // set by Notify()
+	bool m_sync;            // copied from !m_notify on Connect()
+	int m_connectTimeoutMs; // 0 = no bound; honoured on the sync connect path
 };
 
 /**
@@ -808,6 +856,11 @@ bool CLibSocket::IsOk() const
 void CLibSocket::EnableTcpKeepalive(int idleSec, int probeIntervalSec, int probeCount)
 {
 	m_aSocket->EnableTcpKeepalive(idleSec, probeIntervalSec, probeCount);
+}
+
+void CLibSocket::SetConnectTimeout(int ms)
+{
+	m_aSocket->SetConnectTimeout(ms);
 }
 
 wxString CLibSocket::GetPeer()


### PR DESCRIPTION
## Problem

The synchronous EC clients — amulecmd, amuleweb, amuleapi, and the util EC clients — connect to the daemon via a blocking asio `connect()` with no timeout. When the configured host/port is wrong or the host is unreachable (SYN black-holed), the connect hangs for the OS TCP connect timeout — which can be one to two minutes — before failing. amulegui already solved this for the GUI with a 15s `wxTimer` watchdog (#465); the synchronous clients never got an equivalent.

## Fix

Bound the connect on the synchronous path in `CLibSocketImpl::Connect`: `async_connect` raced against a `steady_timer`, both driven locally on the `io_service`. This path is only reached by the `CaMuleExternalConnector` EC clients, which do not start the `CAsioService` thread pool, so the `io_service` is otherwise idle and safe to run here. When no timeout is set the connect keeps its previous plain blocking behaviour, so nothing changes for callers that don't opt in.

The bound is set to 15s in `CaMuleExternalConnector::ConnectAndRun` (matching the amulegui budget), so every synchronous EC client gets it. amulegui is unaffected: it connects asynchronously (the `async_connect` branch) and keeps its own watchdog.

## Why asio, not SO_SNDTIMEO / select

`SO_SNDTIMEO` does not portably bound `connect()` — Linux and Windows ignore it for connect, and the argument type differs (POSIX `struct timeval` vs Winsock `DWORD`). Racing `async_connect` against a `steady_timer` keeps everything inside asio, uniform across macOS / Windows / Linux / OpenBSD, with no per-OS code.

## Testing

Built and tested on macOS. amulecmd against a black-holed TEST-NET address (`192.0.2.1`) now fails in ~15s instead of hanging on the OS timeout; the fast-fail path (connection refused on a closed local port) still returns immediately.
