### PR TITLE
feat: in-app new-version check (GUI popup + About button), gated by ENABLE_VERSION_CHECK for OS-package builds

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -218,11 +218,11 @@ if (NEED_LIB_MULEAPPCOMMON OR BUILD_WEBSERVER)
 	option (ENABLE_UPNP "enable UPnP support in aMule" ON)
 endif()
 
-# Initial value of the "Check for new aMule version" preference for fresh
-# installs (the user can still flip it in Preferences after first launch).
-# Packagers shipping aMule via an OS package manager typically want OFF so
-# the daemon-side updater doesn't conflict with the distro's own update
-# mechanism. Standalone / portable / AppImage builds want ON. Existing
-# users' saved amule.conf is unaffected -- only the per-install default
-# applies on first launch or after a config reset.
-option (DEFAULT_VERSION_CHECK "default state of the 'Check for new aMule version' preference" ON)
+# Master switch for the in-app "check for a new aMule version" feature: the
+# startup notification, the "Check for new version at startup" preference, and
+# the About dialog's "Check for updates" button. When OFF the whole feature
+# (including the CVersionCheck HTTP code) is compiled out, so nothing contacts
+# GitHub and no download links are shown. Packagers shipping aMule via an OS
+# package manager want OFF, so the distro's package manager owns updates.
+# Standalone / portable / AppImage builds and Windows/macOS want ON.
+option (ENABLE_VERSION_CHECK "compile in the in-app new-version check (startup notification + About 'Check for updates'); OFF for OS-package builds" ON)

--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -63,6 +63,8 @@ if (BUILD_MONOLITHIC OR BUILD_REMOTEGUI)
 		amule-gui.cpp
 		AppImageIntegration.cpp
 		amuleDlg.cpp
+		AboutDialog.cpp
+		VersionCheck.cpp
 		CatDialog.cpp
 		ChatSelector.cpp
 		ChatWnd.cpp

--- a/config.h.cm
+++ b/config.h.cm
@@ -10,9 +10,11 @@
 /* Define this to the include prefix of crypto++ */
 #cmakedefine CRYPTOPP_INCLUDE_PREFIX ${CRYPTOPP_INCLUDE_PREFIX}
 
-/* Initial value of the "Check for new aMule version" preference (1 = on,
-   0 = off). Controlled at configure time by -DDEFAULT_VERSION_CHECK. */
-#cmakedefine01 DEFAULT_VERSION_CHECK
+/* Master switch for the in-app new-version check (startup notification, the
+   "check at startup" preference, and the About "Check for updates" button).
+   When undefined the whole feature is compiled out. Controlled at configure
+   time by -DENABLE_VERSION_CHECK (ON by default; OFF for OS-package builds). */
+#cmakedefine ENABLE_VERSION_CHECK
 
 /* Define if upnp was found. */
 #cmakedefine ENABLE_UPNP

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -138,7 +138,7 @@ Common `-D` options (`YES` / `NO` unless noted otherwise):
 | `ENABLE_UPNP`            | YES     | UPnP port forwarding                                                     |
 | `ENABLE_IP2COUNTRY`      | YES     | libmaxminddb country flags ([docs/IP2Country.md](IP2Country.md))         |
 | `ENABLE_CCACHE`          | AUTO    | use ccache as compiler launcher when found (`AUTO`/`ON`/`OFF`); set `OFF` for distro builds that manage ccache themselves, `ON` to hard-fail if ccache is missing |
-| `DEFAULT_VERSION_CHECK`  | ON      | initial state of the in-app "Check for new aMule version" preference on fresh installs; packagers shipping aMule via an OS package manager typically want `OFF` |
+| `ENABLE_VERSION_CHECK`   | ON      | compile in the in-app new-version check (startup notification, the "Check for new version at startup" preference, and the About dialog's "Check for updates" button). Packagers shipping aMule via an OS package manager want `OFF`, so nothing contacts GitHub and the distro's package manager owns updates |
 
 For the full list:
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,3 +1,4 @@
+src/AboutDialog.cpp
 src/AddFriend.cpp
 src/AppImageIntegration.cpp
 src/amuleAppCommon.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,69 +18,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,89 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: src/AboutDialog.cpp:49
+msgid "About aMule"
+msgstr ""
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr ""
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr ""
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+msgid "Click to check for a newer version."
+msgstr ""
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+msgid "Checking for updates..."
+msgstr ""
+
+#: src/AboutDialog.cpp:160
+msgid "You are running the latest version."
+msgstr ""
+
+#: src/AboutDialog.cpp:164
+#, c-format
+msgid "A new version (%s) is available:"
+msgstr ""
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -108,8 +191,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -158,7 +241,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -179,44 +262,44 @@ msgstr ""
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -226,184 +309,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -432,117 +515,71 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr ""
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr ""
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
+#: src/amuleDlg.cpp:605
+msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr ""
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -552,175 +589,175 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -760,7 +797,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -908,7 +945,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr ""
 
@@ -1326,7 +1363,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr ""
 
@@ -1934,14 +1971,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1950,51 +1987,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2303,6 +2340,11 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr ""
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
@@ -2472,7 +2514,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2772,7 +2814,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr ""
 
@@ -2892,7 +2934,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr ""
 
@@ -4743,7 +4785,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5317,7 +5359,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr ""
 
@@ -5337,7 +5379,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr ""
 
@@ -5373,36 +5415,36 @@ msgstr ""
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -20,6 +20,89 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/AboutDialog.cpp:49
+msgid "About aMule"
+msgstr ""
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr ""
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr ""
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+msgid "Click to check for a newer version."
+msgstr ""
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+msgid "Checking for updates..."
+msgstr ""
+
+#: src/AboutDialog.cpp:160
+msgid "You are running the latest version."
+msgstr ""
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "غير متوفر"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -111,8 +194,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -162,7 +245,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -185,45 +268,45 @@ msgstr "قبل إتصال خارجي جديد\n"
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i خادمات وجدت في server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -233,185 +316,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ﻻ نضمن انه خالي من اﻻخطاء, قد يتسبب باعطال\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "إسم الخادم"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -440,119 +523,74 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr ""
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr ""
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "غير متوفر"
 
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr ""
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "متصل"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -562,178 +600,178 @@ msgstr ""
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "إيقاف محاولة اﻹتصال الحاليه"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "فصل"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "فصل من المستضيف الحالي"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "إتصال"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "تحميل: %.1f(%.1f) | رفع: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "رفع : %.1f |تحميل : %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "هل تريد حقا الخروج من البرنامج؟"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "تاكيد الخروج"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "بحث"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "نافذة البحث"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "نافذة ملفات المشاركة"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "رسائل"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "نافذة الرسائل"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "احصائات"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "نافذة اﻻحصائيات"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "اعدادت"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "نافذة اﻹعدادات"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -776,7 +814,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -927,7 +965,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "صنف"
 
@@ -1345,7 +1383,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr ""
 
@@ -1955,14 +1993,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1971,51 +2009,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2330,6 +2368,11 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr ""
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
@@ -2501,7 +2544,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2805,7 +2848,7 @@ msgstr ""
 msgid "Type"
 msgstr "نوع"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr ""
 
@@ -2925,7 +2968,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "التحميل"
 
@@ -4797,7 +4840,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5384,7 +5427,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "بحث"
@@ -5405,7 +5448,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr ""
 
@@ -5442,37 +5485,37 @@ msgstr "غير مقيم"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "طلب ملف اخر"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "إلغاء"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -21,69 +21,63 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -21,20 +21,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Amosar aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Control remotu de aMule"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Versión:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -42,27 +42,7 @@ msgstr ""
 "Veceru p2p multiplataforma basáu en eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -71,28 +51,40 @@ msgstr ""
 "Copyright (C) 2003-2019 Equipu aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Parte d'aMule básase en \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Direicionamientu P2P basáu na métrica XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprobar nueva versión al entamu"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7947,6 +7939,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Web: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Web: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/ast.po
+++ b/po/ast.po
@@ -65,11 +65,11 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Web:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Foru:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -20,6 +20,100 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Amosar aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Control remotu de aMule"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Versión:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Veceru p2p multiplataforma basáu en eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (C) 2003-2019 Equipu aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Parte d'aMule básase en \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Direicionamientu P2P basáu na métrica XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Comprobar nueva versión al entamu"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Coneutando a Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "¡Tas usando una versión antigua de aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Non disponible"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -113,8 +207,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -163,7 +257,7 @@ msgstr "Resultaos de depuración de memoria na salida d'aMule: "
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "La to llingua foi camudada a la de por defeutu del sistema, darréu d'un cambéu de configuración. Siéntolo."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -186,47 +280,47 @@ msgstr "Contraseña fixada y conexones esternes habilitaes."
 msgid "WARNING"
 msgstr "ALERTA"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i sirvidor alcontráu en server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nun ye dable direicionar los puertos a la direición especificada: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puertu %u nun ta disponible. Tendrás IDBaxa\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -241,48 +335,48 @@ msgstr ""
 "\n"
 "Comprueba la to rede y asegúrate de que'l puertu ta abiertu pa entrada y salida."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La llingua seleicionada nun paez tar instalada. (Nota: Tentará de ponese de toes formes)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ye la primer vegada qu'anicies aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esto ye una versión de preba, actualízate diariamente, y \n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nun damos garantía si fraña daqué, ambura to casa,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o fila la to sidra. Pero *tendría* de ser seguru de toes formes. \n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podrás alcontrar na nuesa web, más información, sofitu y nueves versiones, \n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o nel nuesu canal de IRC #aMule en irc.libera.chat. \n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Unvíanos cualesquier fallu a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -290,137 +384,137 @@ msgstr ""
 "El direutoriu qu'especificaste de Robla Online nun ye válidu\n"
 "La Robla Online deshabilitóse hasta que lo igües nes opciones."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Nome sirvidor notificáu"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espaciu en discu pal ficheru '%s' falló: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "FALLU: nun puede abrise'l ficheru de rexistru"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ALERTA: el ficheru de rexistru ta ermu. Hai daqué mal."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "El rexistru resetióse"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensax del sirvidor: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Fallu al descargar la llista de nodos."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Fallu al abrir el ficheru de comprobación de versión descargáu"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Ficheru de comprobación de versión toyíu"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Tas usando una versión antigua de aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La to versión de aMule ye %i.%i.%i y la cabera versión ye %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ALERTA: La to versión de aMuled ye obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "LA to copia de aMule ta actualizada."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Fallu al descargar el ficheru de comprobación de versión"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheros: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheros: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ensin redes seleicionaes"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con IDBaxa"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Coneutáu a %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Coneutando a %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Desconeutáu de eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad aniciáu."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad deteníu."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Coneutáu a Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Coneutáu a Kad (tres torgafueos)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Desconeutáu de Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Red Kad nun pue usase si'l puertu UDP ta deshabilitáu n'opciones, non aniciando."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada n'opciones, nun coneutará."
 
@@ -450,124 +544,72 @@ msgstr "Nun puede Crease un Ficheru Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto ye aMule %s basáu en eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Executándose en %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest pa comprobar si hai una nueva versión disponible"
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FALLU GRAVE: Nun pudo criase'l temporizador"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Control remotu de aMule"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Versión:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Veceru p2p multiplataforma basáu en eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Web: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Non disponible"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (C) 2003-2019 Equipu aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Parte d'aMule básase en \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Direicionamientu P2P basáu na métrica XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Mensax"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Diálogu aMule afaráu"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Coneutando"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Coneutando"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconeutáu"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Tres Tornafueos"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Coneutáu"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Coneutando"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Apagada"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -577,177 +619,177 @@ msgstr "Kad: Apagada"
 msgid "Cancel"
 msgstr "Encaboxar"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexón actuales"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Desconeutar"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconeutase de les redes coneutaes"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Coneutar"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Coneutase a les redes disponibles"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Xu: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Xu: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Coneutáu)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconeutáu)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Daveres quies colar de aMule?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Confirmar colar."
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Llanzar comandu:"
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- Por defeutu -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El direutorio de tema '%s' nun esiste"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENCIÓN: Nun pue abrise'l ficheru de temes '%s' pa llectura"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Guetar"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Ventana de gueta"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Descargues"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Descargando"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Ficheros compartíos"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Ventana de ficheros compartíos"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Ventana de mensaxes"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos d'estadístiques"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencies"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Ventana d'opciones"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "La ferramienta pa importar ficheros part"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tocante a"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Tocante a/Aida"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Ensin rede"
 
@@ -787,7 +829,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Remanador d'eventu EC n'Interface Remota"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Fallu de conexón. Nun ye dable coneutar a %s:%d\n"
@@ -936,7 +978,7 @@ msgid "Enter Captcha"
 msgstr "Inxertar Captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categoría"
 
@@ -1355,7 +1397,7 @@ msgstr "ERROR: Error d'entrada/salida!"
 msgid "ERROR: Failed!"
 msgstr "ERROR: Falló!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "En cola"
 
@@ -1990,7 +2032,7 @@ msgstr ""
 "\n"
 "Criando veceru...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1999,7 +2041,7 @@ msgstr ""
 "\n"
 "Ok, colando %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2013,51 +2055,51 @@ msgstr ""
 "\n"
 "Colando...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Amosar esta aida."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host au ta executándose aMule. (por defeutu: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Puertu de conexón esterna de aMule. (por defeutu: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Contraseña de conexones esternes"
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Lleer configuración dende'l ficheru."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Nun amueses denguna salida."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Mou Estendíu - amuesa tamién los mensaxes de depuración"
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Seleiciona la llingua del programa."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Escribe opciones de la llinia de comandu al ficheru de configuración."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Criar ficheru de configuración basáu nel ficheru de configuración de aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Imprenta versión del programa."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2377,6 +2419,11 @@ msgstr "Puertu non válidu pa coneutar"
 msgid "Please fill all fields required"
 msgstr "Por favor enllene tolos campos requeríos"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Mensax"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "¿De xuru quies descargar un nuevu nodes.dat?\n"
@@ -2547,7 +2594,7 @@ msgstr "Conexón esterna: Accesu denegáu, xida:"
 msgid "External Connection: Handshake failed."
 msgstr "Conexón esterna: Falló handshake."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Descarga HTTP filu entamáu"
@@ -2854,7 +2901,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Triba"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Llocal"
 
@@ -2974,7 +3021,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Encaboxar"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Descarga"
 
@@ -4851,7 +4898,7 @@ msgstr "Asignando"
 msgid "Insufficient disk space"
 msgstr "Espaciu en discu insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descargáu"
@@ -5462,7 +5509,7 @@ msgstr "Recargar llista de ficheros compartíos."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Guetar"
@@ -5483,7 +5530,7 @@ msgstr "El tamañu mínimu tien de ser menor al tamañu máximu. Tamañu máximu
 msgid "Search warning"
 msgstr "Alerta de gueta"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principal"
 
@@ -5521,38 +5568,38 @@ msgstr "Non evaluada"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Descargar na categoría"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Amestar URLs opcionales pa esti ficheru"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Guetar ficheros rellacionaos (eD2k, gueta llocal)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Conseñar como ficheru conocíu"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar l'enllaz eD2k al cartafueyos"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Tas coneutáu al sirvidor, que tentes desaniciar. Por favor desconéutate primero."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "Encaboxar"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -21,6 +21,91 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+msgid "About aMule"
+msgstr ""
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr ""
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr ""
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "форум: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "\tЗа повече информация, моля обърнете се към https://amule-org.github.io/docs"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "форум: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+msgid "Click to check for a newer version."
+msgstr ""
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+msgid "Checking for updates..."
+msgstr ""
+
+#: src/AboutDialog.cpp:160
+msgid "You are running the latest version."
+msgstr ""
+
+#: src/AboutDialog.cpp:164
+#, c-format
+msgid "A new version (%s) is available:"
+msgstr ""
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -112,8 +197,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -163,7 +248,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -185,45 +270,45 @@ msgstr ""
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сървъра бяха намерени в server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -233,184 +318,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -439,121 +524,73 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr ""
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr ""
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tЗа повече информация, моля обърнете се към https://amule-org.github.io/docs"
-
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
+"You are running %s.\n"
 "\n"
-msgstr "форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
+"Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
+#: src/amuleDlg.cpp:605
+msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr ""
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Връзкате е установена"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -563,178 +600,178 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отказ"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Спира текущите опити за свързване"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Разкачи"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Изключване от текущия сървър"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Връзка"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Кач.: %.1f(%.1f) | Свал.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кБ/с"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Кач.: %.1f | Свал.: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Наистина ли желаете да изключите aМуле?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Потвърждение за изход"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- по подразбиране -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Изтегляне"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Съобщения"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Няма мрежа"
 
@@ -777,7 +814,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -926,7 +963,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Категория"
 
@@ -1344,7 +1381,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr ""
 
@@ -1956,14 +1993,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1972,51 +2009,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2328,6 +2365,11 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr ""
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
@@ -2497,7 +2539,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2801,7 +2843,7 @@ msgstr "Име:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr ""
 
@@ -2921,7 +2963,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Изтегляне"
 
@@ -4785,7 +4827,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5364,7 +5406,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Търсене"
@@ -5385,7 +5427,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr ""
 
@@ -5422,37 +5464,37 @@ msgstr "Няма оценки"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Поискан му е друг файл"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "Отказ"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -64,7 +64,7 @@ msgstr ""
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "форум:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -22,71 +22,63 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tЗа повече информация, моля обърнете се към https://amule-org.github.io/docs"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7773,6 +7765,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "форум: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "\tЗа повече информация, моля обърнете се към https://amule-org.github.io/docs"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "форум: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Not found"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,69 +17,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -16,6 +16,89 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+#: src/AboutDialog.cpp:49
+msgid "About aMule"
+msgstr ""
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr ""
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr ""
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+msgid "Click to check for a newer version."
+msgstr ""
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+msgid "Checking for updates..."
+msgstr ""
+
+#: src/AboutDialog.cpp:160
+msgid "You are running the latest version."
+msgstr ""
+
+#: src/AboutDialog.cpp:164
+#, c-format
+msgid "A new version (%s) is available:"
+msgstr ""
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -107,8 +190,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -157,7 +240,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -178,44 +261,44 @@ msgstr ""
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -225,184 +308,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -431,117 +514,71 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr ""
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr ""
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
+#: src/amuleDlg.cpp:605
+msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr ""
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -551,175 +588,175 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -759,7 +796,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -907,7 +944,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr ""
 
@@ -1325,7 +1362,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr ""
 
@@ -1933,14 +1970,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1949,51 +1986,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2302,6 +2339,11 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr ""
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
@@ -2471,7 +2513,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2771,7 +2813,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr ""
 
@@ -2891,7 +2933,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr ""
 
@@ -4742,7 +4784,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5316,7 +5358,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr ""
 
@@ -5336,7 +5378,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr ""
 
@@ -5372,36 +5414,36 @@ msgstr ""
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -25,46 +25,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.7\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostra l'aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Control remot de l'aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr "Client P2P 'Multiplataforma' basat en eMule \n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Lloc web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Lloc web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -73,28 +53,40 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Part de l'aMule està basat en \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Encaminament p2p basat en la mètrica XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprova si hi ha noves versions a l'inici"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7888,6 +7880,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Lloc web: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Lloc web: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -24,6 +24,98 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.7\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Mostra l'aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Control remot de l'aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr "Client P2P 'Multiplataforma' basat en eMule \n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Lloc web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Lloc web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Part de l'aMule està basat en \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Encaminament p2p basat en la mètrica XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Comprova si hi ha noves versions a l'inici"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "S'està connectant a Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Esteu usant una versió antiga de l'aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "No disponible"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -117,8 +209,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -167,7 +259,7 @@ msgstr "Resultat de la depuració de la memòria a la sortida de l'aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "S'ha establert l'idioma Predeterminat del Sistema a causa d'un canvi de configuració. Disculpeu."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -190,47 +282,47 @@ msgstr "Contrassenya definida i connexions externes activades."
 msgid "WARNING"
 msgstr "AVÍS"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Xarxes"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S'ha trobat %i servidor al server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No s'han pogut vincular els ports a l'adreça especificada: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El port %u no està disponible. Tindreu ID BAIXA\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -245,48 +337,48 @@ msgstr ""
 "\n"
 "Comproveu la configuració de la xarxa per a assegurar-vos que el port està obert."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia de l'aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'idioma seleccionat no està instal·lat al PC. (Nota: s'intentarà establir igualment)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "És la primera vegada que executeu l'aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Aquesta és una versió de prova, actualitzada diàriament, i\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no podem garantir que no trenqui res, cremi casa vostra,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o mati al gos. Tanmateix el seu ús *hauria* de ser segur.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podeu trobar més informació, ajuda i noves versions a la nostra pàgina web,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o al nostre canal IRC #aMule de irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Podeu informar de qualsevol error a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -294,137 +386,137 @@ msgstr ""
 "La carpeta especificada per als fitxers de la signatura en línia és INVÀLIDA!\n"
 " S'INHABILITARÀ la signatura en línia fins que ho resolgueu a les preferències."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Nom del servidor notificat"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La preassignació d'espai per al fitxer '%s' ha fallat: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no es pot obrir el fitxer de registre"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVÍS: el fitxer de registre està buit. Alguna cosa no va bé."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "S'ha reiniciat el registre"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Missatge del servidor: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "S'ha omès la baixada de %s perquè el fitxer sol·licitat no és més recent."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "No s'ha pogut baixar la llista de nodes."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "No s'ha pogut obrir el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Fitxer de comprovació de versió corrupte"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Esteu usant una versió antiga de l'aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La vostra versió de l'aMule és %i.%i.%i i l'última versió és %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVÍS: La vostra versió d'aMuled és antiga: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "La vostra versió de l'aMule és l'última."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "No s'ha pogut baixar el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuaris: %s | Fitxers: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuaris: E: %s K: %s | Fitxers: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "No s'han seleccionat xarxes"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "amb ID Baixa"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "amb ID Alta"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connectat a %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "S'està connectant a %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Desconnectat de eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "S'ha engegat la xarxa Kad."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "S'ha aturat la xarxa Kad."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Connectat a Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Connectat a Kad (tallafocs)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Desconnectat de Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "No es pot usar la xarxa Kad si el port UDP està inhabilitat a les preferències, no s'engegarà."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "La xarxa Kad està inhabilitada a les preferències, no es connectarà."
 
@@ -454,122 +546,72 @@ msgstr "No s'ha pogut crear el fitxer Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s basat en eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "S'està executant sobre %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visiteu https://github.com/amule-org/amule/releases/latest per a comprovar si hi ha disponible una versió nova."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR GREU: No s'ha pogut crear el temporitzador"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Control remot de l'aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr "Client P2P 'Multiplataforma' basat en eMule \n"
+"You are running %s.\n"
+"\n"
+"Would you like to open the download page?"
+msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Lloc web: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Lloc web: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "No disponible"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Part de l'aMule està basat en \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Encaminament p2p basat en la mètrica XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Missatge"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Diàleg de l'aMule tancat"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Connectant"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: S'està connectant"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconnectat"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Bloquejat"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Connectat"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Connectant"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Inativa"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -579,175 +621,175 @@ msgstr "Kad: Inativa"
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Atura els intents de connexió actuals"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Desconnecta"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconnecta de les xarxes on s'està connectat actualment"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Connecta"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Connecta a les xarxes habilitades actualment"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "PU: %.1f%s (%.1f) | BA: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "PU: %.1f%s | BA: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connectat)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconnectat)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Esteu segur que voleu eixir de %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Confirmació de sortida"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Ordre: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- defecte -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directori del tema '%s' no existeix"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVÍS: No ha estat possible obrir el fitxer d'aparença '%s' per a lectura"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Xarxes"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Finestra de les Xarxes"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Cerques"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Finestra de cerques"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Baixades"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Finestra de baixades"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Compartits"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Finestra de fitxers compartits"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Missatges"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Finestra de Missatges"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Finestra del gràfic d'estadístiques"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferències"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Finestra de la configuració de preferències"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importa"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Eina d'importació de fitxers de parts"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Quant a"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Quant a / Ajuda"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Xarxa eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Xarxa Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Cap xarxa"
 
@@ -787,7 +829,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Gestor d'esdeveniments de la IGU EC Remota"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Connexió fallida. No ha estat possible connectar-se a %s:%d\n"
@@ -935,7 +977,7 @@ msgid "Enter Captcha"
 msgstr "Introdueix el Captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categoria"
 
@@ -1354,7 +1396,7 @@ msgstr "ERROR: error d'E/S!"
 msgid "ERROR: Failed!"
 msgstr "ERROR: Ha fallat!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "En cua"
 
@@ -1986,7 +2028,7 @@ msgstr ""
 "\n"
 "S'està creant el client...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1995,7 +2037,7 @@ msgstr ""
 "\n"
 "D'acord, eixint %s ...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2009,51 +2051,51 @@ msgstr ""
 "\n"
 "Eixint...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Mostra aquest text d'ajuda."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Ordinador on està executant-se l'aMule. (per defecte: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Port de l'aMule per a connexions externes. (per defecte: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Contrasenya per a les connexions externes."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Llegeix la configuració des del fitxer."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "No mostra res per la sortida estàndard."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Detallat - mostra també els missatges de depuració."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Estableix la localització del programa (idioma)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Escriu al fitxer de configuració les opcions de la línia d'ordres."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Crea un fitxer de configuració basat en el de l'aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Mostra la versió del programa."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2369,6 +2411,11 @@ msgstr "Port invàlid per a l'arrancada"
 msgid "Please fill all fields required"
 msgstr "Si us plau empleneu tots els camps requerits"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Missatge"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Esteu segur que voleu baixar un nou fitxer nodes.dat?\n"
@@ -2539,7 +2586,7 @@ msgstr "Connexió externa: Accés denegat perquè: "
 msgid "External Connection: Handshake failed."
 msgstr "Connexió externa: Conformitat de connexió denegada."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "S'ha iniciat el fil Asio %d"
@@ -2846,7 +2893,7 @@ msgstr "Nom:"
 msgid "Type"
 msgstr "Tipus"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Local"
 
@@ -2966,7 +3013,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Atura"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Baixada"
 
@@ -4830,7 +4877,7 @@ msgstr "Assignant"
 msgid "Insufficient disk space"
 msgstr "Espai en disc insuficient"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Baixat"
@@ -5437,7 +5484,7 @@ msgstr "Recarrega la llista de fitxers compartits."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "És impossible cercar quan l'eD2k i el Kademlia estan inhabilitats."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Error en la cerca"
 
@@ -5457,7 +5504,7 @@ msgstr "La mida mínima ha de ser menor que la màxima. S'ignorarà la mida màx
 msgid "Search warning"
 msgstr "Avís de cerca"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principal"
 
@@ -5494,37 +5541,37 @@ msgstr "Sense Valorar"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Baixa a la categoria"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obté %s per aquest fitxer"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Cerca fitxers relacionats (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Marca com a fitxer conegut"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copia l'enllaç eD2k al porta-retalls"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Esteu connectat al servidor què intenteu eliminar. Si us plau, primer desconnecteu-vos."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Cancel·lat"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Nou"
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -67,11 +67,11 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Lloc web:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Fòrum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -20,6 +20,100 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Zobrazit aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Vzdálené ovládání aMule"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Multiplatformní p2p klient založený na eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Web: https://amule-org.github.io\n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Web: https://amule-org.github.io\n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2019 Tým aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Část aMule je založena na \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Kontrola nové verze po spuštění"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Připojuji se k síti Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Používáte zastaralou verzi aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Nedostupný"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -114,8 +208,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -164,7 +258,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše nastavení locale bylo změněno na výchozí systémové nastavení kvůli změně v konfiguraci. Pardon."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -187,45 +281,45 @@ msgstr "Heslo nastaveno a externí připojení povoleno."
 msgid "WARNING"
 msgstr "VAROVÁNÍ"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sítě"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u je nedostupný. Budete mít LowID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -240,184 +334,184 @@ msgstr ""
 "\n"
 "Zkontrolujte nastavení vaší sítě a ujistěte se, že je port v obou směrech otevřený."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Selhalo vytvoření OnlineSig souboru"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Selhalo vytvoření aMule OnlineSig souboru"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Toto je vaše první spuštění aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Toto je testovací verze, která je denně aktualizovaná a\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "my nezaručujeme, že nemůže nic pokazit, zapálit váš dům,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nebo zabít vašeho psa. Nicméně i tak by *mělo* být její používání bezpečné.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Více informací, podporu a nová vydání naleznete na naší domovské stránce,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, nebo na našem IRC kanálu #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Hlašte chyby na adrese https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Předalokace místa na disku pro soubor '%s' selhala: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "CHYBA: nelze otevřít logovací soubor"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROVÁNÍ: log je prázdný. Něco je špatně."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Log byl vymazán"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Zpráva od serveru: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Selhalo stahování seznamu uzlů."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Selhalo otvírání staženého kontrolního souboru s verzí"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Porušený soubor pro kontrolu verze"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Používáte zastaralou verzi aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Vaše verze aMule je %i.%i.%i a poslední verze je %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROVÁNÍ: Vaše verze aMuled je zastaralá: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Vaše verze aMule je aktuální."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Selhalo stahování kontrolního souboru s verzí"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uživatelů: %s | Souborů: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uživatelů: E: %s K: %s | Souborů: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nezvoleny žádné sítě"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "s LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "s HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Připojen k %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Připojování k %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Odpojen od eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad spuštěn."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad zastaven."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Připojen ke Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Připojen ke kad (za firewallem)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Odpojen od Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Síť Kad nelze použít, když je v nastavení zakázán UDP port."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Síť Kad je zakázána v nastavení, nepřipojuji se."
 
@@ -447,124 +541,72 @@ msgstr "Nelze vytvořit soubor s PID"
 msgid "ERROR: %s"
 msgstr "CHYBA: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Toto je aMule %s založená na eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Běží na %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Navštivte https://github.com/amule-org/amule/releases/latest  pro kontrolu, jestli není dostupná nová verze."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITICKÁ CHYBA: Vytváření časovače selhalo"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Vzdálené ovládání aMule"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Multiplatformní p2p klient založený na eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web: https://amule-org.github.io\n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Web: https://amule-org.github.io\n"
+msgid "New version available"
+msgstr "Nedostupný"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2019 Tým aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Část aMule je založena na \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Zpráva"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Dialog aMule zničen"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Připojuji"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: připojuji"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: odpojeno"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Připojen"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Připojuji"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: vypnut"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -574,176 +616,176 @@ msgstr "Kad: vypnut"
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Zastaví aktuální pokusy o připojení"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Odpojit"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Odpojit se od aktuálně připojených sítí"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Připojit"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Připojit se k povoleným sítím"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Od: %.1f(%.1f) | St: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Od: %.1f | St: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | připojen)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | odpojen)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Opravdu si přejete ukončit %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Potvrzení ukončení"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Spustit příkaz: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- výchozí -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Adresář se skiny '%s' neexistuje"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROVÁNÍ: Nelze otevřít soubor se vzhledem '%s' pro čtení"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Sítě"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Okno sítí"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Vyhledávání"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Vyhledávací okno"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Sdílené soubory"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Okno se sdílenými soubory"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Zprávy"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Okno zpráv"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiky"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Okno se statistikami"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavení"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Okno s nastavením"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Nástroj pro import částečných souborů"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "O programu/Nápověda"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Síť eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Síť Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Žádná síť"
 
@@ -783,7 +825,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -933,7 +975,7 @@ msgid "Enter Captcha"
 msgstr "Vložte captchu"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategorie"
 
@@ -1355,7 +1397,7 @@ msgstr "CHYBA: I/O chyba!"
 msgid "ERROR: Failed!"
 msgstr "CHYBA: Selhání!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Ve frontě"
 
@@ -1977,7 +2019,7 @@ msgstr ""
 "\n"
 "Vytvářím klienta...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1986,7 +2028,7 @@ msgstr ""
 "\n"
 "OK, opouštím %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1995,51 +2037,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Zobrazí tuto nápovědu."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Hostitel, kde běží aMule. (výchozí: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Port aMule pro externí připojení. (výchozí: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Heslo pro externí připojení."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Načíst konfiguraci ze souboru."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Nevypisovat nic na stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Buď upovídaný - ukaž také debugovací hlášky"
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Nastaví locale programu (jazyk)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Vypíše verzi programu."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2358,6 +2400,11 @@ msgstr "Neplatný port pro bootstrap"
 msgid "Please fill all fields required"
 msgstr "Prosím vyplňte všechna potřebná pole"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Zpráva"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Opravdu chcete stáhnout nový soubor nodes.dat?\n"
@@ -2533,7 +2580,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Heslo pro externí připojení."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synchronizační vlákno spuštěno."
@@ -2840,7 +2887,7 @@ msgstr "Název:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Lokální"
 
@@ -2960,7 +3007,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Zastavit"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Stahování"
 
@@ -4832,7 +4879,7 @@ msgstr "Alokuji"
 msgid "Insufficient disk space"
 msgstr "Nedostatek místa na disku"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Staženo"
@@ -5437,7 +5484,7 @@ msgstr "Znovu načte seznam sdílených souborů."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Vyhledávání"
@@ -5458,7 +5505,7 @@ msgstr "Min. velikost musí být menší než max. velikost. Ignoruji max. velik
 msgid "Search warning"
 msgstr "Varování při vyhledávání"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Hlavní"
 
@@ -5495,37 +5542,37 @@ msgstr "Nehodnocené"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Přidat volitelné URL pro tento soubor"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Vyhledat související soubory (eD2k, lokální server)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Označit jako známý soubor"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Zkopírovat eD2k odkaz do schránky"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Snažíte se smazat server, na který jste právě připojen(a). Nejprve se prosím odpojte."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Zrušeno"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Nový"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -21,20 +21,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Zobrazit aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Vzdálené ovládání aMule"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -42,27 +42,7 @@ msgstr ""
 "Multiplatformní p2p klient založený na eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web: https://amule-org.github.io\n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Web: https://amule-org.github.io\n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -71,28 +51,40 @@ msgstr ""
 "Copyright (c) 2003-2019 Tým aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Část aMule je založena na \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kontrola nové verze po spuštění"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7879,6 +7871,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Web: https://amule-org.github.io\n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Web: https://amule-org.github.io\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/cs.po
+++ b/po/cs.po
@@ -65,11 +65,11 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Web:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Fórum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -19,6 +19,91 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Omking wxCas"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr ""
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr ""
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+msgid "Click to check for a newer version."
+msgstr ""
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+msgid "Checking for updates..."
+msgstr ""
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Du bruger en forældet version af aMule"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Ikke tilgængelig"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -110,8 +195,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -161,7 +246,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -184,45 +269,45 @@ msgstr "Accepter ydre forbindelser"
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i Serverer fundet i server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -232,185 +317,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "Vi giver ikke garanti for at det ikke vil ødelægge noget, brænde dit hus,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Servernavn :"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "FEJL: Kan ikke åbne logfil"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FARE: logfilen er tom. Noget er galt"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Log nulstillet"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerBesked: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Fejl ved hentning af node listen"
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Fejl ved åbning af den hentet version check filen"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Korrupt version check fil"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Du bruger en forældet version af aMule"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMule version er %i.%i.%i og den sisdte nye version er %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FARE: Din aMule version er forældet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Din kopi af aMule er op til dato"
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Fejl ved hentning af version check filen"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Forbundet til %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Forbundet til %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad startet."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad stoppet."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Forbundet til Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Forbundet til Kad (med firewall)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Afbrudt fra Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad netværk kan ikke bruges hvis UDP port er fravalgt i instillinger, starter ikke."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad netværk fravalgt i instillinger, forbinder ikke."
 
@@ -439,121 +524,76 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr ""
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr ""
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
+"You are running %s.\n"
 "\n"
-msgstr ""
+"Would you like to open the download page?"
+msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "Ikke tilgængelig"
 
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr ""
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "firewalled"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Forbundet"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -563,178 +603,178 @@ msgstr " Kad: "
 msgid "Cancel"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Stop de nuværende forbindelses forsøg"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Afbryd fra nuvÃŠrende server"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Forbind"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Op: %.1f | Ned: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du virkelig afslutte aMule?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Bekræft afslut"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Søg"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Søge Vindue"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Henter"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Beskeder"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Besked Vindue"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Indstillinger"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -777,7 +817,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -927,7 +967,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategori"
 
@@ -1345,7 +1385,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr ""
 
@@ -1957,14 +1997,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1973,51 +2013,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2332,6 +2372,11 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr ""
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
@@ -2504,7 +2549,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synkroniserings tråd startet."
@@ -2810,7 +2855,7 @@ msgstr ""
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr ""
 
@@ -2930,7 +2975,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Download"
 
@@ -4799,7 +4844,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5387,7 +5432,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Søg"
@@ -5408,7 +5453,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr ""
 
@@ -5445,37 +5490,37 @@ msgstr "Ikke anslået"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Indtast nyt navn for denne fil:"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "Afbryd"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -20,70 +20,64 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Omking wxCas"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -71,7 +71,7 @@ msgstr ""
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
@@ -79,7 +79,7 @@ msgstr ""
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"
-msgstr ""
+msgstr "Probleme:"
 
 #: src/AboutDialog.cpp:107
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -24,20 +24,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Lokalize 26.04.0\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Zeige aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule-Fernbedienung "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Schnappschuss:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -45,27 +45,7 @@ msgstr ""
 "'All-Plattform' p2p Client basierend auf eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Webseite: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Webseite: https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Probleme: https://github.com/amule-org/amule/discussions \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -73,28 +53,40 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Teile von aMule basieren auf \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer Weiterleitung basierend auf der XOR Funktion.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Beim Start auf neue Version prüfen"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7894,6 +7886,25 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Webseite: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Webseite: https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "Probleme: https://github.com/amule-org/amule/discussions \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -23,6 +23,99 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Lokalize 26.04.0\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Zeige aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule-Fernbedienung "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Schnappschuss:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"'All-Plattform' p2p Client basierend auf eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Webseite: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Webseite: https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"Probleme: https://github.com/amule-org/amule/discussions \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Teile von aMule basieren auf \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Peer-to-peer Weiterleitung basierend auf der XOR Funktion.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Beim Start auf neue Version prüfen"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Verbinde mit Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Du benutzt eine veraltete aMule-Version!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Nicht verfügbar"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -122,8 +215,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Konnte %u Link aus ED2KLinks nicht hinzufügen (Details: siehe Log)"
 msgstr[1] "Konnte %u Links aus ED2KLinks nicht hinzufügen (Details: siehe Log)"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -172,7 +265,7 @@ msgstr "Speicherfehlerbehebungsresultate für aMule-Beendung:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Deine Locale wurde wegen einer Konfigurationsänderung auf Systemstandard geändert. Sorry."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -195,11 +288,11 @@ msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "Netzwerk-Bootstrap"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -207,34 +300,34 @@ msgstr ""
 "aMule hat fehlende Netzwerk-Bootstrap-Dateien erkannt.\n"
 "Wählen Sie aus, welche heruntergeladen werden sollen:"
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "eD2k-Serverliste (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad-Bootstrap-Knoten (nodes.dat)"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kann Ports nicht mit der festgelegten Adresse verbinden: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ist nicht erreichbar. Du wirst eine niedrige ID erhalten\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -249,48 +342,48 @@ msgstr ""
 "\n"
 "Bitte überprüfe deine Netzwerkeinstellungen, um sicherzugehen, dass der Port für ein- und ausgehenden Traffic geöffnet ist."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Erstellen der OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erstellen der aMule OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Die ausgewählte Locale scheint nicht auf dem System installiert zu sein.(INFO: Ich werde trotzdem versuchen, sie zu setzen)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dies ist das erste Mal, dass du aMule %s startest"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dies ist eine Testversion, täglich aktualisiert, und\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "wir garantieren nicht, dass sie keine Daten zerstört, dein Haus anzündet\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "oder deinen Hund tötet. Aber es *sollte* sicher sein, sie zu benutzen.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mehr Informationen und neue Releases können auf unserer Homepage gefunden werden\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "unter https://amule-org.github.io, oder in unserem IRC-Channel #amule auf irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bitte melde Fehler unter https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -298,137 +391,137 @@ msgstr ""
 "Das angegebene Verzeichnis für die Online-Signaturdateien ist UNGÜLTIG!\n"
 "Online-Signatur wird bis zur Fehlerbehebung in den Einstellungen DEAKTIVIERT."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Server Hostname benachrichtigt"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Speicherplatzvorbelegung für Datei '%s' fehlgeschlagen: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "FEHLER: kann Logdatei nicht öffnen"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WARNUNG: Logdatei ist leer. Etwas ist falsch."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Das Log wurde zurückgesetzt"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servernachricht: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Lade %s nicht herunter, weil die angeforderte Datei nicht neuer ist."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Knotenliste kann nicht geholt werden."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Konnte heruntergeladene Datei zur Versionsprüfung nicht öffnen"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Fehlerhafte Versionsprüfungsdatei"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Du benutzt eine veraltete aMule-Version!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Diese Version von aMule ist %i.%i.%i und die aktuelle Version ist %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WARNUNG: Diese Version von aMuled ist veraltet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Deine Kopie von aMule ist aktuell."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Konnte die Versionsprüfungsdatei nicht herunterladen"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Benutzer: %s | Dateien: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Benutzer: E: %s K: %s | Dateien: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Keine Netzwerke ausgewählt"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "mit niedriger ID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "mit hoher ID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbunden zu %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinde zu %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "eD2k getrennt"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad gestartet."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad beendet."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Kad verbunden (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad verbunden (firewalled)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Kad getrennt"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-Netzwerk kann mit deaktiviertem UDP-Port nicht benutzt werden, nicht gestartet."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-Netzwerk ist in den Voreinstellungen deaktiviert, kein Verbindungsversuch."
 
@@ -457,123 +550,72 @@ msgstr "Kann keine Pid-Datei erstellen"
 msgid "ERROR: %s"
 msgstr "FEHLER: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dies ist aMule %s, basierend auf eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Läuft auf %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besuche https://github.com/amule-org/amule/releases/latest um zu sehen, ob eine neue Version verfügbar ist."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "UNBEHEBBARER FEHLER: Es konnte kein Zeitgeber erstellt werden."
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule-Fernbedienung "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Schnappschuss:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"'All-Plattform' p2p Client basierend auf eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Webseite: https://amule-org.github.io \n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "Nicht verfügbar"
 
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Webseite: https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Probleme: https://github.com/amule-org/amule/discussions \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Teile von aMule basieren auf \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Peer-to-peer Weiterleitung basierend auf der XOR Funktion.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Nachricht"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMule Dialog zerstört."
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Verbindung getrennt"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Verbunden"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: aus"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -583,175 +625,175 @@ msgstr "Kad: aus"
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Beendet die derzeitigen Verbindungsversuche"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Trennen"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Von den momentan verbundenen Netzwerken trennen."
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Mit den aktuell aktivierten Netzwerken verbinden."
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbunden)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Getrennt)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s wirklich beenden?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Beenden bestätigen"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Startbefehl: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- Voreinstellung -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-Verzeichnis '%s' existiert nicht"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WARNUNG: Öffnen der Skin-Datei '%s' zum Lesen nicht möglich"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Netzwerke"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Übersicht der verwendeten Netzwerke"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Suchen"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Dateisuche in den verbundenen Netzwerken"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Download-Fenster"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Freigegebene Dateien"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Übersicht der freigegebenen Dateien"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Nachrichten, Chat, Freundesliste"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Diverse Statistiken über Up- und Download, Verbindungen, Clients usw."
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Fenster für Einstellungen"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importiere"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Das Importierwerkzeug für Part-Dateien"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Über"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Über/Hilfe - Hinweise zur Version usw."
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k-Netzwerk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad-Netzwerk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Kein Netzwerk"
 
@@ -791,7 +833,7 @@ msgstr "Verbindung fehlgeschlagen. Bitte Host, Port und Passwort prüfen."
 msgid "Remote GUI EC event handler"
 msgstr "EC-Ereignissteuerung für entfernte Benutzeroberfläche"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Verbindung fehlgeschlagen. Konnte nicht zu %s:%d verbinden\n"
@@ -941,7 +983,7 @@ msgid "Enter Captcha"
 msgstr "Captcha eingeben"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategorie"
 
@@ -1359,7 +1401,7 @@ msgstr "FEHLER: IO-Fehler!"
 msgid "ERROR: Failed!"
 msgstr "FEHLER: Fehlgeschlagen!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "In Warteschlange"
 
@@ -1989,7 +2031,7 @@ msgstr ""
 "\n"
 "Erstelle Client...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1998,7 +2040,7 @@ msgstr ""
 "\n"
 "Ok, beende %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2012,51 +2054,51 @@ msgstr ""
 "\n"
 "Beende...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Zeige diese Hilfe."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host, auf dem aMule läuft. (Standard: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMules Port für externe Verbindungen. (Standard: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Passwort für externe Verbindungen."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Lese Konfiguration aus Datei."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Schreibe keinerlei Ausgabe auf stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Sei ausführlich - Zeige auch Debug-Nachrichten."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Setze Programm-Locale (Sprache)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Schreibe Kommandozeilen-Optionen in Konfigurationsdatei."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Erstelle Konfigurationsdatei basierend auf aMules Konfigurationsdatei."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Drucke Programmversion."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "ZLIB Kompression unabhängig der Ziel-IP erzwingen (nützlich wenn der Server per VPN über eine LAN-IP aufgelöst wird)."
 
@@ -2371,6 +2413,11 @@ msgstr "Ungültiger Bootstrap-Port"
 msgid "Please fill all fields required"
 msgstr "Bitte alle erforderlichen Felder ausfüllen"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Nachricht"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Wirklich neue nodes.dat herunterladen?\n"
@@ -2540,7 +2587,7 @@ msgstr "Externe Verbindungen: Zugriff verweigert wegen:"
 msgid "External Connection: Handshake failed."
 msgstr "Externe Verbindungen: Verhandlung fehlgeschlagen."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-Thread %d gestartet"
@@ -2840,7 +2887,7 @@ msgstr "Name:"
 msgid "Type"
 msgstr "Suchtyp"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Lokal"
 
@@ -2960,7 +3007,7 @@ msgstr "Bittet Kad-Peers, die bereits geantwortet haben, die Suche zu erweitern.
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Download"
 
@@ -4821,7 +4868,7 @@ msgstr "Reserviere"
 msgid "Insufficient disk space"
 msgstr "Zu wenig Festplattenplatz"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Heruntergeladen"
@@ -5426,7 +5473,7 @@ msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Eine Suche ist nicht möglich, wenn sowohl eD2k als auch Kademlia deaktiviert sind."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Suchfehler"
 
@@ -5446,7 +5493,7 @@ msgstr "Mindestgröße muss kleiner sein, als die Höchstgröße: Höchstgröße
 msgid "Search warning"
 msgstr "Suchwarnung"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Hauptkategorie"
 
@@ -5483,37 +5530,37 @@ msgstr "Nicht bewertet"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Herunterladen in Kategorie"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "%s für diese Datei erhalten"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Suche verwandte Dateien (eD2k, lokale Server)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Als bekannte Datei kennzeichnen"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiere eD2k-Verweis in die Zwischenablage"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Du bist zu einem Server verbunden, den du zu löschen versuchst. Bitte zuerst trennen."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Abgebrochen"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Neu"
 

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Εμφάνιση aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Τηλεχειρισμός aMule"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Στιγμιότυπο"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,27 +41,7 @@ msgstr ""
 "Πελάτης P2P για όλες τις πλατφόρμες βασισμένος στο eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Ιστοσελίδα: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Ιστοσελίδα: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -70,28 +50,40 @@ msgstr ""
 "Πνευματικά Δικαιώματα (c) 2003-2019 η ομάδα του aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Μέρος του aMule είναι βασισμένο στο  \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Δρομολόγηση Peer-to-peer βασισμένη στην μετρική XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Έλεγχος για νέα έκδοση κατά την εκκίνηση"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7967,6 +7959,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Ιστοσελίδα: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Ιστοσελίδα: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -19,6 +19,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Εμφάνιση aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Τηλεχειρισμός aMule"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Στιγμιότυπο"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Πελάτης P2P για όλες τις πλατφόρμες βασισμένος στο eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Ιστοσελίδα: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Ιστοσελίδα: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Πνευματικά Δικαιώματα (c) 2003-2019 η ομάδα του aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Μέρος του aMule είναι βασισμένο στο  \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Δρομολόγηση Peer-to-peer βασισμένη στην μετρική XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Έλεγχος για νέα έκδοση κατά την εκκίνηση"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Διαδικασία σύνδεσης στο Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Δεν είναι διαθέσιμο"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -112,8 +206,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -167,7 +261,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Οι τοπικές ρυθμίσεις άλλαξαν στις προεπιλεγμένες του συστήματος λόγο μιας αλλαγής παραμέτρων. Sorry!"
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -190,47 +284,47 @@ msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 msgid "WARNING"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Δίκτυα"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "βρέθηκε %i διακομιστής στο server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Δεν μπόρεσε να προσδέσει τις θύρες στην προσδιορισμένη διεύθυνση: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Η θύρα %u δεν είναι διαθέσιμη. Θα σας αποδωθεί LOWID (χαμηλή προτεραιότητα)\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -245,48 +339,48 @@ msgstr ""
 "\n"
 "Ελέξτε το δίκτυο σας για να βεβαιωθήτε ότι η θύρα είναι ανοιχτή για είσοδο και έξοδο."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών του aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Οι επιλεγμένες τοπικές ρυθμίσεις δεν φαίνεται να είναι εγκατεστημένες στο σύστημά σας. (Σημ. Θα προσπαθήσω να τις θέσω ούτως ή άλλως)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Αυτή είναι η πρώτη φορά που τρέχετε το aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Αυτή η έκδοση είναι δοκιμαστική, και αναβαθμίζεται καθημερινά, και\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "δεν δίνουμε εγγύηση ότι δεν θα χαλάσει κάτι, δεν θα κάψει το σπίτι σας,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ή δεν θα σκοτώσει το σκύλο σας. Αλλά πρέπει να είναι ασφαλές στη χρήση\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Περισσότερες πληροφορίες, υποστήριξη και νέες εκδόσεις μπορούν να βρεθούν στην ιστοσελίδα μας,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "στο https://amule-org.github.io, ή στο κανάλι #aMule του IRC στο irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Παρακαλούμε αναφέρετε σφάλματα του προγράμματος στο https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -294,138 +388,138 @@ msgstr ""
 "Ο δικτυακός κατάλογος των ηλεκτρονικών αρχείων υπογραφών που προσδιορίσατε είναι ΑΚΥΡΟΣ!\n"
 "Οι ηλεκτρονικές υπογραφές θα ΑΠΕΝΕΡΓΟΠΟΙΗΘΟΥΝ μέχρι να το φτιάξετε στις προτιμήσεις."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Όνομα διακομιστή:"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Η εκχώρηση χώρου για το αρχείο '%s' απέτυχε: '%s'"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ΣΦΑΛΜΑ: το αρχείο καταγραφής δεν μπορεί να ανοίξει"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: το αρχείο καταγραφών είναι άδειο. Κάτι δεν πάει καλά."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Το αρχείο καταγραφών επαναφέρθηκε στην αρχική κατάσταση"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Μήνυμα Διακομιστή: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Αποτυχία κατεβάσματος της λίστας κόμβων."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Αποτυχία ανοίγματος του κατεβασμένου αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Φθαρμένο αρχείο ελέγχου έκδοσης"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Η παρούσα έκδοση του aMule είναι %i.%i.%i και η τελευταία %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Η έκδοση του aMuled είναι ξεπερασμένη: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Αυτό το αντίγραφο του aMule είναι σύγχρονο. "
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Αποτυχία κατεβάσματος του αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Χρήστες: %s | Αρχεία: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Χρήστες: E: %s K: %s | Αρχεία: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Δεν έχουν επιλεχθεί δίκτυα"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "με Χαμηλή Προτεραιότητα"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "με Υψηλή Προτεραιότητα"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Σύνδεση με το %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Διαδικασία σύνδεσης με %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Αποσυνδεδεμένο από το eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Το Kad ξεκίνησε."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Το Kad είναι σταματημένο."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Συνδεδεμένο στο Kad (ΟΚ)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Συνδεδεμένο στο Kad (με προστατευτικό τοίχο)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Αποσυνδεδεμένο από το Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Το δίκτυο Kad δεν μπορεί να χρησιμοποιηθεί αν η θύρα UDP είναι απενεργοποιημένη στις προτιμήσεις. Δεν έγινε εκκίνηση."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Το δίκτυο Kad είναι απενεργοποιημένο από τις προτιμήσεις. Δεν έγινε σύνδεση."
 
@@ -455,124 +549,72 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "ΣΦΑΛΜΑ: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Αυτό το aMule %s είναι βασισμένο στο eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Τρέχει στο %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Επισκεφτείτε το https://github.com/amule-org/amule/releases/latest για να δείτε αν υπάρχει νέα έκδοση."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ΜΟΙΡΑΙΟ ΣΦΑΛΜΑ: Αποτυχία δημιουργίας Χρονομέτρου"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Τηλεχειρισμός aMule"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Στιγμιότυπο"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Πελάτης P2P για όλες τις πλατφόρμες βασισμένος στο eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Ιστοσελίδα: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Ιστοσελίδα: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Δεν είναι διαθέσιμο"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Πνευματικά Δικαιώματα (c) 2003-2019 η ομάδα του aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Μέρος του aMule είναι βασισμένο στο  \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Δρομολόγηση Peer-to-peer βασισμένη στην μετρική XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Μήνυμα"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Συνδέοντας"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Συνδέεται"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Αποσυνδεδεμένο"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Πίσω από τοίχο προστασίας"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Συνδεδεμένο"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Σε διαδικασία σύνδεσης"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Εκτός"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -582,177 +624,177 @@ msgstr "Kad: Εκτός"
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Σταμάτησε τις τρέχουσες απόπειρες σύνδεσης"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Αποσύνδεση από τα συνδεδεμένα δίκτυα"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Σύνδεση"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Σύνδεση στα ενεργοποιημένα δίκτυα"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Πάνω: %.1f(%.1f) | Κάτω: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Πάνω: %.1f | Κάτω: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Συνδεδεμένο)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Αποσυνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Σίγουρα θέλετε να κλείσετε το aMule;"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- Προεπιλεγμένο -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ο κατάλογος των θεμάτων '%s'  δεν υπάρχει"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατή η ανάγνωση του αρχείου θέματος '%s' "
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Δίκτυα"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Παράθυρο δικτύων"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Αναζητήσεις"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Παράθυρο αναζητήσεων"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Κατεβασμένα"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Κατεβαίνει"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Παράθυρο κοινόχρηστων αρχείων"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Μηνύματα"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Παράθυρό μηνυμάτων"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Στατιστικές"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Παράθυρο στατιστικών διαγραμμάτων"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Παράθυρο ρυθμίσεων"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Το εργαλείο εισαγωγής ημιτελών αρχείων"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Σχετικά"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Σχετικά/Βοήθεια"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Δίκτυο eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Δίκτυο Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Κανένα δίκτυο"
 
@@ -796,7 +838,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -945,7 +987,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Κατηγορία"
 
@@ -1364,7 +1406,7 @@ msgstr "ΣΦΑΛΜΑ: σφάλμα εισόδου/εξόδου!"
 msgid "ERROR: Failed!"
 msgstr "ΣΦΑΛΜΑ: Απέτυχε!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Εν αναμονή"
 
@@ -2001,7 +2043,7 @@ msgstr ""
 "\n"
 " Δημιουργία πελάτη...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2010,7 +2052,7 @@ msgstr ""
 "\n"
 "Όλα μια χαρά, έξοδος %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2023,51 +2065,51 @@ msgstr ""
 "είτε στην γραμμή εντολών είτε προσδιορίζοντας κάποιο όταν ζητηθεί.\n"
 "Έξοδος...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Δείξε αυτό το αρχείο βοήθειας."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Υπολογιστής όπου το aMule τρέχει (προεπιλεγμένος: ο τοπικός υπολογιστής)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Η Θύρα του aMule για Εξωτερική σύνδεση. (προεπιλεγμένη: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Κωδικός εξωτερικής σύνδεσης"
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Διάβασε το αρχείο διευθετήσεων"
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Μην στέλνεις μηνύματα στην stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Να είσαι αναλυτικός - δείξε και να μηνύματα αποσφαλμάτωσης"
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Θέσε τις τοπικές ρυθμίσεις"
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Εγγραφή των παραμέτρων της γραμμής εντολών σε αρχείο."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Δημιουργεί ένα αρχείο παραμέτρων βασισμένο στο αρχείο παραμέτρων του aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Τύπωσε την έκδοση του προγράμματος."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2387,6 +2429,11 @@ msgstr "Άκυρη θύρα για εκκινητήρα"
 msgid "Please fill all fields required"
 msgstr "Παρακαλώ συμπληρώστε όλα τα απαιτούμενα πεδία"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Μήνυμα"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Είστε σίγουροι ότι θέλετε να κατεβάσετε ένα καινούριο αρχείο nodes.dat;\n"
@@ -2559,7 +2606,7 @@ msgstr "Εξωτερική Σύνδεση: Η πρόσβαση απορρίφθ�
 msgid "External Connection: Handshake failed."
 msgstr "Εξωτερική σύνδεση: Η πρόσβαση απορρίφθηκε"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
@@ -2866,7 +2913,7 @@ msgstr "Όνομα:"
 msgid "Type"
 msgstr "Τύπος"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Τοπικό"
 
@@ -2986,7 +3033,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Σταμάτημα"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Κατέβασμα"
 
@@ -4864,7 +4911,7 @@ msgstr "Κατανέμει"
 msgid "Insufficient disk space"
 msgstr "Ανεπαρκής χώρος στο δίσκο"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Έχει κατεβεί"
@@ -5477,7 +5524,7 @@ msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρ
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Αναζητήσεις"
@@ -5498,7 +5545,7 @@ msgstr "Το ελάχιστο μέγεθος πρέπει να είναι μικ
 msgid "Search warning"
 msgstr "Προειδοποίηση ψαξίματος"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Κύρια"
 
@@ -5535,38 +5582,38 @@ msgstr "Μη αποτιμημένο"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Κατέβασμα στην κατηγορία"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Προσθήκη προαιρετικών URL για αυτό το αρχείο"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Αναζήτηση παρόμοιων αρχείων (στο eD2k, τοπικός διακομιστής)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Σημείωση αρχείου ως γνωστού"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Είστε συνδεδεμένος στον διακομιστή που προσπαθείτε να σβήσετε. Παρακαλείστε να αποσυνδεθείτε πρώτα"
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "Ακύρωση"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -64,11 +64,11 @@ msgstr ""
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Ιστοσελίδα:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Συζητήσεις:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -18,69 +18,63 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -17,6 +17,89 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+msgid "About aMule"
+msgstr ""
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr ""
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr ""
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+msgid "Click to check for a newer version."
+msgstr ""
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+msgid "Checking for updates..."
+msgstr ""
+
+#: src/AboutDialog.cpp:160
+msgid "You are running the latest version."
+msgstr ""
+
+#: src/AboutDialog.cpp:164
+#, c-format
+msgid "A new version (%s) is available:"
+msgstr ""
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -108,8 +191,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -158,7 +241,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -179,44 +262,44 @@ msgstr ""
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -226,184 +309,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -432,117 +515,71 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr ""
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr ""
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
+#: src/amuleDlg.cpp:605
+msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr ""
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -552,175 +589,175 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -760,7 +797,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -908,7 +945,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr ""
 
@@ -1326,7 +1363,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr ""
 
@@ -1934,14 +1971,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1950,51 +1987,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2303,6 +2340,11 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr ""
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
@@ -2472,7 +2514,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2772,7 +2814,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr ""
 
@@ -2892,7 +2934,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr ""
 
@@ -4743,7 +4785,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5317,7 +5359,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr ""
 
@@ -5337,7 +5379,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr ""
 
@@ -5373,36 +5415,36 @@ msgstr ""
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -71,19 +71,19 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov (petar@maymounkov.org)\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Web:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Foro:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
-msgstr ""
+msgstr "Documentación:"
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"
-msgstr ""
+msgstr "Problemas:"
 
 #: src/AboutDialog.cpp:107
 #, fuzzy

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -27,6 +27,99 @@ msgstr ""
 "X-Generator: Weblate 2026.6\n"
 "X-Language: es_ES\n"
 "X-Poedit-SourceCharset: utf-8\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Mostrar aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Control remoto de aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Versión:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Cliente p2p multiplataforma basado en eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Documentación: https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"Problemas: https://github.com/amule-org/amule/issues \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 El equipo de aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Parte de aMule está basada en \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: direccionamiento P2P basado en la métrica XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov (petar@maymounkov.org)\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Comprobar si hay una nueva versión al inicio"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Conectando a Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "¡Estás usando una versión desactualizada de aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "No disponible"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -126,8 +219,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "No se pudo añadir %u enlace del archivo ED2KLinks (consulte el registro para más detalles)"
 msgstr[1] "No se pudieron añadir %u enlaces del archivo ED2KLinks (consulte el registro para más detalles)"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -176,7 +269,7 @@ msgstr "Resultados de depuración de memoria en la salida de aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Su configuración regional se ha cambiado a la predefinida del sistema debido a un cambio en la configuración. Disculpe."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -199,11 +292,11 @@ msgstr "Contraseña fijada y conexiones externas habilitadas."
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "Bootstrap de red"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -211,34 +304,34 @@ msgstr ""
 "aMule ha detectado archivos de bootstrap de red faltantes.\n"
 "Seleccione cuáles descargar:"
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web corriendo con pid: %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se pueden asociar los puertos con la dirección especificada: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puerto %u no está disponible. Tendrás Id Baja\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -253,48 +346,48 @@ msgstr ""
 "\n"
 "Comprueba la red y asegúrate de que el puerto está abierto para salida y entrada."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Error al crear el archivo de firma online"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Error al crear el archivo de firma online de aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "El idioma seleccionado no parece estar instalado en tu sistema. (Nota: intentaré configurarlo de todos modos)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Es la primera vez que inicias aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta es una versión de prueba, actualizada diariamente, y\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no garantizamos que no rompa nada, no queme su casa,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o no mate a su perro. Pero *debería* ser seguro usarla de todas formas.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "En nuestra web podrá encontrar más información, soporte y nuevas versiones,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o en nuestro canal de IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Envíenos cualquier fallo a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -302,137 +395,137 @@ msgstr ""
 "¡El directorio que ha especificado para archivos de firma digital no es válido!\n"
 "La firma digital se ha deshabilitado hasta que lo arregle en las preferencias."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Nombre de servidor notificado"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espacio en disco para el archivo '%s' ha fallado: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no se puede abrir el archivo de registro"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: el archivo de registro está vacío. Algo está mal."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "El registro se ha borrado"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaje del servidor: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se ha descartado la descarga de %s, porque el archivo solicitado no es más nuevo."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Error al descargar la lista de nodos."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Error al abrir el archivo de comprobación de versión descargado"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Archivo de comprobación de versión dañado"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Estás usando una versión desactualizada de aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Su versión de aMule es %i.%i.%i y la última versión es %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La última versión siempre se puede encontrar en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: su versión de aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Su copia de aMule está actualizada."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Error al descargar el archivo de comprobación de la versión"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Archivos: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Archivos: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "No hay redes seleccionadas"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con Id Baja"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con Id Alta"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad detenido."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (correcto)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (tras cortafuegos)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La red Kad no se puede usar si el puerto UDP está deshabilitado en las preferencias, no se inicia."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada en las preferencias, no se conecta."
 
@@ -461,123 +554,72 @@ msgstr "No se puede crear el archivo Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto es aMule %s basado en eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Ejecutándose en %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para comprobar si hay una nueva versión disponible."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR FATAL: no se ha podido crear el temporizador"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Control remoto de aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Versión:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Cliente p2p multiplataforma basado en eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "La última versión siempre se puede encontrar en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web: https://amule-org.github.io \n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "No disponible"
 
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentación: https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Problemas: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 El equipo de aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Parte de aMule está basada en \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: direccionamiento P2P basado en la métrica XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov (petar@maymounkov.org)\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Mensaje"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Diálogo de aMule destruido"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: tras cortafuegos"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: conectado"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: conectando"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: apagado"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -587,175 +629,175 @@ msgstr "Kad: apagado"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexión actuales"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectarse de las redes conectadas"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Conectarse a las redes habilitadas"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Su: %.1f%s (%.1f) | De: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Su: %.1f%s | De: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "¿Realmente desea cerrar %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Confirmación de salida"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Ejecutar comando: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- predeterminado -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directorio de tema '%s' no existe"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: no se puede abrir el archivo de tema '%s' para lectura"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Búsquedas"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Ventana de búsquedas"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Ventana de descargas"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Compartidos"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Ventana de archivos compartidos"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Mensajes"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Ventana de mensajes"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Ventana de preferencias de configuración"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "La herramienta para importar archivos de partes"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca de"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Acerca de/Ayuda"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Red eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "No hay red"
 
@@ -795,7 +837,7 @@ msgstr "Conexión fallida. Por favor, compruebe el host, puerto y contraseña."
 msgid "Remote GUI EC event handler"
 msgstr "Gestor de eventos de la EC de la interfaz remota"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Error de conexión. No se puede conectar a %s:%d\n"
@@ -945,7 +987,7 @@ msgid "Enter Captcha"
 msgstr "Introduzca el \"captcha\""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categoría"
 
@@ -1363,7 +1405,7 @@ msgstr "ERROR: ¡error de E/S!"
 msgid "ERROR: Failed!"
 msgstr "ERROR: ¡no se ha podido realizar la acción!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "En la cola"
 
@@ -1993,7 +2035,7 @@ msgstr ""
 "\n"
 "Creando cliente...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2002,7 +2044,7 @@ msgstr ""
 "\n"
 "Vale, terminando %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2016,51 +2058,51 @@ msgstr ""
 "\n"
 "Saliendo...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Mostrar esta ayuda."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host donde se está ejecutando aMule (por defecto: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "El puerto de aMule para la conexión externa (por defecto: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Contraseña para conexiones externas."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Leer la configuración desde el archivo."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "No mostrar ninguna salida en stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Modo detallado - muestra también los mensajes de depuración."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Establece la configuración regional (idioma) del programa."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Escribir las opciones de la línea de comandos al archivo de configuración."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Crear archivo de configuración basado en el archivo de configuración de aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Imprimir la versión del programa."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Forzar compresión ZLIB aunque se conecte a una IP local/LAN (útil cuando se conecta al servidor a través de un túnel VPN que se resuelve a una IP de LAN)."
 
@@ -2375,6 +2417,11 @@ msgstr "Puerto no válido para la inicialización"
 msgid "Please fill all fields required"
 msgstr "Por favor, rellene todos los campos requeridos"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Mensaje"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "¿Seguro que quiere descargar un nuevo archivo nodes.dat?\n"
@@ -2544,7 +2591,7 @@ msgstr "Conexión externa: acceso denegado, razón: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: error al establecer la comunicación."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Hilo Asio %d iniciado"
@@ -2844,7 +2891,7 @@ msgstr "Nombre:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Local"
 
@@ -2964,7 +3011,7 @@ msgstr "Pide a los pares Kad que ya han respondido que amplíen la búsqueda. Ca
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Descarga"
 
@@ -4838,7 +4885,7 @@ msgstr "Asignando"
 msgid "Insufficient disk space"
 msgstr "Espacio en disco insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descargado"
@@ -5441,7 +5488,7 @@ msgstr "Recargando archivos compartidos: %u archivos escaneados"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "No se puede buscar con eD2K y Kademlia deshabilitadas."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Error de búsqueda"
 
@@ -5461,7 +5508,7 @@ msgstr "El tamaño mínimo debe ser menor que el tamaño máximo. Tamaño máxim
 msgid "Search warning"
 msgstr "Aviso de búsqueda"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principal"
 
@@ -5497,36 +5544,36 @@ msgstr "Tasa de bits"
 msgid "Codec"
 msgstr "Códec"
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Descargar en la categoría"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obtener %s para este archivo"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Buscar archivos relacionados (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Marcar como archivo conocido"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar el enlace eD2k al portapapeles"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Actualmente no estás conectado a un servidor que admita la función de búsqueda de 'Archivos Relacionados'"
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Cancelada"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Nuevo"
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -28,20 +28,20 @@ msgstr ""
 "X-Language: es_ES\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Control remoto de aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Versión:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -49,27 +49,7 @@ msgstr ""
 "Cliente p2p multiplataforma basado en eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentación: https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Problemas: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -77,28 +57,40 @@ msgstr ""
 "Copyright (c) 2003-2026 El equipo de aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Parte de aMule está basada en \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: direccionamiento P2P basado en la métrica XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov (petar@maymounkov.org)\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprobar si hay una nueva versión al inicio"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7907,6 +7899,25 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Web: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Documentación: https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "Problemas: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -65,11 +65,11 @@ msgstr " Copyright (C) 2002-2011 Petar Maymounkov <petar@maymounkov.org>\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Web:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Foorum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -20,6 +20,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Näita aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule kaugjuhtimine "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Piiluvaade:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+" eMulel põhinev, platvormist sõltumatu, p2p klient \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2019 aMule Meeskond \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Osa aMule põhineb \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Sõlmest-Sõlmeni ruutimine põhineb XOR meetrikal.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (C) 2002-2011 Petar Maymounkov <petar@maymounkov.org>\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Kontrolli käivitumisel uue versiooni olemasolu"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Ühendun Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Kasutad aegunud aMule versiooni!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Info puudub"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -113,8 +207,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -163,7 +257,7 @@ msgstr "aMule väljumise mälu veajälituse tulemus:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Sinu keelelokaat muudeti süsteemi vaikeväärtuseks seoses konfiguratsiooni muudatustega. Sorry."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -186,47 +280,47 @@ msgstr "Parool on määratud ja välised ühendused võimalikud."
 msgid "WARNING"
 msgstr "HOIATUS"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Võrgud"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Failis server.met on %i serverit"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei suuda siduda porti määratud aadressiga: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ei ole kasutatav. Sa saad LOWID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -241,48 +335,48 @@ msgstr ""
 "Kasuta netstat programmi kontrollimaks kuna port vabaneb\n"
 "ja proovi amule uuesti käivitada."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Ei suutnud luua OnlineSig Faili"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ei suutnud luua aMule OnlineSig Faili"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Tundub et valitud keelelokaat pole sinu karpi installeritud. (Märkus: Ma proovin seda seada sellest hoolimata)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "See on aMule %s käivitamise esimene kord"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "See on testversioon, mida igapäevaselt uuendatakse ja\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "me ei anna mingit garantiid, et see ei lõhu midagi, ei süüta sinu elamist\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ega tapa sinu koera. Sellest hoolimata peaks see olema *turvaline* kasutada.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Rohkem informatsiooni, tuge ja uusi programmi versioone leiad meie kodulehelt,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "aadressil https://amule-org.github.io või meie IRC kanalis #aMule aadressil irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Tunne ennast vabalt suvaliste vigade leidmisest teavitamisel aadressil https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -290,137 +384,137 @@ msgstr ""
 "Online Allkirja kataloog on VIGANE!\n"
 " Online Allkirja ei kasutata, kuni parandad vea seadetes."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Teatatud serveri nimi"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Kettaruumi eraldamine faili '%s' jaoks ebaõnnestus: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "VIGA: Ei suutnud avada logifaili"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "HOIATUS: logifail on tühi, miskit on kapitaalselt viltu."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Log on nullitud"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serveri teade: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Fail %s jäeti vahele, sest soovitud fail pole uuem."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Ebaõnnestus sõlmede nimekirja tõmbamine."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Ebaõnnestus tõmmatud versiooni kotrollfaili avamine"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Versiooni kontrollfail on korrumpeerunud"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Kasutad aegunud aMule versiooni!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sinu aMule versioon on %i.%i.%i ja uusim versioon on %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "HOAITUS: Sinu aMuled versioon on vananenud: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Sinu aMule koopia on ajakohane."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Versiooni kontrollfaili tõmbamine ebaõnnestus"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kasutajaid: %s | Faile: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kasutajaid: E: %s K: %s | Faile E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ühtegi võrku pole valitud"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "koos LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "koos HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ühendatud %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ühendun %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "eD2k ühendus katkestatud."
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad käivitatud."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad peatatud."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Ühendus Kad võrk (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Ühendus Kad võrku (tulemüüriga)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Ühendus Kad võrguga katkestatud"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad võrku ei saa kasutada kui seadetes on UDP port väljalülitatud, ei ühendu."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad on seadetes väljalülitatud, ei ühenda."
 
@@ -450,124 +544,72 @@ msgstr "Ei suuda luua PID faili"
 msgid "ERROR: %s"
 msgstr "VIGA: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "See on eMulel põhinev aMule %s."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Jookseb %s peal"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Külasta https://github.com/amule-org/amule/releases/latest ja vaata ehk on uuem versioon saadaval."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua stopperit."
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule kaugjuhtimine "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Piiluvaade:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-" eMulel põhinev, platvormist sõltumatu, p2p klient \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Web: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Info puudub"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2019 aMule Meeskond \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Osa aMule põhineb \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Sõlmest-Sõlmeni ruutimine põhineb XOR meetrikal.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (C) 2002-2011 Petar Maymounkov <petar@maymounkov.org>\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Teade"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoog hävitatud"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Ühendun"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ühendun"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Lahutatud"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Tulemüüriga"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Ühendatud"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Ühendun"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Väljas"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -577,176 +619,176 @@ msgstr "Kad: Väljas"
 msgid "Cancel"
 msgstr "Loobu"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Lõpeta käimasolevad ühenduskatsed"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Lõpeta ühendus ühendatud võrkudega"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Ühenda"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Ühendu olemasolevate, aktiivsete võrkudega"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Üles: %.1f(%.1f) | Alla: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Üles: %.1f | Alla: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ühendatud)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ühenduseta)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Kas sa tõesti tahad %s'st väljuda?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Kinnitan väljumise"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Käivitamise korraldus: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- vaikimisi -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Rüüde kataloogi  '%s' ei eksiteeri"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "HOIATUS: Ei suuda rüüfaili '%s' lugemiseks avada"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Otsingud"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Otsingu aken"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Jagatud failid"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Jagatud failide Aken"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Teated"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Teadete Aken"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Statistiliste graafikute aken"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Seaded"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Seadete aken"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Impordi"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Osafailide importimise tööriist"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Info"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Info/Appi"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k võrk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad võrk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Võrk puudub"
 
@@ -786,7 +828,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Võrgu GUI EC sündmuse haldur"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Ühendus ebaõnnestus. Ei suuda määratud ühenduda %s:%d\n"
@@ -934,7 +976,7 @@ msgid "Enter Captcha"
 msgstr "Sisesta inimtesti kontrollkood"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategooria"
 
@@ -1353,7 +1395,7 @@ msgstr "VIGA: IO viga!"
 msgid "ERROR: Failed!"
 msgstr "VIGA: Ebaõnnestus!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Järjekorras"
 
@@ -1985,7 +2027,7 @@ msgstr ""
 "\n"
 "Loon klienti ....\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1994,7 +2036,7 @@ msgstr ""
 "\n"
 "Ok, lahkun %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2008,51 +2050,51 @@ msgstr ""
 "\n"
 "Lahkun...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Näita seda abiteksti."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Masin milles aMule töötab. (vaikimisi: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule välisühenduse port. (vaikimisi: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Välisühenduse parool."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Loen konfiguratsiooni failist."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Ära trüki midagi standardväljudisse."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Ole jutukas - näita ka veajälituse infot."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Määrab programmi keele."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Kirjuta käsurea valikud konfiguratsioonifaili."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Loob konfiguratsioonifaili alusel aMule konfigratsioonifaili."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Näita programmi versiooni."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2368,6 +2410,11 @@ msgstr "Bootstrapil vigane port"
 msgid "Please fill all fields required"
 msgstr "Palun täida kõik nõutud väljad"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Teade"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Oled kindel et tahad tõmmata uut nodes.dat faili?\n"
@@ -2538,7 +2585,7 @@ msgstr "Väline Ühendus: Ligipääs keelatud sest: "
 msgid "External Connection: Handshake failed."
 msgstr "Väline Ühendus: Kätlemine ebaõnnestus."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automaatne värskendamine on käivitatud"
@@ -2845,7 +2892,7 @@ msgstr "Nimi:"
 msgid "Type"
 msgstr "Tüüp"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Kohalik"
 
@@ -2965,7 +3012,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Seiska"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Tõmbamine"
 
@@ -4829,7 +4876,7 @@ msgstr "Eraldamine"
 msgid "Insufficient disk space"
 msgstr "Ebapiisav kettaruum"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Allalaetud"
@@ -5438,7 +5485,7 @@ msgstr "Jagatud failide loetelu taaslaadimine."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Otsingud"
@@ -5459,7 +5506,7 @@ msgstr "Min suurus peab olema väiksem kui max suurus. Ignoreerin Max suurust."
 msgid "Search warning"
 msgstr "Otsingu hoiatus"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Peamine"
 
@@ -5497,37 +5544,37 @@ msgstr "Pole hinnatud"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Tõmba kataloogi"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Lisa selle faili alternatiivsed URL'id"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Otsi seotud faile (eD2k, kohalik server)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Märgi fail tuntuks"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopeeri eD2k link lõikepuhvrisse"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Sa oled serveriga, mida soovid kustutada, ühenduses. Palun katkesta ühendus. Serverit ei kustutatud."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Loobutud"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Uus"
 

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -21,20 +21,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Näita aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule kaugjuhtimine "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Piiluvaade:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -42,27 +42,7 @@ msgstr ""
 " eMulel põhinev, platvormist sõltumatu, p2p klient \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -71,28 +51,40 @@ msgstr ""
 "Copyright (c) 2003-2019 aMule Meeskond \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Osa aMule põhineb \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Sõlmest-Sõlmeni ruutimine põhineb XOR meetrikal.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (C) 2002-2011 Petar Maymounkov <petar@maymounkov.org>\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kontrolli käivitumisel uue versiooni olemasolu"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7889,6 +7881,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Web: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Web: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/eu.po
+++ b/po/eu.po
@@ -66,11 +66,11 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Webgunea:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Foroa:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -22,20 +22,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "aMule erakutsi"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule urruneko kontrola "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Argazkia:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -43,27 +43,7 @@ msgstr ""
 "'Plataforma-orotarako' p2p bezeroa eMulen oinarritua \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Webgunea: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Webgunea: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -72,28 +52,40 @@ msgstr ""
 "Copyright (c) 2003-2019 aMule taldea \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "aMuleren zati bat \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Parez-pareko routing-a XOR metrikan oinarritua.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Arakatu bertsio berrien bila abiaraztean"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7889,6 +7881,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Webgunea: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Webgunea: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -21,6 +21,100 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "aMule erakutsi"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule urruneko kontrola "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Argazkia:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"'Plataforma-orotarako' p2p bezeroa eMulen oinarritua \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Webgunea: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Webgunea: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2019 aMule taldea \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "aMuleren zati bat \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Parez-pareko routing-a XOR metrikan oinarritua.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Arakatu bertsio berrien bila abiaraztean"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Kad-era konektatzen..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Ez dago erabilgarri"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -114,8 +208,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -164,7 +258,7 @@ msgstr "aMule ixtearen memoria arazte irteera:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Zure lokalak sistemako lehenetsira aldatu dira konfigurazio aldaketa bat dela eta. Barkatu."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -187,47 +281,47 @@ msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 msgid "WARNING"
 msgstr "OHARRA"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sareak"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "zerbitzari %i aurkiturik server.met fitxategian"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ezin da atakak ezarritako helbidean ireki: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "%u ataka ez dago eskuragarri. IDBaxua izango duzu\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -242,48 +336,48 @@ msgstr ""
 "\n"
 "Egiaztatu zure sarea ataka sarrera eta irteerarako irekirik dagoela ziurtatzeko."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Huts online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Huts aMule online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Aukeratutako lokalak ez dirudi zure sisteman instalaturik. (Oharra: Hala ere erabiltzen saiatuko da)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule %s abiarazten duzun lehen aldia da"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bertsioa hau beta bertsio bat da, egunero eguneratzen da, eta\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ez gara ezer apurtu, zure etxea erre, edo zure zakurra akatzen\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "badu ere kargu egingo. Baina erabiltzeko ziurra izan *beharko* litzateke.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Argibide gehiago, laguntza eta bertsio berriak gure webgunean aurki ditzakezu,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io -en, edo irc.libera.chat IRC sareko #aMule kanalean.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Edozein akatsen berri emateko:https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -291,137 +385,137 @@ msgstr ""
 "Zuk aukeratutako sinadura karpeta BALIOGABEA da!\n"
 " Lehenespenak konpondu artean lineako sinadura EZGAITU egingo da."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Zerbitzari ostalari-izena notifikatua"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Disko aurresleipenak huts egin du '%s' fitxategiarentzat: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ERROREA: ezin da erregistro fitxategia ireki"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ABISUA: erregistro fitxategia hutsik dago. Zerbait oker dago."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Erregistroa berrezarri egin da"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ZerbitzariMezua: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s-ren deskarga baztertua, eskatutako fitxategia ez da berria eta."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Huts egin du nodo zerrenda deskargatzerakoan."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Hondaturiko bertsio arakatze fitxategia"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Zure aMule bertsioa %i.%i.%i da eta azken bertsioa %li.%li.%li da"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OHARRA: Zure aMuled bertsioa zaharkiturik dago: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Zure aMule kopia zaharkiturik dago."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Huts bertsio arakatze fitxategia deskargatzerakoan"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Erab: %s | Fitx: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Erab: E: %s K: %s | Fitx: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ez dago sarerik hautatuta"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "IDBaxuarekin"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "IDAltuarekin"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s-ra konektaturik"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s-ra konektatzen"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "eD2k-tik deskonektatua"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad abiarazirik."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad gelditurik."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Kad-era Konektatuta (ondo)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad-era Konektatuta (suebakirik)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Kad-etik deskonektatua"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad sarea ezin da erabili hobespenetan UDP ataka ezgaiturik badago, ez da abiaraziko."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad sarea hobespenetan ezgaiturik, ez da konektatuko."
 
@@ -451,124 +545,72 @@ msgstr "Ezin da Pid fitxategia sortu"
 msgid "ERROR: %s"
 msgstr "ERROREA: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Hau eMulen oinarrituriko aMule %s da."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "%s-n abiarazirik"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bisitatu https://github.com/amule-org/amule/releases/latest gunea bertsio berriagorik eskuragarri dagoen jakiteko."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE KONPONEZINA: Huts kronometroa sortzean"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule urruneko kontrola "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Argazkia:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"'Plataforma-orotarako' p2p bezeroa eMulen oinarritua \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Webgunea: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Webgunea: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Ez dago erabilgarri"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2019 aMule taldea \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "aMuleren zati bat \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Parez-pareko routing-a XOR metrikan oinarritua.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Mezua"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMule elkarrizketa suntsitua"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Konektatzen"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Konektatzen"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deskonektatua"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Suebakirik"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Konektaturik"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Konektatzen"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Itzalia"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -578,176 +620,176 @@ msgstr "Kad: Itzalia"
 msgid "Cancel"
 msgstr "Utzi"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Geratu uneko konexio saiakerak"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Deskonektatu konektatutako sareetatik"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Konektatu"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Konektatu gaituriko sareetara"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gora: %.1f(%.1f) | Behera: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gora: %.1f | Behera: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Konektaturik)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ez konektaturik)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Benetan %s utzi egin nahi duzu?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Irteera berrespena"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Abiarazi komandoa: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- lehenetsia -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ez dago '%s' itxura direktorioa"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ABISUA: Ezin da '%s' azal fitxategia irakurri"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Sareak"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Sare leihoa"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Bilaketak"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Bilaketa leihoa"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Deskargak"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Deskargak leihoa"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Partekatutako fitxategiak"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Partekatutako fitxategi leihoa"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Mezuak"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Mezu leihoa"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estatistikak"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Estatistika grafiko leihoa"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Hobespenak"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Hobespen ezarpen leihoa"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Inportatu"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Zati fitxategi inportazio tresna"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Honi buruz"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Honi buruz/Laguntza"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k sarea"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad sarea"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Sarerik ez"
 
@@ -787,7 +829,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Urruneko interfaze KK gertaera kudeatzailea"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Konexioak huts egin du. Ezin da %s-ra konektatu:%d\n"
@@ -935,7 +977,7 @@ msgid "Enter Captcha"
 msgstr "Idatzi kaptxa"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategoria"
 
@@ -1354,7 +1396,7 @@ msgstr "ERROREA: SI errorea!"
 msgid "ERROR: Failed!"
 msgstr "ERROREA: Huts egin du!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Ilaran"
 
@@ -1986,7 +2028,7 @@ msgstr ""
 "\n"
 "Bezeroa sortzen...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1995,7 +2037,7 @@ msgstr ""
 "\n"
 "Ados, %s uzten...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2009,51 +2051,51 @@ msgstr ""
 "\n"
 "Irteten...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Laguntza testu hau bistarazi."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "aMule abiarazirik duen ostalaria. (lehenetsia: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Kanpo konexioetarako aMuleren ataka. (Lehenetsia 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Kanpo konexio pasahitza."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Konfigurazio fitxategitik irakurri."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Ez ezer bistarazi irteera estandarrean."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Luze - arazten mezuak ere bistarazi."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Programa lokala (hizkuntza) ezarri."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Idatzi komando lerroko aukerak konfigurazio fitxategira."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "aMuleren konfigurazio fitxategian oinarriturik konfigurazio fitxategia sortzen du."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Programa bertsioa bistarazi."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2369,6 +2411,11 @@ msgstr "Abiarazteko ataka baliogabea"
 msgid "Please fill all fields required"
 msgstr "Beharrezko eremu guztiak bete"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Mezua"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Ziur zaude nodes.dat fitxategi berri bat deskargatu nahi duzula?\n"
@@ -2539,7 +2586,7 @@ msgstr "Kanpo konexioa: Sarrera ukatze arrazoia: "
 msgid "External Connection: Handshake failed."
 msgstr "Kanpo Konexioa: Esku-emateak huts egin du."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP deskarga haria hasia"
@@ -2846,7 +2893,7 @@ msgstr "Izena:"
 msgid "Type"
 msgstr "Mota"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Lokala"
 
@@ -2966,7 +3013,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Gelditu"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Deskargatu"
 
@@ -4829,7 +4876,7 @@ msgstr "Esleitzen"
 msgid "Insufficient disk space"
 msgstr "Disko leku askieza"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Deskargatua"
@@ -5437,7 +5484,7 @@ msgstr "Partekatutako fitxategi zerrenda birkargatu."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Bilaketak"
@@ -5458,7 +5505,7 @@ msgstr "Gutxienezko tamaina gehienezkoa baino txikiagoa izan behar da. Gehienezk
 msgid "Search warning"
 msgstr "Bilaketa oharra"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Nagusia"
 
@@ -5496,37 +5543,37 @@ msgstr "Kalifikatu gabea"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Kategori honetan deskargatu"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Eskuratu %s fitxategi honentzat"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Bilatu erlazionatutako fitxategiak (eD2k, zerbitzari lokala)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Markatu fitxategia ezaguna bezala"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiatu ed2k lotura arbelera"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Konektaturik zauden zerbitzaria ezabatu nahi duzu. Mesedez deskonektatu lehenik."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Utzia"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Berria"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -21,6 +21,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Näytä aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule etähallinta "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Tilannevedos:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"'Kaikkien alustojen' p2p-asiakas perustuen eMuleen\n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Verkkosivu: https://amule-org.github.io\n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Verkkosivu: https://amule-org.github.io\n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Tekijänoikeudet (c) 2003-2019 aMule-Tiimi\n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Osa aMulesta perustuu\n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademliaan: Vertaisreititys perustuen XOR-metriikkaan.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Tekijänoikeudet (c) 2002-2008 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Tarkista uuden version saatavuus käynnistettäessä"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Yhdistetään Kadiin..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Käytät vanhentunutta versiota aMulesta!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Ei saatavissa"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -114,8 +208,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -164,7 +258,7 @@ msgstr "Muistin virheiden etsinnän tulokset aMulen sulkeutuessa:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Maa-asetuksesi vaihdettiin järjestelmän oletuksiksi asetusmuutoksen takia. Pahoittelen."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -187,47 +281,47 @@ msgstr "Salasana asetettu ja etäyhteydet sallittu."
 msgid "WARNING"
 msgstr "VAROITUS"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Verkot"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i palvelin tiedostossa server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei voitu sitoa portteja annettuun osoitteeseen: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portti %u ei ole saatavilla. Sinulle annetaan LowID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -242,48 +336,48 @@ msgstr ""
 "\n"
 "Tarkista yhteytesi varmistaaksesi että portti on avoinna sekä ulos että sisään."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMulen Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Valittu maa-asetus ei näytä olevan asennettuna järjestelmääsi. (Huom: Yritän asettaa sen kuitenkin)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Tämä on ensimmäinen kerta kun käynnistät aMulen version %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Tämä versio on testiversio jota päivitetään päivittäin,\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "emmekä me anna takuuta ettei se riko mitään, polta taloasi,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "tai tapa koiraasi. Mutta sen *pitäisi* olla silti turvallinen käyttää.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Lisätietoa, tukea ja uudet julkaisut löytyvät kotisivuiltamme osoitteessa\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io tai IRC-kanavaltamme #aMule palvelimella irc.libera.chat (englanniksi).\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Voit vapaasti raportoida bugeista osoitteessa https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -291,137 +385,137 @@ msgstr ""
 "Online-Signeeraukselle asettamasi kansio ei ole kelvollinen!\n"
 " Online-Signeeraus kytketään pois päältä kunnes korjaat asian asetuksista."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Palvelimen verkkonimi ilmoitettu"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Levytilan esivaraus tiedostolle '%s' epäonnistui: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "VIRHE: Lokitiedostoa ei voida avata"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROITUS: Lokitiedosto on tyhjä. Jotain on pielessä."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Loki nollattiin"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Palvelimen viesti: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Hypättiin yli latauksesta %s, koska pyydetty tiedosto ei ole uudempi."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Yhteyspisteiden listan lataus epäonnistui."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Ladatun versiotarkistustiedoston avaus epäonnistui"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Turmeltunut versiotarkistustiedosto"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Käytät vanhentunutta versiota aMulesta!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Tämän aMulen versio on %i.%i.%i ja uusin versio on %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROITUS: aMulesi versio on vanhentunut: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "aMulesi on uusinta versiota."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Versiotarkistustiedoston lataus epäonnistui"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Käyttäjiä: %s | Tiedostoja: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Käyttäjiä: E: %s K: %s | Tiedostoja: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ei valittuja verkkoja"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID:llä"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID:llä"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Yhdistetty %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Yhdistän %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Käynnistettiin Kad."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Pysäytettiin Kad."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Yhdistetty Kadiin (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Yhdistetty Kadiin (palomuurattu)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Yhteys Kadiin katkaistu"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-verkkoa ei voida käyttää mikäli UDP-portti on estetty asetuksissa, ei käynnistetä."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-verkko estetty asetuksissa, ei yhdistetä."
 
@@ -451,124 +545,72 @@ msgstr "Ei voitu luoda prosessinumerotiedostoa"
 msgid "ERROR: %s"
 msgstr "VIRHE: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Tämä on aMule %s ja pohjautuu eMuleen."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Käynnissä %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vieraile nettisivulla https://github.com/amule-org/amule/releases/latest tarkistaaksi uuden version saatavuuden."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRIITTINEN VIRHE: Ajastimen luominen epäonnistui"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule etähallinta "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Tilannevedos:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"'Kaikkien alustojen' p2p-asiakas perustuen eMuleen\n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Verkkosivu: https://amule-org.github.io\n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Verkkosivu: https://amule-org.github.io\n"
+msgid "New version available"
+msgstr "Ei saatavissa"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Tekijänoikeudet (c) 2003-2019 aMule-Tiimi\n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Osa aMulesta perustuu\n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademliaan: Vertaisreititys perustuen XOR-metriikkaan.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Tekijänoikeudet (c) 2002-2008 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Viesti"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMulen dialogi tuhottu"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Yhdistetään"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Yhdistetään"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Ei yhdistetty"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Palomuurattu"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Yhdistety"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Yhdistetään"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Pois päältä"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -578,176 +620,176 @@ msgstr "Kad: Pois päältä"
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Pysäytä nykyiset yhteysyritykset"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Katkaise yhteys yhdistettyihin verkkoihin"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Yhdistä"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Yhdistä sallittuihin verkkoihin"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Ylös: %.1f(%.1f) | Alas: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Ylös: %.1f | Alas: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Yhdistetty)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ei yhdistetty)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Haluatko varmasti sulkea %sn?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Lopettamisen varmistus"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Suorita komento: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- oletus -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Teemakansiota '%s' ei ole olemassa"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROITUS: Ei voida avata teematiedostoa '%s' luettavaksi"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Verkot"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Verkkoikkuna"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Haut"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Hakujen ikkuna"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Lataukset"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Latausten ikkuna"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Jaetut tiedostot"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Jaettujen tiedostojen ikkuna"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Viestit"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Viestien ikkuna"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Tilastot"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Tilastokuvaajien ikkuna"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Asetukset"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Asetuksien säätöikkuna"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Tuonti"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Osatiedostojen tuontityökalu"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tietoja"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Tietoja/Ohje"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k-verkko"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad-verkko"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Ei verkkoa"
 
@@ -787,7 +829,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Graafisen etäkäyttöliittymän tapahtumakäsittelijä"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Yhdistäminen epäonnistui. Ei saatu yhteyttä %s:%d\n"
@@ -935,7 +977,7 @@ msgid "Enter Captcha"
 msgstr "Syötä kuvavarmennus"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Luokittelu"
 
@@ -1354,7 +1396,7 @@ msgstr "VIRHE: IO-virhe!"
 msgid "ERROR: Failed!"
 msgstr "VIRHE: Epäonnistui!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Jonossa"
 
@@ -1986,7 +2028,7 @@ msgstr ""
 "\n"
 "Luon asiakasta...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1995,7 +2037,7 @@ msgstr ""
 "\n"
 "Ok, suljen %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2009,51 +2051,51 @@ msgstr ""
 "\n"
 "Suljen...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Näytä tämä ohje."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Verkkonimi koneelle jossa aMule on käynnissä. (oletus: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMulen portti etäyhteydelle. (oletus: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Etäyhteyden salasana."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Lue asetukset tiedostosta."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Älä tulosta mitään stdout:iin."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Ole monisanainen - näytä myös virheenetsintäviestit."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Asettaa ohjelman maa-asetukset (kielen)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Kirjoita komentoriviparametrit asetustiedostoon."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Luo asetustiedoston perustuen aMulen asetustiedostoon."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Näyttää ohjelman version."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2369,6 +2411,11 @@ msgstr "Portti ei kelpaa yhdistämisavuksi"
 msgid "Please fill all fields required"
 msgstr "Ole hyvä ja täytä kaikki vaaditut kentät"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Viesti"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Oletko varma että haluat ladata uuden nodes.dat-tiedoston?\n"
@@ -2539,7 +2586,7 @@ msgstr "Etäyhteys: Pääsy evättiin: "
 msgid "External Connection: Handshake failed."
 msgstr "Etäyhteys: Kättely epäonnistui"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP-lataussäie käynnistetty"
@@ -2846,7 +2893,7 @@ msgstr "Nimi:"
 msgid "Type"
 msgstr "Tyyppi"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Paikallinen"
 
@@ -2966,7 +3013,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Pysäytä"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Lataa"
 
@@ -4829,7 +4876,7 @@ msgstr "Allokoidaan"
 msgid "Insufficient disk space"
 msgstr "Riittämätön levytila"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Ladattu"
@@ -5437,7 +5484,7 @@ msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Haut"
@@ -5458,7 +5505,7 @@ msgstr "Vähimmäiskoon pitää olla pienempi kuin enimmäiskoon. Enimmäiskokoa
 msgid "Search warning"
 msgstr "Hakuvaroitus"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Kaikki"
 
@@ -5496,37 +5543,37 @@ msgstr "Ei luokitusta"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Lataa luokassa"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Hanki %s tälle tiedostolle"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Hae tähän liittyviä tiedostoja (eD2k, paikallinen palvelin)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Merkitse tunnetuksi tiedostoksi"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopioi eD2k-linkki leikepöydälle"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Olet yhdistettynä palvelimeen jota yrität poistaa, katkaise yhteys ensin."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Peruutettu"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Uusi"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -22,20 +22,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Näytä aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule etähallinta "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Tilannevedos:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -43,27 +43,7 @@ msgstr ""
 "'Kaikkien alustojen' p2p-asiakas perustuen eMuleen\n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Verkkosivu: https://amule-org.github.io\n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Verkkosivu: https://amule-org.github.io\n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -72,28 +52,40 @@ msgstr ""
 "Tekijänoikeudet (c) 2003-2019 aMule-Tiimi\n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Osa aMulesta perustuu\n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademliaan: Vertaisreititys perustuen XOR-metriikkaan.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Tekijänoikeudet (c) 2002-2008 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Tarkista uuden version saatavuus käynnistettäessä"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7889,6 +7881,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Verkkosivu: https://amule-org.github.io\n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Verkkosivu: https://amule-org.github.io\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/fi.po
+++ b/po/fi.po
@@ -66,11 +66,11 @@ msgstr " Tekijänoikeudet (c) 2002-2008 Petar Maymounkov ( petar@maymounkov.org 
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Verkkosivu:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Foorumi:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -25,6 +25,99 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Poedit 3.9\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Afficher aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Contrôle à distance d'aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot :"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Client P2P multiplateforme basé sur eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Site web : https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum : https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Documentation : https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"Bugs : https://github.com/amule-org/amule/issues \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 L'équipe aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Une partie d'aMule est basée sur \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia : Routage peer-to-peer basé sur la métrique XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Vérifier les nouvelles versions au démarrage"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Connexion à Kad…"
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Vous utilisez une version obsolète d'aMule !"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Non disponible"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -124,8 +217,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossible d'ajouter %u lien depuis le fichier ED2KLinks (cf. le journal pour les détails)."
 msgstr[1] "Impossible d'ajouter %u liens depuis le fichier ED2KLinks (cf. le journal pour les détails)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -174,7 +267,7 @@ msgstr "Résultats du débogage de la mémoire pour la sortie d'aMule :"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Votre localisation a été remise à la valeur par défaut à cause d'un changement dans la configuration. Désolé."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -198,11 +291,11 @@ msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "Amorçage de réseau"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -210,34 +303,34 @@ msgstr ""
 "aMule a détecté des fichiers d'amorçage de réseau manquants.\n"
 "Sélectionnez ceux à télécharger :"
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "Liste de serveurs eD2k (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nœuds d'amorçage Kad (nodes.dat)"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serveur web s'exécutant avec le pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossible de lier les ports à l'adresse spécifiée : %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Le port %u n'est pas disponible. Vous serez LowID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -252,48 +345,48 @@ msgstr ""
 "\n"
 "Vérifiez votre réseau pour être sûr que le port est ouvert en sortie et en entrée."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Échec de la création du fichier OnlineSig"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Échec de la création du fichier aMule OnlineSig"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La localisation choisie semble ne pas être installée sur votre machine. (Note : Je tente de la forcer quand même)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "C'est la première fois que vous lancez aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Cette version est une version de test, mise à jour quotidiennement, et\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nous ne fournissons aucune garantie que cela n'endommagera rien, brûlera votre maison,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou tuera votre chien. Mais ça *devrait* être à peu près sûr quand-même.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plus d'informations, de l'aide et de nouvelles versions peuvent être trouvées sur notre page web,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, ou sur notre canal IRC : #aMule sur irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Ne vous gênez pas pour reporter tout bogue sur https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -301,137 +394,137 @@ msgstr ""
 "Le répertoire choisi pour les fichiers de signature en ligne est INVALIDE !\n"
 "La signature en ligne sera DÉSACTIVÉE jusqu'à ce que cela soit corrigé dans les préférences."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Nom du serveur signalé"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Erreur lors de la réserve d'espace pour le fichier '%s' : %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ERREUR : impossible d'ouvrir le fichier journal"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVERTISSEMENT : le fichier journal est vide. Quelque chose ne va pas."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Le journal a été effacé"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerMessage : %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saut du téléchargement de %s, car le fichier demandé n'est pas récent."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Échec du téléchargement de la liste des nœuds."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Échec de l'ouverture du fichier de vérification de version téléchargé"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Fichier de vérification de version corrompu"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Vous utilisez une version obsolète d'aMule !"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Votre version d'aMule est %i.%i.%i et la dernière version est %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La dernière version peut toujours être trouvée sur https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVERTISSEMENT : votre version d'aMuled est obsolète : %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Votre version d'aMule est à jour."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Échec du téléchargement du fichier de vérification de version"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilisateurs : %s | Fichiers : %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilisateurs : E : %s K : %s | Fichiers : E : %s K : %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Aucun réseau sélectionné"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "avec un LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "avec un HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connecté à %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connexion à %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Déconnecté de eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad démarré."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad arrêté."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Connecté à Kad (OK)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Connecté à Kad (pare-feu)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Déconnecté de Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Le réseau Kad ne peut être utilisé si le port UDP est désactivé dans les préférences, pas de démarrage."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Le réseau Kad est désactivé dans les préférences, pas de connexion."
 
@@ -460,123 +553,72 @@ msgstr "Impossible de créer le fichier Pid"
 msgid "ERROR: %s"
 msgstr "Erreur : %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ceci est aMule %s basé sur eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Tourne sur %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visitez https://github.com/amule-org/amule/releases/latest pour vérifier si une nouvelle version est disponible."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERREUR FATALE : Échec de la création du minuteur"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Contrôle à distance d'aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot :"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Client P2P multiplateforme basé sur eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "La dernière version peut toujours être trouvée sur https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Site web : https://amule-org.github.io \n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "Non disponible"
 
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum : https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentation : https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Bugs : https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 L'équipe aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Une partie d'aMule est basée sur \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia : Routage peer-to-peer basé sur la métrique XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Message"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "boîte de dialogue aMule détruite"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Connexion en cours"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k : Connexion en cours"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k : Déconnecté"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad : Derrière un pare-feu"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad : Connecté"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad : Connexion en cours"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad : Coupé"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -586,175 +628,175 @@ msgstr "Kad : Coupé"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Stopper les essais de connexions en cours"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Se déconnecter des réseaux actuellement connectés"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Se connecter"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Se connecter aux réseaux actuellement activés"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "E : %.1f%s (%.1f) | R : %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " Mo/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " Ko/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "E : %.1f%s | R : %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connecté)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Déconnecté)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Voulez-vous vraiment quitter %s ?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Confirmation de sortie"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Commande de lancement : "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- défaut -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Le répertoire de thèmes '%s' n'existe pas"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVERTISSEMENT : Impossible d'ouvrir le fichier thème '%s' pour la lecture"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Réseaux"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Fenêtre des réseaux"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Recherches"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Fenêtre de Recherche"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Téléchargements"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Fenêtre des Téléchargements"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Fichiers partagés"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Fenêtre des Fichiers Partagés"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Messages"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Fenêtre des Messages"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Fenêtre des Statistiques"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Fenêtre des Préférences"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importer"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "L'outil d'importation de fichier .part"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "À propos"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "À propos/Aide"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Réseau eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Réseau Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Pas de réseau"
 
@@ -794,7 +836,7 @@ msgstr "Échec de la connexion. Veuillez vérifier l'hôte, le port et le mot de
 msgid "Remote GUI EC event handler"
 msgstr "Gestionnaire d'événement GUI EC distant"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Connexion échouée. Impossible de se connecter à %s : %d\n"
@@ -944,7 +986,7 @@ msgid "Enter Captcha"
 msgstr "Entrer le Captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Catégorie"
 
@@ -1362,7 +1404,7 @@ msgstr "ERREUR : Erreur E/S !"
 msgid "ERROR: Failed!"
 msgstr "ERREUR : Échec !"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Mis en file d'attente"
 
@@ -1992,7 +2034,7 @@ msgstr ""
 "\n"
 "Création du client en cours…\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2001,7 +2043,7 @@ msgstr ""
 "\n"
 "OK, fin de %s…\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2015,51 +2057,51 @@ msgstr ""
 "\n"
 "Fin d'exécution…\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Montre ce texte d'aide."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Hôte où aMule tourne. (défaut : 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Port d'aMule pour les connexions externes. (par défaut : 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Mot de passe pour les connexions externes."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Configuration lue depuis le fichier."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Ne pas afficher de sortie sur stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Mode bavard - montre aussi les messages de débogage."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Change la localisation du programme (langue)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Écrit les options de la ligne de commande dans le fichier de configuration."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Créé le fichier de configuration à partir du fichier de configuration d'aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Affiche la version du programme."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Forcer la compression ZLIB quelle que soit l'adresse IP de destination (utile lorsque le serveur est accessible via un tunnel VPN qui se résout en une adresse IP du réseau local)."
 
@@ -2374,6 +2416,11 @@ msgstr "Port invalide pour l'amorçage"
 msgid "Please fill all fields required"
 msgstr "Veuillez remplir tous les champs requis"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Message"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Êtes-vous sûr de vouloir télécharger un nouveau fichier nodes.dat?\n"
@@ -2543,7 +2590,7 @@ msgstr "Connexion externe : accès refusé car : "
 msgid "External Connection: Handshake failed."
 msgstr "Connexion externe : Échange raté."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Processus ASIO %d démarré"
@@ -2843,7 +2890,7 @@ msgstr "Nom :"
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Local"
 
@@ -2963,7 +3010,7 @@ msgstr "Demande aux pairs Kad ayant déjà répondu d'élargir la recherche. Cha
 msgid "Stop"
 msgstr "Arrêter"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Réception"
 
@@ -4833,7 +4880,7 @@ msgstr "En cours d'allocation"
 msgid "Insufficient disk space"
 msgstr "Espace disque insuffisant"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Téléchargé"
@@ -5436,7 +5483,7 @@ msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Lorsque eD2k et Kademlia sont désactivés tous les deux, il est impossible d'effectuer une recherche."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Erreur de recherche"
 
@@ -5456,7 +5503,7 @@ msgstr "La taille minimum doit être inférieur à la taille maximum. Taille max
 msgid "Search warning"
 msgstr "Avertissement dans la recherche"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principal"
 
@@ -5492,36 +5539,36 @@ msgstr "Débit binaire"
 msgid "Codec"
 msgstr "Codec"
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Télécharger dans la catégorie"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obtenir %s pour ce fichier"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Chercher les fichiers liés (eD2k, serveur local)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Marquer comme fichier connu"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copier le lien eD2k dans le presse-papiers"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Vous n'êtes actuellement pas connecté à un serveur prenant en charge la fonction de recherche de fichiers associés"
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Annulé"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Nouveau"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -26,20 +26,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Poedit 3.9\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Afficher aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Contrôle à distance d'aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot :"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -47,27 +47,7 @@ msgstr ""
 "Client P2P multiplateforme basé sur eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Site web : https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum : https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentation : https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Bugs : https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -75,28 +55,40 @@ msgstr ""
 "Copyright (c) 2003-2026 L'équipe aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Une partie d'aMule est basée sur \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia : Routage peer-to-peer basé sur la métrique XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Vérifier les nouvelles versions au démarrage"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7901,6 +7893,25 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Site web : https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum : https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Documentation : https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "Bugs : https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/fr.po
+++ b/po/fr.po
@@ -69,19 +69,19 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Site web :"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forum :"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
-msgstr ""
+msgstr "Documentation :"
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"
-msgstr ""
+msgstr "Bugs :"
 
 #: src/AboutDialog.cpp:107
 #, fuzzy

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -34,6 +34,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.6\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Mostrar aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "control remoto de aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Instantánea:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Cliente «Multi-Plataforma» p2p baseado no eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Páxina web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Páxina web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Parte do aMule está baseado en \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Encamiñamento entre pares baseado na métrica XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Comprobar se hai unha nova versión ao iniciar"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Conectando a Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Está usando unha versión de aMule desactualizada!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Non dispoñible"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -133,8 +227,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Non se puido engadir a ligazón %u do ficheiro ED2KLinks (consulte o rexistro)."
 msgstr[1] "Non se puideron engadir as ligazóns %u do ficheiro ED2KLinks (consulte o rexistro)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -183,7 +277,7 @@ msgstr "Resultados da depuración da memoria ao sair de aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O idioma cambiouse ao predeterminado do sistema debido a un troco na configuración."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -206,11 +300,11 @@ msgstr "Establecido o contrasinal e habilitadas conexións externas."
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "Arranque da rede"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -218,35 +312,35 @@ msgstr ""
 "aMule detectou que faltan ficheiros necesarios para arrancar a rede.\n"
 "Escolla os que queira descargar:"
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de inicio de Kad (nodes.dat)"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se puideron vincular os portos á dirección especificada: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u non está dispoñible . Terá IDBAIXA\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -261,48 +355,48 @@ msgstr ""
 "\n"
 "Comprobe a súa rede para asegurarse de que o porto está aberto para a entrada e saída."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig de aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado semella non estar instalado. (Nota: Intentarase usalo a pesar diso)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que iniciou aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta versión é unha versión en proba, actualizada diariamente, e\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non lle aseguramos que non se rompa algo, lle prenda lume a súa casa,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou mate ao seu can. Pero non debería pasar nada.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Pode atopar máis información, axuda e novas actualizacións na nosa páxina,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, ou na nosa canle IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Pode avisar de calquera problema en https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -310,137 +404,137 @@ msgstr ""
 "O cartafol que especificou para as Sinaturas En Liña non é válido!\n"
 "A Sinatura En Liña permanecerá desactivada ata que se arranxe a configuración."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Nome do servidor avisado"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Fallou a reserva do espazo no disco duro para o ficheiro «%s»: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: non se pode abrir o ficheiro do rexistro"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de rexistro está baleiro. Algo está mal."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "O rexistro foi borrado"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaxe do servidor: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saltouse a descarga de %s, por que o ficheiro pedido é máis antigo."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Non se puido descargar a lista de nodos."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Non se puido abrir o ficheiro de comprobación da versión descargado"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Ficheiro de comprobación da versión corrupto"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Está usando unha versión de aMule desactualizada!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A súa versión de aMule é %i.%i.%i e a última versión é %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A súa versión de aMule está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "A súa copia de aMule está actualizada."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Non se puido descargar o ficheiro de comprobación de versión"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Sen redes seleccionadas"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con IDBaixa"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Desconectouse do eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Iniciado Kad."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Parado Kad."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (devasa)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Non se pode usar a rede Kad se o porto UDP está desactivado nas preferencias. Non se iniciou."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desactivada nas preferencias. Non se iniciou."
 
@@ -469,124 +563,72 @@ msgstr "Non se puido crear o ficheiro Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é aMule %s baseado en eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Executando en %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para obter actualizacións."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO GRAVE: Non se puido crear o temporizador"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "control remoto de aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Instantánea:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Cliente «Multi-Plataforma» p2p baseado no eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Páxina web: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Páxina web: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Non dispoñible"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Parte do aMule está baseado en \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Encamiñamento entre pares baseado na métrica XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Mensaxe"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Destruído o cadro de diálogo de aMule"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Tras devasa"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Apagado"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -596,175 +638,175 @@ msgstr "Kad: Apagado"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Deter a tentativa actual de conexión"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes conectadas"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar ás redes activas"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Enviado: %.1f%s (%.1f) | Descargado: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Enviado: %.1f%s | Descargado: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Desexar saír de %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Confirmación da saída"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Ordes de Arranque: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- por omisión -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Non existe o directorio de temas «%s»"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Non se puido abrir o ficheiro de temas «%s» en modo lectura"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Xanela de Redes"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Buscas"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Xanela de buscas"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Xanela de descargas"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Xanela de ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Xanela de mensaxes"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Xanela de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Xanela de Preferencias"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "A ferramenta para importar ficheiros «part»"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Sobre/Axuda"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Sen rede"
 
@@ -804,7 +846,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Interface para a manipulación de eventos CE remotos"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Fallou a conexión. Non se puido conectar a %s:%d\n"
@@ -954,7 +996,7 @@ msgid "Enter Captcha"
 msgstr "Introduza o Captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categoría"
 
@@ -1372,7 +1414,7 @@ msgstr "ERRO: Erro de E/S!"
 msgid "ERROR: Failed!"
 msgstr "ERRO: Non se puido realizar a acción!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "En cola"
 
@@ -2002,7 +2044,7 @@ msgstr ""
 "\n"
 "Creando cliente...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2011,7 +2053,7 @@ msgstr ""
 "\n"
 "Vale, saíndo de %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2025,51 +2067,51 @@ msgstr ""
 "\n"
 "Saíndo...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Amosar este texto de axuda."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Anfitrión onde se está executando aMule. (por omisión: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porto de aMule para conexión externa. (por omisión: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Contrasinal para conexión externa."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Ler configuración do ficheiro."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Non imprimir nada á saída normativizada (stdout)."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Explanarse - mostrar ademais as mensaxes de depuración."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Establecer o idioma do programa."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Escribir opcións da liña de ordes ao ficheiro de configuración."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Crea un ficheiro de configuración baseándose no ficheiro de configuración de aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Amosar versión de programa."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2384,6 +2426,11 @@ msgstr "Porto inválido para o arranque"
 msgid "Please fill all fields required"
 msgstr "Enche todos os campos requiridos"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Mensaxe"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Quere descargar un ficheiro nodes.dat novo?\n"
@@ -2554,7 +2601,7 @@ msgstr "Conexión externa: Acceso denegado debido a: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: Fallou o saúdo."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Fío de E/S asíncrono %d iniciado"
@@ -2854,7 +2901,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Local"
 
@@ -2974,7 +3021,7 @@ msgstr "Solicitar que os clientes Kad contactados estendan a busca. Cada pulsaci
 msgid "Stop"
 msgstr "Deter"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Descargar"
 
@@ -4836,7 +4883,7 @@ msgstr "Reservando"
 msgid "Insufficient disk space"
 msgstr "Espazo no disco insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descargado"
@@ -5441,7 +5488,7 @@ msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Non se pode buscar se tanto eD2k coma Kademlia están desactivados."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Erro na busca"
 
@@ -5461,7 +5508,7 @@ msgstr "O tamaño mínimo debe ser máis pequeno que o máximo. Tamaño máximo 
 msgid "Search warning"
 msgstr "Aviso na busca"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principal"
 
@@ -5498,37 +5545,37 @@ msgstr "Non evaluada"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Descargar na categoría"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obter %s para este ficheiro"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Procurar ficheiros relacionados (eD2k, busca local)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Marcar o ficheiro como coñecido"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar a ligazón eD2k ó portapapeis"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Está conectado ao servidor que tenta borrar. Por favor desconéctese primeiro."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Cancelado"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Novo"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -79,11 +79,11 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Páxina web:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Foro:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -35,20 +35,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.6\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "control remoto de aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Instantánea:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -56,27 +56,7 @@ msgstr ""
 "Cliente «Multi-Plataforma» p2p baseado no eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Páxina web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Páxina web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -85,28 +65,40 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Parte do aMule está baseado en \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Encamiñamento entre pares baseado na métrica XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprobar se hai unha nova versión ao iniciar"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7906,6 +7898,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Páxina web: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Páxina web: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -21,46 +21,26 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "אודות wxCas"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "אימיול שלט רחוק"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "צילום:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tעבור מידע נוסף פנה ל https://amule-org.github.io/docs"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -69,27 +49,39 @@ msgstr ""
 "זכוייות יוצרים (C) 2003-2019 צוות אימיול \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "קאדימליה: תקשורת עמית לעמית מנותבת המבוסס על ה XOR המטרי.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7876,6 +7868,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "\tעבור מידע נוסף פנה ל https://amule-org.github.io/docs"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
 
 #, fuzzy
 #~ msgid "Not found"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -20,6 +20,96 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "אודות wxCas"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "אימיול שלט רחוק"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "צילום:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "\tעבור מידע נוסף פנה ל https://amule-org.github.io/docs"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"זכוייות יוצרים (C) 2003-2019 צוות אימיול \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "קאדימליה: תקשורת עמית לעמית מנותבת המבוסס על ה XOR המטרי.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+msgid "Click to check for a newer version."
+msgstr ""
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "מתחבר לקאד..."
+
+#: src/AboutDialog.cpp:160
+msgid "You are running the latest version."
+msgstr ""
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "לא זמין"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -112,8 +202,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -164,7 +254,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -187,45 +277,45 @@ msgstr "גישה חיצונית חדשה התקבלה"
 msgid "WARNING"
 msgstr "אזהרה"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "רשתות"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -235,185 +325,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "שם שרת:"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "שגיאה: לא יכול לפתוח קובץ יומן."
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "היומן אופס."
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "עם מ\"ז נמוך (LowID)"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "עם מ\"ז גבוהה (HighID)"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "קאד התחיל."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "קאד נעצר."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "קאד מחובר (בסדר)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "קאד מחובר (מאחורי חומת אש)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "מנותק מקאד."
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "אי אפשר להשתמש ברשת הקאד אם מוואת UDP מבוטלת בהעדפות, לא התחיל."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "קאד מבוטל בהעדפות, לא מתחבר."
 
@@ -442,122 +532,72 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "אירעה שגיאה: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "זהו אֵימיול %s המבוסס על אִמיול"
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "פועל על %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "בקר ב https://github.com/amule-org/amule/releases/latest כדי לבדוק האם ישנה גירסה חדישה זמינה."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "אימיול שלט רחוק"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "צילום:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
+"You are running %s.\n"
+"\n"
+"Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tעבור מידע נוסף פנה ל https://amule-org.github.io/docs"
+msgid "New version available"
+msgstr "לא זמין"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"זכוייות יוצרים (C) 2003-2019 צוות אימיול \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "קאדימליה: תקשורת עמית לעמית מנותבת המבוסס על ה XOR המטרי.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "הודעה"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "מתחבר"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "קאד: חסום חומתאש"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "קאד: מחובר"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "קאד: מתחבר"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "קאד: מכובה"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -567,177 +607,177 @@ msgstr "קאד: מכובה"
 msgid "Cancel"
 msgstr "ביטול"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "מנותק"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "התנתק מהרשתות שאליהם אתה מחובר כעת"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "התחבר"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "התחבר לרשתות שמאופשרות כרגע"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "מעלה: %.1f(%.1f) | מוריד: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "מ\"ב/ש"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " ק\"ב/ש"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "מעלה: %.1f | מוריד: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "אימיול (%s | מחובר)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "אימיול (%s | מנותק)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "האם אתה באמת רוצה לצאת מאימיול?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "אישרור יצאיה"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "ספריית הסקינים '%s' לא קיימת"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "רשתות"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "חלון הרשתות"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "חיפושים"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "חלון החיפושים"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "הורדות"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "מוריד מהרשת"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "חלון הקבצים המשותפים"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "הודעות"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "חלון ההודעות"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "סטטיסטיקות"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "חלון גרפי הסטטיסטיקה"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "העדפות"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "חלון הגדרת ההעדפות"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "ייבא"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "כלי הייבא עבור קובץ-החלקים"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "אודות"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "אודות/עזרה"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -781,7 +821,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -930,7 +970,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "קטיגוריה"
 
@@ -1349,7 +1389,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "נכנס לתור"
 
@@ -1964,14 +2004,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1980,51 +2020,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2342,6 +2382,11 @@ msgstr "מבואה לא תקפה על מנת לבצע אתחול"
 msgid "Please fill all fields required"
 msgstr "אנא מלא את כל השדות כפי שנדרש"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "הודעה"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "האם את בטוח שברצונח להוריד קובץ nodes.dat חדש?\n"
@@ -2514,7 +2559,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "חיבור חיצוני נסגר."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "רענון אוטמטי התחיל"
@@ -2820,7 +2865,7 @@ msgstr "שם:"
 msgid "Type"
 msgstr "סוג/טיפוס"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "מקומי"
 
@@ -2940,7 +2985,7 @@ msgstr ""
 msgid "Stop"
 msgstr "עצור"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "הורדה"
 
@@ -4809,7 +4854,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5412,7 +5457,7 @@ msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "חיפושים"
@@ -5433,7 +5478,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "ראשי"
 
@@ -5470,37 +5515,37 @@ msgstr "לא מדורג"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "הורדה בקטיגוריה"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "הוסף כתובות URL אופתינליות לקובץ זה"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "סמן בתור קובץ מוכר"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "ביטול"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -20,46 +20,26 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.0beta1\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "O autoru:"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web stranica: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Web stranica: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -68,27 +48,39 @@ msgstr ""
 "Autorsko pravo (c) 2003-2019 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr "Autorsko pravo (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7838,6 +7830,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Web stranica: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Web stranica: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Not found"

--- a/po/hr.po
+++ b/po/hr.po
@@ -62,11 +62,11 @@ msgstr "Autorsko pravo (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Web stranica:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -19,6 +19,95 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.0beta1\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "O autoru:"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr ""
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr ""
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Web stranica: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Web stranica: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Autorsko pravo (c) 2003-2019 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr "Autorsko pravo (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+msgid "Click to check for a newer version."
+msgstr ""
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+msgid "Checking for updates..."
+msgstr ""
+
+#: src/AboutDialog.cpp:160
+msgid "You are running the latest version."
+msgstr ""
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Nije dostupno"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -112,8 +201,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -163,7 +252,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -186,45 +275,45 @@ msgstr "Nova vanjska veza prihvacena\n"
 msgid "WARNING"
 msgstr "UPOZORENJE"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i servera pronadjeno u server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -234,185 +323,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo nikakvu garanciju da nece nista unistiti, tvoju kucu zapaliti, \n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Ime servera :"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -441,124 +530,74 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "POGREŠKA: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr ""
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr ""
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
+"You are running %s.\n"
+"\n"
+"Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web stranica: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Web stranica: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Nije dostupno"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Autorsko pravo (c) 2003-2019 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr "Autorsko pravo (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Poruka"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Veza uspostavljena"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -568,179 +607,179 @@ msgstr ""
 msgid "Cancel"
 msgstr "Otkaz"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Zaustavlja trenutne pokusaje uspostavljanja veze"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekinuti vezu sa sadasnjim serverom"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Uspostavi vezu"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gore: %.1f(%.1f) | Dole: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gore: %.1f | Dole: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Da li zaista zelite iskljuciti aMule?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Potvrda izlaza"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Pretrage"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Prozor pretraga"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Downloading"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Prozor dijeljenih fajlova"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Poruke"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Prozor poruka"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistike"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Prozor grafova statistike"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Opcije"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Prozor postavke opcija"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Uvezi"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O autoru:"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -783,7 +822,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -934,7 +973,7 @@ msgid "Enter Captcha"
 msgstr "Pisati captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1355,7 +1394,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr ""
 
@@ -1969,14 +2008,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1985,51 +2024,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2344,6 +2383,11 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Poruka"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
@@ -2518,7 +2562,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2825,7 +2869,7 @@ msgstr "Naziv:"
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr ""
 
@@ -2945,7 +2989,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Download"
 
@@ -4823,7 +4867,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5418,7 +5462,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Pretrage"
@@ -5439,7 +5483,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr ""
 
@@ -5476,37 +5520,37 @@ msgstr "Bez ocjene"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Upitao za drugi fajl"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "Otkaz"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Novo"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -18,6 +18,99 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.0.6\n"
 "X-Poedit-Basepath: .\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "aMule megjelenítése"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule távoli vezérlő "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Pillanatkép:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"'Minden-platform' p2p ügyfél az eMule alapján \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Honlap: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Dokumentáció: https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"Gondok: https://github.com/amule-org/amule/issues \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Szerzői jog (c) 2003-2026 aMule csapat \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Az aMule részben a következőn alapul: \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Egyenrangú útvonal-megállapítás a XOR metrika alapján.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Indításkor új verzió keresése"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Kapcsolódás a Kad-hoz..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Az aMule egy elavult verzióját használod!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Nem elérhető"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -116,8 +209,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -166,7 +259,7 @@ msgstr "Memória debug eredmények az aMule bezárásáról:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Nyelvi beállításaid egy konfigurációs változás miatt az alapértelmezettre lettek átállítva. Bocs."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -189,11 +282,11 @@ msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 msgid "WARNING"
 msgstr "FIGYELEM"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "Hálózati bootstrap"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -201,34 +294,34 @@ msgstr ""
 "aMule hiányzó hálózati bootstrap fájlokat észlelt.\n"
 "Válassza ki a letölteni kivántakat:"
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "eD2k szerver lista (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad bootstrap csomópontok (nodes.dat)"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nem tudom a portokat a megadott címhez (%s) rendelni."
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "A %u port nem elérhető. Alacsony kliens azonosítót kapsz (LOWID)\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -243,48 +336,48 @@ msgstr ""
 "\n"
 "Ellenőrízd a hálózatodat, hogy megbizonyosodj, hogy a port nyitva van kifelé és befelé egyaránt."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Aláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Az aMule OnlineAláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "A kiválasztott nyelvi beállítások úgy látszik nincsenek telepítve a gépeden. (Megjegyzés: Mindenesetre mepróbálom ezt beállítani)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ez az első alkalom, hogy az aMule %s-t futtatod"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ez egy teszt verzió, naponta frissítve, és\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nem vállalunk garanciát, hogy nem omlik össze, gyújtja fel a házad,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vagy öli meg a kutyád. *Elvileg* nyugodtan használható.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Még több információ, támogatás és új kiadások találhatóak honlapunkon,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "a https://amule-org.github.io, vagy az #aMule IRC csatornánkon az irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nyugodtan jelezz bármilyen hibát a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -292,137 +385,137 @@ msgstr ""
 "Az Online aláírás fájl könyvtárának megadott hely ÉRVÉNYTELEN!\n"
 " Az OnlineAláírás letiltásra kerül, amíg ki nem javítod azt a beállítások menüpontban."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Szerver hostname értesítve"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Lemezterület helyfoglalás a '%s' fájl számára sikertelen: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "HIBA: Nem tudom megnyitni a napló fájlt"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FIGYELEM: a napló üres. Valami nem stimmel."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Napló törölve"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "KiszolgálóÜzenet: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "A %s letöltése kihagyva, mert a kívánt fájl nem újabb."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Csomópont-lista letöltése sikertelen."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Nem sikerült megnyitni a letöltött verzió-ellenőrző fájlt"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Sérült verzió-ellenőrző fájl"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Az aMule egy elavult verzióját használod!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A te aMule verziód %i.%i.%i, a legújabb verzió pedig %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FIGYELEM: A te aMule verziód elavult: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Az aMule verziód naprakész."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Verzió-ellenőrzés fájl letöltése sikertelen."
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Felhasználók: %s | Fájlok: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Felhasználók: E: %s K: %s | Fájlok: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nincs hálózat kiválasztva"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID-val"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID-val"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Kapcsolódva ehhez %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Kapcsolódás %s-hez"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Leválasztva az eD2k-ról"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad elindítva."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad leállítva."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Kapcsolódva a Kad-hoz (rendben)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Kapcsolódva a Kad-hoz (tűzfal mögül)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Leválasztva a Kad-ról"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A Kad hálózat nem használható, ha az UDP port le van tiltva a beállításokban, nem indítom."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A Kad hálózat le van tiltva  a beállításokban, nem kapcsolódom."
 
@@ -451,123 +544,72 @@ msgstr "Pid fájl létrehozása nem lehetséges"
 msgid "ERROR: %s"
 msgstr "HIBA: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ez az aMule %s, az eMule alapján."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "%s-en fut"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Új verzióért látogasd meg a https://github.com/amule-org/amule/releases/latest oldalt."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "VÉGZETES HIBA: Időzítő létrehozása sikertelen"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule távoli vezérlő "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Pillanatkép:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"'Minden-platform' p2p ügyfél az eMule alapján \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Honlap: https://amule-org.github.io \n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "Nem elérhető"
 
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Dokumentáció: https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Gondok: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Szerzői jog (c) 2003-2026 aMule csapat \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Az aMule részben a következőn alapul: \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Egyenrangú útvonal-megállapítás a XOR metrika alapján.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Üzenet"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMule dialógus elpusztítva"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Kapcsolódás"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2K: Kapcsolódás"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Szétkapcsolva"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Tűzfal mögött"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Csatlakozva"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Kapcsolódás"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Nincs kapcsolat"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -577,175 +619,175 @@ msgstr "Kad: Nincs kapcsolat"
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Aktuális kapcsolódási kísérletek leállítása"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Leválaszt az éppen kapcsolódott hálózatokról."
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Kapcsolódás a pillanatnyilag engedélyezett hálózatokhoz."
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Fel: %.1f%s (%.1f) | Le: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Fel: %.1f%s | Le: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Kapcsolódva)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Nincs kapcsolat)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Biztos, hogy ki szeretnél lépni a(z) %s alkalmazásból?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Kilépés megerősítése"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Parancs futtatása: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- alapértelmezett -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "A(z) '%s' felület könyvtár nem létezik"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "FIGYELEM: Nem tudom a(z) '%s' felület fáljt megnyitni olvasásra"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Hálózatok"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Hálózatok ablaka"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Keresések"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Keresés ablaka"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Letöltések ablaka"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Megosztott fájlok"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Megosztott fájlok ablaka"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Üzenetek"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Üzenetek ablaka"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Statisztikai grafikonok ablaka"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Beállítások"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Tulajdonságok beállításának ablaka"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importálás"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "A részfájl importáló eszköz"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Névjegy"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Névjegy/Súgó"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k hálózat"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad hálózat"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Nincs hálózat"
 
@@ -785,7 +827,7 @@ msgstr "Kapcsolat sikertelen. Kerém ellenőrizze a host, port és jelszó ért�
 msgid "Remote GUI EC event handler"
 msgstr "Távoli GUI EC esemény kezelő"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Kapcsolat sikertelen. Kapcsolat felvétel %s:%d-el nem lehetséges\n"
@@ -933,7 +975,7 @@ msgid "Enter Captcha"
 msgstr "Captcha megadása"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategória"
 
@@ -1348,7 +1390,7 @@ msgstr "HIBA: IO hiba!"
 msgid "ERROR: Failed!"
 msgstr "HIBA: Sikertelen!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Várólistán"
 
@@ -1976,7 +2018,7 @@ msgstr ""
 "\n"
 "Kliens létrehozása...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1985,7 +2027,7 @@ msgstr ""
 "\n"
 "Ok, kilépés a %s-ből...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1999,51 +2041,51 @@ msgstr ""
 "\n"
 "Kilépés...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "E súgó megjelenítése."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host, ahol az aMule fut (alap: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Az aMule Távoli Elérés portja (alap: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Külső kapcsolat jelszava."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Konfiguráció betöltése fájlból."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Nem ír ki semmit a szabvány kimenetre."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Legyen bőbeszédű - mutassa a hibakeresési üzeneteket is."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Beállítja a program nyelvét."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "A parancssori opciók konfig fájlba írása."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Konfig fájl létrehozása az aMule konfig fájlja alapján."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "A program verziójának kiírása."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "ZLIB tömörítés kikényszerítése a tárcsázott IP-cím helyétől függetlenül (hasznos, ha a szerver egy VPN-alagúton keresztül érhető el, amely LAN IP-címre kerül feloldásra)."
 
@@ -2356,6 +2398,11 @@ msgstr "Érvénytelen port a rendszerindításhoz"
 msgid "Please fill all fields required"
 msgstr "Kérlek töltsd ki az összes kötelező mezőt"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Üzenet"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Biztos, hogy le akarsz tölteni egy új nodes.dat fájlt?\n"
@@ -2522,7 +2569,7 @@ msgstr "Külső kapcsolat: Hozzáférés megtagadva, mert: "
 msgid "External Connection: Handshake failed."
 msgstr "Külső kapcsolat: Kézfogás sikertelen."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio szál %d elindítva"
@@ -2822,7 +2869,7 @@ msgstr "Név:"
 msgid "Type"
 msgstr "Típus"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Helyi"
 
@@ -2942,7 +2989,7 @@ msgstr "Kérje meg a már válaszolt Kad partnereket, hogy szélesítsék a kere
 msgid "Stop"
 msgstr "Leállít"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Letöltés"
 
@@ -4808,7 +4855,7 @@ msgstr "Helyfoglalás"
 msgid "Insufficient disk space"
 msgstr "Elégtelen lemezterület"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Letöltve"
@@ -5410,7 +5457,7 @@ msgstr "A megosztott fájlok listájának újratöltése."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Nem lehet keresni, ha az eD2k és a Kademlia hálózat is le van tiltva."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Keresési hiba"
 
@@ -5430,7 +5477,7 @@ msgstr "A minimum méretnek kisebbnek kell lennie a maximum méretnél. Maximum 
 msgid "Search warning"
 msgstr "Keresési figyelmeztetés"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Alap"
 
@@ -5467,37 +5514,37 @@ msgstr "Nincs értékelve"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Letöltés kategóriába"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "%s lekérése ehez a fájlhoz"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Kapcsolódó fájlok keresése (eD2k, helyi kiszolgáló)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Ismertként megjelölés"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "eD2k hivatkozás másolása a vágólapra"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Olyan kiszolgálót próbál törölni, amelyikhez csatlakozva van. Kérém először válassza le."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Megszakítva"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Új"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -62,19 +62,19 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Honlap:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Fórum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
-msgstr ""
+msgstr "Dokumentáció:"
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"
-msgstr ""
+msgstr "Gondok:"
 
 #: src/AboutDialog.cpp:107
 #, fuzzy

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -19,20 +19,20 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "X-Poedit-Basepath: .\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "aMule megjelenítése"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule távoli vezérlő "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Pillanatkép:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -40,27 +40,7 @@ msgstr ""
 "'Minden-platform' p2p ügyfél az eMule alapján \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Honlap: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Dokumentáció: https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Gondok: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -68,28 +48,40 @@ msgstr ""
 "Szerzői jog (c) 2003-2026 aMule csapat \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Az aMule részben a következőn alapul: \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Egyenrangú útvonal-megállapítás a XOR metrika alapján.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Indításkor új verzió keresése"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7857,6 +7849,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Honlap: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Dokumentáció: https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "Gondok: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -29,6 +29,99 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.2.2\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Mostra aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Controllo remoto di aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Client p2p multipiattaforma basato su eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Sito: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Documentazione: https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"Segnalazioni: https://github.com/amule-org/amule/issues \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Parte di aMule è basata su \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: routing peer-to-peer basato su metrica XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Verifica la disponibilità di nuove versioni all'avvio"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Connessione alla rete Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Stai usando una versione non aggiornata di aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Non disponibile"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -128,8 +221,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossibile aggiungere %u collegamento dal file ED2KLinks (vedere il log per i dettagli)."
 msgstr[1] "Impossibile aggiungere %u collegamenti dal file ED2KLinks (vedere il log per i dettagli)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -178,7 +271,7 @@ msgstr "Risultati del debug della memoria per la chiusura di aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza del cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -202,12 +295,12 @@ msgid "WARNING"
 msgstr "ATTENZIONE"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -216,35 +309,35 @@ msgstr ""
 "Selezionare quali scaricare:"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "Lista server eD2k (server.met)"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi di bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -259,48 +352,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Puoi segnalare qualsiasi bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -308,137 +401,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione dello spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Il file di log è stato reimpostato"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file scaricato per il controllo della versione"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Il file per il controllo della versione è corrotto"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni. Connessione non avviata."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni. Connessione interrotta."
 
@@ -467,123 +560,72 @@ msgstr "Impossibile creare il file Pid"
 msgid "ERROR: %s"
 msgstr "ERRORE: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Questo è aMule %s basato su eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "In esecuzione su %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest per controllare se è disponibile una nuova versione."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Controllo remoto di aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Client p2p multipiattaforma basato su eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Sito: https://amule-org.github.io \n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "Non disponibile"
 
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentazione: https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Segnalazioni: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Parte di aMule è basata su \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: routing peer-to-peer basato su metrica XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Messaggio"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Finestra di aMule chiusa"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Connessione in corso"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Connessione in corso"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Disconnesso"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Connesso"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Connessione in corso"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Spento"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -593,175 +635,175 @@ msgstr "Kad: Spento"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Connetti"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Connetti alle reti attualmente abilitate"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connesso)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Disconnesso)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vuoi veramente uscire da %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- predefinita -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "La directory delle skin '%s' non esiste"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Reti"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Ricerca"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Download"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "File condivisi"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Messaggi"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Finestra Preferenze"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Nessuna rete"
 
@@ -801,7 +843,7 @@ msgstr "Connessione non riuscita. Controlla host, porta e password."
 msgid "Remote GUI EC event handler"
 msgstr "Gestore eventi GUI EC remota"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Connessione fallita. Impossibile connettersi a %s:%d\n"
@@ -951,7 +993,7 @@ msgid "Enter Captcha"
 msgstr "Inserisci captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categoria"
 
@@ -1369,7 +1411,7 @@ msgstr "ERRORE: Errore di input/output!"
 msgid "ERROR: Failed!"
 msgstr "ERRORE: Fallito!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "In coda"
 
@@ -1999,7 +2041,7 @@ msgstr ""
 "\n"
 "Creazione del client in corso...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2008,7 +2050,7 @@ msgstr ""
 "\n"
 "Ok, uscita in corso da %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2022,51 +2064,51 @@ msgstr ""
 "\n"
 "Sto uscendo...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Mostra questo suggerimento."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host su cui aMule è in esecuzione (default: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porta di aMule per connessioni esterne (default: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Password connessioni esterne."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Leggi la configurazione da file."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Non stampare output sullo stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Verboso - mostra anche i messaggi di debug."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Impostazioni locali (lingua) del programma."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Salva le opzioni linea di comando nel file di configurazione."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Crea un file di configurazione basato su quello di aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Mostra la versione del programma."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Forza la compressione ZLIB indipendentemente dalla località dell'IP contattato (utile quando il server è raggiungibile tramite un tunnel VPN che risolve a un IP locale)."
 
@@ -2381,6 +2423,11 @@ msgstr "Porta non valida per il bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completa tutti i campi obbligatori"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Messaggio"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Sei sicuro di voler scaricare un nuovo file nodes.dat?\n"
@@ -2550,7 +2597,7 @@ msgstr "Connessione esterna: accesso negato a causa di: "
 msgid "External Connection: Handshake failed."
 msgstr "Connessione esterna: errore di negoziazione."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"
@@ -2850,7 +2897,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Locale"
 
@@ -2970,7 +3017,7 @@ msgstr "Chiedi ai peer Kad che hanno già risposto di ampliare la ricerca. Ogni 
 msgid "Stop"
 msgstr "Ferma"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Download"
 
@@ -4840,7 +4887,7 @@ msgstr "Allocazione in corso"
 msgid "Insufficient disk space"
 msgstr "Spazio su disco insufficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Scaricato"
@@ -5442,7 +5489,7 @@ msgstr "Ricarica file condivisi: %u file analizzati"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Impossibile avviare ricerche con eD2k e Kademlia entrambi disabilitati."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Errore di ricerca"
 
@@ -5462,7 +5509,7 @@ msgstr "Min size deve essere più piccola di max size. Ignoro max size."
 msgid "Search warning"
 msgstr "Avviso di ricerca"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principale"
 
@@ -5498,36 +5545,36 @@ msgstr "Bitrate"
 msgid "Codec"
 msgstr "Codec"
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Download nella categoria"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Ottieni %s per questo file"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Cerca file correlati (eD2k, server locale)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Segna come file conosciuto"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copia il collegamento eD2k negli appunti"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Al momento non sei connesso ad un server che supporta la Ricerca di File Correlati"
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Annullata"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Nuovo"
 

--- a/po/it.po
+++ b/po/it.po
@@ -73,19 +73,19 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Sito:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
-msgstr ""
+msgstr "Documentazione:"
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"
-msgstr ""
+msgstr "Segnalazioni:"
 
 #: src/AboutDialog.cpp:107
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -30,20 +30,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostra aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Controllo remoto di aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -51,27 +51,7 @@ msgstr ""
 "Client p2p multipiattaforma basato su eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Sito: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentazione: https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Segnalazioni: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -79,28 +59,40 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Parte di aMule è basata su \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: routing peer-to-peer basato su metrica XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verifica la disponibilità di nuove versioni all'avvio"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7906,6 +7898,25 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Sito: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Documentazione: https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "Segnalazioni: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -69,19 +69,19 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Sito:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
-msgstr ""
+msgstr "Documentazione:"
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"
-msgstr ""
+msgstr "Segnalazioni:"
 
 #: src/AboutDialog.cpp:107
 #, fuzzy

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -26,20 +26,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostra aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Controllo remoto di aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -47,27 +47,7 @@ msgstr ""
 "Client p2p multipiattaforma basato su eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Sito: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentazione: https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Segnalazioni: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -75,28 +55,40 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Parte di aMule è basata su \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: routing peer-to-peer basato su metrica XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verifica la disponibilità di nuove versioni all'avvio"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7893,6 +7885,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Sito: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Documentazione: https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "Segnalazioni: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -25,6 +25,99 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.2.2\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Mostra aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Controllo remoto di aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Client p2p multipiattaforma basato su eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Sito: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Documentazione: https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"Segnalazioni: https://github.com/amule-org/amule/issues \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Parte di aMule è basata su \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: routing peer-to-peer basato su metrica XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Verifica la disponibilità di nuove versioni all'avvio"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Connessione alla rete Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Stai usando una versione non aggiornata di aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Non disponibile"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -124,8 +217,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossibile aggiungere %u collegamento dal file ED2KLinks (vedere il log per i dettagli)."
 msgstr[1] "Impossibile aggiungere %u collegamenti dal file ED2KLinks (vedere il log per i dettagli)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -174,7 +267,7 @@ msgstr "Risultati del debug della memoria per l'uscita da aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza al cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -197,11 +290,11 @@ msgstr "Password impostata, connessioni esterne abilitate."
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -209,35 +302,35 @@ msgstr ""
 "aMule ha rilevato file di bootstrap di rete mancanti.\n"
 "Seleziona quali scaricare:"
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "Elenco server eD2k (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto aMule web server, o compila aMule con l'opzione --enable-webserver"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -252,48 +345,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Segnalare ogni bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -301,137 +394,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Il file di log è stato cancellato"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file per il controllo della versione scaricato"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "File per il controllo della versione corrotto"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni, connessione interrotta."
 
@@ -460,123 +553,72 @@ msgstr "Impossibile creare il file Pid"
 msgid "ERROR: %s"
 msgstr "ERRORE: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Questo è aMule %s basato su eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "In esecuzione su %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest per sapere se è disponibile una nuova versione."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Controllo remoto di aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Client p2p multipiattaforma basato su eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Sito: https://amule-org.github.io \n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "Non disponibile"
 
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentazione: https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Segnalazioni: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Parte di aMule è basata su \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: routing peer-to-peer basato su metrica XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Messaggio"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Finestra di aMule chiusa"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Connessione in corso"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Connessione in corso"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Disconnesso"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Connesso"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Connessione in corso"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Spento"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -586,175 +628,175 @@ msgstr "Kad: Spento"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Connetti"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Connetti alle reti attualmente abilitate"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connesso)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Disconnesso)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vuoi veramente uscire da %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- predefinita -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "La directory delle skin '%s' non esiste"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Reti"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Ricerca"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Download"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "File condivisi"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Messaggi"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Finestra Impostazione preferenze"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Nessuna rete"
 
@@ -794,7 +836,7 @@ msgstr "Connessione non riuscita. Controlla host, porta e password."
 msgid "Remote GUI EC event handler"
 msgstr "Gestore eventi GUI EC remota"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Connessione fallita. Impossibile connettersi a %s:%d\n"
@@ -944,7 +986,7 @@ msgid "Enter Captcha"
 msgstr "Inserisci captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categoria"
 
@@ -1362,7 +1404,7 @@ msgstr "ERRORE: Errore di input/output!"
 msgid "ERROR: Failed!"
 msgstr "ERRORE: Fallito!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "In coda"
 
@@ -1992,7 +2034,7 @@ msgstr ""
 "\n"
 "Creazione del client in corso...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2001,7 +2043,7 @@ msgstr ""
 "\n"
 "Ok, uscita in corso da %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2015,51 +2057,51 @@ msgstr ""
 "\n"
 "Sto uscendo...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Mostra questo suggerimento."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host su cui aMule è in esecuzione (default: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porta di aMule per connessioni esterne (default: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Password connessioni esterne."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Leggi la configurazione da file."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Non stampare output sullo stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Verboso - mostra anche i messaggi di debug."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Impostazioni locali (lingua) del programma."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Salva le opzioni linea di comando nel file di configurazione."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Crea un file di configurazione basato su quello di aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Mostra la versione del programma."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Forza la compressione ZLIB indipendentemente dalla località dell'IP contattato (utile quando il server è raggiungibile tramite un tunnel VPN che risolve a un IP locale)."
 
@@ -2374,6 +2416,11 @@ msgstr "Porta non valida per il bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completa tutti i campi obbligatori"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Messaggio"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Sei sicuro di voler scaricare un nuovo file nodes.dat?\n"
@@ -2543,7 +2590,7 @@ msgstr "Connessione esterna: accesso negato a causa di: "
 msgid "External Connection: Handshake failed."
 msgstr "Connessione esterna: errore di negoziazione."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"
@@ -2843,7 +2890,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Locale"
 
@@ -2963,7 +3010,7 @@ msgstr "Chiedi ai peer Kad che hanno già risposto di ampliare la ricerca. Ogni 
 msgid "Stop"
 msgstr "Ferma"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Download"
 
@@ -4824,7 +4871,7 @@ msgstr "Allocazione in corso"
 msgid "Insufficient disk space"
 msgstr "Spazio su disco insufficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Scaricato"
@@ -5428,7 +5475,7 @@ msgstr "Ricarica file condivisi: %u file analizzati"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Impossibile avviare ricerche con eD2k e Kademlia entrambi disabilitati."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Errore di ricerca"
 
@@ -5448,7 +5495,7 @@ msgstr "Min size deve essere più piccola di max size. Ignoro max size."
 msgid "Search warning"
 msgstr "Avviso di ricerca"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principale"
 
@@ -5485,37 +5532,37 @@ msgstr "Senza voto"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Download nella categoria"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Ottieni %s per questo file"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Cerca file correlati (eD2k, server locale)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Segna come file conosciuto"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copia il collegamento eD2k negli appunti"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Sei connesso al server che vuoi eliminare. Disconnettiti prima."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Annullata"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Nuovo"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -19,6 +19,98 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "aMuleを表示する"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMuleリモート制御"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "スナップショット："
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "\t詳しい情報にはhttps://amule-org.github.io/docsを参考してください"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"  著作権2003-2019、aMuleのチーム\n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademliaに基づいています：XORトリックに基づいたP2Pルーティング。\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "起動時に新バージョンを確認する"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Kadに接続中です…"
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "あなたは古いバージョンのaMuleを使用しています！"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "利用不可"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -110,8 +202,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -165,7 +257,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "申し訳ありませんが、設定の変更を行ったため、あなたのロケールはシステム標準に変更されました。"
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -188,46 +280,46 @@ msgstr "新しい外部接続を認められました"
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "ネットワーク"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.metに%i個のサーバが見つかりました"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "指定したアドレスにポートをバインドできませんでした: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "ポート%uは利用できません。あなたにはLOWIDが与えられます\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -242,48 +334,48 @@ msgstr ""
 "\n"
 "ネットワークを調べ、ポートが入出力に対して開いているか確認してください。"
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "オンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMuleのオンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "選択したロケールはあなたのシステムにインストールされていないようです。（注意：いずれにせよ設定を試みます）"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "初めてaMule %sを起動しています"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "このバージョンはテスト・バージョンで、毎日更新されているものです。\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "あなたに損害を与えないということは保証できません。家を焼いてしまうかも知れないし、\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "犬を殺してしまうかも知れません。しかし、安全に使用できる「はず」です。\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "私たちのホームページamule-org.github.io、またはIRCチャネルirc.libera.chatの#aMuleには、\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "詳細な情報、サポートや新しいリリースがあります。\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -291,138 +383,138 @@ msgstr ""
 "あなたが指定したオンライン証明ファイルのフォルダは不正です！\n"
 "設定で訂正するまでオンライン証明を無効にします。"
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "サーバ名："
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "ファイル '%s' のディスク領域の事前確保が失敗しました: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "エラー：ログファイルを開くことはできません"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "注意：ログファイルは空です。何かがおかしいです。"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "ログはリセットされました"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "サーバ・メッセージ：%s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "ノード・リストをダウンロードのに失敗しました。"
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "ダウンロードされたバージョン確認ファイルを開くのに失敗しました。"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "破損されたバージョン確認ファイル"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "あなたは古いバージョンのaMuleを使用しています！"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "あなたのaMuleバージョンは%i.%i.%iで、最新バージョンは%li.%li.%liです"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：あなたのaMuledバージョンは古くなっています：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "あなたのaMuleは最新のバージョンです。"
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "バージョン確認ファイルのダウンロードに失敗しました"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "ユーザ: %s | ファイル: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "ユーザ: E: %s K: %s | ファイル: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "ネットワークが選択されていません"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowIDを持っています"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighIDを持っています"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "接続しています：%s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "%sに接続中です"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kadを開始しました。"
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kadを中止しました。"
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Kadに接続しています（OK）"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Kadに接続しています（ファイアウォール）"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Kadから切断しています"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDPポートが設定で無効にされていると、Kadネットワークを使用できないため、開始しません。"
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadネットワークは設定で無効にされているため、接続はしません。"
 
@@ -452,122 +544,72 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "エラー： %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "これはeMuleに基づいたaMule %s です。"
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "%s に起動しています"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "新しいバージョンの確認はhttps://github.com/amule-org/amule/releases/latestで。"
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMuleリモート制御"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "スナップショット："
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
+"You are running %s.\n"
+"\n"
+"Would you like to open the download page?"
+msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\t詳しい情報にはhttps://amule-org.github.io/docsを参考してください"
+msgid "New version available"
+msgstr "利用不可"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"  著作権2003-2019、aMuleのチーム\n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademliaに基づいています：XORトリックに基づいたP2Pルーティング。\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "メッセージ"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "接続中"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: ファイアウォールされています"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: 接続"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: 接続中"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: オフ"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -577,178 +619,178 @@ msgstr "Kad: オフ"
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "現在の接続試行を中止する"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "切断する"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "ネットワークから切断します。"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "接続する"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "ネットワークへ接続します。"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "アップ： %.1f(%.1f) | ダウン： %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "アップ： %.1f | ダウン： %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 接続しています)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 切断しています)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "本当にaMuleを終了しますか？"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "終了の確認"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 #, fuzzy
 msgid "Launch Command: "
 msgstr "コマンド： %s"
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "スキンディレクトリ '%s' は存在しません"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "ネットワーク"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "ネットワークウィンドウ"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "検索"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "検索ウィンドウ"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "ダウンロード数"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "ダウンロード"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "共有ファイルウィンドウ"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "メッセージ"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "メッセージウィンドウ"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "統計グラフウィインドウ"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "設定"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "個人設定ウィンドウ"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "インポート"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "部分ファイルをインポートするためのツール"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "情報"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "ソフトウェア情報／ヘルプ"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kadネットワーク"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "ネットワークなし"
 
@@ -792,7 +834,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -939,7 +981,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "カテゴリ"
 
@@ -1355,7 +1397,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "キューに追加しました"
 
@@ -1988,7 +2030,7 @@ msgstr ""
 "\n"
 "クライアントを生成中です…\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1997,7 +2039,7 @@ msgstr ""
 "\n"
 "OK、%s を終了中です…\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2011,51 +2053,51 @@ msgstr ""
 "\n"
 "終了中です…\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "このヘルプ・テキストを表示する。"
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "aMuleが起動しているホストです。（デフォルト：127.0.0.1）"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMuleの外接続用のポート。（デフォルト：4712）"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "外接続用のパスワード。"
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "設定をファイルから読み込む。"
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "アウトプットをstdoutにプリンとしないように。"
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "冗長にして：デバッグ・メッセージも表示する。"
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "プログラム・ロカールを設定する（言語）。"
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "コマンド・ライン・オプションを設定ファイルに書き込む。"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "aMuleの設定ファイルを元に設定ファイルを生成する。"
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "プログラム・バージョンをプリンとする。"
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2369,6 +2411,11 @@ msgstr "ブートストラップするためには正しくないポートです
 msgid "Please fill all fields required"
 msgstr "必要なフィールドをすべて入力してください"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "メッセージ"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "本当に新しいnodes.datファイルをダウンロードしますか？\n"
@@ -2538,7 +2585,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "外接続用のパスワード。"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "同期化スレドを始めました。"
@@ -2844,7 +2891,7 @@ msgstr "名前："
 msgid "Type"
 msgstr "タイプ"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "ローカル"
 
@@ -2964,7 +3011,7 @@ msgstr ""
 msgid "Stop"
 msgstr "中止"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "ダウンロード"
 
@@ -4835,7 +4882,7 @@ msgstr "領域確保中"
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "ダウンロード済み"
@@ -5438,7 +5485,7 @@ msgstr "共有ファイル・リストを再ロードします。"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "検索"
@@ -5459,7 +5506,7 @@ msgstr "最小サイズは最大サイズより小さくなければなりませ
 msgid "Search warning"
 msgstr "検索の注意"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "メイン"
 
@@ -5496,38 +5543,38 @@ msgstr "評価されていません"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "カテゴリにダウンロードする"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "このファイルにオプショナルURLを追加する"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "既知ファイルとしてマークする"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "削除しようとするサーバには現在接続しています。先に切断を行ってください。"
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "キャンセル"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -20,46 +20,26 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "aMuleを表示する"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMuleリモート制御"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "スナップショット："
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\t詳しい情報にはhttps://amule-org.github.io/docsを参考してください"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -68,28 +48,40 @@ msgstr ""
 "  著作権2003-2019、aMuleのチーム\n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademliaに基づいています：XORトリックに基づいたP2Pルーティング。\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "起動時に新バージョンを確認する"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7902,6 +7894,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "\t詳しい情報にはhttps://amule-org.github.io/docsを参考してください"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -22,73 +22,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "어뮬 보이기"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "어뮬 원격제어"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "스냅삿"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\t더 많은 정보는 https://amule-org.github.io/docs을 참조하세요."
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "시작할때 새 버젼이 있는지 확인"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7954,6 +7946,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "\t더 많은 정보는 https://amule-org.github.io/docs을 참조하세요."
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
 
 #, fuzzy
 #~ msgid "Not found"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -21,6 +21,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "어뮬 보이기"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "어뮬 원격제어"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "스냅삿"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "\t더 많은 정보는 https://amule-org.github.io/docs을 참조하세요."
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "시작할때 새 버젼이 있는지 확인"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Kad에 연결중..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "유효하지 않음"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -113,8 +202,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -167,7 +256,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "지역정보(로케일)가 설정 변경으로 인해 시스템 기본값으로 변경되었습니다. 죄송합니다."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -190,46 +279,46 @@ msgstr "새로운 외부연결이 승인되었습니다."
 msgid "WARNING"
 msgstr "경고"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "통신망"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met에서 %i개의 서버가 발견됨"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "포트 %u는 사용할 수 없습니다. 낮은아이디를 가질것입니다.\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -244,48 +333,48 @@ msgstr ""
 "\n"
 "나가고 들어오는것에 대해 포트가 열려있는지 통신망을 체크하세요. "
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "어뮬 온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "컴퓨터에 선택한 지역정보(로케일)가 설치 않된것 같습니다. (주의: 어쨌든 설정하겠습니다)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "이번에 어뮬 %s를 처음 실행했습니다."
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "이 버전은 테스트 버젼으로, 매일 업데이트되며, \n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "이 프로그램이 어느 것도 부수지 않는다고, 집을 태우지 않는다고, 혹은 \n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "개를 죽이지 않는다고 보장하지 않습니다. 그렇지만 안전하게 사용할 수 있을 것입니다.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "더 많은 정보, 지원, 새 릴리즈는 홈페이지 amule-org.github.io, 또는 IRC 채널\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "(irc.libera.chat의 #aMule)에서 찾을 수 있습니다.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -293,138 +382,138 @@ msgstr ""
 "지정한 온라인 서명 파일을 위한 폴더가 유효하지 않습니다.\n"
 " 온라인 서명은 환경설정에서 수정될 때까지 비활성화 됩니다."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "서버 이름:"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "오류: 로그파일을 열 수 없음"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "경고: 로그파일이 비어있습니다. 뭔가 잘못되어 있습니다."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "로그가 초기화되었습니다."
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "서버메시지: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "노드 목록을 내려받지 못했습니다."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "내려받은 버젼 검사 파일을 열지 못했습니다."
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "손상된 버젼 검사 파일"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "어뮬 버젼은 %i.%i.%i이며 최신 버젼은 %li.%li.%li입니다."
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "경고: 어뮬 버젼은 오래되었습니다: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "어뮬은 최신 버전입니다."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "버젼 검사 파일을 내려받지 못했습니다."
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "낮은아이디로"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "높은아이디로"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s에 연결되었음"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s에 연결중"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad를 시작했습니다."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad를 멈췄습니다."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Kad에 연결됨 (양호)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad에 연결됨 (방화벽)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Kad로부터 연결이 끊김"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 네트워크는 UDP 포트가 비활성될 시 사용할 수 없으며, 따라서 시작하지 않습니다."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 네트워크가 환경설정에서 비활성되어, 연결하지 않습니다."
 
@@ -454,123 +543,76 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "오류: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "이 어뮬 %s는 이뮬 기반으로 되어있습니다."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "%s에 동작중"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "https://github.com/amule-org/amule/releases/latest에 방문하셔서 새로운버젼이 있는지 확인하십시오."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "어뮬 원격제어"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "스냅삿"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
+"You are running %s.\n"
+"\n"
+"Would you like to open the download page?"
+msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\t더 많은 정보는 https://amule-org.github.io/docs을 참조하세요."
+msgid "New version available"
+msgstr "유효하지 않음"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "메시지"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "방화벽"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "연결됨"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -580,182 +622,182 @@ msgstr " Kad: "
 msgid "Cancel"
 msgstr "취소"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "현재 연결시도를 멈춤"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "연결 끊기"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "통신망으로부터 연결을 끊습니다."
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "연결"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 #, fuzzy
 msgid "Connect to the currently enabled networks"
 msgstr "통신망에 연결합니다."
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "올려주기: %.1f(%.1f) | 내려받기: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 #, fuzzy
 msgid " kB/s"
 msgstr "kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "올려주기: %.1f | 내려받기: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "어뮬 (%s | 연결됨)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "어뮬 (%s | 끊김)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "어뮬을 종료하시겠습니까?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "종료 확인"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 #, fuzzy
 msgid "Launch Command: "
 msgstr "명령: %s"
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "외형 폴더 '%s'가 없습니다."
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "통신망"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "통신망 창"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "검색"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "검색 창"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "내려받기"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "받는중"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "공유 파일 창"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "메시지"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "메시지 창"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "통계"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "통계 그래프 창"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "환경설정"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "환경 설정 창"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "가져오기"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "부분파일 가져오기 도구"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "정보"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "정보/도움"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -799,7 +841,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -948,7 +990,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "분류"
 
@@ -1366,7 +1408,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "대기열에 있음"
 
@@ -2001,7 +2043,7 @@ msgstr ""
 "\n"
 "클라이언트 생성중...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2010,7 +2052,7 @@ msgstr ""
 "\n"
 "좋아, 나가는중 %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2024,51 +2066,51 @@ msgstr ""
 "\n"
 "종료중...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "이 도움말을 보여줍니다."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "어뮬이 실행중인 호스트. (기본: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "외부연결을 위한 어뮬 포트. (기본: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "외부연결 암호"
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "파일로부터 환경설정을 읽습니다."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "표준출력으로는 어떤 출력도 하지 않습니다."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "상세하게 - 디버그 메시지도 보여줍니다."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "프로그램 지역정보 (로케일, 언어)를 설정합니다."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "명령줄 설정을 환경설정 파일에 기록합니다."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "어뮬의 설정 파일에 기초하여 설정 파일을 생성합니다."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "프로그램 버전을 출력합니다."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2390,6 +2432,11 @@ msgstr "초기적재에 유효하지 않은 포트"
 msgid "Please fill all fields required"
 msgstr "모든 항목을 채워주세요."
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "메시지"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "새로운 nodes.dat파일을 내려받으시겠습니까?\n"
@@ -2562,7 +2609,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "외부연결 암호"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "동기화 스레드가 시작되었습니다."
@@ -2868,7 +2915,7 @@ msgstr "이름:"
 msgid "Type"
 msgstr "종류"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "지역"
 
@@ -2988,7 +3035,7 @@ msgstr ""
 msgid "Stop"
 msgstr "멈춤"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "내려받기"
 
@@ -4864,7 +4911,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5474,7 +5521,7 @@ msgstr "공유된 파일 목록을 다시 읽어들입니다."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "검색"
@@ -5495,7 +5542,7 @@ msgstr "최소 크기가 최대 크기보다 작아야 합니다. 최대 크기�
 msgid "Search warning"
 msgstr "검색 경고"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "주"
 
@@ -5532,38 +5579,38 @@ msgstr "선택되지 않은"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "분류내 내려받기"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "이 파일의 추가주소를 더합니다."
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "삭제하려고하는 서버에 접속되어있습니다. 부디 먼저 연결을 끊으세요."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "취소"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -20,6 +20,98 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Rodyti aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule nuotolinio valdymo pultelis "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Ekrano kopija:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "\tNorėdami sužinoti daugiau informacijos apsilankykite https://amule-org.github.io/docs"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Autorinės teisės (C) 2003-2019 aMule komanda \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: p2p maršrutizavimas, paremtas XOR metrika.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Paleidus programą ieškoti naujesnės versijos"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Jungiamsi prie Kademlia..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Naudojate pasenusią aMule versiją!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Nėra"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -113,8 +205,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -168,7 +260,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Pasikeitus parinktims aplinkos kalba buvo pakeista į sistemoje numatytą kalbą."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -191,47 +283,47 @@ msgstr "Naujas išorinis ryšys priimtas"
 msgid "WARNING"
 msgstr "DĖMESIO"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Tinklas"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met faile rastas %i serveris"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nepavyko susieti prievadų su nurodytu adresu: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Prievadas %u neprieinamas. Gavote žemą ID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -247,48 +339,48 @@ msgstr ""
 "\n"
 "Patikrinkite sistemines tinklo parinktis ir įsitikinkite, kad nurodytas prievadas atviras tiek išsiuntimui, tiek priėmimui."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo parašo failo"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo aMule parašo failo"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Nurodyta lokalė jūsų kompiuteryje neįdiegta. (Dėmesio: šiaip ar taip vis tiek pabandysime naudoti nurodytą lokalę)."
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule paleista pirmą kartą %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ši versija yra darbinė versija, atnaujinama kasdien, ir\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "todėl negalime garantuoti, kad ji nenulūš, nepadegs namų ar\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nenumarins šuns. Bet šiaip ar taip ją naudoti turėtų būti saugu.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daugiau informacijos, pagalbos ir naujausias galutines versijas rasite mūsų\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "svetainėje https://amule-org.github.io arba IRC kanale #aMule serveryje irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -296,138 +388,138 @@ msgstr ""
 "Neteisingai nurodėte keičiamo parašo aplanką!\n"
 "Keičiamas parašas bus išjungtas tol, kol pakeisite parinktis."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Serverio pavadinimas:"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Nepavyko paskirti disko vietos failui „%s“: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "KLAIDA: nepavyko atverti žurnalo failo"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "DĖMESIO: žurnalas tuščias. Kažkas čia ne taip."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Žurnalas išvalytas"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serverio pranešimas: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Nepavyko atsiųsti mazgų sąrašo."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Nepavyko atverti atsiųstos versijos tikrinimo failo"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Sugadintas versijos tikrinimo failas"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Naudojate pasenusią aMule versiją!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ši aMule versija yra %i.%i.%i, o naujausia versija yra %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "DĖMESIO: ši aMule versija yra pasenusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Naudojate naują aMule versiją."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Nepavyko atsiųsti versijos tikrinimo failo"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Naudotojai: %s | Failai: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Naudotojai: eD2k: %s Kad: %s | Failai: eD2k: %s Kad: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Neparinktas joks tinklas"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "žemas ID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "aukštas ID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Prisijungta prie %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Jungiamasi prie %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Atsijungta nuo eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kademlia paleista."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kademlia sustabdyta."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Prisijungta prie Kademlia"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Prisijungta prie Kademlia (už ugniasienės)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Atsijungta nuo Kademlia"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nepavyks prisijungti prie Kademlia tinklo, jei parinktyse yra išjungtas UDP prievadas."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kademlia tinklas išjungtas parinktyse, ryšys nebus užmezgamas."
 
@@ -457,122 +549,72 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "KLAIDA: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s, sukurta eMule pagrindu."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Vykdoma %s sistemoje"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Aplankykite https://github.com/amule-org/amule/releases/latest ir pasitikrinkite ar nėra naujesnės versijos."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule nuotolinio valdymo pultelis "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Ekrano kopija:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
+"You are running %s.\n"
+"\n"
+"Would you like to open the download page?"
+msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tNorėdami sužinoti daugiau informacijos apsilankykite https://amule-org.github.io/docs"
+msgid "New version available"
+msgstr "Nėra"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Autorinės teisės (C) 2003-2019 aMule komanda \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: p2p maršrutizavimas, paremtas XOR metrika.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Žinutė"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Jungiamasi"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: jungiamasi"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: atsijungta"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: už ugniasienės"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: prisijungta"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: jungiamasi"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: išjungta"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -582,177 +624,177 @@ msgstr "Kad: išjungta"
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Nutraukti bandymus prisijungti"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Atsijungti"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Atsijungti nuo pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Prisijungti"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Prisijungti prie pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Išs.: %.1f(%.1f) | Ats.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Išs.: %.1f | Ats.: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | prisijungta)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | neprisijungta)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ar tikrai norite baigti darbą su aMule?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Išvaizdos failų aplankas %s neegzistuoja"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Tinklas"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Tinklo langas"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Paieška"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Paieškos langas"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Siuntimai"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Atsiunčiama"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Dalinami failai"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Dalinamų failų langas"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Žinutės"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Žinučių langas"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Statistikos grafikų langas"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Parinktys"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Parinkčių langas"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Įkelti"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Dalinai atsiųstų failų įkėlimo įrankis"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Apie"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Apie/pagalba"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k tinklas"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad tinklas"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Jokio tinklo"
 
@@ -796,7 +838,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -947,7 +989,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1369,7 +1411,7 @@ msgstr "ERROR: IO klaida!"
 msgid "ERROR: Failed!"
 msgstr "ERROR: nepavyko!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Eilėje"
 
@@ -2008,7 +2050,7 @@ msgstr ""
 "\n"
 "Kuriamas klientas...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2017,7 +2059,7 @@ msgstr ""
 "\n"
 "Darbas baigiamas %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2031,51 +2073,51 @@ msgstr ""
 "\n"
 "Darbas baigiamas...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Rodyti šį pagalbos tekstą."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Mazgas, kuriame paleista aMule. Numatyta: 127.0.0.1"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule išorinių ryšių prievadas. Numatyta: 4712"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Išorinių ryšių slaptažodis."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Nuskaityti parinktis iš failo."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Nepateikti išvesties į stdout įrenginį."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Rodyti išsamius pranešimus, negi klaidų taisymo pranešimus."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Nurodyti programos kalbą."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Komandų eilutės parinktis įrašyti į parinkčių failą."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Sukurti parinkčių failą pagal aMule parinkčių failą."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Atspausdinti programos versiją."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2397,6 +2439,11 @@ msgstr "Klaidingas inicializavimo prievadas"
 msgid "Please fill all fields required"
 msgstr "Prašome užpildyti visus privalomus laukus"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Žinutė"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Ar tikrai norite atsisiųsti naują nodes.dat failą?\n"
@@ -2572,7 +2619,7 @@ msgstr "Išorinis ryšys: prieiga nesuteikta"
 msgid "External Connection: Handshake failed."
 msgstr "Išorinis ryšys: prieiga nesuteikta"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automatinis atnaujinimas paleistas"
@@ -2879,7 +2926,7 @@ msgstr "Pavadinimas:"
 msgid "Type"
 msgstr "Tipas"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Vietinis"
 
@@ -2999,7 +3046,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Sustabdyti"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Atsiųsti"
 
@@ -4878,7 +4925,7 @@ msgstr "Paskiriama vieta"
 msgid "Insufficient disk space"
 msgstr "Nepakanka laisvos vietos"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Atsiųsta"
@@ -5494,7 +5541,7 @@ msgstr "Atnaujinti dalinamų failų sąrašą."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Paieška"
@@ -5515,7 +5562,7 @@ msgstr "Apatinė dydžio riba turi būti mažesnė už viršutinę dydžio ribą
 msgid "Search warning"
 msgstr "Dėmesio"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Pagrindinė"
 
@@ -5552,38 +5599,38 @@ msgstr "Nevertinta"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Atsiunčiamą failą įdėti į kategoriją"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Šiam failui įdėti papildomus URL"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Ieškoti panašių failų (eD2k, vietiniame serveryje)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Pažymėti failą kaip jau žinomą"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Prie serverio, kurį norite pašalinti, esate šiuo metu prisijungę. Norėdami pašalinti serverį, iš pradžių turite atsijungti."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "Atšaukti"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -21,46 +21,26 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Rodyti aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule nuotolinio valdymo pultelis "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Ekrano kopija:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tNorėdami sužinoti daugiau informacijos apsilankykite https://amule-org.github.io/docs"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -69,28 +49,40 @@ msgstr ""
 "Autorinės teisės (C) 2003-2019 aMule komanda \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: p2p maršrutizavimas, paremtas XOR metrika.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Paleidus programą ieškoti naujesnės versijos"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7985,6 +7977,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "\tNorėdami sužinoti daugiau informacijos apsilankykite https://amule-org.github.io/docs"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/lv.po
+++ b/po/lv.po
@@ -58,19 +58,19 @@ msgstr " Autortiesības (c) 2002-2011 Petars Majmunkovs ( petar@maymounkov.org )
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Vietne:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forums:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
-msgstr ""
+msgstr "Dokumentācija:"
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"
-msgstr ""
+msgstr "Problēmas:"
 
 #: src/AboutDialog.cpp:107
 #, fuzzy

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-07-01 15:01+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,46 +17,26 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= 19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Par programmu"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Vietne: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forums: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Dokumentācija: https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Problēmas: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -64,28 +44,40 @@ msgstr ""
 "Autortiesības (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Vienādranga (P2P) maršrutēšana, pamatojoties uz XOR (izslēdzošā VAI) metriku.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Autortiesības (c) 2002-2011 Petars Majmunkovs ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kad palaiž, pārbaudīt, vai nav pieejama jauna versija"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7722,3 +7714,22 @@ msgstr "Izskatās, ka aMule darbojas. Lūdzu, aizveriet to un vēlreiz palaidiet
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Dzēš lietotāja datus, kas atrodas $APPDATA\\aMule mapē…"
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Vietne: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forums: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Dokumentācija: https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "Problēmas: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-07-01 15:01+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -16,6 +16,97 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= 19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Par programmu"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr ""
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr ""
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Vietne: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forums: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Dokumentācija: https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"Problēmas: https://github.com/amule-org/amule/issues \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Autortiesības (c) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Vienādranga (P2P) maršrutēšana, pamatojoties uz XOR (izslēdzošā VAI) metriku.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Autortiesības (c) 2002-2011 Petars Majmunkovs ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Kad palaiž, pārbaudīt, vai nav pieejama jauna versija"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Pieslēdzas Kad…"
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Jūs izmantojiet novecojušu aMule versiju!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Nav pieejama neviena valoda"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -107,8 +198,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -157,7 +248,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -180,44 +271,44 @@ msgstr ""
 msgid "WARNING"
 msgstr "BRĪDINĀJUMS"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "eD2k serveru saraksts (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -227,184 +318,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plašāka informācija, atbalsts un jaunās versijas ir pieejamas mūsu vietnē\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io vai mūsu IRC kanālā #aMule vietnē irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "KĻŪDA: nevar atvērt žurnāldatni"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "BRĪDINĀJUMS: žurnāldatne ir tukša. Te kaut kas nav kā vajag :-(."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Jūs izmantojiet novecojušu aMule versiju!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Jaunāko aMule versiju vienmēr var iegūt https://github.com/amule-org/amule/releases/latest vietnē"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "BRĪDINĀJUMS: Jūsu aMule versija ir novecojusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Šī ir jaunākā aMule versija."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Neizdevās lejupielādēt versijas pārbaudes datni"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Lietotāji: %s | Datnes: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Lietotāji: E: %s K: %s | Datnes: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "ar zemu ID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "ar augstu ID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Pieslēgts %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Pieslēdzas %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Atslēgts no eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Pieslēgts Kad (veiksmīgi)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Pieslēgts Kad (aiz ugunsmūra)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Atslēgts no Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad tīkls ir atspējots iestatījumos, nepieslēdzas tīklam."
 
@@ -433,121 +524,72 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "KĻŪDA: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Apmeklējiet https://github.com/amule-org/amule/releases/latest vietni, lai pārbaudītu, vai nav pieejama jauna versija."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr ""
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr ""
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Vietne: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forums: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Dokumentācija: https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
+"You are running %s.\n"
 "\n"
-msgstr ""
-"Problēmas: https://github.com/amule-org/amule/issues \n"
-"\n"
+"Would you like to open the download page?"
+msgstr "Jaunāko aMule versiju vienmēr var iegūt https://github.com/amule-org/amule/releases/latest vietnē"
 
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Autortiesības (c) 2003-2026 aMule Team \n"
-"\n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "Nav pieejama neviena valoda"
 
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Vienādranga (P2P) maršrutēšana, pamatojoties uz XOR (izslēdzošā VAI) metriku.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Autortiesības (c) 2002-2011 Petars Majmunkovs ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Ziņojums"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Pieslēdzas"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Pieslēdzas"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Atslēgts"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Aiz ugunsmūra"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Pieslēgts"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Pieslēdzas"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Izslēgts"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -557,175 +599,175 @@ msgstr "Kad: Izslēgts"
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Atslēgties"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Atslēgties no tīkliem, kuriem pašlaik esiet pieslēdzies"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Pieslēgties"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Pieslēgties pašlaik iespējotajiem tīkliem"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "↑Augšup.: %.1f%s (%.1f) | ↓Lejup.: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "↑Augšup.: %.1f%s | ↓Lejup.: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Pieslēgts)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Atslēgts)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Tīkli"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Lejupielādes"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Lejupielādes logs"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Kopīgotās datnes"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Ziņojumi"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Iestatījumi"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Par programmu"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Par programmu/Palīdzība"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k tīkls"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad tīkls"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -765,7 +807,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -913,7 +955,7 @@ msgid "Enter Captcha"
 msgstr "Ievadiet Captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1332,7 +1374,7 @@ msgstr "KĻŪDA: ievadizvades (I/O) kļūda!"
 msgid "ERROR: Failed!"
 msgstr "KĻŪDA: Neizdevās!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Rindā"
 
@@ -1940,14 +1982,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1956,51 +1998,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2309,6 +2351,11 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Ziņojums"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
@@ -2478,7 +2525,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2778,7 +2825,7 @@ msgstr "Nosaukums:"
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr ""
 
@@ -2898,7 +2945,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Apturēt"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr ""
 
@@ -4750,7 +4797,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Lejupielādēta"
@@ -5326,7 +5373,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Meklēšana nav iespējama, ja gan eD2k, gan Kademlia ir atspējoti."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr ""
 
@@ -5346,7 +5393,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr ""
 
@@ -5382,36 +5429,36 @@ msgstr "Bitu pārraides ātrums"
 msgid "Codec"
 msgstr "Kodeks"
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopēt eD2k saiti starpliktuvē"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Jūs pašlaik neesiet pieslēgts serverim, kas atbalsta saistīto datņu meklēšanas funkciju"
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -22,6 +22,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.4.2\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Toon aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule controle op afstand "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"'Alle-Platformen' p2p client gebaseerd op eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Website: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Website: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Een deel van aMule is gebaseerd op \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Peer-to-peer routing gebaseerd op de XOR-metric.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Controleer op nieuwe versie bij het starten"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Verbinding met Kad wordt gemaakt..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "U gebruikt een verouderde versie van aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Niet beschikbaar"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -115,8 +209,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -165,7 +259,7 @@ msgstr "Geheugen debug resultaten voor het afsluiten van aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "De taalinstelling is veranderd naar de systeemstandaard vanwege een configuratiewijziging. Sorry."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -188,47 +282,47 @@ msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 msgid "WARNING"
 msgstr "WAARSCHUWING"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Netwerken"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server in server.met gevonden"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kon geen poorten koppelen aan het opgegeven adres: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Poort %u is niet beschikbaar. U krijgt een LAAG ID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -243,48 +337,48 @@ msgstr ""
 "\n"
 "Controleer uw netwerk en zorg ervoor dat de poort open is voor in- en uitgaand verkeer."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Kon bestand met online handtekening niet maken"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Kon aMule OnlineHandtekening Bestand niet maken"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "De gekozen taalinstelling lijkt niet geïnstalleerd te zijn op uw pc. (Let op: Ik probeer het toch in te stellen)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dit is de eerste keer dat u aMule %s draait"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dit is een testversie, dagelijks geupdatet, en\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "we geven geen garantie dat het niks kapot maakt of uw huis in brand steekt,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "of uw hond doodt. Maar het *zou* veilig moeten zijn om het te gebruiken.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meer informatie, ondersteuning en niuwe versies kunnen gevonden worden op onze homepage,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "op https://amule-org.github.io, of op ons IRC-kanaal #amule op irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bugs kunt u altijd melden op https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -292,137 +386,137 @@ msgstr ""
 "De map voor online-handtekeningbestanden die u heeft opgegeven is ONGELDIG!\n"
 " OnlineSignature is UITGESCHAKELD totdat u dit verbetert in voorkeuren."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Server-hostnaam geïnformeerd"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Toewijzen schijfruimte voor bestand '%s' mislukt: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "FOUT: kan logbestand niet openen"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WAARSCHUWING: logboekbestand is leeg. Er is iets mis."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Logboek is gewist"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Server-bericht: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download van %s overgeslagen, omdat gevraagd bestand niet nieuwer is."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Kon nodelijst niet downloaden."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Kon gedownload versie controle bestand niet openen"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Beschadigd bestand voor versiecontrole"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "U gebruikt een verouderde versie van aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Uw aMule-versie is %i.%i.%i en de nieuwste versie is %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WAARSCHUWING: Uw aMuled-versie is verouderd: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "U heeft de nieuwste aMule-versie."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Kon bestand voor versiecontrole niet downloaden"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Gebruikers: %s | Bestanden: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Gebruikers: E: %s K: %s | Bestanden: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Geen netwerken geselecteerd"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "met Laag ID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "met Hoog ID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbonden met %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinden met %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Verbinding verbroken met eD2K"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad gestart."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad gestopt."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Verbonden met Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Verbonden met Kad (firewalled)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Verbinding met Kad verbroken"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-netwerk kan niet gebruikt worden als de UDP-poort is uitgeschakeld in voorkeuren, wordt niet gestart."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-netwerk is uitgeschakeld in voorkeuren, wordt niet mee verbonden."
 
@@ -452,124 +546,72 @@ msgstr "Kan Pid-bestand niet aanmaken"
 msgid "ERROR: %s"
 msgstr "FOUT: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dit is aMule %s gebaseerd op eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Draaiend op %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bezoek https://github.com/amule-org/amule/releases/latest om te zien of een nieuwe versie beschikbaar is."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATALE FOUT: Kon Timer niet aanmaken"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule controle op afstand "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"'Alle-Platformen' p2p client gebaseerd op eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Website: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Website: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Niet beschikbaar"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Een deel van aMule is gebaseerd op \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Peer-to-peer routing gebaseerd op de XOR-metric.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Bericht"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoogvenster afgesloten"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Aan het verbinden"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2K: Verbinden"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2K: Verbinding verbroken"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Verbonden"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Verbinden"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Uitgeschakeld"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -579,175 +621,175 @@ msgstr "Kad: Uitgeschakeld"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Beëindig de huidige verbindingspogingen"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Verbreek"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Verbreek de huidige verbonden netwerken"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Verbind met de momenteel ingeschakelde netwerken"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upload: %.1f%s (%.1f) | Download: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upload: %.1f%s | Download: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbonden)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Niet verbonden)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Wilt u %s echt afsluiten?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Bevestig afsluiten"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Voer commando uit: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- standaard -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinmap '%s' bestaat niet"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WAARSCHUWING: Kon skin-bestand '%s' niet openen om te lezen"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Netwerken"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Netwerkvenster"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Zoeken"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Zoekvenster"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Downloadsvenster"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Gedeelde bestanden"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Gedeelde bestanden-venster"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Berichten"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Berichtenvenster"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistieken"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Statistiekenvenster (Grafieken)"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Voorkeureninstellingen-venster"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importeer"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Het deelbestand importeerprogramma"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Over"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Over/Help"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k-netwerk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad netwerk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Geen netwerk"
 
@@ -787,7 +829,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "GUI EV gebeurtenisafhandelaar op afstand"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Verbinding mislukt. Kon niet verbinden met %s:%d\n"
@@ -935,7 +977,7 @@ msgid "Enter Captcha"
 msgstr "Voer captcha in"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categorie"
 
@@ -1354,7 +1396,7 @@ msgstr "FOUT: IO-fout!"
 msgid "ERROR: Failed!"
 msgstr "FOUT: Mislukt!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "In wachtrij"
 
@@ -1987,7 +2029,7 @@ msgstr ""
 "\n"
 "Aanmaken van client...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1996,7 +2038,7 @@ msgstr ""
 "\n"
 "Ok, %s wordt afgesloten...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2011,51 +2053,51 @@ msgstr ""
 "\n"
 "Bezig met afsluiten...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Toon deze helptekst."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host waar aMule draait. (standaard: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMules poort voor externe verbindingen. (standaard: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Externe verbinding wachtwoord."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Lees configuratie uit bestand."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Print geen uitvoer naar stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Wees uitgebreid - toon ook foutopsporingsberichten."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Stelt programma-locale (taal) in."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Schrijf opties op de opdrachtregel naar configuratiebestand."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Maakt configuratiebestand gebaseerd op aMules configuratiebestand."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Toon programma-versie."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2371,6 +2413,11 @@ msgstr "Ongeldige poort om van te bootstrappen"
 msgid "Please fill all fields required"
 msgstr "Vul alle benodigde velden in"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Bericht"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Weet u zeker dat u een nieuw nodes.dat bestand wilt downloaden?\n"
@@ -2541,7 +2588,7 @@ msgstr "Externe verbinding: toegang geweigerd omdat: "
 msgid "External Connection: Handshake failed."
 msgstr "Externe verbinding: handshake mislukt."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-download thread %d gestart"
@@ -2849,7 +2896,7 @@ msgstr "Naam:"
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Lokaal"
 
@@ -2969,7 +3016,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Download"
 
@@ -4833,7 +4880,7 @@ msgstr "Toewijzen"
 msgid "Insufficient disk space"
 msgstr "Onvoldoende schijfruimte"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Gedownload"
@@ -5440,7 +5487,7 @@ msgstr "Laad gedeelde-bestandenlijst opnieuw."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Er kan niet gezocht worden wanneer eD2k en Kademlia uitgeschakeld zijn."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Fout tijdens zoeken"
 
@@ -5460,7 +5507,7 @@ msgstr "Min grootte moet kleiner zijn dan max grootte. Max grootte wordt genegee
 msgid "Search warning"
 msgstr "Zoekwaarschuwing"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Standaard"
 
@@ -5497,37 +5544,37 @@ msgstr "Niet beoordeeld"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Download in categorie"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Verkrijg %s voor dit bestand"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Zoek gelijkwaardige bestanden (eD2k, lokale server)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Markeer als bekend bestand"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopieer eD2k-link naar klembord"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "U bent verbonden met de server die u probeert te verwijderen. Vebreek eerst de verbinding."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Geannuleerd"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Nieuw"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -23,20 +23,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.4.2\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Toon aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule controle op afstand "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -44,27 +44,7 @@ msgstr ""
 "'Alle-Platformen' p2p client gebaseerd op eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Website: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Website: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -73,28 +53,40 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Een deel van aMule is gebaseerd op \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing gebaseerd op de XOR-metric.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Controleer op nieuwe versie bij het starten"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7895,6 +7887,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Website: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Website: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/nl.po
+++ b/po/nl.po
@@ -67,11 +67,11 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Website:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -20,6 +20,98 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Syne aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule fjernkontroll"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Bilete:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "\tFor meir informasjon, sjå https://amule-org.github.io/docs"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Opphavsrett (c) 2003-2019 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: P2P brukarruting bygd på XOR metric.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Sjå etter ny utgåve ved oppstart"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Koplar til Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Du nyttar ei utdatert utgåve av aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Ikkje tilgjengeleg"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -112,8 +204,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -167,7 +259,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Dine lokale innstilingar har vorte endra til opprinnelege systeminnstillingar på grunn av konfigurasjonsending. Beklager."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -190,47 +282,47 @@ msgstr "Ny ekstern kopling akseptert"
 msgid "WARNING"
 msgstr "ÅTVARING"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nettverk"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i tenar funne i server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Greidde ikkje å knyte portar til adressa: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port·%u er ikkje tilgjengeleg. Du vil få LågID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -245,48 +337,48 @@ msgstr ""
 "\n"
 "Sjekk nettverket ditt for å vere viss på at porten er open for inn- og utgåande trafikk."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Greidde ikkje å lage OnlineSigfil"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Greidde ikkje å lage aMule si OnlineSigfil."
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Dei valte lokale innstillingane ser ikkje ut til å vere installerte på maskina di. (Merk: Eg freistar å setje dei likevel)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dette er første gongen du køyrer aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Denne utgåva er ei testutgåve, oppdatert dagleg, og\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi gir ingen garanti for skade eller nedbrenning av huset ditt,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller drep hunden din. Men det *burde* vere trygt å nytte uansett.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meir informasjon, brukarstøtte og nye utgåver kan verte funne på heimesida vår.\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "på https://amule-org.github.io, eller på IRC-kanalen vår #aMule·på·irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -294,138 +386,138 @@ msgstr ""
 "Mappa spesifisert for nettsignaturar er UGANGBAR!\n"
 " Nettsignaturar vert DEAKTIVERT fram til du ordnar det i innstillingar."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Tenarnamn:"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Henting av diskplass for fila '%s' mislukka: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "FEIL: Greier ikkje å opne loggfila"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ÅTVARING: loggfila er tom. Noko er gale."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Loggen har vorte nullstilt"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Tenarmelding: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Klarte ikkje å laste ned nodelista."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Klarte ikkje å opne den nedlaste utgåvesjekkfila"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Korrupt utgåvesjekkfil"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Du nyttar ei utdatert utgåve av aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Di utgåve av aMule er %i.%i.%i og den siste utgåva er %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ÅTVARING: Utgåva di av aMule er utdatert: %i.%i.%i·<·%li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Utgåva di av aMule er oppdatert."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Klarte ikkje å laste ned utgåvesjekkfila"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Brukarar: %s | Filer: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Brukarar: E %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ingen valde nettverk"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "med LågID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "med HøgID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Tilkopla %s·%s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Koplar til %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Fråkopla eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad starta."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad stogga."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Tilkopla Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Tilkopla Kad (brannmura)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Fråkopla Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad kan ikkje nyttast dersom UDP-porten er deaktivert i innstillingar. Startar ikkje."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-nettverket er deaktivert i innstillingar. Koplar ikkje til."
 
@@ -455,122 +547,72 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "Feil: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dette er aMule %s basert på eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Køyrer på %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vitje https://github.com/amule-org/amule/releases/latest for å sjekke om ei ny utgåve er tilgjengeleg."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule fjernkontroll"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Bilete:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
+"You are running %s.\n"
+"\n"
+"Would you like to open the download page?"
+msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tFor meir informasjon, sjå https://amule-org.github.io/docs"
+msgid "New version available"
+msgstr "Ikkje tilgjengeleg"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Opphavsrett (c) 2003-2019 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: P2P brukarruting bygd på XOR metric.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Melding"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Koplar til"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Koplar til"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Fråkopla"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Brannmura"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Tilkopla"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Koplar til"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -580,177 +622,177 @@ msgstr "Kad: Av"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Stopp inneverande oppkoplingsfreistingar"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Kople frå"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Kople frå dei aktive nettverka"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Kople til"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Kople til dei valde nettverka"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Opp:·%.1f(%.1f)·|·Ned:·%.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Opp:·%.1f·|·Ned:·%.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule·(%s·|·Tilkopla)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule·(%s·|·Fråkopla)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du verkeleg avslutte aMule?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Stadfesting av avslutting"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinnkatalogen '%s' finst ikkje"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Nettverk"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Nettverksavindauge"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Søk"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Søkjevindauge"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Nedlastingar"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Lastar ned"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Delte filer"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Vindauge for delte filer"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Meldingar"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Meldingsvindauge"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistikk"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Statistikkgrafvindauge"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Innstillingar"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Innstillingsvalsvindauge"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importér"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Verkty for delfilimport"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Om/hjelp"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "ed2k nettverk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad nettverk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Ikkje noko nettverk"
 
@@ -794,7 +836,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -943,7 +985,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategori"
 
@@ -1362,7 +1404,7 @@ msgstr "FEIL: Mislukka IO!"
 msgid "ERROR: Failed!"
 msgstr "FEIL: Mislukka!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "I kø"
 
@@ -1997,7 +2039,7 @@ msgstr ""
 "\n"
 "Opprettar klient...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2006,7 +2048,7 @@ msgstr ""
 "\n"
 "Ok,·avsluttar·%s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2020,51 +2062,51 @@ msgstr ""
 "\n"
 "Avsluttar...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Syne denne hjelpeteksten."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Vert der aMule køyrer (standard: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule sin port for eksternkopling (standard: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Passord for eksternkopling."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Les innstillingar frå fil."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Ikkje skriv ut data til stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Vér utførleg - syne óg avfeilingsmeldingar,"
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Set programspråk."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Skriv kommandolinjealternativa til konfigurasjonsfila."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Lagar konfigurasjonsfil basert på aMule si konfigurasjonsfil."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Skriv programutgåve."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2384,6 +2426,11 @@ msgstr "Ikkje gangbar port for eigenoppstart"
 msgid "Please fill all fields required"
 msgstr "Vér god å fylle ut alle naudsynte felt"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Melding"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Er du viss på at du vil laste ned ei ny nodes.dat fil?\n"
@@ -2556,7 +2603,7 @@ msgstr "Ekstern kopling: Tilgang nekta fordi:"
 msgid "External Connection: Handshake failed."
 msgstr "Ekstern kopling: Tilgang nekta"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Autooppfrisking starta"
@@ -2863,7 +2910,7 @@ msgstr "Namn:"
 msgid "Type"
 msgstr "Sort"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Lokal"
 
@@ -2983,7 +3030,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Nedlasting"
 
@@ -4858,7 +4905,7 @@ msgstr "Hentar plass"
 msgid "Insufficient disk space"
 msgstr "Ikkje nok diskplass"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Lasta ned"
@@ -5470,7 +5517,7 @@ msgstr "Lastar inn att lista over delte filer."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Søk"
@@ -5491,7 +5538,7 @@ msgstr "Min storleik må vere mindre enn maks storleik. Maks storleik ignorert."
 msgid "Search warning"
 msgstr "Søkeåtvaring"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Hovud"
 
@@ -5528,38 +5575,38 @@ msgstr "Ikkje gitt verdi"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Nedlasting i kategori"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Legg til valfrie URL`ar for denne fila"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Søk beslekta filer (eD2k, lokal tenar)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Merk som kjend fil"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopier eD2k lenkje til skrivebordet"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Du er tilkopla tenaren du freistar å slette. Vér god å kople frå først."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "Avbryt"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -21,46 +21,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Syne aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule fjernkontroll"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Bilete:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tFor meir informasjon, sjå https://amule-org.github.io/docs"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -69,28 +49,40 @@ msgstr ""
 "Opphavsrett (c) 2003-2019 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: P2P brukarruting bygd på XOR metric.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Sjå etter ny utgåve ved oppstart"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7957,6 +7949,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "\tFor meir informasjon, sjå https://amule-org.github.io/docs"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/pl.po
+++ b/po/pl.po
@@ -67,11 +67,11 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Strona internetowa:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -23,20 +23,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Pokaż aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "zdalna kontrola aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Zrzut ekranu:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -44,27 +44,7 @@ msgstr ""
 "\"Ogólnie-Platformy\" klient P2P oparty na eMule\n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Strona internetowa: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Strona internetowa: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -73,28 +53,40 @@ msgstr ""
 "Copyright (c) 2003-2019 Zespół aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Część aMule oparta jest na \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: routing peer-to-peer oparty na metryce XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Sprawdź podczas startu czy jest nowa wersja"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7935,6 +7927,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Strona internetowa: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Strona internetowa: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -22,6 +22,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Pokaż aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "zdalna kontrola aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Zrzut ekranu:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"\"Ogólnie-Platformy\" klient P2P oparty na eMule\n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Strona internetowa: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Strona internetowa: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2019 Zespół aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Część aMule oparta jest na \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: routing peer-to-peer oparty na metryce XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Sprawdź podczas startu czy jest nowa wersja"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Łączę z Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Używasz przestarzałej wersji aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Niedostępny"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -116,8 +210,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -166,7 +260,7 @@ msgstr "Wyniki debugu pamięci dla wyjścia aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Twoje ustawienia lokalne zostały zmienione na domyślne systemowe w związku ze zmianą konfiguracji. Przepraszamy."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -189,47 +283,47 @@ msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 msgid "WARNING"
 msgstr "UWAGA"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sieci"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i serwer znaleziono w server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nie można było powiązać portów z określonym adresem: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u jest niedostępny. Będziesz mieć LowID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -244,48 +338,48 @@ msgstr ""
 "\n"
 "Sprawdź swoją sieć aby mieć pewność, że port jest otwarty dla wejścia i wyjścia."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Wybrane lokale wydają się być niezainstalowane. (Uwaga: I tak spróbuję je ustawić)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Po raz pierwszy uruchomiłeś aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ta wersja jest aktualizowaną codziennie wersją testową i\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nie dajemy żadnej gwarancji, że nie zniszczy ona niczego, nie spali twojego domu\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "lub zabije twojego psa. *Powinna* ona jednak mimo wszystko działać poprawnie.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Więcej informacji, pomoc i nowe wydania znajdziesz na naszej stronie \n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io lub na naszym kanale IRC: #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nie wahaj się zgłaszać jakichkolwiek błędów na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -293,137 +387,137 @@ msgstr ""
 "Katalog wybrany na pliki sygnatury online jest nieprawidłowy!\n"
 " Sygnatura online zostanie wyłączona dopóki nie poprawisz tego w preferencjach."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Zawiadomiono nazwę hostu serwera"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Wstępna alokacja dysku dla pliku '%s' nie powiodła się: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "BŁĄD: nie mogę otworzyć pliku logów"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UWAGA: plik logów jest pusty. Coś jest nie tak."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Logi zostały zresetowane"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Wiadomość z serwera: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pominięto pobranie %s, ponieważ żądany plik nie jest nowszy."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Pobieranie listy węzłów nie powiodło się."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Nie można otworzyć pobranego pliku kontroli wersji"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Uszkodzony plik kontorli wersji"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Używasz przestarzałej wersji aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Twoje wersja eMule to %i.%i.%i, najnowszą wersją jest %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UWAGA: Twoja wersja aMule jest przestarzała: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Twoja kopia aMule jest przestarzała."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Nie udało się pobrać pliku kontroli wersji"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Użytkowników: %s | Plików: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Użytkowników: E: %s K: %s | Plików: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nie wybrano sieci"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "z LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "z HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Połączony z %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Łączenie z %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Rozłączono z eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Włączono Kad."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Zatrzymano Kad."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Połączono z Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Połączono z Kad (za firewallem)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Rozłączono z Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nie można użyć sieci Kad, jeśli port UDP jest wyłączony w preferencjach, nie włączam."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Zablokowano sieć Kad w preferencjach, nie łączę."
 
@@ -453,124 +547,72 @@ msgstr "Nie można utworzyć pliku Pid"
 msgid "ERROR: %s"
 msgstr "BŁĄD: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To jest aMule %s oparty na eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Uruchomiony na %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Odwiedź https://github.com/amule-org/amule/releases/latest aby sprawdzić czy jest dostępna nowa wersja."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRYTYCZNY BŁĄD: Nie udało się utworzyć Timera"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "zdalna kontrola aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Zrzut ekranu:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"\"Ogólnie-Platformy\" klient P2P oparty na eMule\n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Strona internetowa: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Strona internetowa: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Niedostępny"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2019 Zespół aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Część aMule oparta jest na \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: routing peer-to-peer oparty na metryce XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Wiadomość"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "dialog aMule zniszczony"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Łączenie"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Łączenie"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Rozłączony"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Połączony"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Łączenie"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Wyłączony"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -580,176 +622,176 @@ msgstr "Kad: Wyłączony"
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Zatrzymaj aktualne próby połączenia"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Rozłącz"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Rozłącz z aktualnie połączonymi sieciami"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Podłącz"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Połącz z aktualnie włączonymi sieciami"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Wysł: %.1f(%.1f) | Pobr: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Wysł: %.1f | Pobr: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Połączony)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Rozłączony)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Czy na pewno chcesz opuścić %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Potwierdzenie wyjścia"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Uruchomienie polecenia: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- domyślnie -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Katalog skórek '%s' nie istnieje"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OSTRZEŻENIE: Nie udało się otworzyć pliku skórki '%s' do odczytu"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Sieci"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Okno sieci"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Szukaj"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Okno wyszukiwania"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Pobieranie"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Okno pobierań"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Udostępnione pliki"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Okno udostępnionych plików"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Wiadomości"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Okno wiadomości"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statystyki"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Okno wykresów statystyk"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencje"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Okno preferencji"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Narzędzie importowania plików części"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informacje o"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Informacje/Pomoc"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Sieć eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Sieć Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Brak sieci"
 
@@ -789,7 +831,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Zdalne GUI EC obsługi zdarzenia"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Połączenie nie powiodło się. Nie można połączyć się z %s:%d\n"
@@ -939,7 +981,7 @@ msgid "Enter Captcha"
 msgstr "Wpisz Captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategoria"
 
@@ -1361,7 +1403,7 @@ msgstr "BŁĄD: Błąd IO!"
 msgid "ERROR: Failed!"
 msgstr "BŁĄD: Niepowodzenie!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "W kolejce"
 
@@ -1995,7 +2037,7 @@ msgstr ""
 "\n"
 "Tworzenie klienta...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2004,7 +2046,7 @@ msgstr ""
 "\n"
 "OK, wychodzę %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2018,51 +2060,51 @@ msgstr ""
 "\n"
 "Wychodzę...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Pokazuj ten tekst pomocy."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host gdzie jest uruchomiony aMule. (domyślny: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Port zewnętrznych połączeń aMule. (domyślny: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Hasło połączeń zewnętrznych."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Czyta konfiguracje z pliku."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Nie wysyłaj żadnego wyjścia na stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Bądź gadatliwy - pokazuj także wiadomości diagnostyczne."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Ustawia locale programu (język)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Zapisuje opcje listy komend do pliku konfiguracyjnego."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Tworzy plik konfiguracyjny oparty na pliku konfiguracyjnym aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Drukuj wersję programu."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2380,6 +2422,11 @@ msgstr "Nieprawidłowy port do rozruchu"
 msgid "Please fill all fields required"
 msgstr "Proszę wypełnij wszystkie wymagane pola"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Wiadomość"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Czy jesteś pewien, że chcesz pobrać nowy plik nodes.dat?\n"
@@ -2553,7 +2600,7 @@ msgstr "External Connection: Brak dostępu z powodu: "
 msgid "External Connection: Handshake failed."
 msgstr "External Connection: Brak nawiązania"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rozpoczęte pobranie wątku HTTP"
@@ -2860,7 +2907,7 @@ msgstr "Nazwa:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Lokalne"
 
@@ -2980,7 +3027,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Zatrzymaj"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Pobieranie"
 
@@ -4855,7 +4902,7 @@ msgstr "Alokuję"
 msgid "Insufficient disk space"
 msgstr "Niewystarczająca ilość przestrzeni dyskowej"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Pobrano"
@@ -5470,7 +5517,7 @@ msgstr "Przeładowuje listę udostępnionych plików."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Szukaj"
@@ -5491,7 +5538,7 @@ msgstr "Min. rozmiar musi być mniejszy od maks. Zignorowano maks. rozmiar."
 msgid "Search warning"
 msgstr "Ostrzeżenie wyszukiwania"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Główne"
 
@@ -5529,37 +5576,37 @@ msgstr "Nieoceniony"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Pobieranie w kategorii"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Dodaj opcjonalny URL dla tego pliku"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Szukaj powiązanych plików (eD2k, serwer lokalny)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Oznacz jako znany plik"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Skopiuj link eD2k do schowka"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Jesteś połączony do serwera który chcesz usunąć. Proszę rozłącz się najpierw."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Anulowane"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Nowy"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -26,6 +26,99 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Poedit 3.9\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Mostrar aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Controle Remoto do aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Cliente p2p 'multi-plataforma' baseado no eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Página: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Documentação: https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"Problemas: https://github.com/amule-org/amule/issues \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Direitos Reservados (c) 2003-2026 Equipe do aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Parte do aMule é baseado no \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: roteamento peer-to-peer baseado em métrica XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Direitos autorais reservados (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Procurar por nova versão ao iniciar"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Conectando a rede Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Você está utilizando uma versão anterior do aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Não disponível"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -125,8 +218,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Não foi possível adicionar link %u do arquivo ED2KLinks (veja o log para detalhes)."
 msgstr[1] "Não foi possível adicionar %u links do arquivo ED2KLinks (veja o log para detalhes)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -175,7 +268,7 @@ msgstr "Resultados da depuração da memória para a saída do aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Seu locale foi alterado para o padrão do Sistema devido a mudança na configuração. Desculpe."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -198,11 +291,11 @@ msgstr "Senha definida e conexões externas habilitadas."
 msgid "WARNING"
 msgstr "CUIDADO"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "Inicialização da Rede"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -210,34 +303,34 @@ msgstr ""
 "O aMule detectou que faltam arquivos de inicialização da rede.\n"
 "Selecione quais baixar:"
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nós de inicialização de Kad"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server rodando no pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível conectar às portas desse endereço: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u não disponível. Você ficará com LOWID (id baixa)\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -252,49 +345,49 @@ msgstr ""
 "\n"
 "Verifique sua rede para ver se essa porta está aberta para entrada e saída."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig do aMule"
 
 # src/amuled.cpp:1246:
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Parece que o idioma selecionado não está instalado no seu computador. (Nota: eu irei defini-lo mesmo assim)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Essa é a primeira vez que você executa o aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Essa é uma versão de testes, atualizada diariamente, e\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não daremos garantia se ela quebrar algo, queimar sua casa,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar seu cachorro. Mas ela *deve* ser segura para uso mesmo assim.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Maiores informações, suporte e novas versões podem ser encontradas em nossa\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "homepage https://amule-org.github.io ou em nosso canal de irc #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja a vontade para notificar qualquer bug em https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -302,137 +395,137 @@ msgstr ""
 "A pasta especificada para os arquivos da Online Signature é INVÁLIDA!\n"
 "OnlineSignature ficará DESATIVADA até você atualizar as preferências."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Nome do servidor notificado"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Pré-alocação de espaço em disco para arquivo '%s' falhou: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não foi possível abrir arquivo de log"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o arquivo de log está vazio. Algo está errado."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Arquivo de log resetado"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "MensagemDoServidor: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pulando o download de %s, pois o arquivo requerido não é o mais novo."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Falha ao obter a lista de nodes."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir arquivo de versão baixado"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Arquivo de versão corrompido"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Você está utilizando uma versão anterior do aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A mais recente versão pode ser obtida em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "CUIDADO: Sua versão do aMuled esta ultrapassada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Sua cópia do aMule está em dia."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Falha ao baixar arquivo de controle de versão"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuários:%s | Arquivos: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuários: E: %s K: %s | Arquivos: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nenhuma rede selecionada"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "com HighID (Id alta)"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad parado."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a rede Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a rede Kad (sob firewall)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Desconectado da rede Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se a porta UDP está desabilitada em preferências, não iniciará."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desabilitada em preferências, não iniciará."
 
@@ -461,123 +554,72 @@ msgstr "Incapaz Criar Arquivo Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esse é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Executando em %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para ver se há nova versão disponível."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Timer"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Controle Remoto do aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Cliente p2p 'multi-plataforma' baseado no eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "A mais recente versão pode ser obtida em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Página: https://amule-org.github.io \n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "Não disponível"
 
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentação: https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Problemas: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Direitos Reservados (c) 2003-2026 Equipe do aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Parte do aMule é baseado no \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: roteamento peer-to-peer baseado em métrica XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Direitos autorais reservados (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Mensagem"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "destruído caixa de diálogo do aMule"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectado"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de Firewall"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -587,175 +629,175 @@ msgstr "Kad: Desligado"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Cancelar as tentativas atuais de conexão"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes atualmente conectadas"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar às redes ativas"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Você realmente quer sair %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Lançar Comando: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- padrão -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "O diretório '%s' de skins não existe"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "CUIDADO: Incapaz de abrir o arquivo de pele '%s' para leitura"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Janela de redes"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Arquivos compartilhados"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Janela de compartilhados"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Ferramenta de importação de arquivos .part"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Sobre/Ajuda"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "rede Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Sem redes"
 
@@ -795,7 +837,7 @@ msgstr "A conexão falhou. Por favor, confira o anfitrião, porta e senha."
 msgid "Remote GUI EC event handler"
 msgstr "Manipulador de evento GUI EC remoto"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Falha na conexão. Incapaz de conectar em %s:%d\n"
@@ -945,7 +987,7 @@ msgid "Enter Captcha"
 msgstr "Insira o Captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categoria"
 
@@ -1363,7 +1405,7 @@ msgstr "ERRO: erro de E/S!"
 msgid "ERROR: Failed!"
 msgstr "ERRO: Falhou!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Na fila de espera"
 
@@ -1993,7 +2035,7 @@ msgstr ""
 "\n"
 "Criando cliente..\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2002,7 +2044,7 @@ msgstr ""
 "\n"
 "Ok, abandonando %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2016,51 +2058,51 @@ msgstr ""
 "\n"
 "Finalizando...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Exibir esse texto de ajuda."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host onde o aMule está rodando. (padrão: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porta em que o aMule está esperando Conexões Externas (padrão: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Senha para Conexão Externa."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Ler configuração de arquivo."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Não imprima mensagens em stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Seja verborrágico - mostre até as mensagens de debug."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Defina o locale (idioma)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Gravar opções de linha de comando."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Criar arquivo de configuração baseado no do aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Exibir versão do programa."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Força a compressão ZLIB independente da localidade IP discado (útil quando o servidor for alcançável por um túnel VPN que resolve para um IP de LAN)."
 
@@ -2375,6 +2417,11 @@ msgstr "Porta inválida para inicialização"
 msgid "Please fill all fields required"
 msgstr "Preencha todos os campos necessários"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Mensagem"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Deseja baixar uma nova versão do arquivo nodes.dat?\n"
@@ -2544,7 +2591,7 @@ msgstr "Conexão Externa: Acesso negado porque: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexão Externa: Handshake falhou."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Iniciada a linha Asio %d"
@@ -2844,7 +2891,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Local"
 
@@ -2964,7 +3011,7 @@ msgstr "Pedir para pares Kad que já responderam para alargar a busca. Cada cliq
 msgid "Stop"
 msgstr "Pare"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Download"
 
@@ -4834,7 +4881,7 @@ msgstr "Alocando"
 msgid "Insufficient disk space"
 msgstr "Espaço em disco insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Baixado"
@@ -5437,7 +5484,7 @@ msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "É impossível realizar busca quando ambas eD2K e Kademlia estão desabilitadas."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Erro na busca"
 
@@ -5457,7 +5504,7 @@ msgstr "Tamanho min deve ser menor que tamanho max. Tamanho max ignorado."
 msgid "Search warning"
 msgstr "Alerta da busca"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principal"
 
@@ -5493,36 +5540,36 @@ msgstr "Taxa de Bits"
 msgid "Codec"
 msgstr "Codec"
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Baixar na categoria"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obtendo %s para este arquivo"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Procurando arquivos relacionados (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Marcar como arquivo conhecido"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar ligação eD2k para área de transferência"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Você não está atualmente conectado a um servidor que suporta a função \"Arquivos Relacionados\""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Cancelado"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Novo"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -70,19 +70,19 @@ msgstr " Direitos autorais reservados (c) 2002-2011 Petar Maymounkov ( petar@may
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Página:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Fórum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
-msgstr ""
+msgstr "Documentação:"
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"
-msgstr ""
+msgstr "Problemas:"
 
 #: src/AboutDialog.cpp:107
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -27,20 +27,20 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Controle Remoto do aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -48,27 +48,7 @@ msgstr ""
 "Cliente p2p 'multi-plataforma' baseado no eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Página: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Documentação: https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Problemas: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -76,28 +56,40 @@ msgstr ""
 "Direitos Reservados (c) 2003-2026 Equipe do aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Parte do aMule é baseado no \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: roteamento peer-to-peer baseado em métrica XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Direitos autorais reservados (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Procurar por nova versão ao iniciar"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7902,6 +7894,25 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Página: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Documentação: https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "Problemas: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -27,6 +27,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Mostrar"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Controlo remoto do aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Cliente p2p 'para todas as plataformas' baseado no eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Website: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Website: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (C) 2003-2019 Equipa aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Parte do aMule é baseado em \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Encaminhamento peer-to-peer baseado na métrica XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (C) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Verificar nova versão no arranque"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "A ligar à Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Está a usar uma versão antiga do aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Indisponível"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -120,8 +214,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -170,7 +264,7 @@ msgstr "Resultados da depuração de memória para a saída do aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O seu idioma foi alterado para a predefinição do sistema devido a uma mudança de configuração. Desculpe."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -193,47 +287,47 @@ msgstr "Palavra-passe definida e permitidas as ligações externas."
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Foi encontrado %i servidor no server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível associar os portos ao endereço especificado: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u não está disponível. Ficará com LOWID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -248,48 +342,48 @@ msgstr ""
 "\n"
 "Verifique a sua rede para se certificar de que o porto está aberto para leitura e escrita."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Erro ao criar o ficheiro da Assinatura Online"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erro a criar o ficheiro da Assinatura Online do aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado parece não estar instalado no seu computador. (Nota: de qualquer das formas, irei tentar activá-lo)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que executa o aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta é uma versão de testes actualizada diariamente e\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não há qualquer garantia de que não irá partir nada, pegar fogo à sua casa,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar o seu cão. Mas, *em princípio*, deverá ser seguro usá-lo.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mais informação, suporte e novos lançamentos na nossa página,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "em amule-org.github.io ou no canal de IRC #aMule em irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja à vontade para comunicar erros para https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -297,137 +391,137 @@ msgstr ""
 "A pasta para os ficheiros da Assinatura Online é INVÁLIDA!\n"
 " A Assinatura Online será DESACTIVADA até que resolva a situação nas preferências."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Servidor notificado"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Reserva de espaço em disco para o ficheiro '%s' falhou: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não é possível abrir o ficheiro de relatório"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de relatório está vazio. Algo está mal."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "O relatório foi limpo"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensagem do servidor: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "O download de %s não foi feito porque o ficheiro requisitado não é mais recente."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Falha ao transferir a lista de nós."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir o ficheiro de verificação de versão transferido"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Ficheiro de verificação de versão corrompido"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Está a usar uma versão antiga do aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A sua versão do aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "A sua cópia do aMule está actualizada."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Falha ao transferir o ficheiro de verificação de versão"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizadores: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizadores: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Não foram seleccionadas redes"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "com HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ligado a %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "A ligar a %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Desligado da eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad iniciada."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad parada."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Ligado à Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Ligado à Kad (atrás de firewall)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Desligado da Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se o porto UDP estiver desactivado nas preferências, inicialização não efectuada."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rede Kad desligada nas preferências, a ligação não será efectuada."
 
@@ -457,124 +551,72 @@ msgstr "Não foi Possível Criar o Ficheiro de Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "A correr em %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para verificar se há novas versões."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Temporizador"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Controlo remoto do aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Cliente p2p 'para todas as plataformas' baseado no eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Website: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Website: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Indisponível"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (C) 2003-2019 Equipa aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Parte do aMule é baseado em \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Encaminhamento peer-to-peer baseado na métrica XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (C) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Mensagem"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Caixa de diálogo do aMule destruída"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "A Ligar"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: A Ligar"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desligado"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de firewall"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Ligado"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: A Ligar"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -584,176 +626,176 @@ msgstr "Kad: Desligado"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Cancela as tentativas de ligação actuais"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Desligar"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Desligar das redes presentemente ligadas"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Ligar"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Ligar às redes presentemente activadas"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f | Down: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ligado)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desligado)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Quer mesmo fechar o %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Executar Comando: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- predefinição -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Pasta para os temas '%s' não existe"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Não é possível abrir ficheiro de tema '%s' para leitura"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Janela de Redes"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Ficheiros partilhados"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Janela de Ficheiros Partilhados"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "A ferramenta de importação de ficheiro de partes"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Acerca/Ajuda"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Sem rede"
 
@@ -793,7 +835,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Gestor de eventos da interface gráfica remota"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "A ligação falhou. Não é possível ligar a %s:%d\n"
@@ -941,7 +983,7 @@ msgid "Enter Captcha"
 msgstr "Escrever 'Captcha'"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categoria"
 
@@ -1360,7 +1402,7 @@ msgstr "ERRO: erro de entrada/saída!"
 msgid "ERROR: Failed!"
 msgstr "ERRO: Falhou!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Em Fila"
 
@@ -1992,7 +2034,7 @@ msgstr ""
 "\n"
 "A criar o cliente...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2001,7 +2043,7 @@ msgstr ""
 "\n"
 "OK, a sair %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2015,51 +2057,51 @@ msgstr ""
 "\n"
 "A sair...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Mostra esta ajuda."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Máquina onde o aMule está a ser executado. (predefinida: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porto do aMule para Ligação Externa. (predefinido: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Palavra-passe de Ligação Externa."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Ler a configuração a partir do ficheiro."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Não mostrar qualquer mensagem para a saída padrão."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Detalhado - mostrar também mensagens de depuração."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Define a localização do programa (idioma)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Escrever as opções da linha de comandos para o ficheiro de configuração."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Cria ficheiro de configuração baseado no ficheiro de configuração do aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Mostrar a versão do programa."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2375,6 +2417,11 @@ msgstr "Porto inválido para arranque"
 msgid "Please fill all fields required"
 msgstr "Por favor, preencha todos os campos pedidos"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Mensagem"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Tem a certeza que deseja transferir um novo ficheiro nodes.dat?\n"
@@ -2545,7 +2592,7 @@ msgstr "Ligação Externa: Acesso negado porque: "
 msgid "External Connection: Handshake failed."
 msgstr "Ligação Externa: Negociação inicial falhou."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Actualização automática iniciada"
@@ -2852,7 +2899,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Local"
 
@@ -2972,7 +3019,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Download"
 
@@ -4836,7 +4883,7 @@ msgstr "A atribuir"
 msgid "Insufficient disk space"
 msgstr "Espaço em disco insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Transferido"
@@ -5445,7 +5492,7 @@ msgstr "Recarrega a lista de ficheiros partilhados."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Pesquisas"
@@ -5466,7 +5513,7 @@ msgstr "O Tamanho mínimo tem de ser menor que o tamanho máximo. Tamanho máxim
 msgid "Search warning"
 msgstr "Aviso de pesquisa"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principal"
 
@@ -5504,37 +5551,37 @@ msgstr "Não avaliado"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Transferir para a categoria"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obter %s para este ficheiro"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Procurar ficheiros relacionados (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Marcar como ficheiro conhecido"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar ligação eD2k para a área de transferência"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Está ligado ao servidor que está a tentar remover. Por favor, desligue-se primeiro."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Cancelado"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Novo"
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -28,20 +28,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Controlo remoto do aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -49,27 +49,7 @@ msgstr ""
 "Cliente p2p 'para todas as plataformas' baseado no eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Website: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Website: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -78,28 +58,40 @@ msgstr ""
 "Copyright (C) 2003-2019 Equipa aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Parte do aMule é baseado em \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Encaminhamento peer-to-peer baseado na métrica XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (C) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verificar nova versão no arranque"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7898,6 +7890,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Website: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Website: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -72,11 +72,11 @@ msgstr " Copyright (C) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Website:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Fórum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 "X-Generator: Lokalize 2.0\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Arată aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "control distant aMule"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Variantă versiune:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,27 +41,7 @@ msgstr ""
 "Client p2p bazat pe eMule pentru toate platformele \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Site web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Site web: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -70,28 +50,40 @@ msgstr ""
 "Drept de autor (c) 2003-2019 Echipa aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Părți din aMule sunt bazate pe \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Rutare P2P bazată pe XOR metric.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Drept de autor (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verifică la pornire dacă au apărut versiuni noi"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7912,6 +7904,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Site web: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Site web: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -19,6 +19,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 "X-Generator: Lokalize 2.0\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Arată aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "control distant aMule"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Variantă versiune:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Client p2p bazat pe eMule pentru toate platformele \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Site web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Site web: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Drept de autor (c) 2003-2019 Echipa aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Părți din aMule sunt bazate pe \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Rutare P2P bazată pe XOR metric.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Drept de autor (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Verifică la pornire dacă au apărut versiuni noi"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Se conectează la Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Utilizați o versiune învechită de aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Indisponibil"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -113,8 +207,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -163,7 +257,7 @@ msgstr "Rezultatele depanării memoriei pentru ieșirea aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Limba dumneavoastră a fost schimbată la cea implicită a sistemului datorită schimbării configurației. Regretăm."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -186,47 +280,47 @@ msgstr "Configurarea parolei și conexiunile externe sunt activate."
 msgid "WARNING"
 msgstr "ATENȚIE"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rețele"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S-a găsit %i server în server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nu se pot lega porturile la adresa specificată: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portul %u nu este disponibil. Veți fi LOWID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -241,48 +335,48 @@ msgstr ""
 "\n"
 "Verificați rețeaua pentru a vă asigura că portul este deschis pentru intrare și ieșire."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "A eșuat crearea fișierului Semnătură Online"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "A eșuat crearea fișierului aMule Semnătură Online"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Localizarea selectată se pare că nu este instalată pe computer. (Notă: Se va încerca configurarea acesteia oricum)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Aceasta este prima dată când rulați aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Această versiune este o versiune de testare, actualizată zilnic și\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nu vă dăm nici un fel de garanție dacă nu se va strica nimic, ardeți-vă casa,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "sau omorâți-vă câinele. Dar * ar trebui să fie * sigur de utilizat oricum.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mai multe informații, suport și versiuni noi pot fi găsite pe pagina noastră web,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "la https://amule-org.github.io, sau în canalul nostru IRC #aMule at irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportați orice fel de probleme la https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -290,137 +384,137 @@ msgstr ""
 "Dosarul specificat pentru Semnătura Online NU ESTE VALID!\n"
 "Semnătura Online va fi DEZACTIVATĂ până va fi reparată problema în preferințe."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "S-a notificat numele serverului"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Prealocarea spațiului pe disc pentru fișierul '%s' a eșuat: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "EROARE: nu se poate deschide fișierul jurnal"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ATENȚIE: fișierul jurnal este gol. Ceva este greșit."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Jurnalul a fost resetat"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesaj server: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se omite descărcarea a %s, fiindcă fișierul solicitat nu este mai nou."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "A eșuat descărcarea listei de noduri."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "A eșuat deschiderea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Fișierul de verificare a versiunii este corupt"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Utilizați o versiune învechită de aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versiunea dumneavoastră de aMule este %i.%i.%i iar ultima versiune este %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATENȚIE: Versiunea dumneavoastră aMuled este învechită: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Copia dumneavoastră aMule este actualizată."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "A eșuat descărcarea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizatori: %s | Fișiere: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizatori: E: %s K: %s | Fișiere: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nu este selectată nicio rețea"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "cu LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "cu HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectat la %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectare la %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Deconectat de la eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad este pornit."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad este oprit."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Conectat la Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectat la Kad (prin firewall)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Deconectat de la Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nu se poate utiliza rețeaua Kad dacă portul UDP este dezactivat în preferințe, nu se pornește."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rețeaua Kad este dezactivată în preferințe, nu se conectează."
 
@@ -450,124 +544,72 @@ msgstr "Nu se poate crea fișierul Pid"
 msgid "ERROR: %s"
 msgstr "EROARE: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Acesta este aMule %s bazat pe eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Rulând pe %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitați https://github.com/amule-org/amule/releases/latest pentru a verifica dacă este disponibilă o nouă versiune."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "EROARE FATALĂ: A eșuat crearea temporizatorului"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "control distant aMule"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Variantă versiune:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Client p2p bazat pe eMule pentru toate platformele \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Site web: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Site web: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Indisponibil"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Drept de autor (c) 2003-2019 Echipa aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Părți din aMule sunt bazate pe \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Rutare P2P bazată pe XOR metric.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Drept de autor (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Mesaj"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "dialogul aMule distrus"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Se conecteză"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Se conectează"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deconectat"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Prin firewall"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Conectat"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Se conectează"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Închis"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -577,176 +619,176 @@ msgstr "Kad: Închis"
 msgid "Cancel"
 msgstr "Anulare"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Oprește încercările curente de conectare"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Deconectează"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Deconectează de la rețelele curent conectate"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Conectează"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Conectează la rețelele activate curent"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "În: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MO/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "În: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectat)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Deconectat)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Sigur doriți să închideți %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Confirmare închidere"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Lansare comandă:"
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- implicit -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Directorul aspectului aplicației '%s' nu există"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENȚIE: Nu se poate deschide fișierul aspect '%s' pentru citit"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Rețele"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Fereastra rețelelor"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Căutări"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Fereastra căutărilor"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Descărcări"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Fereastra descărcărilor"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Fișiere partajate"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Fereastra fișierelor partajate"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Mesaje"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Fereastra mesajelor"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistici"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Fereastra graficului statisticilor"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferințe"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Fereastra configurare preferințe"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importă"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Unealta de importat fișiere parțiale"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Despre"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Despre/Ajutor"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Rețea eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Rețea Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Nicio rețea"
 
@@ -786,7 +828,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "GUI distant rezolvare eveniment EC"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Conectare eșuată. Nu se poate conecta la %s:%d\n"
@@ -936,7 +978,7 @@ msgid "Enter Captcha"
 msgstr "Introduceți Captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Categorie"
 
@@ -1358,7 +1400,7 @@ msgstr "EROARE: Eroare IO!"
 msgid "ERROR: Failed!"
 msgstr "EROARE: Eșuare!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "În coadă"
 
@@ -1992,7 +2034,7 @@ msgstr ""
 "\n"
 "Se creează clientul...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2001,7 +2043,7 @@ msgstr ""
 "\n"
 "Ok, se iese %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2013,51 +2055,51 @@ msgstr ""
 "Trebuie să specificați o parolă fie în fișierul de configurare\n"
 "sau în linia de comandă, sau introduceți una când se solicită.\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Arată acest text de ajutor."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Gazda unde aMule rulează. (implicit: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Portul aMule pentru conexiunea externă. (implicit: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Parolă conexiune externă."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Citește configurația din fișier."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Nu tipării nicio ieșire la stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Fi detaliat - arată și mesajele de depanare."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Configurează localizarea programului (limba)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Scrie opțiunile liniei de comandă la fișierul de configurare."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Creează fișierul de configurare bazat pe fișierul de configurare al aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Tipărește versiunea programului."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2375,6 +2417,11 @@ msgstr "Port nevalid la bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completați toate câmpurile solicitate"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Mesaj"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Sigur doriți să descărcați un nou fișier nodes.dat?\n"
@@ -2548,7 +2595,7 @@ msgstr "Conexiune externă; Acces interzis fiindcă:"
 msgid "External Connection: Handshake failed."
 msgstr "Conexiune externă: A eșuat strângerea de mână."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Procesul Asio %d pornit"
@@ -2855,7 +2902,7 @@ msgstr "Name:"
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Local"
 
@@ -2975,7 +3022,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Oprește"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Descarcă"
 
@@ -4841,7 +4888,7 @@ msgstr "Se alocă"
 msgid "Insufficient disk space"
 msgstr "Spațiu pe disc insuficient"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descărcat"
@@ -5452,7 +5499,7 @@ msgstr "Reîncarcă lista fișierelor partajate."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Căutări"
@@ -5473,7 +5520,7 @@ msgstr "Dimensiunea mică trebuie să fie mai mică decât dimensiunea mare. Dim
 msgid "Search warning"
 msgstr "Atenționare căutare"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Principal"
 
@@ -5511,37 +5558,37 @@ msgstr "Nu este apreciat"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Descarcă în categoria"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obține %s pentru acest fișier"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Caută fișiere asociate (eD2k, server local)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Marchează ca fișier cunoscut"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiază link-ul eD2k în memoria temporară"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Sunteți conectat la serverul pe care încercați să-l ștergeți, deconectați-vă întâi."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Anulat"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Nou"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -64,11 +64,11 @@ msgstr " Drept de autor (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Site web:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -26,21 +26,21 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Показать aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Удаленное управление aMule"
 
 # Used only in CVS!
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Версия CVS:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -48,27 +48,7 @@ msgstr ""
 "Многоплатформенный p2p клиент основанный на eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Сайт: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Сайт: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -77,28 +57,40 @@ msgstr ""
 "Copyright (c) 2003-2019 команда aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Часть aMule основана на \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: пиринговый роутинг на основе XOR-метрики.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr "Copyright (c) 2002-2011 Петр Маймунков ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Проверка наличия новой версии при запуске"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7964,6 +7956,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Сайт: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Сайт: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/ru.po
+++ b/po/ru.po
@@ -71,11 +71,11 @@ msgstr "Copyright (c) 2002-2011 Петр Маймунков ( petar@maymounkov.o
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Сайт:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Форум:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -25,6 +25,101 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Показать aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Удаленное управление aMule"
+
+# Used only in CVS!
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Версия CVS:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Многоплатформенный p2p клиент основанный на eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Сайт: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Сайт: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2019 команда aMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Часть aMule основана на \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: пиринговый роутинг на основе XOR-метрики.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr "Copyright (c) 2002-2011 Петр Маймунков ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Проверка наличия новой версии при запуске"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Подключаюсь к Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Вы используете устаревшую версию aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Недоступен"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -119,8 +214,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -169,7 +264,7 @@ msgstr "Результаты дебага памяти при выходе из 
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "В связи со сменой версии, значение вашей локали было изменено на значение по умолчанию. Извините."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -192,47 +287,47 @@ msgstr "Пароль задан и внешние соединения разр�
 msgid "WARNING"
 msgstr "ПРЕДУПРЕЖДЕНИЕ"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Сети"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "В файле 'server.met' найден %i сервер"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Невозможно связать порты с указанными адресами: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u не доступен. У вас будет LowID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -247,48 +342,48 @@ msgstr ""
 "\n"
 "Проверьте вашу сетевую конфигурацию, убедитесь что необходимый порт открыт."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Выбранная локаль отсутствует в вашей системе (тем не менее, будет произведена попытка ее использовать)."
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Это первый запуск aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Эта версия является тестовой и обновляется ежедневно.\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "мы не предоставляем никаких гарантий на случай каких либо повреждений, пожара \n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "или же смерти вашей любимой собачки. И все же использование ее *должно* быть безопасным. \n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Дополнительную информацию, поддержку и обновленные версии вы найдете на нашем сайте \n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, или на нашем irc-канале #aMule, находящемся на сервере irc.libera.chat. \n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Сообщайте нам о найденных ошибках на форум https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -296,141 +391,141 @@ msgstr ""
 "Указан неверный каталог для файлов Online-подписей!\n"
 "Online-подписи будут отключены пока вы не исправите это в настройках."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Имя сервера подтверждено"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Выделение место под файл '%s' не удалось: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "Ошибка: невозможно открыть файл журнала"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: файл журнала пуст. Что-то здесь не так :-("
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Журнал был очищен"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Сообщение сервера: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Пропущена загрузка %s, так как запрашиваемый файл не новее."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Ошибка при загрузке списка узлов."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Поврежден файл контроля версии"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Вы используете устаревшую версию aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Версия вашего aMule - %i.%i.%i, тогда как актуальная версия - %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ВНИМАНИЕ: Версия вашего aMule устарела: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копия aMule актуальна."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Польз.: %s | Файлов: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Польз.: E: %s K: %s | Файлов: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Нет выделенной сети"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Соединен с %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Подключение к %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Отсоединен от eD2k"
 
 # Kad как сеть, или служба - поэтому в женском роде
 # да, согласен
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad запущена."
 
 # Kad как сеть, или служба - поэтому в женском роде
 # согласен
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad остановлена."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Подключен к Kad (норм.)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Подключен к Kad (за брандмауэром)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Отключился от Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Сеть Kad не может быть использована если порт UDP выключен в настройках. Отменяю запуск."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Сеть Kad выключена в настройках. Отменяю соединение."
 
@@ -460,125 +555,72 @@ msgstr "Не удалось создать pid-файл"
 msgid "ERROR: %s"
 msgstr "Ошибка: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s (основан на eMule)."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Работает на %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Посетите https://github.com/amule-org/amule/releases/latest для проверки наличия новой версии."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ФАТАЛЬНАЯ ОШИБКА: не удалось создать таймер"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Удаленное управление aMule"
-
-# Used only in CVS!
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Версия CVS:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Многоплатформенный p2p клиент основанный на eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Сайт: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Сайт: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Недоступен"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2019 команда aMule \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Часть aMule основана на \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: пиринговый роутинг на основе XOR-метрики.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr "Copyright (c) 2002-2011 Петр Маймунков ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Сообщение"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "диалоговое окно aMule уничтожено"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Идет подключение"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Соединение"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: не соединено"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: За брандмауэром"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Подключена"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Идет подключение"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr " Kad: Выключено"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -588,176 +630,176 @@ msgstr " Kad: Выключено"
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Прекратить попытки соединения"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Отключиться"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Отключиться от работающих сетей"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Подключиться"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Подключиться к разрешенным сетям"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Передача: %.1f(%.1f) | Прием: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "МБ/с"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr "kB/сек"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Передача: %.1f | Прием: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Подключен)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Отключен)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Вы действительно хотите выйти из %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Подтверждение выхода"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Команда запуска:"
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- по умолчанию -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Каталог с темами оформления '%s' не существует."
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: невозможно открыть для чтения файл скина '%s'"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Сети"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Окно сетей"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Поиск"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Окно поиска"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Загрузки"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Окно загрузки"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Публикуемые файлы"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Окно публикуемых файлов"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Окно настроек клиента"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Импорт"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Инструмент импортирования частично загруженных файлов (part files)"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "О программе"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "О программе/Помощь"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Сеть eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Сеть Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Нет сети"
 
@@ -797,7 +839,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Обработчик событий EC удаленного GUI"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Неудачное соединение. Невозможно соединиться с %s:%d\n"
@@ -947,7 +989,7 @@ msgid "Enter Captcha"
 msgstr "Введите код"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Категория"
 
@@ -1370,7 +1412,7 @@ msgstr "ОШИБКА: Ошибка ввода/вывода!"
 msgid "ERROR: Failed!"
 msgstr "ОШИБКА: Неудачно!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "В очереди"
 
@@ -2006,7 +2048,7 @@ msgstr ""
 "\n"
 "Создается клиент...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2015,7 +2057,7 @@ msgstr ""
 "\n"
 "Ok, выход из %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2029,51 +2071,51 @@ msgstr ""
 "\n"
 "Завершение работы...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Показать эту справку."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Узел, на котором работает aMule (по умолчанию: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Порт aMule для внешних подключений (по умолчанию: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Пароль для внешнего соединения."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Прочесть настройки из файла."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Не выводить ничего в поток стандартного вывода."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Детально - выводить отладочную информацию."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Установить локаль программы (язык)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Записать параметры командной строки в конфигурационный файл."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Создает конфигурационный файл на основе оного из aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Вывести версию программы."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2392,6 +2434,11 @@ msgstr "Неверный порт для инициализации"
 msgid "Please fill all fields required"
 msgstr "Пожалуйста, заполните все необходимые поля"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Сообщение"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Вы уверены что хотите загрузить новый файл nodes.dat?\n"
@@ -2566,7 +2613,7 @@ msgstr "Внешнее Соединение: В доступе отказано 
 msgid "External Connection: Handshake failed."
 msgstr "Внешнее Соединение: авторизация неудачна."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Автоматическое обновление начато"
@@ -2877,7 +2924,7 @@ msgstr "Имя:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Локальный"
 
@@ -2997,7 +3044,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Остановить"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Загрузка"
 
@@ -4877,7 +4924,7 @@ msgstr "Выделяется место"
 msgid "Insufficient disk space"
 msgstr "Недостаточно места на диске"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Загружено"
@@ -5492,7 +5539,7 @@ msgstr "Обновить список публикуемых файлов."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Поиск"
@@ -5514,7 +5561,7 @@ msgid "Search warning"
 msgstr "Предупреждение поиска"
 
 # It's about default category to download to.
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Общая"
 
@@ -5553,37 +5600,37 @@ msgstr "Без оценки"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Загрузить в категории"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Получить %s для этого файла"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Искать связанные файлы (eD2k, локально)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Отметить как известный"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Копировать eD2k ссылку в буфер"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Вы соединены с сервером, который вы пытаетесь удалить. Отключитесь от него."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Отменено"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Новый"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -22,20 +22,20 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);\n"
 "X-Generator: Poedit 3.9\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Prikaži aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Oddaljen nadzor aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Posnetek:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -43,29 +43,7 @@ msgstr ""
 "Odjemalec P2P, ki temelji na eMule in je za vse platforme\n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-#, fuzzy
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Spletna stran: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-#, fuzzy
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Spletna stran: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -74,28 +52,40 @@ msgstr ""
 "Avtorske pravice © 2003–2019 ekipa aMule\n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Del aMule temelji na\n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: usmerjanje med enakovrednimi, ki temelji na metriki XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Avtorske pravice 2002–2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Ob zagonu preveri za novo različico"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7949,6 +7939,27 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Spletna stran: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Spletna stran: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -21,6 +21,102 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);\n"
 "X-Generator: Poedit 3.9\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Prikaži aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Oddaljen nadzor aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Posnetek:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"Odjemalec P2P, ki temelji na eMule in je za vse platforme\n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+#, fuzzy
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Spletna stran: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+#, fuzzy
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Spletna stran: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Avtorske pravice © 2003–2019 ekipa aMule\n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Del aMule temelji na\n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: usmerjanje med enakovrednimi, ki temelji na metriki XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Avtorske pravice 2002–2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Ob zagonu preveri za novo različico"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Povezovanje s Kad …"
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Uporabljate zastarelo različico aMule."
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Ni na voljo"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -116,8 +212,8 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -166,7 +262,7 @@ msgstr "Rezultati razhroščevanja pomnilnika za izhod iz aMule:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše področne nastavitve so bile spremenjene na sistemsko privzete zaradi spremembe v nastavitvah. Oprostite."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -189,47 +285,47 @@ msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 msgid "WARNING"
 msgstr "OPOZORILO"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Omrežja"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i najdenih strežnikov v server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Vrat ni bilo moč povezati z navedenim naslovom: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Vrata %u niso razpoložljiva. Imeli boste nizek ID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -244,49 +340,49 @@ msgstr ""
 "\n"
 "Preverite omrežje in se prepričajte, da so vrata odprta za izhod in vhod."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti datoteke spletnega podpisa"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti aMule datoteke spletnega podpisa"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Kot kaže izbrana področna nastavitev ni nameščena na vašem računalniku. (Opomba: vseeno se jo bo poskusilo nastaviti)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "To je vaš prvi zagon aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "To je testna različica, posodobljena dnevno in\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo zagotovila, da ne bo ničesar poškodovala, zažgala vaše hiše\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ali ubila vašega psa. Vendar bi vseeno morala biti varna za uporabo.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Več informacij, podporo in nove različice, lahko najdete na naši domači strani,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, ali na kanalu IRC #aMule, na strežniku irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 #, fuzzy
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Morebitne hrošče lahko sporočite na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -294,138 +390,138 @@ msgstr ""
 "Navedena mapa za datoteke za spletni podpis je NEVELJAVNA.\n"
 "Spletni podpis bo ONEMOGOČEN, dokler težave ne odpravite v nastavitvah."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Gostitelj strežnika obveščen"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Vnaprejšnja dodelitev prostora na disku za datoteko »%s« ni uspela: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "NAPAKA: ni mogoče odpreti dnevniške datoteke"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "OPOZORILO: dnevniška datoteka je prazna. Nekaj je narobe."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Dnevnik je bil ponastavljen"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sporočilo strežnika: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Prejemanje %s je bilo preskočeno, ker zahtevana datoteka ni novejša."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Ni bilo mogoče prejeti seznama vozlišč."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Ni bilo mogoče odpreti prejete datoteke za preverjanje različice"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Datoteka za preverjanje različice je pokvarjena"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Uporabljate zastarelo različico aMule."
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Različica vaše aMule je %i.%i.%i, najnovejša različica pa je %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 #, fuzzy
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OPOZORILO: vaša različica aMule je zastarela: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Uporabljate najnovejšo različico aMule."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Ni bilo mogoče prejeti datoteke za preverjanje različice"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uporabniki: %s | Datoteke: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uporabniki: E: %s K: %s | Datoteke: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Izbranega ni nobenega omrežja"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "z nizkim ID-jem"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "z visokim ID-jem"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Povezano na %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Povezovanje z %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Povezava z eD2k prekinjena"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad zagnan."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad ustavljen."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Povezano v Kad (v redu)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Povezano v Kad (za požarnim zidom)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Povezava s Kad prekinjena"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Omrežja Kad ni mogoče uporabljati, če so vrata UDP onemogočena v nastavitvah. Kad ni zagnan."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Omrežje Kad je onemogočeno v nastavitvah. Ni povezave."
 
@@ -455,127 +551,73 @@ msgstr "Ni moč ustvariti datoteke PID"
 msgid "ERROR: %s"
 msgstr "NAPAKA: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To je aMule %s, ki temelji na eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Operacijski sistem: %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 #, fuzzy
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Obiščite https://github.com/amule-org/amule/releases/latest da preverite, če je na voljo nova različica."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "USODNA NAPAKA: ustvaritev časomerilnika ni uspela"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Oddaljen nadzor aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Posnetek:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"Odjemalec P2P, ki temelji na eMule in je za vse platforme\n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Spletna stran: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Ni na voljo"
 
-#: src/amuleDlg.cpp:535
-#, fuzzy
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Spletna stran: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Avtorske pravice © 2003–2019 ekipa aMule\n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Del aMule temelji na\n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: usmerjanje med enakovrednimi, ki temelji na metriki XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Avtorske pravice 2002–2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Sporočilo"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Pogovorno okno aMule je bilo uničeno"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Povezovanje"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: povezovanje"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: povezava prekinjena"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: za požarnim zidom"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: povezano"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: povezovanje"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: izklopljen"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -585,175 +627,175 @@ msgstr "Kad: izklopljen"
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Ustavi trenutne poskuse povezovanja"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekini povezavo s trenutno povezanimi omrežji"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Poveži se"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Poveži se s trenutno omogočenimi omrežji"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gor: %.1f%s (%.1f) | Dol: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MiB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gor: %.1f%s | Dol: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Povezano)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ni povezave)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ali res želite zapustiti %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Potrditev izhoda"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Zaženi ukaz: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "– privzeto –"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Mapa za preobleke »%s« ne obstaja"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OPOZORILO: datoteke s preobleko »%s« ni moč odpreti za branje"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Omrežja"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Okno z omrežji"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Iskanja"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Okno z iskanji"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Prejemanja"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Okno s prejemanji"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Deljene datoteke"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Okno z deljenimi datotekami"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Sporočila"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Okno s sporočili"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Okno s statističnimi grafi"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavitve"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Okno z nastavitvami"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Uvoz"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Orodje za uvažanje delnih datotek"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "O programu/pomoč"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Omrežje eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Omrežje Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Brez omrežja"
 
@@ -793,7 +835,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Rokovalnik z dogodki zunanje povezave oddaljenega vmesnika"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Povezava ni uspela. Ni se moč povezati z %s: %d\n"
@@ -945,7 +987,7 @@ msgid "Enter Captcha"
 msgstr "Vnesite besedilo s slike"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1370,7 +1412,7 @@ msgstr "NAPAKA: vhodno/izhodna napaka"
 msgid "ERROR: Failed!"
 msgstr "NAPAKA: neuspeh"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "V vrsti"
 
@@ -2007,7 +2049,7 @@ msgstr ""
 "\n"
 "Ustvarjanje odjemalca …\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2016,7 +2058,7 @@ msgstr ""
 "\n"
 "V redu, končevanje %s …\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2030,51 +2072,51 @@ msgstr ""
 "\n"
 "Končevanje …\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Prikaži to besedilo pomoči."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Gostitelj kjer teče aMule. (privzeto: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Vrata aMule za zunanje povezave. (privzeto: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Geslo za zunanje povezave."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Preberi nastavitve iz datoteke."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Ne izpisuj izhodnih podatkov na standardni izhod."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Zgovorno – prikaži tudi razhroščevalna sporočila."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Nastavi področne nastavitve (jezik) programa."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Zapiši možnosti ukazne vrstice v nastavitveno datoteko."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Ustvari nastavitveno datoteko, ki temelji na nastavitveni datoteki aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Izpiši različico programa."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2394,6 +2436,11 @@ msgstr "Neveljavna vrata za začetno nalaganje"
 msgid "Please fill all fields required"
 msgstr "Prosimo, izpolnite vsa zahtevana polja"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Sporočilo"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Ali res želite prejeti novo datoteko nodes.dat?\n"
@@ -2570,7 +2617,7 @@ msgstr "Zunanja povezava: dostop je bil zavrnjen. Razlog: "
 msgid "External Connection: Handshake failed."
 msgstr "Zunanja povezava: rokovanje ni uspelo."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asinhrona nit %d se je začela"
@@ -2877,7 +2924,7 @@ msgstr "Ime:"
 msgid "Type"
 msgstr "Vrsta"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Krajevno"
 
@@ -2997,7 +3044,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Ustavi"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Pridobi"
 
@@ -4872,7 +4919,7 @@ msgstr "Dodeljevanje"
 msgid "Insufficient disk space"
 msgstr "Premalo prostora na disku"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Prejeto"
@@ -5489,7 +5536,7 @@ msgstr "Ponovno naloži seznam deljenih datotek."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Iskanje ni mogoče, ko sta tako eD2k kot tudi Kademlia onemogočena."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Napaka iskanja"
 
@@ -5509,7 +5556,7 @@ msgstr "Min. velikost mora biti manjša kot maks. velikost. Maks. velikost ni up
 msgid "Search warning"
 msgstr "Opozorilo iskanja"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Glavna"
 
@@ -5546,37 +5593,37 @@ msgstr "Ni ocenjena"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Prejemaj v kategoriji"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Dobi %s za to datoteko"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Poišči sorodne datoteke (eD2k, krajevni strežnik)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Označi kot znano datoteko"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Skopiraj povezavo eD2k na odložišče"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Povezani ste na strežnik, ki ga poskušate izbrisati. Prosimo, najprej prekinite povezavo."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Preklicano"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Novo"
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -20,46 +20,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Trego aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Kontrolli remote i aMule "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tPer me shume informacion ju lutem vizitoni https://amule-org.github.io/docs"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -68,28 +48,40 @@ msgstr ""
 "Copyright (C) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing i bazuar ne metriken XOR.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kerko per versione te reja sapo te filloje"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7930,6 +7922,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "\tPer me shume informacion ju lutem vizitoni https://amule-org.github.io/docs"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
 
 #, fuzzy
 #~ msgid "Not found"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -19,6 +19,98 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Trego aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Kontrolli remote i aMule "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "\tPer me shume informacion ju lutem vizitoni https://amule-org.github.io/docs"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (C) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Peer-to-peer routing i bazuar ne metriken XOR.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Kerko per versione te reja sapo te filloje"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Duke u lidhur me Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Ju po perdorni nje version te vjeter te aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Nuk eshte ne dispozicion"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -111,8 +203,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -166,7 +258,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vendndodhja juaj eshte ndryshuar tek System Default i pershtatur per nje nderrim konfigurimi. Me vjen keq."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -189,46 +281,46 @@ msgstr "U pranua nje lidhje e jashtme e re"
 msgid "WARNING"
 msgstr "KUJDES"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rrjetet"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i u gjet server ne server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nuk mund te lidh portat tek adresa e dhene: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u nuk eshte me vlere. Ju do te keni ID te ulet\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -243,48 +335,48 @@ msgstr ""
 "\n"
 "KOntrolloni rrjetin tuaj per tu siguruar qe porta eshte hapur per hyrje dhe dalje."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online te aMule-s"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Vendi i zgjedur duket se nuk do te instalohet ne kutine tuaj. (Shenim: Une do te mundohem ta vendos ate)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Kjo eshte hera e pare qe ju po persorni aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ky eshte nje version per testim,i azhornuar per dite, dhe\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne nuk japim siguri per te ai nuk do te thyej asgje,nuk do te djegi shtepine tuaj,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ose te vrasi qenin tuaj. Por ai *do te* behet i sigurte per tu perdorur.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Me shume informacion,mbeshtetje dhe leshime te reja do ti gjeni tek faqet tona,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "tek amule-org.github.io ose ne kanalin tone IRC #amule tek irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -292,138 +384,138 @@ msgstr ""
 "Kartela e faileve per Firmen Online qe ju specifikuat eshte e PAVLERE!\n"
 " Firma Online do te C'AKTIVIZOHET deri sa ju ta rregulloni tek Preferencat."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Emri i Serverit:"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "GABIM: nuk mund te hapet logfile"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "KUJDES: faili i log-ve eshte bosh. Dicka nuk shkon."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Faili i Log eshte risetuar"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesazhe nga Serveri: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Deshtoi ne shkarkimin e listave nod."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Deshtoi te hapi failin per kontrollin e versionit qe sapo shkarkuat"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Fili per kontrollin e versionit eshte i demtuar"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Ju po perdorni nje version te vjeter te aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versioni juaj i amUle eshte %i.%i-%i dhe versioni i fundit eshte %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "KUJDES: Versioni juaj i aMule-s eshte i vjeteruar: %i.%i-%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Kopja juaj e aMule eshte azhornuar."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Deshtoi ne shkarkimin e failit per kontrollin e versionit"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "me ID te ulet"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "me ID te larte"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "I lidhur tek %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Duke u lidhur tek %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad filloi."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad u ndalua."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "I lidhur ne Kad (Ne rregull)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "I lidhur ne Kad (Me firewall)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "I shkeputur nga Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Rrjeti Kad nuk mund te perdoret nqs porta UDP eshte c'aktivizuar tek Preferencat, nuk po filloj."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rrjeti Kad eshte c'aktivizuar tek Preferencat,nuk eshte duke u lidhur."
 
@@ -453,122 +545,72 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "GABIM: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Kjo eshte aMule %s dhe bazohet ne eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Duke punuar ne %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitoni https://github.com/amule-org/amule/releases/latest per te kontrolluar nqs eshte ne dispozicion nje version i ri."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Kontrolli remote i aMule "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
+"You are running %s.\n"
+"\n"
+"Would you like to open the download page?"
+msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "\tPer me shume informacion ju lutem vizitoni https://amule-org.github.io/docs"
+msgid "New version available"
+msgstr "Nuk eshte ne dispozicion"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (C) 2003-2026 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Peer-to-peer routing i bazuar ne metriken XOR.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Mesazh"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Duke u lòidhur"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Me Firewall"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: I lidhur"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Po lidhet"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Fikur"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -578,177 +620,177 @@ msgstr "Kad: Fikur"
 msgid "Cancel"
 msgstr "Fshij"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Ndalo tentativat e lidhjes qe po behen"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Shkeputu"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Shkeputu nga rrjetet e lidhura"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Lidhu"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Lidhu tek rrjetet"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Larte: %.1f(%.1f) | Poshte: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Larte: %.1f | Poshte: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | e lidhur)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | e shkeputur)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vertet deshironi qe te dilni nga aMule?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Konfirmimi i daljes"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Direktoria e skin '%s' nuk ekziston"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Rrjetet"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Dritaret e rrjeteve"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Kerkimet"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Dritaret e kerkimeve"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Shkarkime"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Duke shkarkuar"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Dritarja e faileve te ndara"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Mesazhe"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Dritarja e mesazheve"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistikat"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Dritarja e grafikut te statistikave"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencat"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Dritarja e rregullimeve te preferencave"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importimi"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Veglat per importimin e pjeseve te faileve"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Rreth"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Rreth/Ndihme"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Rrjeti Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Nuk ka rrjet"
 
@@ -792,7 +834,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -941,7 +983,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategori"
 
@@ -1360,7 +1402,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Ne radhe"
 
@@ -1993,7 +2035,7 @@ msgstr ""
 "\n"
 "Duke krijuar klientin...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2002,7 +2044,7 @@ msgstr ""
 "\n"
 "Ne rregull, duke dalur %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2015,51 +2057,51 @@ msgstr ""
 "ose ne nje linje-komande, ose futni nje kur kerkohet.\n"
 "Duke dalur.\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Trego kete tekstin ndihmues."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host ne te cilin aMule vepron. (default: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porta e aMule per Lidhjet e Jashtme. (default: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Fjalekalimi per Lidhjet e Jashtme."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Lexo rregullimin nga faili."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Mos printo asnje output tek stdout"
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Behu fjaleshume - trego dhe mesazhet e Debug-ut."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Vendos Locale-n e programit (gjuha)"
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Shkruaj opsionet e lenjes se komandave tek faili i konfigurimeve(rregullimeve)"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Krijo nje fail per konfigurimin te bazuar ne ate te aMule-s."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Printo versioni ne programit."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2379,6 +2421,11 @@ msgstr "Porte e pavlefshme per bootstrap"
 msgid "Please fill all fields required"
 msgstr "Ju lutem plotesoni te gjitha fushat e kerkuara"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Mesazh"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Jeni te sigurte qe deshironi te shkarkoni nje fail te ri nodes.dat?\n"
@@ -2551,7 +2598,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Fjalekalimi per Lidhjet e Jashtme."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rifreskimi Automatik filloi"
@@ -2857,7 +2904,7 @@ msgstr "Emri:"
 msgid "Type"
 msgstr "Tipi"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Lokale"
 
@@ -2977,7 +3024,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Ndalo"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Shkarkime"
 
@@ -4852,7 +4899,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5462,7 +5509,7 @@ msgstr "Ringarko listen e faileve te ndara."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Kerkimet"
@@ -5483,7 +5530,7 @@ msgstr "Masa minimale duhet te jete me e vogel se masa maksimale.Po injoroj Mase
 msgid "Search warning"
 msgstr "PoParalajmerim per kerkim"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Kryesore"
 
@@ -5520,38 +5567,38 @@ msgstr "E pavotuar"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Shkarko ne kategori"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Shtoni URLs opsionale per kete fail"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Shenoje si fail te njohur"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Ju jeni i lidhur tek serveri qe deshironi te fshini. ju lutem ne fillim shkeputuni prej tij."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "Fshij"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -64,11 +64,11 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Webbsida:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forum:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -19,6 +19,104 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Visa aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule fjärrkontroll"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"'Alla-Platformar' p2p-klient basserad på eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+"Webbsida: https://amule-org.github.io \n"
+"\n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr ""
+"Webbsida: https://amule-org.github.io \n"
+"\n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Delar av aMule är baserad på \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Peer-to-peer routing baserad på XOR metric.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Sök efter ny version vid start"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Ansluter till Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Du använder en gammal version av aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Inte tillgänglig"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -112,8 +210,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -162,7 +260,7 @@ msgstr "Minnes-debug-resultat för aMules avslut"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Din plats har ändrats till systemets standard på grund av en konfigurationsändring. Ledsen."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -185,47 +283,47 @@ msgstr "Lösenord sparad och extern anslutning aktiverad."
 msgid "WARNING"
 msgstr "VARNING"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nätverk"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server hittad i server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kunde inte binda portarna till specificerad adress: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u är inte tillgänglig. Du kommer att bli LOWID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -240,48 +338,48 @@ msgstr ""
 "\n"
 "Kontrollera ditt nätverk för att se att porten är öppen för ut och in-trafik."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Misslyckades med att skapa OnlineSig-fil"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Misslyckades med att skapa aMule OnlineSig-fil"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Den valda platsen verkar inte vara installerad på din burk. (OBS: Jag försöker ändå)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Det här är första gången du kör aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Den här versionen är en testversion, uppdateras dagligen, och\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi ger inga garantier att den inte förstör allt, bränner ner huset,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller dödar din hund. Men den *bör* vara säker att använda.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mer information, support och nya versioner kan hittas på vår hemsida,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, eller i vår IRC-kanal #aMule på irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Rapportera gärna eventuella fel på https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -289,137 +387,137 @@ msgstr ""
 "Katalogen för Online Signaturefiler som du angav är OGILTIG!\n"
 " OnlineSignatur kommer vara INAKTIVERAD tills du ändrar inställningarna."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Serverns hostname underrättad"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Förallokerad diskutrymme för filen '%s' misslyckades: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "FEL: kan inte öppna loggfilen"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VARNING: loggfilen är tom. Någonting är fel."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Loggen har nollställts"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servermeddelande: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Avslutade nerladdningen av %s eftersom begärd fil inte är nyare."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Misslyckades med att hämta nodlistan."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Misslyckades med att öppna den hämtade versionskontrollfilen"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Korrupt versionskontrollfil"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Du använder en gammal version av aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMuleversion är %i.%i.%i och den senaste versionen är %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VARNING: Din version av aMuled är gammal: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Din version av aMule är den senaste."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Misslyckades med att hämta versionskontrollfilen"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Användare: %s | Filer: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Användare: E: %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Inga nätverk valda"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "med LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "med HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ansluten till %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ansluter till %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Frånkopplad från eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad startad."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad stoppad."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Ansluten till Kad (ok)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Ansluten till Kad (brandvägg)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Frånkopplad från Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kadnätverket kan inte användas om UDP-porten är inaktiverad i inställningarna, startar inte."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadnätverket är inaktiverad i inställningarna, ansluter inte."
 
@@ -449,128 +547,72 @@ msgstr "Kan inte skapa Pid-fil"
 msgid "ERROR: %s"
 msgstr "FEL: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Det här är aMule %s baserad på eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Kör på %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besök https://github.com/amule-org/amule/releases/latest för att se om en ny version finns tillgänglig."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ALLVARLIGT FEL: Kunde inte skapa Timer"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule fjärrkontroll"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"'Alla-Platformar' p2p-klient basserad på eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-"Webbsida: https://amule-org.github.io \n"
-"\n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-"Webbsida: https://amule-org.github.io \n"
-"\n"
+msgid "New version available"
+msgstr "Inte tillgänglig"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Delar av aMule är baserad på \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Peer-to-peer routing baserad på XOR metric.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Meddelande"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMule-dialog avslutad"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Ansluter"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ansluter"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Frånkopplad"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Via brandvägg"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Ansluten"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Ansluter"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -580,176 +622,176 @@ msgstr "Kad: Av"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Stoppa de nuvarande anslutningsförsöken"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Koppla från"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Koppla från de nätverk som nu är anslutna."
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Anslut"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Anslut till de nätverk som är aktiverade."
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upp: %.1f(%.1f) | Ner: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upp: %.1f | Ner: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ansluten)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Frånkopplad)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vill du verkligen avsluta %s?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Bekräfta avslutning"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Kör kommando:"
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- standard -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-mappen '%s' finns inte"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "Varning: Kan inte öppna skin-filen '%s' för läsning"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Nätverk"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Nätverksfönster"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Sökningar"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Sökfönster"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Hämtningar"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "Hämtningsfönster"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Delade filer"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Delade filer-fönster"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Meddelanden"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Meddelandefönster"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Statistiksgrafsfönster"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Inställningar"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Inställningsfönster"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Importera"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Partfile-importerings-verktyget"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Om/Hjälp"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k-nätverk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad-nätverk"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Inget nätverk"
 
@@ -789,7 +831,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Fjärr-GUI EC händelse-hanterare"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Anslutning misslyckades. Kan inte ansluta till %s:%d\n"
@@ -937,7 +979,7 @@ msgid "Enter Captcha"
 msgstr "Ange Captcha"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Kategori"
 
@@ -1356,7 +1398,7 @@ msgstr "FEL: IO-fel"
 msgid "ERROR: Failed!"
 msgstr "FEL: Mysslyckades!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Lagd i kö"
 
@@ -1988,7 +2030,7 @@ msgstr ""
 "\n"
 "Skapar klient...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1997,7 +2039,7 @@ msgstr ""
 "\n"
 "Ok, avslutar %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2011,51 +2053,51 @@ msgstr ""
 "\n"
 "Avslutar...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Visa den här hjälptexten."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Värd där aMule körs. (standard: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMules port for extern anslutning. (standard: 4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Lösenord för extern anslutning"
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Läs in konfiguration från fil."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Skriv inte någon output till stout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Använd verbose - visa även debug-meddelanden."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Ställer in program locale (språk)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Skriv kommandon för inställningar till configfilen."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Skapar config-fil baserad på aMules configfil."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Skriv ut programversion."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2371,6 +2413,11 @@ msgstr "Ogiltig port till bootstrap"
 msgid "Please fill all fields required"
 msgstr "Fyll i alla fält som krävs"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Meddelande"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Är du säker på att du vill hämta en ny nodes.dat-fil?\n"
@@ -2541,7 +2588,7 @@ msgstr "Extern Anslutning: Åtkomst nekad på grund av: "
 msgid "External Connection: Handshake failed."
 msgstr "Extern anslutning: Handskakning misslyckades."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio tråd %d startad"
@@ -2848,7 +2895,7 @@ msgstr "Namn:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Lokal"
 
@@ -2968,7 +3015,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stoppa"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Hämta"
 
@@ -4830,7 +4877,7 @@ msgstr "Allokera"
 msgid "Insufficient disk space"
 msgstr "Otillräckligt diskutrymme"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Nedladdad"
@@ -5437,7 +5484,7 @@ msgstr "Ladda om listan med delade filer."
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Sökningar"
@@ -5458,7 +5505,7 @@ msgstr "Min storlek måste vara mindre än max storlek. Max storlek ignoreras."
 msgid "Search warning"
 msgstr "Sökvarning"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Huvud"
 
@@ -5496,37 +5543,37 @@ msgstr "Inte betygsatt"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Nedladdning i kategori"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Hämta %s för den här filen:"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Sök relaterade filer (eD2k, lokal server)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Markera som känd fil"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiera eD2k-länken till urklipp"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Du är ansluten till den server som du försöker ta bort. Vänligen koppla ifrån först."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "Avbryten"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Ny"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Visa aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule fjärrkontroll"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,31 +41,7 @@ msgstr ""
 "'Alla-Platformar' p2p-klient basserad på eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-"Webbsida: https://amule-org.github.io \n"
-"\n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-"Webbsida: https://amule-org.github.io \n"
-"\n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -74,28 +50,40 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Delar av aMule är baserad på \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing baserad på XOR metric.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Sök efter ny version vid start"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7890,6 +7878,29 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr ""
+#~ "Webbsida: https://amule-org.github.io \n"
+#~ "\n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr ""
+#~ "Webbsida: https://amule-org.github.io \n"
+#~ "\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:16+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -16,6 +16,89 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#: src/AboutDialog.cpp:49
+msgid "About aMule"
+msgstr ""
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr ""
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr ""
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr ""
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr ""
+
+#: src/AboutDialog.cpp:94
+msgid "Click to check for a newer version."
+msgstr ""
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+msgid "Checking for updates..."
+msgstr ""
+
+#: src/AboutDialog.cpp:160
+msgid "You are running the latest version."
+msgstr ""
+
+#: src/AboutDialog.cpp:164
+#, c-format
+msgid "A new version (%s) is available:"
+msgstr ""
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -107,8 +190,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -157,7 +240,7 @@ msgstr ""
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -178,44 +261,44 @@ msgstr ""
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -225,184 +308,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -431,117 +514,71 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr ""
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr ""
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
+#: src/amuleDlg.cpp:605
+msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr ""
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr ""
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr ""
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -551,175 +588,175 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr ""
 
@@ -759,7 +796,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
@@ -907,7 +944,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr ""
 
@@ -1325,7 +1362,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr ""
 
@@ -1933,14 +1970,14 @@ msgid ""
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -1949,51 +1986,51 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "அகோவேறுகழுதை இயங்கும் புரவலன். (இயல்புநிலை: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2302,6 +2339,11 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr ""
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
@@ -2471,7 +2513,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2771,7 +2813,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr ""
 
@@ -2891,7 +2933,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr ""
 
@@ -4742,7 +4784,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5316,7 +5358,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr ""
 
@@ -5336,7 +5378,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr ""
 
@@ -5372,36 +5414,36 @@ msgstr ""
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:16+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,69 +17,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr ""
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.9\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "aMule'yi Göster"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule uzak denetimi "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Bilgileri:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,27 +41,7 @@ msgstr ""
 "eMule üzerine kurulu 'Sistem-Üstü' p2p yazılımı \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web Sitemiz: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forumumuz: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Belgelendirme: https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Hata raporları: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -69,28 +49,40 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Ekibi \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "aMule'nin üzerinde kurulduğu parçalar: \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: XOR matrisi üzerine kurulu eşten eşe iletişim.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Yeni sürümü başlangıçta denetle."
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7894,6 +7886,25 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Web Sitemiz: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Forumumuz: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Belgelendirme: https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "Hata raporları: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -19,6 +19,99 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.9\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "aMule'yi Göster"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule uzak denetimi "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Bilgileri:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"eMule üzerine kurulu 'Sistem-Üstü' p2p yazılımı \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Web Sitemiz: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Forumumuz: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Belgelendirme: https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"Hata raporları: https://github.com/amule-org/amule/issues \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 aMule Ekibi \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "aMule'nin üzerinde kurulduğu parçalar: \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: XOR matrisi üzerine kurulu eşten eşe iletişim.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Yeni sürümü başlangıçta denetle."
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Kad ağına bağlanıyor…"
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "aMule'nin eski bir sürümünü kullanıyorsunuz!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Devre dışı"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -118,8 +211,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "ED2Links dosyasından %u bağlantı eklenemedi (ayrıntılar için kütüğe bakın)."
 msgstr[1] "ED2Links dosyasından %u bağlantı eklenemedi (ayrıntılar için kütüğe bakın)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -168,7 +261,7 @@ msgstr "aMule çıkışı için hafıza hata raporlama sonuçları:"
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Bir yapılandırma değişikliği nedeniyle dil ayarınız 'Sistem Varsayılanı'na çevrildi. Üzgünüm. Vallahi…"
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -191,11 +284,11 @@ msgstr "Parola ayarlandı ve dış bağlantılar etkinleştirildi."
 msgid "WARNING"
 msgstr "UYARI"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "Ağ başlatması"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -203,34 +296,34 @@ msgstr ""
 "aMule, eksik ağ başlatma dosyaları olduğunu tespit etti.\n"
 "Hangilerinin indirileceklerini seçin:"
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "eD2k sunucu listesi (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad başlangıç düğümleri (nodes.dat)"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web sunucusu pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Belirtilen şu adrese portlar bağlanamıyor: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port. %u kullanılamıyor. DÜŞÜKID alacaksınız.\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -245,48 +338,48 @@ msgstr ""
 "\n"
 "Ağ ayarlarınıza göz atarak portun giriş ve çıkışlar için açık olup olmadığını denetleyiniz."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMule Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Seçilen yerelleştirme görünüşe göre bilgisayarınızda yüklü değil. (Not: Bunu yine de yapmaya çalışacağım)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Hoş geldiniz! aMule %s sürümünü ilk kez kullanıyorsunuz."
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bu sürüm bir deneme sürümü, her gün güncellenir ve\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "bir şeyleri bozmayacağını veya evinizi yakmayacağını \n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "yahut da köpeğinizi öldürmeyeceğini garanti edemeyiz. Fakat bir *sorun* yaratmayacağını da umuyoruz.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daha fazla bilgi, destek ve yeni sürümler ana sayfamızda bulunabilir\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io veya IRC kanalımız: irc.libera.chat sunucusunda #aMule \n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Her türlü hatayı bize bildirmekten çekinmeyin https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -294,137 +387,137 @@ msgstr ""
 "Belirlediğiniz Çevrim içi İmza dosyaları dizini GEÇERSİZ!\n"
 " Çevrim içi İmza, ayarlarınızda düzeltene kadar DEVRE DIŞI bırakıldı."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Sunucu makine adı uyarıldı"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "%s dosyası için diskte yer ayırma başarısız oldu: %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "HATA: Günlük dosyası açılamıyor."
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UYARI: Günlük dosyası boş, bir şeyler yanlış."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Günlük kaydı silindi"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sunucu İletisi: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s indirilmeyecek; çünkü istenen dosya yeni değil."
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Nod listesini indirme başarısız."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "İndirilen sürüm denetleme dosyasını açma başarısız oldu."
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Bozuk sürüm denetleme dosyası"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "aMule'nin eski bir sürümünü kullanıyorsunuz!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "aMule sürümünüz %i.%i.%i ve en güncel sürüm %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "En güncel sürüm her zaman https://github.com/amule-org/amule/releases/latest adresinde bulunabilir."
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UYARI: aMuled sürümünüz eski: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "aMule sürümünüz güncel."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Sürüm denetleme dosyasını indirme başarısız oldu."
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kullanıcılar: %s | Dosyalar: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kullanıcılar: E: %s K: %s | Dosyalar: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Hiç bir ağ seçilmedi"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "DüşükID ile"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "YüksekID ile"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Bağlandı: %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "Bağlanıyor: %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "eD2k Bağlantısı kesildi"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kademlia başladı."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kademlia durdu."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "Kademlia ağına bağlanıldı (tamam)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "Kademlia ağına bağlanıldı (Güvenlik duvarı arkasında)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Kademlia bağlantısı kesildi."
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDP portu ayarlarda devre dışı bırakılmışsa Kad ağı kullanılamaz. Başlatılmıyor."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad ağı ayarlarda devre dışı bırakılmış, bağlanılmıyor."
 
@@ -453,123 +546,72 @@ msgstr "Pid dosyası oluşturulamıyor"
 msgid "ERROR: %s"
 msgstr "HATA: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Bu, eMule üzerine kurulu olan aMule %s yazılımıdır."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "%s üzerinde çalışıyor"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Yeni sürüm denetimi için https://github.com/amule-org/amule/releases/latest adresini ziyaret ediniz."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ÖNEMLİ HATA: Zamanlayıcı oluşturulamadı"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule uzak denetimi "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Bilgileri:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"eMule üzerine kurulu 'Sistem-Üstü' p2p yazılımı \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "En güncel sürüm her zaman https://github.com/amule-org/amule/releases/latest adresinde bulunabilir."
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Web Sitemiz: https://amule-org.github.io \n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "Devre dışı"
 
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forumumuz: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Belgelendirme: https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"Hata raporları: https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 aMule Ekibi \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "aMule'nin üzerinde kurulduğu parçalar: \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: XOR matrisi üzerine kurulu eşten eşe iletişim.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "İleti"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMule diyaloğu imha edildi"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Bağlanıyor"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: Bağlanıyor"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Bağlantı kesildi"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: Güvenlik Duvarı"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: Bağlandı"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: Bağlanıyor"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: Kapalı"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -579,175 +621,175 @@ msgstr "Kad: Kapalı"
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Durdur"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Bağlanılmış olan ağlar ile bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "Bağlan"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "Etkinleştirilmiş olan ağlara bağlan"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gön: %.1f%s (%.1f) | İnd: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/sn"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gön: %.1f%s | İnd: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Bağlandı)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Bağlantı kesildi)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s üzerinden çıkmayı gerçekten istiyor musunuz?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Çıkışı onaylayınız"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Çalıştırma Komutu: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- ön tanımlı -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Kaplama dizini '%s' yok"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "UYARI: Kaplama dosyası '%s' okuma için açılamıyor"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Ağlar"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Ağ Penceresi"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Aramalar"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Arama Penceresi"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "İndirmeler"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "İndirme Penceresi"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Paylaşılan dosyalar"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Paylaşılan Dosya Penceresi"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Sohbet"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Sohbet Penceresi"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "İstatistikler"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "İstatistik Grafik Penceresi"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Ayarlar"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Ayar Penceresi"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Parça dosyası içe aktarım aracı"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Hakkında"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Hakkında/Yardım"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k ağı"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kademlia ağı"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Ağ yok"
 
@@ -787,7 +829,7 @@ msgstr "Bağlantı başarısız oldu. Lütfen makine ismini, bağlantı noktası
 msgid "Remote GUI EC event handler"
 msgstr "Uzak ARAYÜZ EC olay yakalayıcı"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Bağlantı Başarısız Oldu. %s:%d bağlanılamıyor\n"
@@ -937,7 +979,7 @@ msgid "Enter Captcha"
 msgstr "Captcha Gir"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Sınıf"
 
@@ -1355,7 +1397,7 @@ msgstr "HATA: Girdi-çıktı hatası!"
 msgid "ERROR: Failed!"
 msgstr "HATA: Başarısız!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "Sıraya girdi"
 
@@ -1985,7 +2027,7 @@ msgstr ""
 "\n"
 "Yazılım oluşturuluyor…\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1994,7 +2036,7 @@ msgstr ""
 "\n"
 "Tamam, çıkılıyor %s…\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2008,51 +2050,51 @@ msgstr ""
 "\n"
 "Çıkılıyor…\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Bu yardım dosyasını göster."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "aMule'nin çalıştığı makine. (varsayılan: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Dışarıdan bağlantı için aMule portu. (Varsayılan:4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Dışarıdan bağlantı şifresi."
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Yapılandırmayı dosyadan oku."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "stdout' a herhangi bir çıktı yazdırma."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Geveze ol - hata iletilerini de göster."
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Yazılım yerelini ayarla (dil)"
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Komut satırı seçeneklerini yapılandırma dosyasına yaz."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "aMule'nin yapılandırma dosyasını temel alan yapılandırma dosyası oluşturur."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Yazılım sürümünü yazdır."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Seçilen IP adresinin konumuna bakılmaksızın ZLIB sıkıştırmasını zorla (sunucuya, bir LAN IP adresine çözümlenen VPN tüneli üzerinden erişilebildiğinde kullanışlıdır)."
 
@@ -2367,6 +2409,11 @@ msgstr "Ön yükleme için geçersiz port"
 msgid "Please fill all fields required"
 msgstr "İstenilen tüm alanları doldurunuz."
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "İleti"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Yeni bir nodes.dat dosyası indirmek istediğinizden emin misiniz?\n"
@@ -2536,7 +2583,7 @@ msgstr "Dış Bağlantı: Erişim engellendi çünkü: "
 msgid "External Connection: Handshake failed."
 msgstr "Dış Bağlantı: Tanılama engellendi."
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio iş parçacığı %d başladı"
@@ -2836,7 +2883,7 @@ msgstr "Ad:"
 msgid "Type"
 msgstr "Tür"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Sunucu"
 
@@ -2956,7 +3003,7 @@ msgstr "Zaten cevap vermiş Kad eşlerinden aramayı genişletmelerini iste. Ara
 msgid "Stop"
 msgstr "Durdur"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "İndir"
 
@@ -4826,7 +4873,7 @@ msgstr "Ayrılıyor"
 msgid "Insufficient disk space"
 msgstr "Yetersiz disk alanı"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "İndirildi"
@@ -5429,7 +5476,7 @@ msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Hem eD2k hem de Kademlia devre dışı bırakıldığında arama yapmak mümkün değildir."
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "Arama hatası"
 
@@ -5449,7 +5496,7 @@ msgstr "En küçük boyut, en büyük boyuttan küçük olmalıdır. En büyük 
 msgid "Search warning"
 msgstr "Arama uyarısı."
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Ana"
 
@@ -5485,36 +5532,36 @@ msgstr "Akış hızı"
 msgid "Codec"
 msgstr "Kodlama"
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Sınıfa göre indir"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "Bu dosya için %s iste"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "İlgili dosyaları ara (eD2k, yerel sunucu)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Bilinen dosya olarak işaretle"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "eD2k bağlantısını panoya kopyala"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Şu anda İlgili Dosyalar arama işlevini destekleyen bir sunucuya bağlı değilsiniz"
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "İptal edildi"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "Yeni"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -63,19 +63,19 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Web Sitemiz:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Forumumuz:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
-msgstr ""
+msgstr "Belgelendirme:"
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"
-msgstr ""
+msgstr "Hata raporları:"
 
 #: src/AboutDialog.cpp:107
 #, fuzzy

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -19,6 +19,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "Показати aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "Віддалене керування aMule"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Знімок:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"'Багатоплатформений' p2p-клієнт, що оснований на eMule \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "Сторінка в Інтернет: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "Сторінка в Інтернет: https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "Частина aMule основана на \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "Перевірити наявність нової версії під час запуску"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "З'єднується з Kad"
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "Ви використовуєте застарілу версію aMule!"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "Недоступний"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -113,8 +207,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -163,7 +257,7 @@ msgstr "Наслідки зневадження пам'яті для виход�
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Ваша локаль змінена на системну за замовчуванням із-за зміни налаштувань. Вибачте."
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -186,47 +280,47 @@ msgstr "Пароль встановлений та дозволені зовні
 msgid "WARNING"
 msgstr "ЗАСТЕРЕЖЕННЯ"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Мережі"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сервер знайдено в server.met"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Неможливо прив'язати порт до визначеної адреси: %s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u недоступний. Ви будете мати LowID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -241,48 +335,48 @@ msgstr ""
 "\n"
 "Перевірте вашу мережу, щоб впевнитись, що порт відкритий."
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису aMule"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Обрана локаль здається не встановлена. (примітка: спроба встановити її в будь-якому випадку)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ви запускаєте aMule %s вперше"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Це тестова версія, оновлюється щодня, та\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ми не даємо жодної гарантії, якщо вона щось пошкодить, спалить ваш будинок,\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "або вб'є собаку. Але вона *має бути* безпечною у використанні всюди.\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Більше подробиць, підтримка та нові випуски можуть бути знайдені на нашій сторінці,\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "на https://amule-org.github.io, або у нашому IRC-каналі #aMule на irc.libera.chat.\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Не соромтеся повідомити про будь-які помилки на https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -290,137 +384,137 @@ msgstr ""
 "Тека для файлів онлайн-підпису НЕВІРНА!\n"
 "Онлайн-підпис буде ВИМКНЕНО поки ви не виправите це в налаштуваннях."
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "Назва сервера повідомлена"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Не вдалося виділити місце на диску для файлу '%s': %s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "ПОМИЛКА: не можу відкрити файл часопису"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ЗАСТЕРЕЖЕННЯ: журнал порожній. Щось негаразд."
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "Часопис очищено"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Повідомлення сервера: %s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "Не вдалося звантажити перелік вузлів."
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "Не вдалося відкрити звантажений файл перевірки версії"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "Файл перевірки версії зіпсований"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "Ви використовуєте застарілу версію aMule!"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ваша версія aMule %i.%i.%i, а остання %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ЗАСТЕРЕЖЕННЯ: Ваша версія aMuled застаріла: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копія aMule оновлена."
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "Неможливо звантажити файл перевірки версії"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Користувачі: %s | Файли: %s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Користувачі: %s K: %s | Файли: E: %s K: %s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Не вибрано жодної мережі"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "з LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "з HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "З'єднано з %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "З'єднується з %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "Від'єднано від eD2k"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad запущена."
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad зупинена."
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "З'єднано з Kad (все гаразд)"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "З'єднано з Kad (за фаєрволом)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "Від'єднано від Kad"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Мережа Kad не може бути використана якщо UDP-порт вимкнено в налаштуваннях, не починаю."
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Мережа Kad вимкнена в налаштуваннях, не з'єднуюсь."
 
@@ -450,124 +544,72 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "ПОМИЛКА: %s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Це aMule %s оснований на eMule."
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "Запущений на %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Відвідайте https://github.com/amule-org/amule/releases/latest, щоб перевірити наявність нових версій."
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ЖАХЛИВА ПОМИЛКА: не вдалося створити Timer"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "Віддалене керування aMule"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Знімок:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"'Багатоплатформений' p2p-клієнт, що оснований на eMule \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Сторінка в Інтернет: https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Сторінка в Інтернет: https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "Недоступний"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "Частина aMule основана на \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "Повідомлення"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "Діалог aMule знищений"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "З'єднується"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: з'єднання"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: від'єднаний"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: за фаєрволом"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: з'єднаний"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: з'єднуюсь"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: вимкнена"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -577,177 +619,177 @@ msgstr "Kad: вимкнена"
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "Зупинити поточні спроби з'єднань"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "Від'єднатися від з'єднаних мереж"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "З'єднатися"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "З'єднатися з дозволеними мережами"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Вивантаження: %.1f(%.1f) | Звантаження: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "Мбайт/с"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кбайт/с"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Вивантаження: %.1f | Звантаження: %.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | З'єднано)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Від'єднано)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ви справді хочете вийти з aMule?"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "Підтвердження виходу"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "Команда для запуску: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- за замовчуванням -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Тека з шкірами '%s' не існує"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ЗАСТЕРЕЖЕННЯ: Неможливо відкрити файл шкіри '%s' для читання"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "Мережі"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "Вікно мереж"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "Пошук"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "Вікно пошуку"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Звантаження"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Звантажується"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "Спільні файли"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "Вікно спільних файлів"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "Повідомлення"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "Вікно повідомлень"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "Вікно статистики"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Налаштування"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "Вікно налаштувань"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "Зовн. внесення"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "Засіб зовнішнього внесення частково звантажених файлів"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Про програму"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "Про/Допомога"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "Мережа eD2k"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Мережа Kad"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "Немає мережі"
 
@@ -787,7 +829,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "Віддалений обробник подій зовнішніх з'єднань графічного інтерфейсу"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "З'єдання невдале. Неможливо з'єднатися з %s:%d\n"
@@ -938,7 +980,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "Категорія"
 
@@ -1364,7 +1406,7 @@ msgstr "ПОМИЛКА: помилка введення-виведення!"
 msgid "ERROR: Failed!"
 msgstr "ПОМИЛКА: невдача!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "В черзі"
 
@@ -2002,7 +2044,7 @@ msgstr ""
 "\n"
 "Створюється клієнт...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -2011,7 +2053,7 @@ msgstr ""
 "\n"
 "Добре, виходимо %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2025,51 +2067,51 @@ msgstr ""
 "\n"
 "Вихід...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "Показати цей текст допомоги."
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Хост, де запущений aMule (за замовчуванням: 127.0.0.1)."
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Порт aMule для зовнішніх з'єднань (зазвичай: 4712)."
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "Пароль зовнішнього з'єднання"
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "Читати налаштування з файлу."
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "Не друкувати нічого до stdout."
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "Бути докладним: показувати також всі повідомлення налагодження"
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "Вибрати локаль програми (мова)."
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "Записати параметри командного рядка до файлу налаштувань."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "Створити файл налаштувань оснований на файлі налаштувань aMule."
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "Друкувати версію програми."
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2391,6 +2433,11 @@ msgstr "Недопустимий порт для початкового запу
 msgid "Please fill all fields required"
 msgstr "Будь ласка, заповніть потрібні поля"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "Повідомлення"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Ви впевнені, що хочете звантажити новий файл nodes.dat?\n"
@@ -2567,7 +2614,7 @@ msgstr "Зовнішнє з'єднання: в доступі відмовлен
 msgid "External Connection: Handshake failed."
 msgstr "Зовнішнє з'єднання: в доступі відмовлено"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Потік звантаження HTTP розпочатий"
@@ -2874,7 +2921,7 @@ msgstr "Назва:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "Місцевий"
 
@@ -2994,7 +3041,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Зупинити"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "Звантаження"
 
@@ -4875,7 +4922,7 @@ msgstr "Виділяється"
 msgid "Insufficient disk space"
 msgstr "Не вистачає місця на диску"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Звантажені"
@@ -5493,7 +5540,7 @@ msgstr "Перезавантажується перелік спільних ф�
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "Пошук"
@@ -5514,7 +5561,7 @@ msgstr "Найменший розмір має бути меншим ніж на
 msgid "Search warning"
 msgstr "Очікування пошуку"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "Головна"
 
@@ -5552,38 +5599,38 @@ msgstr "Без рейтингу"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "Звантажити в категорію"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Додати додаткові URL-адреси для цього файлу"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "Пошук схожих файлів (eD2k, місцевий сервер)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "Позначити як відомий файл"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "Скопіювати eD2k посилання до буферу обміну"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Ви з'єднані з сервером, який хочете видалити, будь ласка, роз'єднайтесь спочатку."
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 #, fuzzy
 msgid "Canceled"
 msgstr "Скасувати"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "Показати aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "Віддалене керування aMule"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Знімок:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,27 +41,7 @@ msgstr ""
 "'Багатоплатформений' p2p-клієнт, що оснований на eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "Сторінка в Інтернет: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "Сторінка в Інтернет: https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -70,28 +50,40 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "Частина aMule основана на \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Перевірити наявність нової версії під час запуску"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7986,6 +7978,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "Сторінка в Інтернет: https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "Сторінка в Інтернет: https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/uk.po
+++ b/po/uk.po
@@ -64,11 +64,11 @@ msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
 #: src/AboutDialog.cpp:96
 msgid "Website:"
-msgstr ""
+msgstr "Сторінка в Інтернет:"
 
 #: src/AboutDialog.cpp:97
 msgid "Forum:"
-msgstr ""
+msgstr "Форум:"
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-26 15:01+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -23,6 +23,99 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.5\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "显示 aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule 远程控制 "
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "Snapshot:"
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"基于 eMule 的“全平台” P2P客户端 \n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "网站：https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "论坛：https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "文档： https://amule-org.github.io/docs \n"
+
+#: src/AboutDialog.cpp:70
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr ""
+"提交问题：https://github.com/amule-org/amule/issues \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"版权所有 (c) 2003-2026 aMule 团队 \n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "aMule 的一部分是基于 \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr "Kademlia: 基于异或算法的点对点路由。\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " 版权所有 (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "启动时检查新版本"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "正在连接至 Kad..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "您使用的是老版本的aMule！"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "不可用"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -122,8 +215,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "无法添加 ED2KLinks 文件的 %u 个链接（详情见日志）。"
 msgstr[1] "无法添加 ED2KLinks 文件的 %u 个链接（详情见日志）。"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -172,7 +265,7 @@ msgstr "对 aMule 退出的内存 Debug 结果："
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "对不起，由于配置变动，您的地区设置已经变为系统默认值。"
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -195,11 +288,11 @@ msgstr "密码已设置，启用远程连接。"
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 msgid "Network bootstrap"
 msgstr "网络引导"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -207,34 +300,34 @@ msgstr ""
 "aMule 检测到缺少网络引导文件。\n"
 "请选择需要下载的文件："
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 msgid "eD2k server list (server.met)"
 msgstr "eD2k 服务器列表 (server.met)"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad 引导节点 (nodes.dat)"
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web 服务器正在运行，pid 为 %d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "无法绑定端口到指定的地址：%s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "端口 %u 不可用，你会成为 Low ID\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -249,48 +342,48 @@ msgstr ""
 "\n"
 "请检测网络设置以确保端口可用于输入输出。"
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "创建在线统计文件失败"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "创建 aMule 在线统计文件失败"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "您所选择的地区设置在您的计算机上似乎没有安装。(注意：我还是会尝试您所选择的地区设置。)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "这是您第一次运行 aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "此版本是测试版，更新频繁， \n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "我们无法承诺它不会损坏任何东西，烧毁您的房子，\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或杀死你的狗，但 * 一般来讲 * 它应该是安全的。\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "如要获取使用信息、用户支持以及下载最新版本，请访问我们的首页\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或进入我们在 irc.libera.chat 的 IRC 频道 #aMule。\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "欢迎您到 https://github.com/amule-org/amule/issues 去提交错误报告"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -298,137 +391,137 @@ msgstr ""
 "您为在线统计文件所选择的文件夹无效！\n"
 "在您更正设置之前在线统计将被禁用。"
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "获取服务器名称"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "为文件 '%s' 预分配磁盘空间失败：%s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "错误：无法打开日志文件"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：日志文件为空。肯定有什么地方出错了。"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "记录文件已被重置"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "服务器消息：%s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "跳过下载%s，因为请求的文件不是最新的。"
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "下载节点列表失败。"
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "打开已下载的版本检查文件失败"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "损坏的版本检查文件"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是老版本的aMule！"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可从这里下载：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本太旧：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "您的aMule是最新版本。"
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "下载版本检查文件失败"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "用户：%s | 文件：%s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "用户：E：%s K：%s | 文件：E：%s K：%s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "没有选择网络"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "是 Low ID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "是 High ID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已连接到 %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在连接到 %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "已从 eD2k 断开"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad 已启动。"
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "已连接至 Kad (ok）"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "已连接至 Kad 网络 (有防火墙)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "已断开 Kad 连接"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "如果在设置中禁用了 UDP 端口，Kad 网络将不能使用，没有启动。"
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 网络在设置中被禁用了，没有连接。"
 
@@ -457,123 +550,72 @@ msgstr "不能创建 Pid 文件"
 msgid "ERROR: %s"
 msgstr "错误：%s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "这是基于 eMule 的 aMule %s。"
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "运行于 %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "访问 https://github.com/amule-org/amule/releases/latest 来检查 是否有新版本。"
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "致命错误：创建计时器失败"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule 远程控制 "
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "Snapshot:"
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"基于 eMule 的“全平台” P2P客户端 \n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "最新版本可从这里下载：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "网站：https://amule-org.github.io \n"
+#: src/amuleDlg.cpp:605
+#, fuzzy
+msgid "New version available"
+msgstr "不可用"
 
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "论坛：https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "文档： https://amule-org.github.io/docs \n"
-
-#: src/amuleDlg.cpp:537
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"提交问题：https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"版权所有 (c) 2003-2026 aMule 团队 \n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "aMule 的一部分是基于 \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr "Kademlia: 基于异或算法的点对点路由。\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " 版权所有 (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "消息"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMule 对话框损坏"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "正在连接"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k: 正在连接"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k: 已断开"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad: 通过防火墙"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad: 已连接"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad: 正在连接"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad: 关闭"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -583,175 +625,175 @@ msgstr "Kad: 关闭"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "终止本次连接尝试"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "断开连接"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "从当前已连接的网络断开"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "连接"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "连接至当前已启用的网络"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上传: %.1f%s（%.1f） | 下载: %.1f%s（%.1f）"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上传: %.1f%s | 下载: %.1f%s"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule（%s | 已连接）"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule（%s | 已断开）"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您确定要退出 %s 吗？"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "退出确认"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "运行命令: "
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- 默认 -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "皮肤目录 %s 不存在"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：无法打开皮肤文件 %s 进行读取"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "网络"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "网络窗口"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "搜索"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "搜索窗口"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "下载"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "下载窗口"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "共享文件"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "共享文件窗口"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "消息"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "消息窗口"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "统计"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "统计图窗口"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "设置"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "设置窗口"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "导入"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "part 文件导入工具"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "关于"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "关于/帮助"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k 网络"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "Kad 网络"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "无网络"
 
@@ -791,7 +833,7 @@ msgstr "连接失败。请检查主机、端口和密码。"
 msgid "Remote GUI EC event handler"
 msgstr "远程 GUI 外部连接事件处理程序"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "连接失败。不能连接到 %s:%d\n"
@@ -941,7 +983,7 @@ msgid "Enter Captcha"
 msgstr "输入验证码"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "分类"
 
@@ -1359,7 +1401,7 @@ msgstr "错误：IO 错误！"
 msgid "ERROR: Failed!"
 msgstr "错误：失败！"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "已加入队列"
 
@@ -1989,7 +2031,7 @@ msgstr ""
 "\n"
 "正在建立用户...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1998,7 +2040,7 @@ msgstr ""
 "\n"
 "完成，正在退出 %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2012,51 +2054,51 @@ msgstr ""
 "\n"
 "退出...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "显示帮助信息。"
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "aMule 正在运行的主机 (默认: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule 的远程连接端口。(默认：4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "远程连接密码。"
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "从文件读取设置。"
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "不在控制台输出任何信息。"
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "详细显示调试信息。"
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "设置程序地区(语言)。"
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "把命令行参数写入设置文件。"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "基于 aMule 的设置文件建立新设置文件。"
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "输出程序版本。"
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "强制使用 ZLIB 压缩，忽略目标 IP 的地域属性（适用于服务器可通过解析为局域网 IP 的 VPN 隧道访问场景）。"
 
@@ -2369,6 +2411,11 @@ msgstr "无效端口"
 msgid "Please fill all fields required"
 msgstr "请填写所有必要信息"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "消息"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "确定要下载新的 node.dat 文件吗？\n"
@@ -2538,7 +2585,7 @@ msgstr "远程连接：访问被拒绝，原因："
 msgid "External Connection: Handshake failed."
 msgstr "远程连接：握手失败。"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio 线程 %d 已启动"
@@ -2838,7 +2885,7 @@ msgstr "名称:"
 msgid "Type"
 msgstr "类型"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "本地"
 
@@ -2958,7 +3005,7 @@ msgstr "向已响应的 Kad 节点请求扩大搜索范围。每次点击都会�
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "下载"
 
@@ -4828,7 +4875,7 @@ msgstr "正在分配"
 msgid "Insufficient disk space"
 msgstr "磁盘空间不足"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "已下载"
@@ -5431,7 +5478,7 @@ msgstr "正重新加载共享文件：扫描了 %u 个文件"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "同时禁用 eD2k 和 Kademlia 时将无法搜索。"
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 msgid "Search error"
 msgstr "搜索错误"
 
@@ -5451,7 +5498,7 @@ msgstr "最小值必须小于最大值，最大值已被忽略。"
 msgid "Search warning"
 msgstr "搜索警告"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "主要"
 
@@ -5487,36 +5534,36 @@ msgstr "比特率"
 msgid "Codec"
 msgstr "编解码器"
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "下载分类"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "获取此文件的 %s"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "搜索相关文件（eD2k，本地服务器）"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "标记为已知文件"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "复制eD2k链接至剪贴板"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "当前未连接到支持“相关文件”搜索功能的服务器"
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "已取消"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "新建"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -75,7 +75,7 @@ msgstr ""
 
 #: src/AboutDialog.cpp:98
 msgid "Documentation:"
-msgstr ""
+msgstr "文档："
 
 #: src/AboutDialog.cpp:99
 msgid "Issues:"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-26 15:01+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -24,20 +24,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.5\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "显示 aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule 远程控制 "
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -45,27 +45,7 @@ msgstr ""
 "基于 eMule 的“全平台” P2P客户端 \n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "网站：https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "论坛：https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "文档： https://amule-org.github.io/docs \n"
-
-#: src/AboutDialog.cpp:70
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr ""
-"提交问题：https://github.com/amule-org/amule/issues \n"
-"\n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -73,28 +53,40 @@ msgstr ""
 "版权所有 (c) 2003-2026 aMule 团队 \n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "aMule 的一部分是基于 \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: 基于异或算法的点对点路由。\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " 版权所有 (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "启动时检查新版本"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7893,6 +7885,25 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "网站：https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "论坛：https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "文档： https://amule-org.github.io/docs \n"
+
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr ""
+#~ "提交问题：https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-01 09:20-0700\n"
+"POT-Creation-Date: 2026-07-02 15:39+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -25,6 +25,100 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: utf-8\n"
+
+#: src/AboutDialog.cpp:49
+#, fuzzy
+msgid "About aMule"
+msgstr "顯示 aMule"
+
+#: src/AboutDialog.cpp:59
+msgid "aMule remote control "
+msgstr "aMule 遠端控制"
+
+#: src/AboutDialog.cpp:64
+msgid "Snapshot:"
+msgstr "快照："
+
+#: src/AboutDialog.cpp:66
+msgid ""
+"'All-Platform' p2p client based on eMule \n"
+"\n"
+msgstr ""
+"源自 eMule 的「跨平台」P2P 客戶端程式\n"
+"\n"
+
+#: src/AboutDialog.cpp:67
+msgid "Website: https://amule-org.github.io \n"
+msgstr "網站：https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:68
+msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:69
+#, fuzzy
+msgid "Documentation: https://amule-org.github.io/docs \n"
+msgstr "網站：https://amule-org.github.io \n"
+
+#: src/AboutDialog.cpp:70
+#, fuzzy
+msgid ""
+"Issues: https://github.com/amule-org/amule/issues \n"
+"\n"
+msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
+
+#: src/AboutDialog.cpp:71
+#, fuzzy
+msgid ""
+"Copyright (c) 2003-2026 aMule Team \n"
+"\n"
+msgstr ""
+"Copyright (c) 2003-2019 aMule 團隊\n"
+"\n"
+
+#: src/AboutDialog.cpp:71
+msgid "Part of aMule is based on \n"
+msgstr "部份 aMule 源自 \n"
+
+#: src/AboutDialog.cpp:72
+msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
+msgstr " KAD：基於 XOR 演算法的 P2P 路由。\n"
+
+#: src/AboutDialog.cpp:73
+msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
+
+#: src/AboutDialog.cpp:74
+msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+
+#: src/AboutDialog.cpp:94
+#, fuzzy
+msgid "Click to check for a newer version."
+msgstr "啓動時檢查新版本"
+
+#: src/AboutDialog.cpp:95
+msgid "Check for updates"
+msgstr ""
+
+#: src/AboutDialog.cpp:150
+#, fuzzy
+msgid "Checking for updates..."
+msgstr "Kad 連線中..."
+
+#: src/AboutDialog.cpp:160
+#, fuzzy
+msgid "You are running the latest version."
+msgstr "您使用的是過期的 aMule 版本！"
+
+#: src/AboutDialog.cpp:164
+#, fuzzy, c-format
+msgid "A new version (%s) is available:"
+msgstr "不可用"
+
+#: src/AboutDialog.cpp:168
+msgid "Could not check for updates. Please try again later."
+msgstr ""
 
 #: src/AddFriend.cpp:44
 msgid "Add a Friend"
@@ -117,8 +211,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:988 src/amule.cpp:1101
-#: src/amule.cpp:1403 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
+#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -167,7 +261,7 @@ msgstr "離開 aMule 時記憶體除錯結果："
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "對不起，由於版本變更，您的地區設定已經被變更爲系統預設值。"
 
-#: src/amule.cpp:614 src/amule.cpp:1391 src/CatDialog.cpp:129
+#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
@@ -190,47 +284,47 @@ msgstr "密碼已設定，外部連線已啟用。"
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:875
+#: src/amule.cpp:883
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "網路"
 
-#: src/amule.cpp:880
+#: src/amule.cpp:888
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:889
+#: src/amule.cpp:897
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "在 server.met 中找到 %i 個伺服器"
 
-#: src/amule.cpp:896
+#: src/amule.cpp:904
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:982
+#: src/amule.cpp:990
 #, c-format
 msgid "web server running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:985
+#: src/amule.cpp:1003
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1069
+#: src/amule.cpp:1090
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "無法選定使用此位址的通訊埠：%s"
 
-#: src/amule.cpp:1093
+#: src/amule.cpp:1114
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "通訊埠 %u 已被佔用。您會變成 LOWID。\n"
 
-#: src/amule.cpp:1098
+#: src/amule.cpp:1119
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -245,48 +339,48 @@ msgstr ""
 "\n"
 "請檢查網路設定以確保通訊埠可正常使用。"
 
-#: src/amule.cpp:1195
+#: src/amule.cpp:1216
 msgid "Failed to create OnlineSig File"
 msgstr "無法建立線上簽名識別檔"
 
-#: src/amule.cpp:1203
+#: src/amule.cpp:1224
 msgid "Failed to create aMule OnlineSig File"
 msgstr "無法建立 aMule 線上簽名識別檔"
 
-#: src/amule.cpp:1366
+#: src/amule.cpp:1387
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "在您的電腦上似乎沒有安裝您所選取的地區設定。 (但仍會採用您所選擇的設定)"
 
-#: src/amule.cpp:1376
+#: src/amule.cpp:1397
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "這是您第一次執行 aMule %s"
 
-#: src/amule.cpp:1379
+#: src/amule.cpp:1400
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "這個版本是測試版，每日有更新，\n"
 
-#: src/amule.cpp:1380
+#: src/amule.cpp:1401
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "但我們無法擔保它不會造成任何損害、燒掉您的房子、\n"
 
-#: src/amule.cpp:1381
+#: src/amule.cpp:1402
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或害死您的狗。但一般來講它「應該」是安全的。\n"
 
-#: src/amule.cpp:1386
+#: src/amule.cpp:1407
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "在我們的網頁可找到更多資訊、使用者支援以及程式最新版本：\n"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或我們在 irc.libera.chat 的 IRC 頻道 #aMule。\n"
 
-#: src/amule.cpp:1389
+#: src/amule.cpp:1410
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "歡迎您到 https://github.com/amule-org/amule/issues 提出錯誤報告"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -294,137 +388,137 @@ msgstr ""
 "您選擇的線上簽名識別檔案所在資料夾無效！\n"
 " 在您變更偏好設定之前，線上簽名識別功能將被停用。"
 
-#: src/amule.cpp:1464
+#: src/amule.cpp:1485
 msgid "Server hostname notified"
 msgstr "已通伺服器主機名稱"
 
-#: src/amule.cpp:1773
+#: src/amule.cpp:1794
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "無法為檔案 %s 預先分配磁碟空間：%s"
 
-#: src/amule.cpp:1902
+#: src/amule.cpp:1923
 msgid "ERROR: can't open logfile"
 msgstr "錯誤：無法開啟記錄檔"
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1927
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：沒有記錄檔，肯定有什麽地方出錯了。"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "Log has been reset"
 msgstr "記錄已被清除"
 
-#: src/amule.cpp:1947
+#: src/amule.cpp:1968
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "伺服器訊息：%s"
 
-#: src/amule.cpp:1988 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "略過不下載 %s ，因為並不是新近檔案。"
 
-#: src/amule.cpp:1991
+#: src/amule.cpp:2012
 msgid "Failed to download the nodes list."
 msgstr "無法下載節點清單。"
 
-#: src/amule.cpp:2011
+#: src/amule.cpp:2032
 msgid "Failed to open the downloaded version check file"
 msgstr "無法開啟下載的版本檢查檔"
 
-#: src/amule.cpp:2014 src/amule.cpp:2033 src/amule.cpp:2064 src/amule.cpp:2086
+#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
 msgid "Corrupted version check file"
 msgstr "損壞的版本檢查檔"
 
-#: src/amule.cpp:2097
+#: src/amule.cpp:2118
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是過期的 aMule 版本！"
 
-#: src/amule.cpp:2099
+#: src/amule.cpp:2120
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2103
+#: src/amule.cpp:2124
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2106
+#: src/amule.cpp:2127
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本已經過期：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2112
+#: src/amule.cpp:2133
 msgid "Your copy of aMule is up to date."
 msgstr "您的 aMule 是最新版本。"
 
-#: src/amule.cpp:2119
+#: src/amule.cpp:2140
 msgid "Failed to download the version check file"
 msgstr "無法下載版本檢查檔"
 
-#: src/amule.cpp:2287 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "使用者：%s | 檔案：%s"
 
-#: src/amule.cpp:2288 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "使用者：E:%s K:%s | 檔案：E:%s K:%s"
 
-#: src/amule.cpp:2302 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "未選取網路"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:855
+#: src/amule.cpp:2391 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "有 LowID"
 
-#: src/amule.cpp:2370 src/TextClient.cpp:856
+#: src/amule.cpp:2391 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "有 HighID"
 
-#: src/amule.cpp:2372
+#: src/amule.cpp:2393
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已連線到 %s %s"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2397
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在連線到 %s"
 
-#: src/amule.cpp:2378
+#: src/amule.cpp:2399
 msgid "Disconnected from eD2k"
 msgstr "已中斷 eD2k 網路連線"
 
-#: src/amule.cpp:2386
+#: src/amule.cpp:2407
 msgid "Kad started."
 msgstr "Kad 已啓動。"
 
-#: src/amule.cpp:2388
+#: src/amule.cpp:2409
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2396
+#: src/amule.cpp:2417
 msgid "Connected to Kad (ok)"
 msgstr "已連線到 Kad"
 
-#: src/amule.cpp:2398
+#: src/amule.cpp:2419
 msgid "Connected to Kad (firewalled)"
 msgstr "已連線到 Kad 網路 (防火牆內)"
 
-#: src/amule.cpp:2401
+#: src/amule.cpp:2422
 msgid "Disconnected from Kad"
 msgstr "已中斷 Kad 網路連線"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2453
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 網路未啟動：如果在偏好設定中停用了 UDP 埠，Kad 網路將不能使用。"
 
-#: src/amule.cpp:2436
+#: src/amule.cpp:2457
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 網路在偏好設定中被停用了，沒有連線。"
 
@@ -454,124 +548,72 @@ msgstr "無法建立 pid 檔案"
 msgid "ERROR: %s"
 msgstr "錯誤：%s"
 
-#: src/amuleDlg.cpp:264
+#: src/amuleDlg.cpp:265
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "這是 aMule %s (源自 eMule)。"
 
-#: src/amuleDlg.cpp:265
+#: src/amuleDlg.cpp:266
 #, c-format
 msgid "Running on %s"
 msgstr "執行於 %s"
 
-#: src/amuleDlg.cpp:266
+#: src/amuleDlg.cpp:267
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "請到 https://github.com/amule-org/amule/releases/latest 下載最新版本。"
 
-#: src/amuleDlg.cpp:293
+#: src/amuleDlg.cpp:294
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "嚴重錯誤：無法建立計時器"
 
-#: src/amuleDlg.cpp:524
-msgid "aMule remote control "
-msgstr "aMule 遠端控制"
-
-#: src/amuleDlg.cpp:530
-msgid "Snapshot:"
-msgstr "快照："
-
-#: src/amuleDlg.cpp:533
+#: src/amuleDlg.cpp:601
+#, fuzzy, c-format
 msgid ""
-"'All-Platform' p2p client based on eMule \n"
+"A new version of aMule (%s) is available.\n"
 "\n"
-msgstr ""
-"源自 eMule 的「跨平台」P2P 客戶端程式\n"
+"You are running %s.\n"
 "\n"
+"Would you like to open the download page?"
+msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:534
-msgid "Website: https://amule-org.github.io \n"
-msgstr "網站：https://amule-org.github.io \n"
-
-#: src/amuleDlg.cpp:535
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:536
+#: src/amuleDlg.cpp:605
 #, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "網站：https://amule-org.github.io \n"
+msgid "New version available"
+msgstr "不可用"
 
-#: src/amuleDlg.cpp:537
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
-
-#: src/amuleDlg.cpp:538
-#, fuzzy
-msgid ""
-"Copyright (c) 2003-2026 aMule Team \n"
-"\n"
-msgstr ""
-"Copyright (c) 2003-2019 aMule 團隊\n"
-"\n"
-
-#: src/amuleDlg.cpp:538
-msgid "Part of aMule is based on \n"
-msgstr "部份 aMule 源自 \n"
-
-#: src/amuleDlg.cpp:539
-msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
-msgstr " KAD：基於 XOR 演算法的 P2P 路由。\n"
-
-#: src/amuleDlg.cpp:540
-msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
-
-#: src/amuleDlg.cpp:541
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-
-#: src/amuleDlg.cpp:544 src/KadDlg.cpp:190 src/PartFile.cpp:1015
-#: src/PrefsUnifiedDlg.cpp:854 src/PrefsUnifiedDlg.cpp:982
-#: src/PrefsUnifiedDlg.cpp:1167
-msgid "Message"
-msgstr "訊息"
-
-#: src/amuleDlg.cpp:578
+#: src/amuleDlg.cpp:623
 msgid "aMule dialog destroyed"
 msgstr "aMule 對話方塊已銷毀"
 
-#: src/amuleDlg.cpp:601 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "正在連線"
 
-#: src/amuleDlg.cpp:770
+#: src/amuleDlg.cpp:815
 msgid "eD2k: Connecting"
 msgstr "eD2k：正在連線"
 
-#: src/amuleDlg.cpp:774
+#: src/amuleDlg.cpp:819
 msgid "eD2k: Disconnected"
 msgstr "eD2k：已中斷連線"
 
-#: src/amuleDlg.cpp:780
+#: src/amuleDlg.cpp:825
 msgid "Kad: Firewalled"
 msgstr "Kad：防火牆內"
 
-#: src/amuleDlg.cpp:784
+#: src/amuleDlg.cpp:829
 msgid "Kad: Connected"
 msgstr "Kad：已連線"
 
-#: src/amuleDlg.cpp:789
+#: src/amuleDlg.cpp:834
 msgid "Kad: Connecting"
 msgstr "Kad：正在連線"
 
-#: src/amuleDlg.cpp:793
+#: src/amuleDlg.cpp:838
 msgid "Kad: Off"
 msgstr "Kad：關閉"
 
-#: src/amuleDlg.cpp:841 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
 #: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
@@ -581,176 +623,176 @@ msgstr "Kad：關閉"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:842
+#: src/amuleDlg.cpp:887
 msgid "Stop the current connection attempts"
 msgstr "停止連線作業"
 
-#: src/amuleDlg.cpp:847 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
 #: src/muuli_wdr.cpp:2173
 msgid "Disconnect"
 msgstr "中斷連線"
 
-#: src/amuleDlg.cpp:848
+#: src/amuleDlg.cpp:893
 msgid "Disconnect from the currently connected networks"
 msgstr "中斷已連線的網路"
 
-#: src/amuleDlg.cpp:853 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
 #: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
 msgid "Connect"
 msgstr "連線"
 
-#: src/amuleDlg.cpp:854
+#: src/amuleDlg.cpp:899
 msgid "Connect to the currently enabled networks"
 msgstr "連線到目前已啟用的網路"
 
-#: src/amuleDlg.cpp:930
+#: src/amuleDlg.cpp:975
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上傳：%.1f (%.1f) | 下載：%.1f (%.1f)"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:932 src/amuleDlg.cpp:934 src/amuleDlg.cpp:938
-#: src/amuleDlg.cpp:940 src/amuleDlg.cpp:951 src/amuleDlg.cpp:953
+#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:937
+#: src/amuleDlg.cpp:982
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上傳：%.1f | 下載：%.1f"
 
-#: src/amuleDlg.cpp:969
+#: src/amuleDlg.cpp:1014
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 已連線)"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1016
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 已中斷連線)"
 
-#: src/amuleDlg.cpp:1019
+#: src/amuleDlg.cpp:1064
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您確定要離開 %s 嗎？"
 
-#: src/amuleDlg.cpp:1021
+#: src/amuleDlg.cpp:1066
 msgid "Exit confirmation"
 msgstr "確認離開"
 
-#: src/amuleDlg.cpp:1335
+#: src/amuleDlg.cpp:1380
 msgid "Launch Command: "
 msgstr "執行指令："
 
-#: src/amuleDlg.cpp:1354 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
 msgid "- default -"
 msgstr "- 預設 -"
 
-#: src/amuleDlg.cpp:1382
+#: src/amuleDlg.cpp:1427
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "面板目錄 %s 不存在"
 
-#: src/amuleDlg.cpp:1385
+#: src/amuleDlg.cpp:1430
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：無法開啟面板檔案 %s 供讀取"
 
-#: src/amuleDlg.cpp:1473 src/amuleDlg.cpp:1689 src/muuli_wdr.cpp:1403
+#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
 #: src/muuli_wdr.cpp:3105
 msgid "Networks"
 msgstr "網路"
 
-#: src/amuleDlg.cpp:1477 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
 msgid "Networks Window"
 msgstr "網路 視窗"
 
-#: src/amuleDlg.cpp:1479 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
 msgid "Searches"
 msgstr "搜尋"
 
-#: src/amuleDlg.cpp:1483 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
 msgid "Searches Window"
 msgstr "搜尋 視窗"
 
-#: src/amuleDlg.cpp:1485 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
 #: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "下載"
 
-#: src/amuleDlg.cpp:1489 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
 msgid "Downloads Window"
 msgstr "下載 視窗"
 
-#: src/amuleDlg.cpp:1491 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
 msgid "Shared files"
 msgstr "檔案分享"
 
-#: src/amuleDlg.cpp:1495 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
 msgid "Shared Files Window"
 msgstr "檔案分享 視窗"
 
-#: src/amuleDlg.cpp:1497 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
 #: src/muuli_wdr.cpp:3110
 msgid "Messages"
 msgstr "訊息"
 
-#: src/amuleDlg.cpp:1501 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
 msgid "Messages Window"
 msgstr "訊息 視窗"
 
-#: src/amuleDlg.cpp:1503 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:1507 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
 msgid "Statistics Graph Window"
 msgstr "統計 視窗"
 
-#: src/amuleDlg.cpp:1510 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "偏好設定"
 
-#: src/amuleDlg.cpp:1514 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
 msgid "Preferences Settings Window"
 msgstr "偏好設定 視窗"
 
-#: src/amuleDlg.cpp:1517 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
 msgid "Import"
 msgstr "匯入"
 
-#: src/amuleDlg.cpp:1521 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
 msgid "The partfile importer tool"
 msgstr "暫存檔匯入工具"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "關於"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
 msgid "About/Help"
 msgstr "關於/幫助"
 
-#: src/amuleDlg.cpp:1692
+#: src/amuleDlg.cpp:1737
 msgid "eD2k network"
 msgstr "eD2k 網路"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "Kad network"
 msgstr "kad 網路"
 
-#: src/amuleDlg.cpp:1695
+#: src/amuleDlg.cpp:1740
 msgid "No network"
 msgstr "無網路"
 
@@ -790,7 +832,7 @@ msgstr ""
 msgid "Remote GUI EC event handler"
 msgstr "遠端 GUI 外部連線事件處理器"
 
-#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:463
+#: src/amule-remote-gui.cpp:513 src/ExternalConnector.cpp:469
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "無法連線到 %s:%d\n"
@@ -936,7 +978,7 @@ msgid "Enter Captcha"
 msgstr "輸入圖形驗證碼"
 
 #: src/CatDialog.cpp:59 src/DownloadListCtrl.cpp:681 src/muuli_wdr.cpp:241
-#: src/SearchListCtrl.cpp:688 src/TransferWnd.cpp:333
+#: src/SearchListCtrl.cpp:690 src/TransferWnd.cpp:333
 msgid "Category"
 msgstr "分類"
 
@@ -1352,7 +1394,7 @@ msgstr "錯誤：IO 錯誤！"
 msgid "ERROR: Failed!"
 msgstr "錯誤：失敗！"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1081
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1083
 msgid "Queued"
 msgstr "待處理"
 
@@ -1982,7 +2024,7 @@ msgstr ""
 "\n"
 "正在建立客戶端...\n"
 
-#: src/ExternalConnector.cpp:477
+#: src/ExternalConnector.cpp:483
 #, c-format
 msgid ""
 "\n"
@@ -1991,7 +2033,7 @@ msgstr ""
 "\n"
 "OK，正在離開 %s...\n"
 
-#: src/ExternalConnector.cpp:483
+#: src/ExternalConnector.cpp:489
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2005,51 +2047,51 @@ msgstr ""
 "\n"
 "正在離開...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp:498
 msgid "Show this help text."
 msgstr "顯示協助資訊。"
 
-#: src/ExternalConnector.cpp:495
+#: src/ExternalConnector.cpp:501
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "執行 aMule 的主機。(預設：127.0.0.1)"
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:506
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule 的外部連線埠。 (預設：4712)"
 
-#: src/ExternalConnector.cpp:505
+#: src/ExternalConnector.cpp:511
 msgid "External Connection password."
 msgstr "外部連線密碼。"
 
-#: src/ExternalConnector.cpp:510
+#: src/ExternalConnector.cpp:516
 msgid "Read configuration from file."
 msgstr "從檔案讀取設定。"
 
-#: src/ExternalConnector.cpp:513
+#: src/ExternalConnector.cpp:519
 msgid "Do not print any output to stdout."
 msgstr "不顯示任何輸出訊息。"
 
-#: src/ExternalConnector.cpp:515
+#: src/ExternalConnector.cpp:521
 msgid "Be verbose - show also debug messages."
 msgstr "詳細顯示除錯資訊。"
 
-#: src/ExternalConnector.cpp:518
+#: src/ExternalConnector.cpp:524
 msgid "Sets program locale (language)."
 msgstr "設定程式的地區設定 (語言)。"
 
-#: src/ExternalConnector.cpp:523
+#: src/ExternalConnector.cpp:529
 msgid "Write command line options to config file."
 msgstr "把命令列選項寫入設定檔。"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp:533
 msgid "Creates config file based on aMule's config file."
 msgstr "使用 aMule 的設定檔建立新設定檔。"
 
-#: src/ExternalConnector.cpp:530
+#: src/ExternalConnector.cpp:536
 msgid "Print program version."
 msgstr "列出程式版本。"
 
-#: src/ExternalConnector.cpp:533
+#: src/ExternalConnector.cpp:539
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
@@ -2361,6 +2403,11 @@ msgstr "無效的通訊埠"
 msgid "Please fill all fields required"
 msgstr "請填寫所有必要資訊"
 
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
+#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+msgid "Message"
+msgstr "訊息"
+
 #: src/KadDlg.cpp:207
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "確定要下載新的 node.dat 檔案嗎？\n"
@@ -2528,7 +2575,7 @@ msgstr "外部連線：拒絕存取，原因： "
 msgid "External Connection: Handshake failed."
 msgstr "外部連線：訊號交換失敗"
 
-#: src/LibSocketAsio.cpp:1522
+#: src/LibSocketAsio.cpp:1575
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "已開始 HTTP 下載執行緒"
@@ -2835,7 +2882,7 @@ msgstr "名稱："
 msgid "Type"
 msgstr "類型"
 
-#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:789
+#: src/muuli_wdr.cpp:203 src/SearchDlg.cpp:107 src/SearchListCtrl.cpp:791
 msgid "Local"
 msgstr "本地"
 
@@ -2955,7 +3002,7 @@ msgstr ""
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:686
+#: src/muuli_wdr.cpp:336 src/muuli_wdr.cpp:1319 src/SearchListCtrl.cpp:688
 msgid "Download"
 msgstr "下載"
 
@@ -4814,7 +4861,7 @@ msgstr "正在分配"
 msgid "Insufficient disk space"
 msgstr "磁碟空間不足"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1076
+#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "已下載"
@@ -5418,7 +5465,7 @@ msgstr "重新載入分享檔案清單。"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:794
+#: src/SearchDlg.cpp:270 src/SearchListCtrl.cpp:796
 #, fuzzy
 msgid "Search error"
 msgstr "搜尋"
@@ -5439,7 +5486,7 @@ msgstr "最小值必須小於最大值，最大值已被忽略。"
 msgid "Search warning"
 msgstr "搜尋警告"
 
-#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:689
+#: src/SearchDlg.cpp:649 src/SearchListCtrl.cpp:691
 msgid "Main"
 msgstr "主要"
 
@@ -5477,37 +5524,37 @@ msgstr "未評價"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:694
+#: src/SearchListCtrl.cpp:696
 msgid "Download in category"
 msgstr "分類下載"
 
-#: src/SearchListCtrl.cpp:699
+#: src/SearchListCtrl.cpp:701
 #, c-format
 msgid "Get %s for this file"
 msgstr "取得這個檔案的 %s"
 
-#: src/SearchListCtrl.cpp:703
+#: src/SearchListCtrl.cpp:705
 msgid "Search related files (eD2k, local server)"
 msgstr "搜尋相關檔案 (eD2k，本地伺服器)"
 
-#: src/SearchListCtrl.cpp:709
+#: src/SearchListCtrl.cpp:711
 msgid "Mark as known file"
 msgstr "標記為已知檔案"
 
-#: src/SearchListCtrl.cpp:713 src/ServerListCtrl.cpp:436
+#: src/SearchListCtrl.cpp:715 src/ServerListCtrl.cpp:436
 msgid "Copy eD2k link to clipboard"
 msgstr "複製 eD2k 連結到剪貼簿"
 
-#: src/SearchListCtrl.cpp:792
+#: src/SearchListCtrl.cpp:794
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "現在正連線到要刪除的伺服器。請先中斷連線。"
 
-#: src/SearchListCtrl.cpp:1084
+#: src/SearchListCtrl.cpp:1086
 msgid "Canceled"
 msgstr "已取消"
 
-#: src/SearchListCtrl.cpp:1087
+#: src/SearchListCtrl.cpp:1089
 msgid "New"
 msgstr "新"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 15:39+0200\n"
+"POT-Creation-Date: 2026-07-02 19:51+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -26,20 +26,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: src/AboutDialog.cpp:49
+#: src/AboutDialog.cpp:60
 #, fuzzy
 msgid "About aMule"
 msgstr "顯示 aMule"
 
-#: src/AboutDialog.cpp:59
+#: src/AboutDialog.cpp:70
 msgid "aMule remote control "
 msgstr "aMule 遠端控制"
 
-#: src/AboutDialog.cpp:64
+#: src/AboutDialog.cpp:75
 msgid "Snapshot:"
 msgstr "快照："
 
-#: src/AboutDialog.cpp:66
+#: src/AboutDialog.cpp:77
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -47,27 +47,7 @@ msgstr ""
 "源自 eMule 的「跨平台」P2P 客戶端程式\n"
 "\n"
 
-#: src/AboutDialog.cpp:67
-msgid "Website: https://amule-org.github.io \n"
-msgstr "網站：https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:68
-msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:69
-#, fuzzy
-msgid "Documentation: https://amule-org.github.io/docs \n"
-msgstr "網站：https://amule-org.github.io \n"
-
-#: src/AboutDialog.cpp:70
-#, fuzzy
-msgid ""
-"Issues: https://github.com/amule-org/amule/issues \n"
-"\n"
-msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
-
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -76,28 +56,40 @@ msgstr ""
 "Copyright (c) 2003-2019 aMule 團隊\n"
 "\n"
 
-#: src/AboutDialog.cpp:71
+#: src/AboutDialog.cpp:81
 msgid "Part of aMule is based on \n"
 msgstr "部份 aMule 源自 \n"
 
-#: src/AboutDialog.cpp:72
+#: src/AboutDialog.cpp:82
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr " KAD：基於 XOR 演算法的 P2P 路由。\n"
 
-#: src/AboutDialog.cpp:73
+#: src/AboutDialog.cpp:83
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:74
-msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
-msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#: src/AboutDialog.cpp:96
+msgid "Website:"
+msgstr ""
 
-#: src/AboutDialog.cpp:94
+#: src/AboutDialog.cpp:97
+msgid "Forum:"
+msgstr ""
+
+#: src/AboutDialog.cpp:98
+msgid "Documentation:"
+msgstr ""
+
+#: src/AboutDialog.cpp:99
+msgid "Issues:"
+msgstr ""
+
+#: src/AboutDialog.cpp:107
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "啓動時檢查新版本"
 
-#: src/AboutDialog.cpp:95
+#: src/AboutDialog.cpp:108
 msgid "Check for updates"
 msgstr ""
 
@@ -7863,6 +7855,25 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Website: https://amule-org.github.io \n"
+#~ msgstr "網站：https://amule-org.github.io \n"
+
+#~ msgid "Forum: https://github.com/amule-org/amule/discussions \n"
+#~ msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
+
+#, fuzzy
+#~ msgid "Documentation: https://amule-org.github.io/docs \n"
+#~ msgstr "網站：https://amule-org.github.io \n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Issues: https://github.com/amule-org/amule/issues \n"
+#~ "\n"
+#~ msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
+
+#~ msgid "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
+#~ msgstr "https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n"
 
 #, fuzzy
 #~ msgid "Loaded"

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -39,8 +39,10 @@
 
 namespace
 {
+#ifdef ENABLE_VERSION_CHECK
 const int ID_CHECK_UPDATES = wxID_HIGHEST + 1;
 const wxString RELEASES_URL = wxT("https://github.com/amule-org/amule/releases/latest");
+#endif // ENABLE_VERSION_CHECK
 
 // A hyperlink whose colour is uniform (system link colour) in every state —
 // dropping wxHyperlinkCtrl's red rollover / purple visited defaults so links
@@ -58,9 +60,11 @@ wxHyperlinkCtrl *MakeLink(wxWindow *parent, const wxString &url)
 
 CAboutDlg::CAboutDlg(wxWindow *parent)
 : wxDialog(parent, wxID_ANY, _("About aMule"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
+#ifdef ENABLE_VERSION_CHECK
 , m_status(NULL)
 , m_downloadLink(NULL)
 , m_checkButton(NULL)
+#endif
 {
 	// Header (version + description) and the credits block reuse the exact
 	// strings the old wxMessageBox About used, so their existing translations
@@ -103,6 +107,7 @@ CAboutDlg::CAboutDlg(wxWindow *parent)
 		linkGrid->Add(MakeLink(this, l.url), wxSizerFlags().CenterVertical());
 	}
 
+#ifdef ENABLE_VERSION_CHECK
 	// Update-check controls.
 	m_status = new wxStaticText(this, wxID_ANY, _("Click to check for a newer version."));
 	m_checkButton = new wxButton(this, ID_CHECK_UPDATES, _("Check for updates"));
@@ -113,6 +118,7 @@ CAboutDlg::CAboutDlg(wxWindow *parent)
 	wxBoxSizer *checkRow = new wxBoxSizer(wxHORIZONTAL);
 	checkRow->Add(m_status, wxSizerFlags(1).CenterVertical().Border(wxRIGHT, 10));
 	checkRow->Add(m_checkButton, wxSizerFlags().CenterVertical());
+#endif // ENABLE_VERSION_CHECK
 
 	wxBoxSizer *right = new wxBoxSizer(wxVERTICAL);
 	right->Add(new wxStaticText(this, wxID_ANY, head));
@@ -121,9 +127,11 @@ CAboutDlg::CAboutDlg(wxWindow *parent)
 	right->Add(
 		MakeLink(this, wxT("https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf")),
 		wxSizerFlags().Border(wxTOP, 2));
+#ifdef ENABLE_VERSION_CHECK
 	right->Add(new wxStaticLine(this, wxID_ANY), wxSizerFlags().Expand().Border(wxTOP | wxBOTTOM, 10));
 	right->Add(checkRow, wxSizerFlags().Expand());
 	right->Add(m_downloadLink, wxSizerFlags().Border(wxTOP, 4));
+#endif // ENABLE_VERSION_CHECK
 
 	wxBoxSizer *topRow = new wxBoxSizer(wxHORIZONTAL);
 	if (logoBmp.IsOk()) {
@@ -139,9 +147,13 @@ CAboutDlg::CAboutDlg(wxWindow *parent)
 	SetSizerAndFit(top);
 	Centre();
 
+#ifdef ENABLE_VERSION_CHECK
 	Bind(wxEVT_BUTTON, &CAboutDlg::OnCheckClicked, this, ID_CHECK_UPDATES);
 	Bind(wxEVT_VERSION_CHECK_DONE, &CAboutDlg::OnCheckDone, this);
+#endif // ENABLE_VERSION_CHECK
 }
+
+#ifdef ENABLE_VERSION_CHECK
 
 void CAboutDlg::OnCheckClicked(wxCommandEvent &WXUNUSED(evt))
 {
@@ -173,3 +185,4 @@ void CAboutDlg::OnCheckDone(wxCommandEvent &evt)
 	GetSizer()->Layout();
 	Fit();
 }
+#endif // ENABLE_VERSION_CHECK

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -1,0 +1,175 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "AboutDialog.h"
+
+#include "config.h" // Needed for VERSION, GITDATE
+
+#include <common/Format.h> // Needed for CFormat
+
+#include <wx/artprov.h>
+#include <wx/button.h>
+#include <wx/hyperlink.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/statbmp.h>
+#include <wx/statline.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/utils.h> // Needed for wxLaunchDefaultBrowser
+
+namespace
+{
+const int ID_CHECK_UPDATES = wxID_HIGHEST + 1;
+const wxString RELEASES_URL = wxT("https://github.com/amule-org/amule/releases/latest");
+} // namespace
+
+CAboutDlg::CAboutDlg(wxWindow *parent)
+: wxDialog(parent, wxID_ANY, _("About aMule"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
+, m_aboutText(NULL)
+, m_status(NULL)
+, m_downloadLink(NULL)
+, m_checkButton(NULL)
+{
+	// Reuse the exact strings the old wxMessageBox About used so their
+	// existing translations carry over unchanged.
+	wxString about;
+#ifdef CLIENT_GUI
+	about << _("aMule remote control ") << VERSION;
+#else
+	about << wxT("aMule ") << VERSION;
+#endif
+#ifdef GITDATE
+	about << wxT("\n") << _("Snapshot:") << wxT(" ") << GITDATE;
+#endif
+	about << wxT("\n\n") << _("'All-Platform' p2p client based on eMule \n\n")
+	      << _("Website: https://amule-org.github.io \n")
+	      << _("Forum: https://github.com/amule-org/amule/discussions \n")
+	      << _("Documentation: https://amule-org.github.io/docs \n")
+	      << _("Issues: https://github.com/amule-org/amule/issues \n\n")
+	      << _("Copyright (c) 2003-2026 aMule Team \n\n") << _("Part of aMule is based on \n")
+	      << _("Kademlia: Peer-to-peer routing based on the XOR metric.\n")
+	      << _(" Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n")
+	      << _("https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n");
+
+	// aMule logo on the left, matching the previous wxMessageBox About.
+	const wxBitmap logoBmp = wxArtProvider::GetBitmap(wxT("amule:amule"), wxART_MESSAGE_BOX);
+
+	// Selectable, URL-aware text area (the old static text/message box could
+	// be neither selected nor clicked). Its background is blended into the
+	// dialog so it still reads like a label, not an input field.
+	m_aboutText = new wxTextCtrl(this,
+		wxID_ANY,
+		about,
+		wxDefaultPosition,
+		wxDefaultSize,
+		wxTE_MULTILINE | wxTE_READONLY | wxTE_NO_VSCROLL | wxTE_AUTO_URL | wxBORDER_NONE);
+	m_aboutText->SetBackgroundColour(GetBackgroundColour());
+	// Size the control to its content so no scrollbar is needed.
+	const int lines = static_cast<int>(about.Freq(wxT('\n'))) + 1;
+	m_aboutText->SetMinSize(wxSize(560, (lines + 1) * m_aboutText->GetCharHeight()));
+
+	// Update-check controls.
+	m_status = new wxStaticText(this, wxID_ANY, _("Click to check for a newer version."));
+	m_checkButton = new wxButton(this, ID_CHECK_UPDATES, _("Check for updates"));
+	// Clickable download link, revealed only when a newer version is found.
+	m_downloadLink = new wxHyperlinkCtrl(this, wxID_ANY, RELEASES_URL, RELEASES_URL);
+	// Use the system hyperlink colour (what the auto-URLs in the text area
+	// above use) for every state, dropping wxHyperlinkCtrl's hardcoded blue
+	// plus its red rollover / purple visited defaults so the link is uniform.
+	const wxColour linkColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT);
+	m_downloadLink->SetNormalColour(linkColour);
+	m_downloadLink->SetHoverColour(linkColour);
+	m_downloadLink->SetVisitedColour(linkColour);
+	m_downloadLink->Hide();
+
+	wxBoxSizer *checkRow = new wxBoxSizer(wxHORIZONTAL);
+	checkRow->Add(m_status, wxSizerFlags(1).CenterVertical().Border(wxRIGHT, 10));
+	checkRow->Add(m_checkButton, wxSizerFlags().CenterVertical());
+
+	wxBoxSizer *right = new wxBoxSizer(wxVERTICAL);
+	right->Add(m_aboutText, wxSizerFlags().Expand());
+	right->Add(new wxStaticLine(this, wxID_ANY), wxSizerFlags().Expand().Border(wxTOP | wxBOTTOM, 8));
+	right->Add(checkRow, wxSizerFlags().Expand());
+	right->Add(m_downloadLink, wxSizerFlags().Border(wxTOP, 4));
+
+	wxBoxSizer *topRow = new wxBoxSizer(wxHORIZONTAL);
+	if (logoBmp.IsOk()) {
+		topRow->Add(
+			new wxStaticBitmap(this, wxID_ANY, logoBmp), wxSizerFlags().Top().Border(wxALL, 10));
+	}
+	topRow->Add(right, wxSizerFlags(1).Border(wxALL, 10));
+
+	wxBoxSizer *top = new wxBoxSizer(wxVERTICAL);
+	top->Add(topRow, wxSizerFlags(1).Expand());
+	top->Add(CreateButtonSizer(wxOK), wxSizerFlags().Right().Border(wxALL, 10));
+
+	SetSizerAndFit(top);
+	Centre();
+
+	Bind(wxEVT_BUTTON, &CAboutDlg::OnCheckClicked, this, ID_CHECK_UPDATES);
+	Bind(wxEVT_VERSION_CHECK_DONE, &CAboutDlg::OnCheckDone, this);
+	m_aboutText->Bind(wxEVT_TEXT_URL, &CAboutDlg::OnTextUrl, this);
+}
+
+void CAboutDlg::OnTextUrl(wxTextUrlEvent &evt)
+{
+	// Open the clicked URL in the default browser (on mouse-up, so a
+	// selection drag doesn't launch it). wxTE_AUTO_URL drives this on the
+	// platforms that support it; the text stays selectable everywhere.
+	if (evt.GetMouseEvent().LeftUp()) {
+		wxLaunchDefaultBrowser(m_aboutText->GetRange(evt.GetURLStart(), evt.GetURLEnd()));
+	}
+}
+
+void CAboutDlg::OnCheckClicked(wxCommandEvent &WXUNUSED(evt))
+{
+	m_checkButton->Enable(false);
+	m_downloadLink->Hide();
+	m_status->SetLabel(_("Checking for updates..."));
+	Layout();
+	m_check.Start(this, wxID_ANY);
+}
+
+void CAboutDlg::OnCheckDone(wxCommandEvent &evt)
+{
+	m_checkButton->Enable(true);
+	switch (evt.GetInt()) {
+	case CVersionCheck::UpToDate:
+		m_status->SetLabel(_("You are running the latest version."));
+		m_downloadLink->Hide();
+		break;
+	case CVersionCheck::Outdated:
+		m_status->SetLabel(CFormat(_("A new version (%s) is available:")) % m_check.LatestVersion());
+		m_downloadLink->Show();
+		break;
+	default:
+		m_status->SetLabel(_("Could not check for updates. Please try again later."));
+		m_downloadLink->Hide();
+		break;
+	}
+	// The status/link can change height; relayout so the dialog resizes.
+	GetSizer()->Layout();
+	Fit();
+}

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -36,72 +36,78 @@
 #include <wx/statbmp.h>
 #include <wx/statline.h>
 #include <wx/stattext.h>
-#include <wx/textctrl.h>
-#include <wx/utils.h> // Needed for wxLaunchDefaultBrowser
 
 namespace
 {
 const int ID_CHECK_UPDATES = wxID_HIGHEST + 1;
 const wxString RELEASES_URL = wxT("https://github.com/amule-org/amule/releases/latest");
+
+// A hyperlink whose colour is uniform (system link colour) in every state —
+// dropping wxHyperlinkCtrl's red rollover / purple visited defaults so links
+// look native and consistent on GTK / macOS / MSW.
+wxHyperlinkCtrl *MakeLink(wxWindow *parent, const wxString &url)
+{
+	wxHyperlinkCtrl *link = new wxHyperlinkCtrl(parent, wxID_ANY, url, url);
+	const wxColour linkColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT);
+	link->SetNormalColour(linkColour);
+	link->SetHoverColour(linkColour);
+	link->SetVisitedColour(linkColour);
+	return link;
+}
 } // namespace
 
 CAboutDlg::CAboutDlg(wxWindow *parent)
 : wxDialog(parent, wxID_ANY, _("About aMule"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
-, m_aboutText(NULL)
 , m_status(NULL)
 , m_downloadLink(NULL)
 , m_checkButton(NULL)
 {
-	// Reuse the exact strings the old wxMessageBox About used so their
-	// existing translations carry over unchanged.
-	wxString about;
+	// Header (version + description) and the credits block reuse the exact
+	// strings the old wxMessageBox About used, so their existing translations
+	// carry over unchanged; trailing whitespace is trimmed for the layout.
+	wxString head;
 #ifdef CLIENT_GUI
-	about << _("aMule remote control ") << VERSION;
+	head << _("aMule remote control ") << VERSION;
 #else
-	about << wxT("aMule ") << VERSION;
+	head << wxT("aMule ") << VERSION;
 #endif
 #ifdef GITDATE
-	about << wxT("\n") << _("Snapshot:") << wxT(" ") << GITDATE;
+	head << wxT("\n") << _("Snapshot:") << wxT(" ") << GITDATE;
 #endif
-	about << wxT("\n\n") << _("'All-Platform' p2p client based on eMule \n\n")
-	      << _("Website: https://amule-org.github.io \n")
-	      << _("Forum: https://github.com/amule-org/amule/discussions \n")
-	      << _("Documentation: https://amule-org.github.io/docs \n")
-	      << _("Issues: https://github.com/amule-org/amule/issues \n\n")
-	      << _("Copyright (c) 2003-2026 aMule Team \n\n") << _("Part of aMule is based on \n")
-	      << _("Kademlia: Peer-to-peer routing based on the XOR metric.\n")
-	      << _(" Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n")
-	      << _("https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n");
+	head << wxT("\n\n") << _("'All-Platform' p2p client based on eMule \n\n");
+	head.Trim();
+
+	wxString credits;
+	credits << _("Copyright (c) 2003-2026 aMule Team \n\n") << _("Part of aMule is based on \n")
+		<< _("Kademlia: Peer-to-peer routing based on the XOR metric.\n")
+		<< _(" Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n");
+	credits.Trim();
 
 	// aMule logo on the left, matching the previous wxMessageBox About.
 	const wxBitmap logoBmp = wxArtProvider::GetBitmap(wxT("amule:amule"), wxART_MESSAGE_BOX);
 
-	// Selectable, URL-aware text area (the old static text/message box could
-	// be neither selected nor clicked). Its background is blended into the
-	// dialog so it still reads like a label, not an input field.
-	m_aboutText = new wxTextCtrl(this,
-		wxID_ANY,
-		about,
-		wxDefaultPosition,
-		wxDefaultSize,
-		wxTE_MULTILINE | wxTE_READONLY | wxTE_NO_VSCROLL | wxTE_AUTO_URL | wxBORDER_NONE);
-	m_aboutText->SetBackgroundColour(GetBackgroundColour());
-	// Size the control to its content so no scrollbar is needed.
-	const int lines = static_cast<int>(about.Freq(wxT('\n'))) + 1;
-	m_aboutText->SetMinSize(wxSize(560, (lines + 1) * m_aboutText->GetCharHeight()));
+	// The project links, as native clickable hyperlinks.
+	wxFlexGridSizer *linkGrid = new wxFlexGridSizer(2, wxSize(6, 2));
+	const struct
+	{
+		wxString label;
+		wxString url;
+	} projectLinks[] = {
+		{ _("Website:"), wxT("https://amule-org.github.io") },
+		{ _("Forum:"), wxT("https://github.com/amule-org/amule/discussions") },
+		{ _("Documentation:"), wxT("https://amule-org.github.io/docs") },
+		{ _("Issues:"), wxT("https://github.com/amule-org/amule/issues") },
+	};
+	for (const auto &l : projectLinks) {
+		linkGrid->Add(new wxStaticText(this, wxID_ANY, l.label), wxSizerFlags().CenterVertical());
+		linkGrid->Add(MakeLink(this, l.url), wxSizerFlags().CenterVertical());
+	}
 
 	// Update-check controls.
 	m_status = new wxStaticText(this, wxID_ANY, _("Click to check for a newer version."));
 	m_checkButton = new wxButton(this, ID_CHECK_UPDATES, _("Check for updates"));
 	// Clickable download link, revealed only when a newer version is found.
-	m_downloadLink = new wxHyperlinkCtrl(this, wxID_ANY, RELEASES_URL, RELEASES_URL);
-	// Use the system hyperlink colour (what the auto-URLs in the text area
-	// above use) for every state, dropping wxHyperlinkCtrl's hardcoded blue
-	// plus its red rollover / purple visited defaults so the link is uniform.
-	const wxColour linkColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT);
-	m_downloadLink->SetNormalColour(linkColour);
-	m_downloadLink->SetHoverColour(linkColour);
-	m_downloadLink->SetVisitedColour(linkColour);
+	m_downloadLink = MakeLink(this, RELEASES_URL);
 	m_downloadLink->Hide();
 
 	wxBoxSizer *checkRow = new wxBoxSizer(wxHORIZONTAL);
@@ -109,8 +115,13 @@ CAboutDlg::CAboutDlg(wxWindow *parent)
 	checkRow->Add(m_checkButton, wxSizerFlags().CenterVertical());
 
 	wxBoxSizer *right = new wxBoxSizer(wxVERTICAL);
-	right->Add(m_aboutText, wxSizerFlags().Expand());
-	right->Add(new wxStaticLine(this, wxID_ANY), wxSizerFlags().Expand().Border(wxTOP | wxBOTTOM, 8));
+	right->Add(new wxStaticText(this, wxID_ANY, head));
+	right->Add(linkGrid, wxSizerFlags().Border(wxTOP | wxBOTTOM, 8));
+	right->Add(new wxStaticText(this, wxID_ANY, credits));
+	right->Add(
+		MakeLink(this, wxT("https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf")),
+		wxSizerFlags().Border(wxTOP, 2));
+	right->Add(new wxStaticLine(this, wxID_ANY), wxSizerFlags().Expand().Border(wxTOP | wxBOTTOM, 10));
 	right->Add(checkRow, wxSizerFlags().Expand());
 	right->Add(m_downloadLink, wxSizerFlags().Border(wxTOP, 4));
 
@@ -130,17 +141,6 @@ CAboutDlg::CAboutDlg(wxWindow *parent)
 
 	Bind(wxEVT_BUTTON, &CAboutDlg::OnCheckClicked, this, ID_CHECK_UPDATES);
 	Bind(wxEVT_VERSION_CHECK_DONE, &CAboutDlg::OnCheckDone, this);
-	m_aboutText->Bind(wxEVT_TEXT_URL, &CAboutDlg::OnTextUrl, this);
-}
-
-void CAboutDlg::OnTextUrl(wxTextUrlEvent &evt)
-{
-	// Open the clicked URL in the default browser (on mouse-up, so a
-	// selection drag doesn't launch it). wxTE_AUTO_URL drives this on the
-	// platforms that support it; the text stays selectable everywhere.
-	if (evt.GetMouseEvent().LeftUp()) {
-		wxLaunchDefaultBrowser(m_aboutText->GetRange(evt.GetURLStart(), evt.GetURLEnd()));
-	}
 }
 
 void CAboutDlg::OnCheckClicked(wxCommandEvent &WXUNUSED(evt))

--- a/src/AboutDialog.h
+++ b/src/AboutDialog.h
@@ -1,0 +1,60 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef ABOUTDIALOG_H
+#define ABOUTDIALOG_H
+
+#include <wx/dialog.h>
+
+#include "VersionCheck.h"
+
+class wxTextCtrl;
+class wxTextUrlEvent;
+class wxStaticText;
+class wxButton;
+class wxHyperlinkCtrl;
+
+// The Help/About dialog. Shows the aMule version + credits in a selectable,
+// URL-clickable text area (previously a plain wxMessageBox) and adds a live
+// "Check for updates" control backed by the shared CVersionCheck, so both the
+// monolithic GUI and amulegui can tell the user whether a newer release is
+// available and offer a clickable download link.
+class CAboutDlg : public wxDialog
+{
+public:
+	explicit CAboutDlg(wxWindow *parent);
+
+private:
+	void OnCheckClicked(wxCommandEvent &evt);
+	void OnCheckDone(wxCommandEvent &evt);
+	void OnTextUrl(wxTextUrlEvent &evt);
+
+	CVersionCheck m_check;
+	wxTextCtrl *m_aboutText;
+	wxStaticText *m_status;
+	wxHyperlinkCtrl *m_downloadLink;
+	wxButton *m_checkButton;
+};
+
+#endif // ABOUTDIALOG_H

--- a/src/AboutDialog.h
+++ b/src/AboutDialog.h
@@ -27,6 +27,8 @@
 
 #include <wx/dialog.h>
 
+#include "config.h" // for ENABLE_VERSION_CHECK
+
 #include "VersionCheck.h"
 
 class wxStaticText;
@@ -34,14 +36,15 @@ class wxButton;
 class wxHyperlinkCtrl;
 
 // The Help/About dialog. Shows the aMule version + credits with native
-// clickable links (previously a plain wxMessageBox) and adds a live "Check
-// for updates" control backed by the shared CVersionCheck, so both the
-// monolithic GUI and amulegui can tell the user whether a newer release is
-// available and offer a clickable download link.
+// clickable links (previously a plain wxMessageBox) and, when the version
+// check is compiled in (ENABLE_VERSION_CHECK), a live "Check for updates"
+// control backed by the shared CVersionCheck.
 class CAboutDlg : public wxDialog
 {
 public:
 	explicit CAboutDlg(wxWindow *parent);
+
+#ifdef ENABLE_VERSION_CHECK
 
 private:
 	void OnCheckClicked(wxCommandEvent &evt);
@@ -51,6 +54,7 @@ private:
 	wxStaticText *m_status;
 	wxHyperlinkCtrl *m_downloadLink;
 	wxButton *m_checkButton;
+#endif // ENABLE_VERSION_CHECK
 };
 
 #endif // ABOUTDIALOG_H

--- a/src/AboutDialog.h
+++ b/src/AboutDialog.h
@@ -29,15 +29,13 @@
 
 #include "VersionCheck.h"
 
-class wxTextCtrl;
-class wxTextUrlEvent;
 class wxStaticText;
 class wxButton;
 class wxHyperlinkCtrl;
 
-// The Help/About dialog. Shows the aMule version + credits in a selectable,
-// URL-clickable text area (previously a plain wxMessageBox) and adds a live
-// "Check for updates" control backed by the shared CVersionCheck, so both the
+// The Help/About dialog. Shows the aMule version + credits with native
+// clickable links (previously a plain wxMessageBox) and adds a live "Check
+// for updates" control backed by the shared CVersionCheck, so both the
 // monolithic GUI and amulegui can tell the user whether a newer release is
 // available and offer a clickable download link.
 class CAboutDlg : public wxDialog
@@ -48,10 +46,8 @@ public:
 private:
 	void OnCheckClicked(wxCommandEvent &evt);
 	void OnCheckDone(wxCommandEvent &evt);
-	void OnTextUrl(wxTextUrlEvent &evt);
 
 	CVersionCheck m_check;
-	wxTextCtrl *m_aboutText;
 	wxStaticText *m_status;
 	wxHyperlinkCtrl *m_downloadLink;
 	wxButton *m_checkButton;

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1376,14 +1376,15 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	 **/
 	NewCfgItem(IDC_AUTOSORT, (new Cfg_Bool("/eMule/AutoSortDownloads", s_AutoSortDownload, false)));
 
+#ifdef ENABLE_VERSION_CHECK
 	/**
-	 * Version check.
-	 * Default value is set at configure time via -DDEFAULT_VERSION_CHECK
-	 * (ON by default, OFF for OS-package builds that don't want the
-	 * in-app updater to compete with the distro's package manager).
+	 * Version check. Only registered when the feature is compiled in
+	 * (-DENABLE_VERSION_CHECK, ON by default; OFF for OS-package builds where
+	 * the distro's package manager owns updates). Defaults to on; the user can
+	 * still turn it off in Preferences.
 	 */
-	NewCfgItem(IDC_NEWVERSION,
-		(new Cfg_Bool("/eMule/NewVersionCheck", s_NewVersionCheck, DEFAULT_VERSION_CHECK)));
+	NewCfgItem(IDC_NEWVERSION, (new Cfg_Bool("/eMule/NewVersionCheck", s_NewVersionCheck, true)));
+#endif // ENABLE_VERSION_CHECK
 
 	/**
 	 * Obfuscation

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -317,6 +317,13 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 
 		if (pages[i].m_function == PreferencesGeneralTab) {
 // This must be done now or pages won't Fit();
+#ifndef ENABLE_VERSION_CHECK
+			// The in-app version check is compiled out (OS-package build):
+			// hide the now-dead "Check for new version at startup" checkbox.
+			if (wxWindow *vc = FindWindow(IDC_NEWVERSION)) {
+				vc->Hide();
+			}
+#endif
 #ifdef __WINDOWS__
 			CastChild(IDC_BROWSERTABS, wxCheckBox)->Enable(false);
 #endif /* __WINDOWS__ */

--- a/src/VersionCheck.cpp
+++ b/src/VersionCheck.cpp
@@ -26,6 +26,8 @@
 
 #include "config.h" // Needed for VERSION_MJR / MIN / UPDATE (via ClientVersion.h)
 
+#ifdef ENABLE_VERSION_CHECK
+
 #include <common/ClientVersion.h> // VERSION_MJR / VERSION_MIN / VERSION_UPDATE
 #include "OtherFunctions.h"       // make_full_ed2k_version
 #include "Logger.h"               // AddDebugLogLineN / logGeneral
@@ -153,3 +155,5 @@ void CVersionCheck::Finish(Status status)
 		m_notify->AddPendingEvent(evt);
 	}
 }
+
+#endif // ENABLE_VERSION_CHECK

--- a/src/VersionCheck.cpp
+++ b/src/VersionCheck.cpp
@@ -1,0 +1,155 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "VersionCheck.h"
+
+#include "config.h" // Needed for VERSION_MJR / MIN / UPDATE (via ClientVersion.h)
+
+#include <common/ClientVersion.h> // VERSION_MJR / VERSION_MIN / VERSION_UPDATE
+#include "OtherFunctions.h"       // make_full_ed2k_version
+#include "Logger.h"               // AddDebugLogLineN / logGeneral
+
+#include <wx/regex.h>
+#include <wx/tokenzr.h>
+
+wxDEFINE_EVENT(wxEVT_VERSION_CHECK_DONE, wxCommandEvent);
+
+// GitHub Releases "latest" endpoint — returns the most recent
+// non-prerelease, non-draft release as JSON. Same source the daemon-side
+// CamuleApp::CheckNewVersion uses.
+static const wxString VERSION_CHECK_URL = wxT("https://api.github.com/repos/amule-org/amule/releases/latest");
+
+CVersionCheck::CVersionCheck()
+: m_notify(NULL)
+, m_notifyId(wxID_ANY)
+, m_status(Failed)
+{
+}
+
+CVersionCheck::~CVersionCheck()
+{
+	if (m_request.IsOk() && m_request.GetState() == wxWebRequest::State_Active) {
+		m_request.Cancel();
+	}
+}
+
+void CVersionCheck::Start(wxEvtHandler *notify, int notifyId)
+{
+	if (m_status == Checking) {
+		return;
+	}
+	m_notify = notify;
+	m_notifyId = notifyId;
+	m_status = Checking;
+	m_latest.Clear();
+
+	m_request = wxWebSession::GetDefault().CreateRequest(this, VERSION_CHECK_URL);
+	if (!m_request.IsOk()) {
+		Finish(Failed);
+		return;
+	}
+	// The body is a few KB of JSON — keep it in memory, no temp file.
+	m_request.SetStorage(wxWebRequest::Storage_Memory);
+	// GitHub's API rejects requests without a User-Agent header.
+	m_request.SetHeader(wxT("User-Agent"), wxT("aMule"));
+	m_request.SetHeader(wxT("Accept"), wxT("application/vnd.github+json"));
+	Bind(wxEVT_WEBREQUEST_STATE, &CVersionCheck::OnRequestState, this);
+	m_request.Start();
+}
+
+void CVersionCheck::OnRequestState(wxWebRequestEvent &evt)
+{
+	switch (evt.GetState()) {
+	case wxWebRequest::State_Completed:
+		Finish(Evaluate(evt.GetResponse().AsString()));
+		break;
+	case wxWebRequest::State_Failed:
+	case wxWebRequest::State_Unauthorized:
+		AddDebugLogLineN(logGeneral, wxT("Version check failed: ") + evt.GetErrorDescription());
+		Finish(Failed);
+		break;
+	case wxWebRequest::State_Cancelled:
+		Finish(Failed);
+		break;
+	default:
+		// State_Idle / State_Active — request still in progress.
+		break;
+	}
+}
+
+CVersionCheck::Status CVersionCheck::Evaluate(const wxString &json)
+{
+	// Extract the `tag_name` string — the same field the daemon-side check
+	// reads. /releases/latest excludes pre-releases, so the tag names a
+	// stable release. A regex on the one well-known field is robust against
+	// whitespace and field-order changes without a full JSON parser.
+	wxRegEx tagRe(wxT("\"tag_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\""));
+	if (!tagRe.IsValid() || !tagRe.Matches(json)) {
+		return Failed;
+	}
+	wxString tag = tagRe.GetMatch(json, 1);
+
+	// Tolerate an optional leading v/V (aMule tags are bare semver, but be
+	// defensive in case a future maintainer switches to vX.Y.Z).
+	if (tag.StartsWith(wxT("v")) || tag.StartsWith(wxT("V"))) {
+		tag = tag.Mid(1);
+	}
+	// Strip any pre-release / build-metadata suffix so the integer compare
+	// sees only MAJOR.MINOR.UPDATE.
+	size_t suffixPos = tag.find_first_of(wxT("-+"));
+	if (suffixPos != wxString::npos) {
+		tag = tag.Mid(0, suffixPos);
+	}
+	if (tag.IsEmpty()) {
+		return Failed;
+	}
+
+	long fields[] = { 0, 0, 0 };
+	wxStringTokenizer tkz(tag, wxT("."));
+	for (int i = 0; i < 3 && tkz.HasMoreTokens(); ++i) {
+		// Tags with fewer than three components (e.g. "3.1") are valid;
+		// the missing fields stay 0.
+		if (!tkz.GetNextToken().ToLong(&fields[i])) {
+			return Failed;
+		}
+	}
+
+	long curVer = make_full_ed2k_version(VERSION_MJR, VERSION_MIN, VERSION_UPDATE);
+	long newVer = make_full_ed2k_version(fields[0], fields[1], fields[2]);
+	if (curVer < newVer) {
+		m_latest = wxString::Format(wxT("%ld.%ld.%ld"), fields[0], fields[1], fields[2]);
+		return Outdated;
+	}
+	return UpToDate;
+}
+
+void CVersionCheck::Finish(Status status)
+{
+	m_status = status;
+	if (m_notify) {
+		wxCommandEvent evt(wxEVT_VERSION_CHECK_DONE, m_notifyId);
+		evt.SetInt(status);
+		m_notify->AddPendingEvent(evt);
+	}
+}

--- a/src/VersionCheck.h
+++ b/src/VersionCheck.h
@@ -25,6 +25,10 @@
 #ifndef VERSIONCHECK_H
 #define VERSIONCHECK_H
 
+#include "config.h" // for ENABLE_VERSION_CHECK
+
+#ifdef ENABLE_VERSION_CHECK
+
 #include <wx/event.h>
 #include <wx/string.h>
 #include <wx/webrequest.h>
@@ -82,5 +86,7 @@ private:
 	Status m_status;
 	wxString m_latest;
 };
+
+#endif // ENABLE_VERSION_CHECK
 
 #endif // VERSIONCHECK_H

--- a/src/VersionCheck.h
+++ b/src/VersionCheck.h
@@ -1,0 +1,86 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef VERSIONCHECK_H
+#define VERSIONCHECK_H
+
+#include <wx/event.h>
+#include <wx/string.h>
+#include <wx/webrequest.h>
+
+// Posted (as a wxCommandEvent) to the handler passed to CVersionCheck::Start()
+// when a check finishes. GetInt() carries the resulting CVersionCheck::Status.
+wxDECLARE_EVENT(wxEVT_VERSION_CHECK_DONE, wxCommandEvent);
+
+// Fetches the latest published aMule release from GitHub and compares it
+// against the running client version (VERSION_MJR / MIN / UPDATE).
+//
+// Shared by the monolithic GUI and amulegui: both are GUI clients built from
+// the same version macros, so neither needs the daemon core nor an EC
+// round-trip to answer "is a newer aMule available?".
+//
+// Asynchronous: Start() kicks off a wxWebRequest and returns immediately; the
+// result arrives later as a wxEVT_VERSION_CHECK_DONE event on the caller's
+// handler. One instance runs at most one check at a time.
+class CVersionCheck : public wxEvtHandler
+{
+public:
+	enum Status
+	{
+		Checking, // a request is currently in flight
+		UpToDate, // running version is the latest release (or newer)
+		Outdated, // a newer release exists — see LatestVersion()
+		Failed    // network or parse error
+	};
+
+	CVersionCheck();
+	~CVersionCheck() override;
+
+	// Start an asynchronous check. On completion a wxEVT_VERSION_CHECK_DONE
+	// command event with id == notifyId is posted to notify. A Start() call
+	// while a check is already in flight is ignored.
+	void Start(wxEvtHandler *notify, int notifyId);
+
+	Status GetStatus() const { return m_status; }
+
+	// Latest release version as "X.Y.Z"; populated when the status is
+	// Outdated, empty otherwise.
+	const wxString &LatestVersion() const { return m_latest; }
+
+private:
+	void OnRequestState(wxWebRequestEvent &evt);
+	void Finish(Status status);
+
+	// Parse the /releases/latest JSON, extract tag_name, and compare it
+	// against the running version. Sets m_latest on Outdated.
+	Status Evaluate(const wxString &json);
+
+	wxWebRequest m_request;
+	wxEvtHandler *m_notify;
+	int m_notifyId;
+	Status m_status;
+	wxString m_latest;
+};
+
+#endif // VERSIONCHECK_H

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -807,7 +807,7 @@ bool CamuleApp::OnInit()
 
 	// Fire the deferred startup HTTP downloads now that the heavy local
 	// I/O is done — see the comment in OnInit() further up.
-#ifdef AMULE_DAEMON
+#if defined(AMULE_DAEMON) && defined(ENABLE_VERSION_CHECK)
 	// Only the headless daemon runs the core (log-only) version check.
 	// The GUI clients (monolithic + amulegui) run their own check via the
 	// shared CVersionCheck (CamuleDlg::StartupVersionCheck), which also
@@ -832,7 +832,7 @@ bool CamuleApp::OnInit()
 		version_check->Create();
 		version_check->Run();
 	}
-#endif // AMULE_DAEMON
+#endif // AMULE_DAEMON && ENABLE_VERSION_CHECK
 	if (thePrefs::GetNetworkED2K() && thePrefs::AutoServerlist()) {
 		serverlist->StartAutoUpdate();
 	}
@@ -1984,9 +1984,11 @@ void CamuleApp::OnFinishedHTTPDownload(CMuleInternalEvent &event)
 	case HTTP_ServerMetAuto:
 		serverlist->AutoDownloadFinished(event.GetExtraInt64());
 		break;
+#ifdef ENABLE_VERSION_CHECK
 	case HTTP_VersionCheck:
 		CheckNewVersion(event.GetExtraInt64());
 		break;
+#endif
 	case HTTP_NodesDat:
 		if (event.GetExtraInt64() == HTTP_Success) {
 
@@ -2022,6 +2024,7 @@ void CamuleApp::OnFinishedHTTPDownload(CMuleInternalEvent &event)
 	}
 }
 
+#ifdef ENABLE_VERSION_CHECK
 void CamuleApp::CheckNewVersion(uint32 result)
 {
 	if (result == HTTP_Success) {
@@ -2140,6 +2143,7 @@ void CamuleApp::CheckNewVersion(uint32 result)
 		AddLogLineC(_("Failed to download the version check file"));
 	}
 }
+#endif // ENABLE_VERSION_CHECK
 
 bool CamuleApp::IsConnected() const
 {

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -807,6 +807,13 @@ bool CamuleApp::OnInit()
 
 	// Fire the deferred startup HTTP downloads now that the heavy local
 	// I/O is done — see the comment in OnInit() further up.
+#ifdef AMULE_DAEMON
+	// Only the headless daemon runs the core (log-only) version check.
+	// The GUI clients (monolithic + amulegui) run their own check via the
+	// shared CVersionCheck (CamuleDlg::StartupVersionCheck), which also
+	// drives the About dialog's "Check for updates" button — so gating
+	// this to the daemon avoids a redundant second fetch in the monolithic
+	// app.
 	if (thePrefs::GetCheckNewVersion()) {
 		// Test if there's any new version. The URL is the GitHub
 		// Releases "latest" endpoint, which returns JSON describing the
@@ -825,6 +832,7 @@ bool CamuleApp::OnInit()
 		version_check->Create();
 		version_check->Run();
 	}
+#endif // AMULE_DAEMON
 	if (thePrefs::GetNetworkED2K() && thePrefs::AutoServerlist()) {
 		serverlist->StartAutoUpdate();
 	}

--- a/src/amule.h
+++ b/src/amule.h
@@ -393,7 +393,9 @@ protected:
 private:
 	virtual void OnUnhandledException();
 
+#ifdef ENABLE_VERSION_CHECK
 	void CheckNewVersion(uint32 result);
+#endif
 
 	uint32 m_localip;
 };

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -264,8 +264,10 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 	AddLogLineN(wxString(" - ") +
 		    wxString(CFormat(_("This is aMule %s based on eMule.")) % GetMuleVersion()));
 	AddLogLineN(wxString("   ") + wxString(CFormat(_("Running on %s")) % wxGetOsDescription()));
+#ifdef ENABLE_VERSION_CHECK
 	AddLogLineN(" - " + wxString(_("Visit https://github.com/amule-org/amule/releases/latest to check if "
 				       "a new version is available.")));
+#endif
 	AddLogLineN("");
 
 #ifdef ENABLE_IP2COUNTRY
@@ -324,10 +326,12 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 
 	Show(true);
 
+#ifdef ENABLE_VERSION_CHECK
 	// Defer the "is a newer aMule available?" check until the event loop is
 	// running (past the heavy startup I/O), then check and maybe pop up.
 	// Shared with amulegui — both frontends run it from CamuleDlg.
 	CallAfter(&CamuleDlg::StartupVersionCheck);
+#endif
 
 	// Workaround for wxMSW: Create_Toolbar() above (and the Realize()
 	// inside Apply_Toolbar_Skin) runs before the frame is mapped at
@@ -555,6 +559,7 @@ void CamuleDlg::OnImportButton(wxCommandEvent &WXUNUSED(ev))
 #endif
 }
 
+#ifdef ENABLE_VERSION_CHECK
 void CamuleDlg::StartupVersionCheck()
 {
 	if (!thePrefs::GetCheckNewVersion()) {
@@ -608,13 +613,16 @@ void CamuleDlg::OnStartupVersionCheckDone(wxCommandEvent &evt)
 		wxLaunchDefaultBrowser(wxT("https://github.com/amule-org/amule/releases/latest"));
 	}
 }
+#endif // ENABLE_VERSION_CHECK
 
 CamuleDlg::~CamuleDlg()
 {
 	theApp->amuledlg = NULL;
 
+#ifdef ENABLE_VERSION_CHECK
 	delete m_startupVersionCheck;
 	m_startupVersionCheck = NULL;
+#endif
 
 #ifdef ENABLE_IP2COUNTRY
 	delete m_IP2Country;

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -46,6 +46,7 @@
 #include "amuleDlg.h" // Interface declarations.
 
 #include <common/Format.h>    // Needed for CFormat
+#include "AboutDialog.h"      // Needed for CAboutDlg
 #include "amule.h"            // Needed for theApp
 #include "ChatWnd.h"          // Needed for CChatWnd
 #include "SourceListCtrl.h"   // Needed for CSourceListCtrl
@@ -323,6 +324,11 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 
 	Show(true);
 
+	// Defer the "is a newer aMule available?" check until the event loop is
+	// running (past the heavy startup I/O), then check and maybe pop up.
+	// Shared with amulegui — both frontends run it from CamuleDlg.
+	CallAfter(&CamuleDlg::StartupVersionCheck);
+
 	// Workaround for wxMSW: Create_Toolbar() above (and the Realize()
 	// inside Apply_Toolbar_Skin) runs before the frame is mapped at
 	// its final on-screen size. wxMSW's native toolbar control
@@ -519,29 +525,11 @@ void CamuleDlg::OnToolBarButton(wxCommandEvent &ev)
 
 void CamuleDlg::OnAboutButton(wxCommandEvent &WXUNUSED(ev))
 {
-	wxString msg = " ";
-#ifdef CLIENT_GUI
-	msg << _("aMule remote control ") << VERSION;
-#else
-	msg << "aMule " << VERSION;
-#endif
-	msg << " ";
-#ifdef GITDATE
-	msg << _("Snapshot:") << "\n " << GITDATE;
-#endif
-	msg << "\n\n"
-	    << _("'All-Platform' p2p client based on eMule \n\n")
-	    << _("Website: https://amule-org.github.io \n")
-	    << _("Forum: https://github.com/amule-org/amule/discussions \n")
-	    << _("Documentation: https://amule-org.github.io/docs \n")
-	    << _("Issues: https://github.com/amule-org/amule/issues \n\n")
-	    << _("Copyright (c) 2003-2026 aMule Team \n\n") << _("Part of aMule is based on \n")
-	    << _("Kademlia: Peer-to-peer routing based on the XOR metric.\n")
-	    << _(" Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n")
-	    << _("https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n");
-
+	// The version + credits text, plus a live "Check for updates" control
+	// backed by the shared CVersionCheck, now live in CAboutDlg.
 	if (m_is_safe_state) {
-		wxMessageBox(msg, _("Message"), wxOK | wxICON_INFORMATION, this);
+		CAboutDlg dlg(this);
+		dlg.ShowModal();
 	}
 }
 
@@ -567,9 +555,66 @@ void CamuleDlg::OnImportButton(wxCommandEvent &WXUNUSED(ev))
 #endif
 }
 
+void CamuleDlg::StartupVersionCheck()
+{
+	if (!thePrefs::GetCheckNewVersion()) {
+		return;
+	}
+	if (!m_startupVersionCheck) {
+		m_startupVersionCheck = new CVersionCheck();
+		Bind(wxEVT_VERSION_CHECK_DONE, &CamuleDlg::OnStartupVersionCheckDone, this);
+	}
+	m_startupVersionCheck->Start(this, wxID_ANY);
+}
+
+void CamuleDlg::OnStartupVersionCheckDone(wxCommandEvent &evt)
+{
+	if (evt.GetInt() != CVersionCheck::Outdated || !m_startupVersionCheck || !m_is_safe_state) {
+		return;
+	}
+	const wxString latest = m_startupVersionCheck->LatestVersion();
+
+	// Notify at most once per detected version: the last version we popped
+	// up about is remembered in a small file next to the other
+	// version-check state, so we don't nag on every startup.
+	const wxString stampPath = thePrefs::GetConfigDir() + wxT("last_version_notified");
+	wxTextFile stamp(stampPath);
+	if (wxFileExists(stampPath)) {
+		if (stamp.Open()) {
+			const wxString seen = stamp.GetLineCount() ? stamp.GetLine(0) : wxString();
+			if (seen == latest) {
+				stamp.Close();
+				return; // already notified about this version
+			}
+			stamp.Clear();
+			stamp.AddLine(latest);
+			stamp.Write();
+			stamp.Close();
+		}
+	} else if (stamp.Create()) {
+		stamp.AddLine(latest);
+		stamp.Write();
+		stamp.Close();
+	}
+
+	wxMessageDialog dlg(this,
+		CFormat(_("A new version of aMule (%s) is available.\n\n"
+			  "You are running %s.\n\n"
+			  "Would you like to open the download page?")) %
+			latest % VERSION,
+		_("New version available"),
+		wxYES_NO | wxICON_INFORMATION);
+	if (dlg.ShowModal() == wxID_YES) {
+		wxLaunchDefaultBrowser(wxT("https://github.com/amule-org/amule/releases/latest"));
+	}
+}
+
 CamuleDlg::~CamuleDlg()
 {
 	theApp->amuledlg = NULL;
+
+	delete m_startupVersionCheck;
+	m_startupVersionCheck = NULL;
 
 #ifdef ENABLE_IP2COUNTRY
 	delete m_IP2Country;

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -26,6 +26,8 @@
 #ifndef AMULEDLG_H
 #define AMULEDLG_H
 
+#include "config.h" // for ENABLE_VERSION_CHECK (gates the startup version-check members)
+
 #include <wx/archive.h>
 #include <wx/filename.h>
 #include <wx/frame.h> // Needed for wxFrame
@@ -227,6 +229,7 @@ private:
 	int m_CurrentBlinkBitmap;
 	uint32 m_last_iconizing;
 
+#ifdef ENABLE_VERSION_CHECK
 	// Deferred startup "is a newer aMule available?" check, shared with
 	// amulegui via CVersionCheck. Owned; created lazily by
 	// StartupVersionCheck() when the "check at startup" preference is on.
@@ -236,6 +239,7 @@ private:
 	// shows the "new version" popup at most once per detected version.
 	void StartupVersionCheck();
 	void OnStartupVersionCheckDone(wxCommandEvent &evt);
+#endif // ENABLE_VERSION_CHECK
 
 public:
 	// Track iconize state from wxIconizeEvent::IsIconized(), which is

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -39,6 +39,7 @@
 
 class wxTimerEvent;
 class wxTextCtrl;
+class CVersionCheck;
 
 class CIP2Country;
 class CTransferWnd;
@@ -225,6 +226,16 @@ private:
 	bool m_BlinkMessages;
 	int m_CurrentBlinkBitmap;
 	uint32 m_last_iconizing;
+
+	// Deferred startup "is a newer aMule available?" check, shared with
+	// amulegui via CVersionCheck. Owned; created lazily by
+	// StartupVersionCheck() when the "check at startup" preference is on.
+	CVersionCheck *m_startupVersionCheck = nullptr;
+	// Kick off the deferred startup version check (no-op if the preference
+	// is off); the result is handled by OnStartupVersionCheckDone, which
+	// shows the "new version" popup at most once per detected version.
+	void StartupVersionCheck();
+	void OnStartupVersionCheckDone(wxCommandEvent &evt);
 
 public:
 	// Track iconize state from wxIconizeEvent::IsIconized(), which is


### PR DESCRIPTION
Closes #246.

## What

Adds a shared version-availability check to the GUI. `CVersionCheck` (new) fetches GitHub's latest aMule release via `wxWebRequest`, parses the tag, and compares it against the running `VERSION_MJR/MIN/UPDATE`. Both the monolithic GUI and amulegui use it directly — they're GUI clients built from the same version macros, so there's no daemon-core dependency and no EC round-trip.

Two entry points, both in the shared `CamuleDlg`:

- **Startup popup** — a deferred check (gated by the existing "Check for new version at startup" preference), shown at most once per detected version (tracked in `~/.aMule/last_version_notified`), offering to open the download page in the browser.
- **About dialog** — converted from a plain `wxMessageBox` into a small dialog with selectable, URL-clickable text (icon + credits preserved) and a live **"Check for updates"** button that runs the check on demand, plus a clickable download link when a newer version is found.

The daemon core keeps its existing log-only `CheckNewVersion`, now gated to `#ifdef AMULE_DAEMON` so the monolithic app doesn't fetch twice.

## Notes

- Headless `amuled` behaviour is unchanged (still logs).
- Existing About-box translations are preserved (the same msgids are reused); catalogs are regenerated in a separate commit for the new strings so the code commit stays reviewable.
- `wxTE_AUTO_URL` makes the in-text URLs clickable on Linux/Windows; on macOS the dedicated download link (`wxHyperlinkCtrl`) is always clickable and the text is selectable everywhere.

## Testing

Built and exercised on macOS with a temporarily-faked older version so 3.0.1 registers as new: the startup Yes/No popup opens the releases page, and the About "Check for updates" button correctly reports up-to-date / new-version-available. Linux + Windows testing still pending — please hold merge until that's done.
