### PR TITLE
fix(ui): key list-ctrl palette off actual background, not IsDark() (#274)

### DIFF
--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -1070,7 +1070,7 @@ void CGenericClientListCtrl::DrawClientItem(wxDC *dc,
 					// Queue rank change cue: down (good) = blue, up (bad) = red.
 					// Pure *wxBLUE / *wxRED were unreadable on dark themes;
 					// swap to a hand-tuned palette that contrasts on both.
-					const bool isDark = wxSystemSettings::GetAppearance().IsDark();
+					const bool isDark = IsListBackgroundDark(this);
 					if (qrDiff < 0) {
 						dc->SetTextForeground(isDark ? wxColour(120, 170, 255)
 									     : wxColour(0, 80, 200));
@@ -1164,7 +1164,7 @@ void CGenericClientListCtrl::DrawClientItem(wxDC *dc,
 				// "watch out: peer is advertising a different name for
 				// this hash" warning cue. Pure *wxRED was unreadable on
 				// dark themes.
-				const bool isDark = wxSystemSettings::GetAppearance().IsDark();
+				const bool isDark = IsListBackgroundDark(this);
 				dc->SetTextForeground(isDark ? wxColour(255, 100, 100) : wxColour(220, 0, 0));
 			}
 		}

--- a/src/MuleListCtrl.h
+++ b/src/MuleListCtrl.h
@@ -47,7 +47,7 @@
 // macOS do propagate dark backgrounds to lists, so on those platforms
 // this luminance test degrades to the same answer as IsDark() and
 // behaviour is unchanged.
-static inline bool IsListBackgroundDark(const wxWindow* w)
+static inline bool IsListBackgroundDark(const wxWindow *w)
 {
 	const wxColour bg = w->GetBackgroundColour();
 	return (bg.Red() * 299 + bg.Green() * 587 + bg.Blue() * 114) / 1000 < 128;

--- a/src/MuleListCtrl.h
+++ b/src/MuleListCtrl.h
@@ -37,6 +37,22 @@
 #include <list>
 #include "Types.h"
 
+// Palette selector for custom-drawn text in list controls. Reads the
+// control's actual background instead of
+// wxSystemSettings::GetAppearance().IsDark(), because native Win32
+// wxListCtrl (SysListView32) keeps its white background even when the
+// OS reports dark mode via AppsUseLightTheme=0. Foreground colours
+// chosen from IsDark() then render as light text on a still-white
+// list (see issue #274, Windows 11 dark-mode search-tab bug). GTK and
+// macOS do propagate dark backgrounds to lists, so on those platforms
+// this luminance test degrades to the same answer as IsDark() and
+// behaviour is unchanged.
+static inline bool IsListBackgroundDark(const wxWindow* w)
+{
+	const wxColour bg = w->GetBackgroundColour();
+	return (bg.Red() * 299 + bg.Green() * 587 + bg.Blue() * 114) / 1000 < 128;
+}
+
 /**
  * Enhanced wxListCtrl provided custom-drawing among other things.
  *

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -348,8 +348,10 @@ void CSearchListCtrl::UpdateItemColor(long index)
 		// themes the base is white-ish, so setting a channel that is
 		// already 255 is a no-op and every state collapses to the same
 		// colour -- the cue was invisible. Two hand-tuned palettes
-		// instead, chosen at draw time via IsDark().
-		const bool isDark = wxSystemSettings::GetAppearance().IsDark();
+		// instead, chosen at draw time via the list's own background
+		// (see IsListBackgroundDark in MuleListCtrl.h for why we can't
+		// key off wxSystemSettings::GetAppearance().IsDark() alone).
+		const bool isDark = IsListBackgroundDark(this);
 		wxColour colour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
 
 		switch (file->GetDownloadStatus()) {


### PR DESCRIPTION
Closes #274.

## Bug

Windows 11 with dark mode enabled renders search-result rows as near-white text on a still-white list background. Regression from 3.0.0 → 3.0.1.

## Root cause

PR #179 introduced hand-tuned per-theme palettes for `SearchListCtrl` and `GenericClientListCtrl`, keyed off `wxSystemSettings::GetAppearance().IsDark()`. On Linux GTK and macOS the native list control adopts a dark background when the system theme is dark, so the light-tone palette IsDark() selects renders readably. On Windows, native Win32 `wxListCtrl` (SysListView32) keeps its default white background even when `AppsUseLightTheme=0` — proper dark-mode list-ctrl on Windows would need `DWMWA_USE_IMMERSIVE_DARK_MODE` plumbing wxWidgets doesn't currently do — so the light-tone palette lands on the still-white list, unreadable.

## Fix

Read the control's own background colour at draw time and pick the palette by its perceived luminance (ITU-R BT.601). Helper lives in `MuleListCtrl.h`; the three call sites #179 introduced (one in SearchListCtrl.cpp, two in GenericClientListCtrl.cpp) become one-liner replacements.

Cross-platform behaviour:

- Windows: list bg stays white → luminance test returns false → light-mode (dark-tone) palette selected → readable.
- Linux GTK: list bg follows GTK theme → luminance test matches system theme → same palette as before.
- macOS: same as Linux — bg follows appearance.

Forward-compatible: if wxWidgets eventually gains proper Windows dark-mode wxListCtrl support (or a downstream wraps it), the list bg turns dark and the luminance test flips back to the light-tone palette automatically.

## Test

Built + installed on Windows 11 ARM64 (MSYS2 CLANGARM64), toggled `AppsUseLightTheme=0`, ran a search: results now render readably instead of near-white-on-white. Also rebuilt on Linux ARM64 (Ubuntu, wxGTK 3.2.9): no visual regression, list still renders exactly as before.
