### PR TITLE
fix(startup): defer amuleweb-missing modal so boot never hangs on Windows

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -982,11 +982,24 @@ bool CamuleApp::OnInit()
 			AddLogLineC(CFormat(_("web server running on pid %d")) % webserver_pid);
 		} else {
 			delete p;
-			ShowAlert(_("You requested to run web server on startup, but the amuleweb binary "
-				    "cannot be run. Please install the package containing aMule web server, "
-				    "or build aMule from source with -DBUILD_WEBSERVER=YES and install it."),
-				_("ERROR"),
-				wxOK | wxICON_ERROR);
+			// Defer the modal until after OnInit returns. During
+			// OnInit the main window is not yet visible on Windows,
+			// so a modal ShowAlert spawns invisible and blocks the
+			// message loop waiting on input that can't be given —
+			// aMule then boots into an unresponsive white window
+			// with only the Windows error ding audible. CallAfter
+			// fires the alert once amuledlg is shown, matching the
+			// AppImage-integration prompt pattern in
+			// CamuleGuiApp::OnInit.
+			CallAfter([this]() {
+				ShowAlert(_("You requested to run web server on startup, "
+					    "but the amuleweb binary cannot be run. Please "
+					    "install the package containing aMule web "
+					    "server, or build aMule from source with "
+					    "-DBUILD_WEBSERVER=YES and install it."),
+					_("ERROR"),
+					wxOK | wxICON_ERROR);
+			});
 		}
 	}
 


### PR DESCRIPTION
## Bug

On Windows, aMule hangs on startup — an unresponsive white main window with the Windows error ding as the only feedback — when the user has "run web server on startup" enabled but the `amuleweb` binary is not installed (e.g. distros that split it into a separate package, or local builds without `-DBUILD_WEBSERVER=YES`).

## Root cause

Inside `CamuleApp::OnInit()`, the webserver-launch block calls `wxExecute(amulewebPath, wxEXEC_ASYNC, ...)`. When that fails (binary missing), the error path invokes `ShowAlert(..., wxOK | wxICON_ERROR)` synchronously — a modal `wxMessageDialog` — while still inside `OnInit()`. At that point on Windows the main frame has been constructed but not yet `Show()`n. The modal spawns with an invisible parent and blocks the message loop waiting on input that can't be given.

Reproducer: Windows, `[WebServer]/Enabled=1` in `amule.conf`, no `amuleweb.exe` in the bin dir → aMule launches, plays the Windows error sound, and hangs indefinitely.

## Fix

Wrap the `ShowAlert` in `CallAfter(...)` so it fires once `OnInit()` returns and `amuledlg` has been shown. The modal then renders correctly over the visible main window and the app remains fully functional after dismissal. Same pattern already in use for the AppImage first-run integration prompt at [`src/amule-gui.cpp:381-385`](https://github.com/amule-org/amule/blob/master/src/amule-gui.cpp#L381).

## Test

Reproduced on Windows 11 ARM64 (MSYS2 CLANGARM64): rebuilt aMule without `-DBUILD_WEBSERVER=YES`, kept `Enabled=1` in the config. Before the fix: aMule hangs at the reported "Not Responding" white window with the error ding. After the fix: main window renders, error modal appears over it after startup completes, dismissible normally, app remains fully usable.

Linux / macOS behaviour is unchanged — the modal there already displayed correctly because the main window is visible by the time `OnInit()` returns. `CallAfter` is a no-op-shape defer on all platforms.
