### PR TITLE
Add option to bind aMule to a specific network interface

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -185,8 +185,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -231,79 +231,89 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -313,184 +323,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -2518,7 +2528,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -185,8 +185,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -231,89 +231,94 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -323,184 +328,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -858,7 +863,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2186,49 +2191,49 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr ""
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2528,7 +2533,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,80 +18,80 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -185,8 +185,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -201,99 +201,109 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -303,184 +313,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -519,15 +529,15 @@ msgstr ""
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -537,221 +547,221 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -839,8 +849,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr ""
@@ -1203,19 +1213,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1247,7 +1257,7 @@ msgid "On Queue"
 msgstr ""
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr ""
 
@@ -1307,7 +1317,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr ""
@@ -1378,7 +1388,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr ""
 
@@ -1391,7 +1401,7 @@ msgid "Progress"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr ""
 
@@ -1401,7 +1411,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr ""
 
@@ -1432,7 +1442,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr ""
@@ -2056,7 +2066,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr ""
 
@@ -2334,8 +2344,8 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr ""
 
@@ -2407,7 +2417,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2441,30 +2451,30 @@ msgstr ""
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr ""
 
@@ -2508,7 +2518,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2530,7 +2540,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr ""
 
@@ -2639,7 +2649,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -2879,7 +2889,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr ""
@@ -2948,7 +2958,7 @@ msgstr ""
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr ""
 
@@ -2969,7 +2979,7 @@ msgstr ""
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr ""
 
@@ -3143,7 +3153,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3152,15 +3162,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr ""
 
@@ -3172,7 +3182,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr ""
 
@@ -3180,7 +3190,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr ""
 
@@ -3381,8 +3391,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3456,745 +3466,753 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4202,11 +4220,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4216,222 +4234,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr ""
 
@@ -4508,7 +4526,7 @@ msgstr ""
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr ""
 
@@ -4697,355 +4715,355 @@ msgstr ""
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr ""
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5055,296 +5073,300 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+msgid "- Network interface binding changed.\n"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -21,80 +21,80 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "غير متوفر"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -188,8 +188,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -205,102 +205,112 @@ msgstr "فشل لفتح %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "فشل"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "معلومات"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "تاكيد الخروج"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i خادمات وجدت في server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -310,185 +320,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ﻻ نضمن انه خالي من اﻻخطاء, قد يتسبب باعطال\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "إسم الخادم"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -527,15 +537,15 @@ msgstr ""
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -545,227 +555,227 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "غير متوفر"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "متصل"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "إيقاف محاولة اﻹتصال الحاليه"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "فصل"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "فصل من المستضيف الحالي"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "إتصال"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "تحميل: %.1f(%.1f) | رفع: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "رفع : %.1f |تحميل : %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "هل تريد حقا الخروج من البرنامج؟"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "تاكيد الخروج"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "بحث"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "نافذة البحث"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "نافذة ملفات المشاركة"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "رسائل"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "نافذة الرسائل"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "احصائات"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "نافذة اﻻحصائيات"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "اعدادت"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "نافذة اﻹعدادات"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -858,8 +868,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "غير معرف"
@@ -1223,19 +1233,19 @@ msgstr "ذاتي عالي"
 msgid "Very low"
 msgstr "متدني جدا"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "متدني"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "عادي"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1267,7 +1277,7 @@ msgid "On Queue"
 msgstr "في اﻻنتظار"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "تحميل"
 
@@ -1327,7 +1337,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr ""
@@ -1398,7 +1408,7 @@ msgstr ""
 msgid "Size"
 msgstr "حجم"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "نقل"
 
@@ -1411,7 +1421,7 @@ msgid "Progress"
 msgstr "تقدم"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "مصدر"
 
@@ -1421,7 +1431,7 @@ msgstr "مصدر"
 msgid "Priority"
 msgstr "أولوية"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "حالة"
 
@@ -1454,7 +1464,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "ذاتي"
@@ -2078,7 +2088,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "اصدقاء"
 
@@ -2362,8 +2372,8 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr ""
 
@@ -2435,7 +2445,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2469,30 +2479,30 @@ msgstr "غير معروف :%i"
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "اكتمال"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "اكتمل"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "ايقاف مؤقت"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "خاطئ"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "انتظار"
 
@@ -2538,7 +2548,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2560,7 +2570,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "اغلق"
 
@@ -2673,7 +2683,7 @@ msgstr "خروج"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -2913,7 +2923,7 @@ msgstr "بايت"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr ""
@@ -2983,7 +2993,7 @@ msgstr ""
 msgid "File sources:"
 msgstr "ايجاد المصدر :"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "عام"
 
@@ -3004,7 +3014,7 @@ msgstr "اﻻسم كامل :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "غير متوفر"
 
@@ -3178,7 +3188,7 @@ msgstr "اسم المستخدم :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "اضف"
@@ -3187,15 +3197,15 @@ msgstr "اضف"
 msgid "Download-Speed"
 msgstr "سرعة-التحميل"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "الحالي"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "معدل العمل"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "معدل الجلسة"
 
@@ -3207,7 +3217,7 @@ msgstr "سرعة-الرفع"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "تحميل نشط"
 
@@ -3215,7 +3225,7 @@ msgstr "تحميل نشط"
 msgid "Active connections (1:1)"
 msgstr "إتصال نشط (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "رفع نشط"
 
@@ -3417,8 +3427,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3492,749 +3502,757 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "إعادة اﻹتصال عند الفصل"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "إحذ الخادمات التي ﻻ تعمل بعد"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "أعد المحاولة"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "قائمة"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "إستخدم نظام اﻷولوية"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "إتصال أمن"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "جعل الخادمات المضافة يدويا ذو اولوية عالية"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "أضف الملفات للتحميل بوضع متوقف"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "أضف الملفات للتحميل بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "حاول تحميل القطع اﻻولى واﻻخيرة اوﻻ"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "ارفع"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "أضف ملفات مشاركة جديدة بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "رسم بياني"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "تحيدث كل:5 ثواني"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "خلفية"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "شبكة"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "حمل الحالي"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "معدل تحميل الحالي"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "معدل تحميل الجلسة"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "ارفع الحالي"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "معدل رفع الحالي"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "معدل رفع الجلسة"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "اتصال نشط"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "اختر"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!!تحذير!!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "الحد اﻷعلى للتصالات لكل 5 ثواني"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "اقبل اتصال خارجي"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "زمن تحديث الصفحة (بالثانية)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr " Gzipتمكين ضغط نوع"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "موافق"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "عنوان :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "تعليق :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "مجلد القادم"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "تغير الأولوية للملفات الحديثة :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "ﻻ تغير"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "معاد"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "قم بالضغط على هذا الزر لتحديث قائمة الخادمات من العنوان ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "قائمة الخادمات"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "عنوان شبكي :منفذ"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "اضف خادم يدويا )قم بمل الخانة على اليسار اوﻻ)..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "سجل aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "معلومات الخادم"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "الكل"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "تمكين التوقيع الشبكي"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "نسبة المصادر :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "مصدر"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4242,11 +4260,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4256,233 +4274,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "التحميل"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "أكتسب بواسطة الضغط :"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&فتح الملف"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "إنتظار..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "رفع نشط :"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 #, fuzzy
 msgid "Percent of total files"
 msgstr "مجموع الملفات"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "ملفات مشاركة"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "إختر فلتر العرض"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "رفع نشط"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "اعد تحميل"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "ارسل"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "ملفات مشاركة"
 
@@ -4561,7 +4579,7 @@ msgstr "الكل ماعدا"
 msgid "Incomplete"
 msgstr "غير مكتمل"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "إيقاف"
 
@@ -4752,359 +4770,359 @@ msgstr ""
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "فشل في تحميل قائمة الخادمات من %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "العربيه"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "البلغاريه"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "الدانماركيه"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "الهولنديه"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "الفلنديه"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "الفرنسية"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "الألمانيه"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "الهنغاريه"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "الايطاليه"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr ""
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "الكوريه"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "الليتوانيه"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "البرتغاليه"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "الروسيه"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "الإسبانيه"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "الغة"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "غير متوفر"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "اتصال"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "مجلدات"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "الخادمات"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "ملفات"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "تحكم عن بعد"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5114,157 +5132,162 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "عوامل اﻻتصال الخارجي"
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "ذاتي"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5272,147 +5295,147 @@ msgstr ""
 "أضف هنا عنوان لتحميل ملفات server.met \n"
 "عنوان واحد فقط لكل سطر"
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "تحيدث كل:5 ثواني"
 msgstr[1] "تحيدث كل:5 ثواني"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "فترة تحديث الإتصال بالخادم %i دقيقة"
 msgstr[1] "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "فترة تحديث الإتصال بالخادم :معطل"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "تعطيل"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "وجد %i ملف مشاركة معرف"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -188,8 +188,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -235,92 +235,97 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "معلومات"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "تاكيد الخروج"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i خادمات وجدت في server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -330,185 +335,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ﻻ نضمن انه خالي من اﻻخطاء, قد يتسبب باعطال\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "إسم الخادم"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -877,7 +882,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2213,50 +2218,50 @@ msgstr "ﻻ"
 msgid "Yes"
 msgstr "نعم"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "تحميل ..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 #, fuzzy
 msgid "HTTP download cancelled"
 msgstr "سعة نطاق التحميل الحقيقية"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "فشل في حفظ ملف part.met.seeds لي %s"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "مجموع التحميل"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "سعة نطاق التحميل الحقيقية"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2558,7 +2563,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -188,8 +188,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -235,82 +235,92 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "معلومات"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "تاكيد الخروج"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i خادمات وجدت في server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -320,185 +330,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ﻻ نضمن انه خالي من اﻻخطاء, قد يتسبب باعطال\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "إسم الخادم"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -2548,7 +2558,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -21,20 +21,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Amosar aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Control remotu de aMule"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Versión:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -42,7 +42,7 @@ msgstr ""
 "Veceru p2p multiplataforma basáu en eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -51,59 +51,59 @@ msgstr ""
 "Copyright (C) 2003-2019 Equipu aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Parte d'aMule básase en \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Direicionamientu P2P basáu na métrica XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Web:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Foru:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprobar nueva versión al entamu"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Coneutando a Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "¡Tas usando una versión antigua de aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Non disponible"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -199,8 +199,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -215,47 +215,57 @@ msgstr "Fallu al abrir ficheru ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISU: Nun pues amestate a tí mesmu como una fonte pa un enllaz eD2k teniendo ID baxa."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Agora, saliendo de l'aplicación principal..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Falló"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Terminando núcleu."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Zarru d'aMule completáu."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultaos de depuración de memoria na salida d'aMule: "
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "La to llingua foi camudada a la de por defeutu del sistema, darréu d'un cambéu de configuración. Siéntolo."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -263,56 +273,56 @@ msgstr ""
 "\n"
 "Configuración EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ALERTA"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i sirvidor alcontráu en server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nun ye dable direicionar los puertos a la direición especificada: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puertu %u nun ta disponible. Tendrás IDBaxa\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -327,48 +337,48 @@ msgstr ""
 "\n"
 "Comprueba la to rede y asegúrate de que'l puertu ta abiertu pa entrada y salida."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La llingua seleicionada nun paez tar instalada. (Nota: Tentará de ponese de toes formes)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ye la primer vegada qu'anicies aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esto ye una versión de preba, actualízate diariamente, y \n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nun damos garantía si fraña daqué, ambura to casa,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o fila la to sidra. Pero *tendría* de ser seguru de toes formes. \n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podrás alcontrar na nuesa web, más información, sofitu y nueves versiones, \n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o nel nuesu canal de IRC #aMule en irc.libera.chat. \n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Unvíanos cualesquier fallu a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -376,137 +386,137 @@ msgstr ""
 "El direutoriu qu'especificaste de Robla Online nun ye válidu\n"
 "La Robla Online deshabilitóse hasta que lo igües nes opciones."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Nome sirvidor notificáu"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espaciu en discu pal ficheru '%s' falló: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "FALLU: nun puede abrise'l ficheru de rexistru"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ALERTA: el ficheru de rexistru ta ermu. Hai daqué mal."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "El rexistru resetióse"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensax del sirvidor: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Fallu al descargar la llista de nodos."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Fallu al abrir el ficheru de comprobación de versión descargáu"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Ficheru de comprobación de versión toyíu"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Tas usando una versión antigua de aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La to versión de aMule ye %i.%i.%i y la cabera versión ye %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ALERTA: La to versión de aMuled ye obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "LA to copia de aMule ta actualizada."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Fallu al descargar el ficheru de comprobación de versión"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheros: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheros: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ensin redes seleicionaes"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con IDBaxa"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Coneutáu a %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Coneutando a %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Desconeutáu de eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad aniciáu."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad deteníu."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Coneutáu a Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Coneutáu a Kad (tres torgafueos)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Desconeutáu de Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Red Kad nun pue usase si'l puertu UDP ta deshabilitáu n'opciones, non aniciando."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada n'opciones, nun coneutará."
 
@@ -546,15 +556,15 @@ msgstr "Esto ye aMule %s basáu en eMule."
 msgid "Running on %s"
 msgstr "Executándose en %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest pa comprobar si hai una nueva versión disponible"
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FALLU GRAVE: Nun pudo criase'l temporizador"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -564,224 +574,224 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Non disponible"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Diálogu aMule afaráu"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Coneutando"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Coneutando"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconeutáu"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Tres Tornafueos"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Coneutáu"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Coneutando"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Apagada"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Encaboxar"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexón actuales"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Desconeutar"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconeutase de les redes coneutaes"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Coneutar"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Coneutase a les redes disponibles"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Xu: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Xu: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Coneutáu)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconeutáu)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Daveres quies colar de aMule?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Confirmar colar."
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Llanzar comandu:"
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- Por defeutu -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El direutorio de tema '%s' nun esiste"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENCIÓN: Nun pue abrise'l ficheru de temes '%s' pa llectura"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Guetar"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Ventana de gueta"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Descargues"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Descargando"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Ficheros compartíos"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Ventana de ficheros compartíos"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Ventana de mensaxes"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos d'estadístiques"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencies"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Ventana d'opciones"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "La ferramienta pa importar ficheros part"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tocante a"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Tocante a/Aida"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Ensin rede"
 
@@ -869,8 +879,8 @@ msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo di
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Desconocíu"
@@ -1234,19 +1244,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Mui baxa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Baxa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1278,7 +1288,7 @@ msgid "On Queue"
 msgstr "Na cola"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Descargando"
 
@@ -1338,7 +1348,7 @@ msgstr "Sirvidor llocal"
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1410,7 +1420,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamañu"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Tresferío"
 
@@ -1423,7 +1433,7 @@ msgid "Progress"
 msgstr "Progresu"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Fontes"
 
@@ -1433,7 +1443,7 @@ msgstr "Fontes"
 msgid "Priority"
 msgstr "Prioridá"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Estáu"
 
@@ -1466,7 +1476,7 @@ msgstr ""
 "Reaición dende: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2122,7 +2132,7 @@ msgstr "¡ Nun pudo abrise'l ficheru de collacios 'emfriends.met' pa la so escri
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICU - ensin veceru en sesión charra d'aniciu"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Collacios"
 
@@ -2411,8 +2421,8 @@ msgstr "Puertu non válidu pa coneutar"
 msgid "Please fill all fields required"
 msgstr "Por favor enllene tolos campos requeríos"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Mensax"
 
@@ -2484,7 +2494,7 @@ msgstr "Media compartío"
 msgid "Uploaded"
 msgstr "Xubío"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Pidío"
 
@@ -2518,30 +2528,30 @@ msgstr "Versión desconocía"
 msgid "Unable to get error description for error %d"
 msgstr "Carpeta de destín pa les descargues"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Codificando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Completando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Completáu"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Posáu"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Erróneu"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Aguardando"
 
@@ -2586,7 +2596,7 @@ msgstr "Conexón esterna: Accesu denegáu, xida:"
 msgid "External Connection: Handshake failed."
 msgstr "Conexón esterna: Falló handshake."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Descarga HTTP filu entamáu"
@@ -2608,7 +2618,7 @@ msgid "WARNING: "
 msgstr "AVISU:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Zarrar"
 
@@ -2724,7 +2734,7 @@ msgstr "Colar"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2964,7 +2974,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3034,7 +3044,7 @@ msgstr "Llimpiar descargues completaes"
 msgid "File sources:"
 msgstr "Fontes completes"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Xeneral"
 
@@ -3055,7 +3065,7 @@ msgstr "Nome Completu :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3231,7 +3241,7 @@ msgstr "Nome d'usuariu :"
 msgid "Userhash :"
 msgstr "Hash del usuariu :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Amestar"
@@ -3240,15 +3250,15 @@ msgstr "Amestar"
 msgid "Download-Speed"
 msgstr "Velocidá de descarga"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Media d'execución"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3260,7 +3270,7 @@ msgstr "Velocidá de xuba"
 msgid "Connections"
 msgstr "Conexones"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Descargues actives"
 
@@ -3268,7 +3278,7 @@ msgstr "Descargues actives"
 msgid "Active connections (1:1)"
 msgstr "Conexones actives (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Xubes actives"
 
@@ -3470,8 +3480,8 @@ msgstr "Seleición del restolador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduz el nome del to restolador. Déxalo ermo si quies usar el que hai por defeutu."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3545,755 +3555,764 @@ msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Namái usuarios avanzaos: Si tu tienes múltiples tarxetes de rede, introduz la direición de la tarxeta, que aMule tendrá d'usar."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Max. fontes descargando un ficheru:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Máx. conexones al empar:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Autoconeutar al aniciar"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Reconeutar al perder la conexón"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Desaniciar sirvidores cayíos tres"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "reintentos"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Auto-actualizar la llista de sirvidores al aniciu"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Llista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar la llista de sirvidores al coneutar a un sirvidor"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Actualizar la llista de sirvidores cuando un veceru se coneuta"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Usar sistema de prioridaes"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Control intelixente de IDBaxa al coneutar"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Conexón segura"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconeutar namái a Sirvidores fixos"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar alta prioridá a los sirvidores amestaos manualmente"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Remanador Intelixente de Corrupciones (I.C.H)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avanzáu, confiar en tolos hash (non recomendáu)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Amestar ficheros pa descargar en mou posáu"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Amestar nueves descargues con auto prioridá"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Tentar descargar enantes la primer y cabera parte"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Descargar siguiente ficheru posáu cuandu otru se complete"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Namái na mesma categoría"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Reservar espaciu en discu pa los nuevos ficheros"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pa los nuevos ficheros reservar tol espaciu del ficheru, esto amenorga la fragmentación"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener descargues cuando s'algame l'espaciu llibre en discu"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleiciona esta opción si quies que aMule comprebe l'espaciu en discu"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Introduz l'espaciu mínimu de discu deseyáu."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes en ficheros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Xubíes"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Amestar nuevos ficheros compartíos con auto prioridá"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destín pa les descargues"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click drechu n'iconu de carpeta, pa compartición recursiva)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Compartir ficheros anubríos"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Intervalu d'actualización : 5 segs"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempu de promediu del gráficu: 100 min"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráficu de les conexones: 100"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Descargar escala gráfica:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fondu"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Rexella"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Promediu descarga n'execución"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Promediu Descarga/sesión"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Xuba actual"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Promediu Xuba/tiempu"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Promediu xuba/sesión"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Conexones actives"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidá del iconu de sistema"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Kad-nodos actual"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kad-nodos executando"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kad-nodos sesión"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Seleicionar"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Númberu de versiones de veceros a amosar (0=ensin llímite)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISU !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Nueves conexones máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamañu del buffer de ficheru: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamañu cola d'espera: 5000 veceros"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalu d'actualización de conexón al sirvidor: Desactiváu"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar \"Xestor rápidu d'enllaces eD2k\", en toles ventanes."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Amosar info estendía nes llingüetes de les categoríes"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Enantes del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Dempués del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Amosar anchor de banda escedente"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de ferramientes"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Ficheros de la cola de descarga"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Amosar porcentax de progresu"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Amosar barra de progresu"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Planu"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Auto-ordenar ficheros (Alta CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule ordenará automáticamente les columnes na to llista de descargues"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parámetros de conexón esterna"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Aceutar conexones esternes"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP de la interface que ta escuchando"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduz una IP válida de la interface que ta escuchando. Un campu ermu o 0.0.0.0 significará cualesquier interface."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar UPnP port forwarding nel puertu EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Aniciar sirvidor web al entamu"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Plantía Web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Contraseña alministrador"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Activar invitáu"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Contraseña invitáu"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Usar forwarding de puertos UPnP nel puertu del sirvidor web"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puertu HTTP del sirvidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Tiempu d'actualización de páxina (en segs)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Activar compresión gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Aceutar"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Encaboxar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Títulu :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Comentariu : "
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Direutoriu entrante :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridá a nuevos ficheros asignaos :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleiciona color pa esta categoría (seleicionada) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Reafitar"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Calca esti botón pa llimpiar el registru."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de sirvidores dende una URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Llista de sirvidores"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduz la url a un ficheru server.met y calca'l botón de la esquierda p'actualizar la llista de sirvidores conocíos."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Amestar sirvidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Introduz el nome del nuevu sirvidor"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Puertu"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduz la IP del sirvidor, usando'l formatu X.X.X.X."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Introduz el puertu del sirvidor"
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Amestar manualmente un sirvidor (rellena los campos) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Rexistru"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Info. sirvidores"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Info ED2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de nodos dende la URL ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduz equí la url al ficheru nodes.dat y calca'l botón de la esquierda, p'actualizar la llista de nodos conocíos."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Estadístiques nodos"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Coneutar"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nuevu nodu"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Puertu:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Coneutar dende \n"
 "veceros conocíos"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Desconeutar Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Usar Identificación Segura d'Usuariu"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Encamiéntase a activar esta opción. Nun recibirá créditos si la ISU (Identificación Segura d'Usuariu) nun ta habilitada."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Sofitu d'ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolu, y fai que aMule aceute conexones ofuscaes de otros veceros."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación pa conexones salientes"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use ofuscación de protocolu cuando se coneuten otros veceros/sirvidores."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Aceutar namái conexones ofuscaes"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esa opción fai que aMule namái aceute conexones ofuscaes. Tendrá menos fontes, pero tol so tráficu sedrá ofuscáu."
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Toos"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Dengún"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Quién pue adicar los mios ficheros compartíos:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleiciona quién pue solicitar adicar la nuesa llista de ficheros compartíos."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Fieltráu de IPs"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Fieltru veceros"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de veceros definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Fieltru sirvidores"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de sirvidores definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar llista de fieltráu de IPs dende ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Nivel de fieltráu:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Fieltrar siempres IP's de LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Control paranoicu de IPs non comprobaes"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Refugar paquetes si la ip del veceru ye diferente de la ip dende au el paquete ye recibíu. Usar con curiáu."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat de sistema si ta disponible"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si nun s'alcuentra un ficheru ipfilter.dat llocal, permitir l'usu d'un ficheru ipfilter de sistema"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Activar Robla online"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar la escritura de ficheros del SO, suel usase pa criar robles por aplicaciones esternes."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia d'actualización (segs):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de l'actualización de la robla-online"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Guardar ficheru de robla online en: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Click equí pa seleicionar el direutoriu que contién los ficheros de robles-online."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Fluxu de datos :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4301,11 +4320,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4315,232 +4334,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargáu:"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Fieltrar mensaxes entrantes (sacantes conversación actual):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Fieltrar tolos mensaxes"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Fieltrar mensaxes de xente que nun ta na to llista de collacios"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Fieltrar mensaxes que contienen (usa ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amiesta equí les pallabres que amule tien de fieltrar y bloquiar mensaxes incluyíos"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Amosar mensaxes recibíos nel rexistru"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fieltrar comentarios que contengan (usar ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Habilitar autentificación"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/deshabilita autentificación usuariu/contraseña"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Nome d'usuariu:"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "El nome d'usuariu a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Habilitar Proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/Deshabilitar soporte Proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Triba Proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Sirvidor Proxy:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Nome del host del proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Puertu Proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "El puertu del proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Coneutar a:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Conexón a aMule remotu"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nome usuariu:"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Remembrar estes opciones"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita mou estendíu de depuración al aniciu"
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir el ficheru"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Mensaxes de categoríes:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Amestar imports"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Reintentar seleicionáu"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Desaniciar seleicionáu"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tipos Eventos"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Anubre los ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Seleicionar fieltru de vistes"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Xubes actives"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Unviar"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Unviar un mensax específicu."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Zarrar esta sesión de charra"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Coneutar a cualesquier sirvidor y/o Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Fich compartíos"
 
@@ -4617,7 +4636,7 @@ msgstr "el restu"
 msgid "Incomplete"
 msgstr "Incompletu"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Deteníu"
 
@@ -4808,359 +4827,359 @@ msgstr "Guardáu %i semiente de fontes en ficheru part: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Fallu lleendo semientes del ficheru part (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Parte toyía alcontrada (%i) en %d parte del ficheru %s - Resultáu del hash del ficheru |%s| Hash del ficheru |%s|"
 msgstr[1] "Parte toyía alcontrada (%i) en %d partes del ficheru %s - Resultáu del hash del ficheru |%s| Hash del ficheru |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Parte (%i) completa alcontrada en %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Recodificación finada %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Fallu inesperáu mientres se completaba %s. Ficheru posáu"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Descarga finada: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Descarga finada: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Desaniciando ficheru: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVISU: Nun pue criase'l hash de la parte descargada, set de hashes incompletu pa '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERROR: Nun pue criase'l hash de la parte descargada, set de hashes incompletu pa (%s). Esto nun tendría de pasar enxamás"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISU: Nun hai espaciu llibre nel discu! Posando ficheru: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Parte descargada %i toyía nel ficheru: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Recuperada parte toyía %i de %s -> Bytes salvaos: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Asignando"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Espaciu en discu insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descargáu"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: Fallu al abrir ficheru part '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Por defeutu"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturianu"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Búlgaru"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chinu (simplificáu)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chinu (Tradicional)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Checu"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estoniu"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Gallegu"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Griegu"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebréu"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Húngaru"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italianu"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italianu (Suizu)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Coreanu"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituanu"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegu"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polacu"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasil)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Rusu"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Eslovenu"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Suecu"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turcu"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ucranianu"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "Llingua: "
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Non disponible"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "opciones non disponibles"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida alcontrada, saltando"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Puertu TCP nun pue ser más altu de 65532 darréu que'l socket del sirvidor UDP ye TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puertu por defeutu que s'usará (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Conexón"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Direutorios"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Sirvidores"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Ficheros"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Seguridá"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Fieltros"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Robla online"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avanzáu"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5176,26 +5195,26 @@ msgstr ""
 "aMule furrulará bien ensin que camudes dengún\n"
 "d'estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al coneutar configuración con programa, col ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al tresferir datos dende la configuración al programa, col ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "La triba de proxy a la que tas coneutando"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al tresferir datos dende'l programa a la configuración, col ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5203,35 +5222,40 @@ msgstr ""
 "aMule tien de reaniciase p'aplicar los cambeos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- Puertu TCP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- Puertu UDP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Conexón esterna zarrada."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nueva conexón esterna, aceutada"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscación de protocolu"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5239,7 +5263,7 @@ msgstr ""
 "La to llista Auto-actualizable de sirvidores ta erma.\n"
 "La llista de sirvidores auto-actualizable al entamu desactivaráse."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5247,19 +5271,19 @@ msgstr ""
 "Tienes habilitao les conexones externes, pero nun tienes especificada una contraseña.\n"
 "Les conexones externes nun puen ser habilitaes sacante qu'especifiques una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Llingua camudada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Direutoriu TEMP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5267,7 +5291,7 @@ msgstr ""
 "eD2k y Kad tán desactivaos.\n"
 "Nun podrás coneutate hasta qu'actives a lo menos ún d'ellos."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5275,7 +5299,7 @@ msgstr ""
 "Kad nun s'aniciará si'l to puertu UDP ta deshabilitáu.\n"
 "Habilita un puertu UDP o deshabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5285,20 +5309,20 @@ msgstr ""
 "Hai de reaniciar aMule agora.\n"
 "Si nun reanicies agora, nun sabemos si pasará daqué malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto recargar, aniciáu"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5308,41 +5332,41 @@ msgstr ""
 "Por favor introduz a lo menos una URL con un ficheru server.met válidu.\n"
 "Click nel botón \"Llista\" d'esta caxella  pa introducir una URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Ficheros temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Ficheros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Robles online"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escueye una carpeta pa %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Esplorar"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Seleiciona restolador"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Editar llista de sirvidores"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5350,149 +5374,149 @@ msgstr ""
 "Amesta equí les URL's pa descargar los ficheros server.met.\n"
 "Namái una url per llinia."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completes"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalu d'actualización: %d seg"
 msgstr[1] "Intervalu d'actualización: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempu mediu del gráficu: %d min"
 msgstr[1] "Tiempu mediu del gráficu: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamañu del buffer de ficheru: %d byte"
 msgstr[1] "Tamañu del buffer de ficheru: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamañu de la cola de xuba: %d veceru"
 msgstr[1] "Tamañu de la cola de xuba: %d veceros"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalu de refrescu de la conexón al sirvidor: %d minutu"
 msgstr[1] "Intervalu de refrescu de la conexón al sirvidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalu de refrescu de la conexón al sirvidor: Deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comandu nel eventu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Habilitar execución de comandu nel núcleu"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Comandu del núcleu:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execución de comandu na Interface"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Comandu de la Interface: "
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Les siguientes variables trocaránse:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargar llista de ficheros compartíos."

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -199,8 +199,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,27 +245,37 @@ msgstr "Zarru d'aMule completáu."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultaos de depuración de memoria na salida d'aMule: "
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "La to llingua foi camudada a la de por defeutu del sistema, darréu d'un cambéu de configuración. Siéntolo."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -273,56 +283,56 @@ msgstr ""
 "\n"
 "Configuración EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ALERTA"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i sirvidor alcontráu en server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nun ye dable direicionar los puertos a la direición especificada: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puertu %u nun ta disponible. Tendrás IDBaxa\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -337,48 +347,48 @@ msgstr ""
 "\n"
 "Comprueba la to rede y asegúrate de que'l puertu ta abiertu pa entrada y salida."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La llingua seleicionada nun paez tar instalada. (Nota: Tentará de ponese de toes formes)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ye la primer vegada qu'anicies aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esto ye una versión de preba, actualízate diariamente, y \n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nun damos garantía si fraña daqué, ambura to casa,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o fila la to sidra. Pero *tendría* de ser seguru de toes formes. \n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podrás alcontrar na nuesa web, más información, sofitu y nueves versiones, \n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o nel nuesu canal de IRC #aMule en irc.libera.chat. \n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Unvíanos cualesquier fallu a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -386,137 +396,137 @@ msgstr ""
 "El direutoriu qu'especificaste de Robla Online nun ye válidu\n"
 "La Robla Online deshabilitóse hasta que lo igües nes opciones."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Nome sirvidor notificáu"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espaciu en discu pal ficheru '%s' falló: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "FALLU: nun puede abrise'l ficheru de rexistru"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ALERTA: el ficheru de rexistru ta ermu. Hai daqué mal."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "El rexistru resetióse"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensax del sirvidor: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Fallu al descargar la llista de nodos."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Fallu al abrir el ficheru de comprobación de versión descargáu"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Ficheru de comprobación de versión toyíu"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Tas usando una versión antigua de aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La to versión de aMule ye %i.%i.%i y la cabera versión ye %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ALERTA: La to versión de aMuled ye obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "LA to copia de aMule ta actualizada."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Fallu al descargar el ficheru de comprobación de versión"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheros: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheros: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ensin redes seleicionaes"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con IDBaxa"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Coneutáu a %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Coneutando a %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Desconeutáu de eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad aniciáu."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad deteníu."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Coneutáu a Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Coneutáu a Kad (tres torgafueos)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Desconeutáu de Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Red Kad nun pue usase si'l puertu UDP ta deshabilitáu n'opciones, non aniciando."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada n'opciones, nun coneutará."
 
@@ -2596,7 +2606,7 @@ msgstr "Conexón esterna: Accesu denegáu, xida:"
 msgid "External Connection: Handshake failed."
 msgstr "Conexón esterna: Falló handshake."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Descarga HTTP filu entamáu"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -199,8 +199,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,37 +245,42 @@ msgstr "Zarru d'aMule completáu."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultaos de depuración de memoria na salida d'aMule: "
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "La to llingua foi camudada a la de por defeutu del sistema, darréu d'un cambéu de configuración. Siéntolo."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -283,56 +288,56 @@ msgstr ""
 "\n"
 "Configuración EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ALERTA"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i sirvidor alcontráu en server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nun ye dable direicionar los puertos a la direición especificada: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puertu %u nun ta disponible. Tendrás IDBaxa\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -347,48 +352,48 @@ msgstr ""
 "\n"
 "Comprueba la to rede y asegúrate de que'l puertu ta abiertu pa entrada y salida."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La llingua seleicionada nun paez tar instalada. (Nota: Tentará de ponese de toes formes)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ye la primer vegada qu'anicies aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esto ye una versión de preba, actualízate diariamente, y \n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nun damos garantía si fraña daqué, ambura to casa,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o fila la to sidra. Pero *tendría* de ser seguru de toes formes. \n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podrás alcontrar na nuesa web, más información, sofitu y nueves versiones, \n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o nel nuesu canal de IRC #aMule en irc.libera.chat. \n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Unvíanos cualesquier fallu a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -396,137 +401,137 @@ msgstr ""
 "El direutoriu qu'especificaste de Robla Online nun ye válidu\n"
 "La Robla Online deshabilitóse hasta que lo igües nes opciones."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Nome sirvidor notificáu"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espaciu en discu pal ficheru '%s' falló: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "FALLU: nun puede abrise'l ficheru de rexistru"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ALERTA: el ficheru de rexistru ta ermu. Hai daqué mal."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "El rexistru resetióse"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensax del sirvidor: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Fallu al descargar la llista de nodos."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Fallu al abrir el ficheru de comprobación de versión descargáu"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Ficheru de comprobación de versión toyíu"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Tas usando una versión antigua de aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La to versión de aMule ye %i.%i.%i y la cabera versión ye %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ALERTA: La to versión de aMuled ye obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "LA to copia de aMule ta actualizada."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Fallu al descargar el ficheru de comprobación de versión"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheros: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheros: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ensin redes seleicionaes"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con IDBaxa"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Coneutáu a %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Coneutando a %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Desconeutáu de eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad aniciáu."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad deteníu."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Coneutáu a Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Coneutáu a Kad (tres torgafueos)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Desconeutáu de Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Red Kad nun pue usase si'l puertu UDP ta deshabilitáu n'opciones, non aniciando."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada n'opciones, nun coneutará."
 
@@ -888,7 +893,7 @@ msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo di
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2260,49 +2265,49 @@ msgstr "Non"
 msgid "Yes"
 msgstr "Sí"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Descarga HTTP encaboxada"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Fallu al obtener la llista de compartíos del usuariu '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Descargaos %d bytes"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Descarga HTTP encaboxada"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2606,7 +2611,7 @@ msgstr "Conexón esterna: Accesu denegáu, xida:"
 msgid "External Connection: Handshake failed."
 msgstr "Conexón esterna: Falló handshake."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Descarga HTTP filu entamáu"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -189,8 +189,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -236,91 +236,96 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Потвърждение за изход"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сървъра бяха намерени в server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -330,184 +335,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -873,7 +878,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2209,49 +2214,49 @@ msgstr "Не"
 msgid "Yes"
 msgstr "Да"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Изтеглям..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Свален:"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Файлове за сваляне (%i)"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2551,7 +2556,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -22,80 +22,80 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "форум:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -189,8 +189,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -206,101 +206,111 @@ msgstr "Грешка при запис на файла с кредити"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Грешка"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Потвърждение за изход"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сървъра бяха намерени в server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -310,184 +320,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -526,15 +536,15 @@ msgstr ""
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -544,226 +554,226 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Връзкате е установена"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Отказ"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Спира текущите опити за свързване"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Разкачи"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Изключване от текущия сървър"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Връзка"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Кач.: %.1f(%.1f) | Свал.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кБ/с"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Кач.: %.1f | Свал.: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Наистина ли желаете да изключите aМуле?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Потвърждение за изход"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- по подразбиране -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Изтегляне"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Съобщения"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Няма мрежа"
 
@@ -854,8 +864,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Неизвестен"
@@ -1219,19 +1229,19 @@ msgstr "Автоматичен [Hi]"
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Ниско"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Нормален"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1263,7 +1273,7 @@ msgid "On Queue"
 msgstr "На опашката"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Изтегляне"
 
@@ -1323,7 +1333,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr ""
@@ -1394,7 +1404,7 @@ msgstr ""
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Пренесен"
 
@@ -1407,7 +1417,7 @@ msgid "Progress"
 msgstr "Прогрес"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Източници"
 
@@ -1417,7 +1427,7 @@ msgstr "Източници"
 msgid "Priority"
 msgstr "Приоритет"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Статус"
 
@@ -1450,7 +1460,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Автоматично"
@@ -2076,7 +2086,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Приятели"
 
@@ -2357,8 +2367,8 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr ""
 
@@ -2430,7 +2440,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2464,30 +2474,30 @@ msgstr "неизвестна грешка %d"
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Завършено"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Пауза"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr ""
 
@@ -2531,7 +2541,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2553,7 +2563,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Затвори"
 
@@ -2666,7 +2676,7 @@ msgstr "Изход"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/с"
@@ -2906,7 +2916,7 @@ msgstr "Байта"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -2976,7 +2986,7 @@ msgstr ""
 msgid "File sources:"
 msgstr "Намерени източници: %i"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Общи"
 
@@ -2997,7 +3007,7 @@ msgstr ""
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "Няма"
 
@@ -3171,7 +3181,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавяне"
@@ -3180,15 +3190,15 @@ msgstr "Добавяне"
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Текущ"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr ""
 
@@ -3200,7 +3210,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr ""
 
@@ -3208,7 +3218,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr ""
 
@@ -3410,8 +3420,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3485,747 +3495,755 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Списък"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Диаграми"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Цветове: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Мрежа"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Избор"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Заглавие :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Нулира"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Всеки"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Източници"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4233,11 +4251,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4247,229 +4265,229 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Изтегляне"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Изчакване"
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Общо файлове"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Всички файлове"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Избор на филтър"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Изпраща"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr ""
 
@@ -4547,7 +4565,7 @@ msgstr "всички останали"
 msgid "Incomplete"
 msgstr "Незавършен"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Спрян"
 
@@ -4737,355 +4755,355 @@ msgstr ""
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Сваляне %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "албанец"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "арабски"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Астурия"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "баска"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "български"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Каталунски"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Китайски (опростен)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Китайски (традиционен)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "хърватски"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "чешки"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "датски"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "холандски"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "естонски"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "фински"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Френски"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "галисийски"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Немски"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Гръцки"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "иврит"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "унгарски"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Италиански"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Италиански (швейцарски)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "японски"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "корейски"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "литовски"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "норвежки (Съвременен)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "полски"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "португалски"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "португалски (бразилски)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "румънски"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Руски"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "словенски"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "шведски"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Турски"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "украински"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Смени езика"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Връзка"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Директории"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Сървъри"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Файлове"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Дистанционни управления"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "напреднал"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5095,153 +5113,157 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+msgid "- Network interface binding changed.\n"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Език променило.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматично"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Търсене на видео плеър"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5249,147 +5271,147 @@ msgstr ""
 "Тук добавете линкове за сваляне на .met файлове.\n"
 "Само по един URL на ред."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "деактивиране"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Известни са %i споделени файлове"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:05+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -189,8 +189,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -236,81 +236,91 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Потвърждение за изход"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сървъра бяха намерени в server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -320,184 +330,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -2541,7 +2551,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -184,8 +184,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -230,79 +230,89 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -312,184 +322,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -2517,7 +2527,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,80 +17,80 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -184,8 +184,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -200,99 +200,109 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -302,184 +312,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -518,15 +528,15 @@ msgstr ""
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -536,221 +546,221 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -838,8 +848,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr ""
@@ -1202,19 +1212,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1246,7 +1256,7 @@ msgid "On Queue"
 msgstr ""
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr ""
 
@@ -1306,7 +1316,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr ""
@@ -1377,7 +1387,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr ""
 
@@ -1390,7 +1400,7 @@ msgid "Progress"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr ""
 
@@ -1400,7 +1410,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr ""
 
@@ -1431,7 +1441,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr ""
@@ -2055,7 +2065,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr ""
 
@@ -2333,8 +2343,8 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr ""
 
@@ -2406,7 +2416,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2440,30 +2450,30 @@ msgstr ""
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr ""
 
@@ -2507,7 +2517,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2529,7 +2539,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr ""
 
@@ -2638,7 +2648,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -2878,7 +2888,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr ""
@@ -2947,7 +2957,7 @@ msgstr ""
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr ""
 
@@ -2968,7 +2978,7 @@ msgstr ""
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr ""
 
@@ -3142,7 +3152,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3151,15 +3161,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr ""
 
@@ -3171,7 +3181,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr ""
 
@@ -3179,7 +3189,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr ""
 
@@ -3380,8 +3390,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3455,745 +3465,753 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4201,11 +4219,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4215,222 +4233,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr ""
 
@@ -4507,7 +4525,7 @@ msgstr ""
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr ""
 
@@ -4696,355 +4714,355 @@ msgstr ""
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr ""
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5054,296 +5072,300 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+msgid "- Network interface binding changed.\n"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -184,8 +184,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -230,89 +230,94 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -322,184 +327,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -857,7 +862,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2185,49 +2190,49 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr ""
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2527,7 +2532,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -201,8 +201,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -247,37 +247,42 @@ msgstr "Aturada aMule completada."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultat de la depuració de la memòria a la sortida de l'aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "S'ha establert l'idioma Predeterminat del Sistema a causa d'un canvi de configuració. Disculpeu."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informació"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -285,56 +290,56 @@ msgstr ""
 "\n"
 "Configuració EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVÍS"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Xarxes"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S'ha trobat %i servidor al server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No s'han pogut vincular els ports a l'adreça especificada: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El port %u no està disponible. Tindreu ID BAIXA\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -349,48 +354,48 @@ msgstr ""
 "\n"
 "Comproveu la configuració de la xarxa per a assegurar-vos que el port està obert."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia de l'aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'idioma seleccionat no està instal·lat al PC. (Nota: s'intentarà establir igualment)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "És la primera vegada que executeu l'aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Aquesta és una versió de prova, actualitzada diàriament, i\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no podem garantir que no trenqui res, cremi casa vostra,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o mati al gos. Tanmateix el seu ús *hauria* de ser segur.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podeu trobar més informació, ajuda i noves versions a la nostra pàgina web,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o al nostre canal IRC #aMule de irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Podeu informar de qualsevol error a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -398,137 +403,137 @@ msgstr ""
 "La carpeta especificada per als fitxers de la signatura en línia és INVÀLIDA!\n"
 " S'INHABILITARÀ la signatura en línia fins que ho resolgueu a les preferències."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Nom del servidor notificat"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La preassignació d'espai per al fitxer '%s' ha fallat: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no es pot obrir el fitxer de registre"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVÍS: el fitxer de registre està buit. Alguna cosa no va bé."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "S'ha reiniciat el registre"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Missatge del servidor: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "S'ha omès la baixada de %s perquè el fitxer sol·licitat no és més recent."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "No s'ha pogut baixar la llista de nodes."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "No s'ha pogut obrir el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Fitxer de comprovació de versió corrupte"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Esteu usant una versió antiga de l'aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La vostra versió de l'aMule és %i.%i.%i i l'última versió és %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVÍS: La vostra versió d'aMuled és antiga: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "La vostra versió de l'aMule és l'última."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "No s'ha pogut baixar el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuaris: %s | Fitxers: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuaris: E: %s K: %s | Fitxers: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "No s'han seleccionat xarxes"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "amb ID Baixa"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "amb ID Alta"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connectat a %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "S'està connectant a %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Desconnectat de eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "S'ha engegat la xarxa Kad."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "S'ha aturat la xarxa Kad."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Connectat a Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Connectat a Kad (tallafocs)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Desconnectat de Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "No es pot usar la xarxa Kad si el port UDP està inhabilitat a les preferències, no s'engegarà."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "La xarxa Kad està inhabilitada a les preferències, no es connectarà."
 
@@ -888,7 +893,7 @@ msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantin
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2253,49 +2258,49 @@ msgstr "No"
 msgid "Yes"
 msgstr "Sí"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "S'està baixant..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Descàrrega HTTP cancel·lada"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "L'adreça URL a baixar no pot estar buida"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "No s'han pogut obtenir els compartits de l'usuari '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Carpeta on desar les descàrregues temporals"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "S'han baixat %d bytes"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "L'adreça URL %s ha retornat: %i - Error (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Descàrrega HTTP cancel·lada"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2598,7 +2603,7 @@ msgstr "Connexió externa: Accés denegat perquè: "
 msgid "External Connection: Handshake failed."
 msgstr "Connexió externa: Conformitat de connexió denegada."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "S'ha iniciat el fil Asio %d"

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -25,26 +25,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.7\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostra l'aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Control remot de l'aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr "Client P2P 'Multiplataforma' basat en eMule \n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -53,59 +53,59 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Part de l'aMule està basat en \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Encaminament p2p basat en la mètrica XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Lloc web:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Fòrum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprova si hi ha noves versions a l'inici"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "S'està connectant a Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Esteu usant una versió antiga de l'aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "No disponible"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -201,8 +201,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -217,47 +217,57 @@ msgstr "No s'ha pogut obrir el fitxer de enllaços ED2K."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVÍS: No us podeu afegir com a font per a un enllaç eD2k mentre teniu ID Baixa."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Sortint del programa..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "S'està aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Fallades"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Sortida: Finalitzant nucli."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Aturada aMule completada."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultat de la depuració de la memòria a la sortida de l'aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "S'ha establert l'idioma Predeterminat del Sistema a causa d'un canvi de configuració. Disculpeu."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informació"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -265,56 +275,56 @@ msgstr ""
 "\n"
 "Configuració EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVÍS"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Xarxes"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S'ha trobat %i servidor al server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No s'han pogut vincular els ports a l'adreça especificada: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El port %u no està disponible. Tindreu ID BAIXA\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -329,48 +339,48 @@ msgstr ""
 "\n"
 "Comproveu la configuració de la xarxa per a assegurar-vos que el port està obert."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia de l'aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'idioma seleccionat no està instal·lat al PC. (Nota: s'intentarà establir igualment)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "És la primera vegada que executeu l'aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Aquesta és una versió de prova, actualitzada diàriament, i\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no podem garantir que no trenqui res, cremi casa vostra,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o mati al gos. Tanmateix el seu ús *hauria* de ser segur.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podeu trobar més informació, ajuda i noves versions a la nostra pàgina web,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o al nostre canal IRC #aMule de irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Podeu informar de qualsevol error a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -378,137 +388,137 @@ msgstr ""
 "La carpeta especificada per als fitxers de la signatura en línia és INVÀLIDA!\n"
 " S'INHABILITARÀ la signatura en línia fins que ho resolgueu a les preferències."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Nom del servidor notificat"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La preassignació d'espai per al fitxer '%s' ha fallat: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no es pot obrir el fitxer de registre"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVÍS: el fitxer de registre està buit. Alguna cosa no va bé."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "S'ha reiniciat el registre"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Missatge del servidor: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "S'ha omès la baixada de %s perquè el fitxer sol·licitat no és més recent."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "No s'ha pogut baixar la llista de nodes."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "No s'ha pogut obrir el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Fitxer de comprovació de versió corrupte"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Esteu usant una versió antiga de l'aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La vostra versió de l'aMule és %i.%i.%i i l'última versió és %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVÍS: La vostra versió d'aMuled és antiga: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "La vostra versió de l'aMule és l'última."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "No s'ha pogut baixar el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuaris: %s | Fitxers: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuaris: E: %s K: %s | Fitxers: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "No s'han seleccionat xarxes"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "amb ID Baixa"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "amb ID Alta"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connectat a %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "S'està connectant a %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Desconnectat de eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "S'ha engegat la xarxa Kad."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "S'ha aturat la xarxa Kad."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Connectat a Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Connectat a Kad (tallafocs)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Desconnectat de Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "No es pot usar la xarxa Kad si el port UDP està inhabilitat a les preferències, no s'engegarà."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "La xarxa Kad està inhabilitada a les preferències, no es connectarà."
 
@@ -548,15 +558,15 @@ msgstr "aMule %s basat en eMule."
 msgid "Running on %s"
 msgstr "S'està executant sobre %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visiteu https://github.com/amule-org/amule/releases/latest per a comprovar si hi ha disponible una versió nova."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR GREU: No s'ha pogut crear el temporitzador"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -566,222 +576,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "No disponible"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Diàleg de l'aMule tancat"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Connectant"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: S'està connectant"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconnectat"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Bloquejat"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Connectat"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Connectant"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Inativa"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Atura els intents de connexió actuals"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Desconnecta"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconnecta de les xarxes on s'està connectat actualment"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Connecta"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Connecta a les xarxes habilitades actualment"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "PU: %.1f%s (%.1f) | BA: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "PU: %.1f%s | BA: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connectat)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconnectat)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Esteu segur que voleu eixir de %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Confirmació de sortida"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Ordre: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- defecte -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directori del tema '%s' no existeix"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVÍS: No ha estat possible obrir el fitxer d'aparença '%s' per a lectura"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Xarxes"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Finestra de les Xarxes"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Cerques"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Finestra de cerques"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Baixades"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Finestra de baixades"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Compartits"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Finestra de fitxers compartits"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Missatges"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Finestra de Missatges"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Finestra del gràfic d'estadístiques"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferències"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Finestra de la configuració de preferències"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importa"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Eina d'importació de fitxers de parts"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Quant a"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Quant a / Ajuda"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Xarxa eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Xarxa Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Cap xarxa"
 
@@ -869,8 +879,8 @@ msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantin
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Desconegut"
@@ -1233,19 +1243,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1277,7 +1287,7 @@ msgid "On Queue"
 msgstr "Cua"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "S'està baixant"
 
@@ -1337,7 +1347,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1409,7 +1419,7 @@ msgstr "Part"
 msgid "Size"
 msgstr "Mida"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Transferit"
 
@@ -1422,7 +1432,7 @@ msgid "Progress"
 msgstr "Progrés"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Fonts"
 
@@ -1432,7 +1442,7 @@ msgstr "Fonts"
 msgid "Priority"
 msgstr "Prioritat"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Estat"
 
@@ -1465,7 +1475,7 @@ msgstr ""
 "Retroacció des de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2118,7 +2128,7 @@ msgstr "No s'ha pogut obrir el fitxer amb la llista d'amics 'emfriends.met' per 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - no hi ha client a l'Inici de Sessió del Xat"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Amics"
 
@@ -2403,8 +2413,8 @@ msgstr "Port invàlid per a l'arrancada"
 msgid "Please fill all fields required"
 msgstr "Si us plau empleneu tots els camps requerits"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Missatge"
 
@@ -2476,7 +2486,7 @@ msgstr "Ràtio"
 msgid "Uploaded"
 msgstr "Transferit"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Peticions"
 
@@ -2510,30 +2520,30 @@ msgstr "Error desconegut %d"
 msgid "Unable to get error description for error %d"
 msgstr "No s'ha pogut obtenir la descripció de l'error per a l'error %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Resumint"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Completant"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Complet"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pausat"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Erroni"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Esperant"
 
@@ -2578,7 +2588,7 @@ msgstr "Connexió externa: Accés denegat perquè: "
 msgid "External Connection: Handshake failed."
 msgstr "Connexió externa: Conformitat de connexió denegada."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "S'ha iniciat el fil Asio %d"
@@ -2600,7 +2610,7 @@ msgid "WARNING: "
 msgstr "AVÍS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Tanca"
 
@@ -2716,7 +2726,7 @@ msgstr "Surt"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2956,7 +2966,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3025,7 +3035,7 @@ msgstr "Neteja les baixades completades"
 msgid "File sources:"
 msgstr "Fonts del fitxer:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "General "
 
@@ -3046,7 +3056,7 @@ msgstr "Nom Complet:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/D"
 
@@ -3222,7 +3232,7 @@ msgstr "Usuari:"
 msgid "Userhash :"
 msgstr "Resum de l'usuari:"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Afegeix"
@@ -3231,15 +3241,15 @@ msgstr "Afegeix"
 msgid "Download-Speed"
 msgstr "Velocitat de baixada"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Mitjana total"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Mitjana de la sessió"
 
@@ -3251,7 +3261,7 @@ msgstr "Velocitat de pujada"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Baixades actives"
 
@@ -3259,7 +3269,7 @@ msgstr "Baixades actives"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Pujades actives"
 
@@ -3460,8 +3470,8 @@ msgstr "Selecció del navegador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introdueix el nom del teu navegador. Deixa el camp buit per usar el navegador per defecte del sistema."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3535,750 +3545,759 @@ msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Només usuaris avançats: Si disposeu de multiples interfícies de xarxa, entreu l'adreça de la interfície a la que l'aMule hauria d'estar vinculada."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Nombre màxim de fonts per descàrrega:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Nombre màxim de connexions simultànies:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Autoconnecta a l'inici"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Reconnecta en perdre la connexió"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Elimina els servidors morts després de"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "intents"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Actualitza automàticament la llista de servidors a l'inici"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Llista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Actualitza la llista de servidors quan es connecti amb un servidor"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Actualitza la llista de servidors quan es connecta un client"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Usa el sistema de prioritats"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Usa la comprovació intel·ligent d'ID Baixa en connectar"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Connexió segura"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconnecta només a servidors de la llista estàtica"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Estableix prioritat Alta per als servidors afegits manualment"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestió d'Errors Inteligent (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Activa"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançat confia en totes les comprovacions (no recomanat)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Afegeix les noves baixades en mode pausat"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Afegeix les noves baixades amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Intenta baixar abans les parts inicials i finals"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Inicia el següent fitxer pausat quan s'acabi una descàrrega"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "De la mateixa categoria"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "En ordre alfabètic"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Preassigna l'espai al disc per als fitxers nous"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per a fitxers nous reserva l'espai que ocuparà el fitxer complet. Açò redueix la fragmentació"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Atura les descàrregues quan l'espai buit al disc arribi a "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccioneu-ho si voleu que l'aMule comprovi l'espai del disc"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Poseu l'espai mínim de disc desitjat."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Recorda 10 fonts dels fitxers rars (amb < 20 fonts)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Pujades"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Afegeix els nous fitxer compartits amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Carpeta on desar les descàrregues"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Carpeta on desar les descàrregues temporals"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Carpetes compartides"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Per a compartir recursivament feu clic dret sobre el directori)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Comparteix els fitxers ocults"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Gràfics"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Actualitza cada: 5 segs"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Temps per al gràfic de mitjana: 100 mins"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del Gràfic de Connexions: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Escala del gràfic de descàrrega:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Escala del gràfic de pujada:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Colors: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Graella"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Baixada actual"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Mitjana de baixada total"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Mitjana de baixada de la sessió"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Pujada actual"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Mitjana de pujada total"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Mitjana de pujada de la sessió"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocitat de la icona d'estat"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Nodes-Kad actuals"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Nodes-Kad funcionant"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Nodes-Kad de la sessió"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Selecciona"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions de client a mostrar (0=il·limitat)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! AVÍS !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Connexions noves màx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Mida del buffer de fitxer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Mida de la cua de pujades: 5000 clients"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Inhabilita el mode d'espera programat de l'ordinador"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Aparença a usar: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra \"Gestor ràpid de links eD2k\" en totes les finestres."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informació estesa a les pestanyes de les categories"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Mostra la versió de l'aplicació al títol"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Mostra les velocitats de transferència al títol"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Abans del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Després del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Mostra ample de banda sobrecarregat"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientació vertical de la barra d'eines"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Cua de descàrregues"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Mostra el percentatge de descàrrega"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Mostra barra de descàrrega"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Arrodonida"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Auto ordena els fitxers (Alta CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "L'aMule ordenarà automàticament les columnes de la llista de baixades"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Paràmetres de la connexió externa "
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Accepta connexions externes"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP de la interfície que rep connexions:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduïu una IP vàlida amb format a.b.c.d per a la interfície EC que escolta. Un camp buit o 0.0.0.0 significarà qualsevol interfície."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activa l'encaminament UPnP al port de connexions externes"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasenya"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Executa el servidor web a l'inici"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Contrasenya de l'administrador:"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Habilita l'usuari convidat"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Contrasenya del convidat:"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activa redirecció de ports UPnP en el port del servidor web"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP del servidor web (Opcional):"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Temps de refresc de la pàgina (en segons):"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Habilita la compressió Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Feu clic per a aplicar qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Reinicia qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Títol:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Comentari:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Dir. d'entrada:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Canvia la prioritat per als nous fitxers assignats:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "No canviar"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccioneu un color per a la Categoria (actualment seleccionat):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Reinicia"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Feu clic per a reiniciar el registre."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de servidors des d'una URL ... "
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Llista de servidors"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduïu l'adreça d'un fitxer server.met i premeu el botó de l'esquerra per a actualitzar la llista de servidors coneguts."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Afegeix un servidor manualment: Nom"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Introduïu el nom del nou servidor"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduïu la IP del servidor, fent servir el format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Introduïu el port del servidor."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Afegeix un servidor manualment (abans omple els camps de l'esquerra) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Registre de l'aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Informació del servidor"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de nodes des d'una URL ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduïu la URL d'un fitxer nodes.dat i premeu el botó de l'esquerra per a actualitzar la llista de nodes coneguts."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Estadístiques de nodes"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Arrancada"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nou node"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Inicia des dels clients coneguts"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Desconnecta Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Usa la Identificació Segura d'Usuari"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es recomana activar aquesta opció. No rebreu crèdits (punts) si la Identificació Segura d'Usuari no és habilitada."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Suport per a l'ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Habilita l'ofuscació de protocol, i permet a l'aMule acceptar connexions ofuscades d'altres clients."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usa l'ofuscació per a les connexions sortints"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "L'aMule usarà l'ofuscació de protocol en connectar amb altres clients/servidors."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Accepta únicament les connexions ofuscades"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "L'aMule només acceptarà les connexions ofuscades. Tindreu menys fonts, però tot el tràfic serà ofuscat"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Tothom"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Ningú"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Qui pot veure els meus fitxers compartits:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecciona qui pot veure la llista de fitxers compartits."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtratge IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtra els clients"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de clients especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtra els servidors"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de servidors especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Recarrega la llista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarrega la llista d'IPs a filtrar des del fitxer ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "Adreça:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Actualitza ara"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Nivell de filtratge:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre les IP LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestió paranoica de les IP no corresponents"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Rebutja el paquet si l'IP del client és diferent de l'IP on es rep el paquet. Useu amb prudència."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat del sistema si està disponible"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no es troba l'ipfilter.dat local, permet l'ús del fitxer ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Habilita la signatura en línia"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita l'escriptura del fitxer de signatura, que altres aplicacions externes poden usar per a crear signatures i similars."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Freqüència d'actualització (segs):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Canvia la freqüència d'actualització (en segons) de la signatura en línia."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Desa el fitxer de signatura en línia a: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Feu clic per a seleccionar el directori que conté els fitxers de signatura en línia."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Mostra les banderes dels països per als clients"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Velocitat:"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Fonts"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4286,11 +4305,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4300,225 +4319,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Baixant: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra els missatges entrants (excepte el xat actual):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtra tots els missatges"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra els missatges de la gent que no és a la llista d'amics"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtra els missatges dels clients desconeguts"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra els missatges que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Els missatges que continguin aquestes paraules seran filtrats i bloquejats per l'aMule"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Mostra els missatges rebuts en el registre"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Comentaris"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra els comentaris que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Habilita l'autenticació"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/inhabilita l'autenticació amb usuari/contrasenya"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Nom d'usuari:"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "El nom d'usuari per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Contrasenya:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "La contrasenya per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Habilita el servidor intermediari"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Habilita/inhabilita el suport per a servidor intermediari"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Tipus de servidor:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Servidor intermediari:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "El nom del servidor intermediari"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Port del servidor:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "El port del servidor intermediari"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Connecta a:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Entra a l'aMule remot"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nom d'usuari"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Recorda la configuració"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usa la compressió gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita la depuració-registre detallats."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Només al fitxer de registre"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Categories de missatge:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperant..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Afegeix"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Reintenta"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tipus d'esdeveniments"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadístiques i clients en cua per als fitxers seleccionats: Sessió / Total"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Pujades actives"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Percentatge del total de fitxers"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Tots els fitxers"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Fitxers seleccionats"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Només pujades actives"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Recarrega:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Recarrega els compartits"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Envia"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Envia el missatge especificat."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Tanca aquesta sessió de xat."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Connecta amb qualsevol servidor i/o Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Compartits"
 
@@ -4595,7 +4614,7 @@ msgstr "tota la resta"
 msgid "Incomplete"
 msgstr "Incomplet"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Aturat"
 
@@ -4785,34 +4804,34 @@ msgstr "No es pot llegir el fitxer de llavors per al fitxer de parts: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Error en llegir el fitxer de llavors del fitxer de parts (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "S'ha trobat una part corrupta (%d) en el fitxer de parts %d %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "S'ha trobat una part corrupta (%d) en els fitxers de parts %d %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "S'ha trobat una part completa (%i) a %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "S'ha acabat de refer els resums de %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "S'ha produït un error inesperat mentre es completava %s. S'ha pausat el fitxer."
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "S'ha acabat de baixar: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4821,307 +4840,307 @@ msgstr ""
 "S'ha acabat de baixar:\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "S'està esborrant el fitxer: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVÍS: No ha estat possible fer el resum de la part descarregada - conjunt de resums incomplet per a '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERROR: No ha estat possible fer el resum de la part descarregada - conjunt de resums incomplet (%s). Açò no hauria de passar mai."
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "S'ha arribat al final del fitxer (EOF) mentre es calculava el resum de la part baixada %u amb longitud %u (màx %u) del fitxer de part '%s' amb longitud %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVÍS: No hi ha suficient espai al disc dur! S'està pausant el fitxer: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Corrupció a la part baixada %i del fitxer: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: S'ha recuperat la part corrupta %i de %s -> Bytes desats: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Assignant"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Espai en disc insuficient"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Baixat"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: No s'ha pogut obrir el fitxer part '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Predeterminat"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanès"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Àrab"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturià"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Basc"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Búlgar"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Català; Valencià"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Xinès (Simplificat)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Xinès (Tradicional)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croat"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Txec"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danès"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holandès"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonià"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finès"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francès"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Gallec"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Alemany"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Hongarès"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italià"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italià (Suïssa)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonès"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Coreà"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituà"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruec"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polonès"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portuguès"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portuguès (Brasil)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Romanès"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Rus"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Eslovè"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Espanyol; Castellà"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Suec"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ucranià"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Canvi d'idioma"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "No hi ha traduccions instal·lades per a l'aMule"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Sense idiomes disponibles"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "No hi ha opcions disponibles"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Categoria invàlida trobada, omitint"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El port TCP no pot ser més gran que 65532 puix el sòcol UDP del servidor és TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "S'usarà el port per defecte (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Connexió"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Directoris"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servidors"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Fitxers"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Seguretat"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interfície"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Servidor intermediari"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Control remot"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Signatura en línia"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avançat"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Esdeveniments"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Depuració"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5131,15 +5150,15 @@ msgstr ""
 "    %PARTFILE - camí complet al fitxer\n"
 "    %PARTNAME - només el nom del fitxer"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5155,26 +5174,26 @@ msgstr ""
 "L'aMule anirà bé sense canviar cap\n"
 "d'aquests paràmetres."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Connexió fallida entre Cfg i el giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades de Cfg al giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "El tipus de servidor intermediari al que connecteu"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades del giny al Cfg amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5182,31 +5201,36 @@ msgstr ""
 "S'ha de reiniciar l'aMule per a habilitar aquests canvis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- El port TCP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- El port UDP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- S'ha canviat la interfície de connexió externa.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- S'ha canviat el port de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- S'ha canviat l'acceptació de la connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- S'ha canviat la interfície de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- S'ha canviat el suport d'ofuscació de protocol.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5214,7 +5238,7 @@ msgstr ""
 "La llista d'actualització de servidors és buida.\n"
 "L'actualització de servidors a l'inici serà desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5222,19 +5246,19 @@ msgstr ""
 "Heu habilitat les connexions externes però no heu especificat una contrasenya.\n"
 "Les connexions externes no poden ser habilitades a menys que s'hagi especificat una contrasenya externa vàlida."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- L'idioma ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- El directori temporal ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Xarxa ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5242,7 +5266,7 @@ msgstr ""
 "Les xarxes eD2k i Kad estan inhabilitades.\n"
 "No podreu connectar fins que n'habiliteu almenys una."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5250,7 +5274,7 @@ msgstr ""
 "La xarxa Kad no s'engegarà si el port UDP està inhabilitat.\n"
 "Habiliteu el port UDP o inhabiliteu la xarxa Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5260,20 +5284,20 @@ msgstr ""
 "HEU de reiniciar l'aMule ara mateix.\n"
 "Si no reinicieu ara, no vos queixeu dels possibles problemes.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Autorefresc iniciat"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5283,41 +5307,41 @@ msgstr ""
 "Si us plau, ompliu-la amb una URL que apunti a un fitxer server.met vàlid.\n"
 "Feu clic sobre el botó \"Llista\" d'aquest quadre de verificació per afegir una adreça."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Fitxers temporals"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Fitxers entrants"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Signatures en línia"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Carpeta per a %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Explora per a trobar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Selecciona navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Edita la llista de servidors"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5325,149 +5349,149 @@ msgstr ""
 "Afegiu adreces URL d'on baixar el fitxer server.met.\n"
 "Només una adreça a cada línia."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Fonts completes"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Retard de l'actualització: %d seg"
 msgstr[1] "Retard de l'actualització: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps per al gràfic de mitjanes: %d min"
 msgstr[1] "Temps per al gràfic de mitjanes: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala del gràfic de connexions: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Mida de la memòria intermèdia de fitxer: %d byte"
 msgstr[1] "Mida de la memòria intermèdia de fitxer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Mida de la cua de pujada: %d client"
 msgstr[1] "Mida de la cua de pujada: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Interval de refresc de la connexió amb el servidor: %d minut"
 msgstr[1] "Interval de refresc de la connexió amb el servidor: %d minuts"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executa una ordre per a l'esdeveniment '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Activa l'execució d'ordres al nucli"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Odre del nucli:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Activa l'execució d'ordres a la interfície gràfica"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Ordre de la IGU:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Les següents variables seran reemplaçades:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Recarrega els compartits"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega la llista de fitxers compartits."

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -201,8 +201,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -247,27 +247,37 @@ msgstr "Aturada aMule completada."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultat de la depuració de la memòria a la sortida de l'aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "S'ha establert l'idioma Predeterminat del Sistema a causa d'un canvi de configuració. Disculpeu."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informació"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -275,56 +285,56 @@ msgstr ""
 "\n"
 "Configuració EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVÍS"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Xarxes"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S'ha trobat %i servidor al server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No s'han pogut vincular els ports a l'adreça especificada: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El port %u no està disponible. Tindreu ID BAIXA\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -339,48 +349,48 @@ msgstr ""
 "\n"
 "Comproveu la configuració de la xarxa per a assegurar-vos que el port està obert."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia de l'aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'idioma seleccionat no està instal·lat al PC. (Nota: s'intentarà establir igualment)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "És la primera vegada que executeu l'aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Aquesta és una versió de prova, actualitzada diàriament, i\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no podem garantir que no trenqui res, cremi casa vostra,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o mati al gos. Tanmateix el seu ús *hauria* de ser segur.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podeu trobar més informació, ajuda i noves versions a la nostra pàgina web,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o al nostre canal IRC #aMule de irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Podeu informar de qualsevol error a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -388,137 +398,137 @@ msgstr ""
 "La carpeta especificada per als fitxers de la signatura en línia és INVÀLIDA!\n"
 " S'INHABILITARÀ la signatura en línia fins que ho resolgueu a les preferències."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Nom del servidor notificat"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La preassignació d'espai per al fitxer '%s' ha fallat: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no es pot obrir el fitxer de registre"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVÍS: el fitxer de registre està buit. Alguna cosa no va bé."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "S'ha reiniciat el registre"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Missatge del servidor: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "S'ha omès la baixada de %s perquè el fitxer sol·licitat no és més recent."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "No s'ha pogut baixar la llista de nodes."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "No s'ha pogut obrir el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Fitxer de comprovació de versió corrupte"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Esteu usant una versió antiga de l'aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La vostra versió de l'aMule és %i.%i.%i i l'última versió és %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVÍS: La vostra versió d'aMuled és antiga: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "La vostra versió de l'aMule és l'última."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "No s'ha pogut baixar el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuaris: %s | Fitxers: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuaris: E: %s K: %s | Fitxers: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "No s'han seleccionat xarxes"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "amb ID Baixa"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "amb ID Alta"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connectat a %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "S'està connectant a %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Desconnectat de eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "S'ha engegat la xarxa Kad."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "S'ha aturat la xarxa Kad."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Connectat a Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Connectat a Kad (tallafocs)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Desconnectat de Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "No es pot usar la xarxa Kad si el port UDP està inhabilitat a les preferències, no s'engegarà."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "La xarxa Kad està inhabilitada a les preferències, no es connectarà."
 
@@ -2588,7 +2598,7 @@ msgstr "Connexió externa: Accés denegat perquè: "
 msgid "External Connection: Handshake failed."
 msgstr "Connexió externa: Conformitat de connexió denegada."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "S'ha iniciat el fil Asio %d"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -21,20 +21,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Zobrazit aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Vzdálené ovládání aMule"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -42,7 +42,7 @@ msgstr ""
 "Multiplatformní p2p klient založený na eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -51,59 +51,59 @@ msgstr ""
 "Copyright (c) 2003-2019 Tým aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Část aMule je založena na \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Web:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Fórum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kontrola nové verze po spuštění"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Připojuji se k síti Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Používáte zastaralou verzi aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nedostupný"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -200,8 +200,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -216,47 +216,57 @@ msgstr "Selhalo otvírání souboru ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROVÁNÍ: Nemůžete přidat sebe jako zdroj pro eD2k odkaz, když máte LowID."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Ukončuji hlavní aplikaci..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Ukončuji instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabíjím instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Selhal"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Ukončuji jádro."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Ukončení aMule dokončeno."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše nastavení locale bylo změněno na výchozí systémové nastavení kvůli změně v konfiguraci. Pardon."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -264,54 +274,54 @@ msgstr ""
 "\n"
 "Konfigurace EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "VAROVÁNÍ"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sítě"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u je nedostupný. Budete mít LowID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -326,184 +336,184 @@ msgstr ""
 "\n"
 "Zkontrolujte nastavení vaší sítě a ujistěte se, že je port v obou směrech otevřený."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Selhalo vytvoření OnlineSig souboru"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Selhalo vytvoření aMule OnlineSig souboru"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Toto je vaše první spuštění aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Toto je testovací verze, která je denně aktualizovaná a\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "my nezaručujeme, že nemůže nic pokazit, zapálit váš dům,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nebo zabít vašeho psa. Nicméně i tak by *mělo* být její používání bezpečné.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Více informací, podporu a nová vydání naleznete na naší domovské stránce,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, nebo na našem IRC kanálu #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Hlašte chyby na adrese https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Předalokace místa na disku pro soubor '%s' selhala: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "CHYBA: nelze otevřít logovací soubor"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROVÁNÍ: log je prázdný. Něco je špatně."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Log byl vymazán"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Zpráva od serveru: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Selhalo stahování seznamu uzlů."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Selhalo otvírání staženého kontrolního souboru s verzí"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Porušený soubor pro kontrolu verze"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Používáte zastaralou verzi aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Vaše verze aMule je %i.%i.%i a poslední verze je %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROVÁNÍ: Vaše verze aMuled je zastaralá: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Vaše verze aMule je aktuální."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Selhalo stahování kontrolního souboru s verzí"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uživatelů: %s | Souborů: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uživatelů: E: %s K: %s | Souborů: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nezvoleny žádné sítě"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "s LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "s HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Připojen k %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Připojování k %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Odpojen od eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad spuštěn."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad zastaven."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Připojen ke Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Připojen ke kad (za firewallem)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Odpojen od Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Síť Kad nelze použít, když je v nastavení zakázán UDP port."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Síť Kad je zakázána v nastavení, nepřipojuji se."
 
@@ -543,15 +553,15 @@ msgstr "Toto je aMule %s založená na eMule."
 msgid "Running on %s"
 msgstr "Běží na %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Navštivte https://github.com/amule-org/amule/releases/latest  pro kontrolu, jestli není dostupná nová verze."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITICKÁ CHYBA: Vytváření časovače selhalo"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -561,223 +571,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Nedostupný"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Dialog aMule zničen"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Připojuji"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: připojuji"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: odpojeno"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Připojen"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Připojuji"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: vypnut"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Zastaví aktuální pokusy o připojení"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Odpojit"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Odpojit se od aktuálně připojených sítí"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Připojit"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Připojit se k povoleným sítím"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Od: %.1f(%.1f) | St: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Od: %.1f | St: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | připojen)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | odpojen)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Opravdu si přejete ukončit %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Potvrzení ukončení"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Spustit příkaz: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- výchozí -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Adresář se skiny '%s' neexistuje"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROVÁNÍ: Nelze otevřít soubor se vzhledem '%s' pro čtení"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Sítě"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Okno sítí"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Vyhledávání"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Vyhledávací okno"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Sdílené soubory"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Okno se sdílenými soubory"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Zprávy"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Okno zpráv"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiky"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Okno se statistikami"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavení"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Okno s nastavením"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Nástroj pro import částečných souborů"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "O programu/Nápověda"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Síť eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Síť Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Žádná síť"
 
@@ -865,8 +875,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Neznámý"
@@ -1234,19 +1244,19 @@ msgstr "Auto [Vy]"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Nízká"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normální"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1278,7 +1288,7 @@ msgid "On Queue"
 msgstr "Ve frontě"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Stahuji"
 
@@ -1338,7 +1348,7 @@ msgstr "Lokální server"
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1410,7 +1420,7 @@ msgstr "Část"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Přeneseno"
 
@@ -1423,7 +1433,7 @@ msgid "Progress"
 msgstr "Průběh"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Zdroje"
 
@@ -1433,7 +1443,7 @@ msgstr "Zdroje"
 msgid "Priority"
 msgstr "Priorita"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Stav"
 
@@ -1466,7 +1476,7 @@ msgstr ""
 "Odezva od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2104,7 +2114,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Kamarádi"
 
@@ -2392,8 +2402,8 @@ msgstr "Neplatný port pro bootstrap"
 msgid "Please fill all fields required"
 msgstr "Prosím vyplňte všechna potřebná pole"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Zpráva"
 
@@ -2468,7 +2478,7 @@ msgstr "Poměr sdílení"
 msgid "Uploaded"
 msgstr "Odesláno"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Vyžádáno"
 
@@ -2502,30 +2512,30 @@ msgstr "Neznámá verze"
 msgid "Unable to get error description for error %d"
 msgstr "Nemohu otevřít soubor se skinem %s pro čtení"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Hashuji"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Dokončování"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Dokončeno"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pozastaveno"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Poškozený"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Čekám"
 
@@ -2572,7 +2582,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Heslo pro externí připojení."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synchronizační vlákno spuštěno."
@@ -2594,7 +2604,7 @@ msgid "WARNING: "
 msgstr "VAROVÁNÍ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Zavřít"
 
@@ -2710,7 +2720,7 @@ msgstr "Ukončit"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2950,7 +2960,7 @@ msgstr "bajtů"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3019,7 +3029,7 @@ msgstr "Vyčistí dokončená stahování"
 msgid "File sources:"
 msgstr "Zdroje souboru:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Hlavní"
 
@@ -3040,7 +3050,7 @@ msgstr "Celá název:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3214,7 +3224,7 @@ msgstr "Uživatelské jméno:"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Přidat"
@@ -3223,15 +3233,15 @@ msgstr "Přidat"
 msgid "Download-Speed"
 msgstr "Rychlost stahování"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Průměr sezení"
 
@@ -3243,7 +3253,7 @@ msgstr "Rychlost odesílání"
 msgid "Connections"
 msgstr "Připojení"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktivní stahování"
 
@@ -3251,7 +3261,7 @@ msgstr "Aktivní stahování"
 msgid "Active connections (1:1)"
 msgstr "Aktivní připojení (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktivní odesílání"
 
@@ -3453,8 +3463,8 @@ msgstr "Výběr prohlížeče"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3528,751 +3538,759 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Max. zdrojů na stahovaný soubor:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Maximum připojení naráz:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Automatické připojení po spuštění"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Po odpojení znovu připojit"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Odstranit mrtvý server po"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "pokusech"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Automaticky aktualizovat seznam serverů po spuštění"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Seznam"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Použít systém priorit"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Použít po připojení chytrou kontrolu LowID"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Bezpečné připojení"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Přidělit ručně přidaným serverům vysokou prioritu"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentní zpracování poškození (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Povolit"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Přidávat soubory ke stažení do fronty pozastavené"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Přidávat soubory ke stažení do fronty s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Pokusit se nejprve stáhnout první a poslední části"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Ze stejné kategorie"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Předalokovat místo na disku pro nové soubory"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Toto zvolte chcete-li, aby aMule kontrolovala místo na disku"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Zadejte minimum místa na disku."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Odesílání"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Přidat nově sdílené soubory s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Cílový adresář pro stahování"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Sdílet skryté soubory"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafy"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Prodleva aktualizace: 5 sekund"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Barvy: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Na pozadí"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Mřížka"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktivní připojení"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ukazatel rychlosti v tray ikoně"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Vyberte"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Strom"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Počet verzí klientů k zobrazení (0=neomezeně)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROVÁNÍ !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Max. nových připojení za 5 sek."
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Velikost zásobníku pro soubory: 240000 bytů"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost fronty odesílání: 5000 klientů"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Vzhled: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Zobrazit rozšířené informace na tabech kategorií"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Před názvem programu"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Za názvem programu"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Zobrazit šířku pásma režie"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Vertikální umístění nástrojové lišty"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Zobrazit procenta průběhu"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Zobrazit ukazatel průběhu"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plochý"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Kulatý"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Automaticky řadit soubory (žere CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule automaticky seřadí kolonky ve vaší frontě stahování"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Nastavení externího připojení"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Přijímat externí připojení"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP naslouchajícího zařízení:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Povolit UPnP port forwarding na EC portu"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Heslo"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Spustit webserver při spuštění aMule"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Šablona webu"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Heslo pro plná práva"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Povolit uživatele s omezenými právy"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Heslo pro omezená práva"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Povolit UPnP port forwarding portu webserveru"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP port webserveru (volitelné)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Obnovování stránky (v sek.)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Povoliz Gzip kompresi"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Budiž"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikněte zde pro aplikování změn nastavení."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Zahodí všechny změny v nastavení."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titulek:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Komentář:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Příchozí adresář:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Změnit prioritu pro nově přiřazené soubory:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "Neměnit"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Barva pro tuto kategorii:"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Reset"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Klikněte na toto tlačítko pro vynulování logu."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Seznam serverů"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Přidat server ručně: Název"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Zadejte název serveru"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Zadejte IP serveru ve tvaru x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Zadejte port serveru."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Log aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Info o serveru"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Aktualizuje seznam uzlů z dané URL..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Uzly (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Statistiky uzlů"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nový uzel"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap od známých klientů"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Odpojit Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Použít bezpečnou uživatelskou identifikaci"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Podporuje zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Použít zatemnění protokolu pro odchozí spojení"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Přijímat pouze zatemněná spojení"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Všichni"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Nikdo"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Kdo může prohlížet moje sdílené soubory:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP filtrování"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtrovat klienty"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtrovat servery"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Obnovit seznam"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Obnovit"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Úroveň filtrování:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Vždy filtrovat LAN IP"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidní nakládání s nesouhlasícími IP"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Použít systémový ipfilter.dat, je-li dostupný"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Neexistuje-li místní ipfilter.dat, umožní použití systémového."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Povolit online podpis"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Prodleva aktualizace (sek.):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Zdroje"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4280,11 +4298,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4294,230 +4312,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Stahování: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtrovat všechny zprávy"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrovat zprávy, které nejsou od přátel"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtrovat zprávy od neznámých klientů"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrovat zprávy obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "zadejte slova, která by měla amule filtrovat a blokovat zprávy obsahující je"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Komentáře"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrovat komentáře obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Povolit autentizaci"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Povolí/zakáže autentizaci (uživatelské jméno a heslo)"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Uživatelské jméno: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Uživatelské jméno, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Heslo:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Heslo, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Povolit proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Povolí/zakáže proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Hostitel proxy:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Název hostitele proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Port proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Připojit se k:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Připojit k vzdálené aMuli"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Uživatelské jméno"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Zapamatovat si toto nastavení"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Použít gzip kompresi"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otevřít tento soubor"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čekání..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Odstranit vybrané"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Všechny sdílené soubory"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Sdílené soubory"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Obnovit:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Odeslat"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Odešle zadanou zprávu."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Zavře tento chat."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Připojit k nějakému serveru a/nebo Kadu"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Sdílené soubory"
 
@@ -4596,7 +4614,7 @@ msgstr "vše ostatní"
 msgid "Incomplete"
 msgstr "Nekompletní"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Zastaveno"
 
@@ -4788,7 +4806,7 @@ msgstr ""
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -4796,350 +4814,350 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Dokončeno přehashování %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Dokončené stahování: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Dokončené stahování: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Mazání souboru: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "VAROVÁNÍ: Nedostatek volného místa na disku! Pozastavuji soubor: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Stažená část %i souboru '%s' je poškozená."
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Alokuji"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Nedostatek místa na disku"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Staženo"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Výchozí pro systém"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albánština"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabský"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskičtina"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulharský"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalánština"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Čínština (zjednodušená)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Čínština (tradiční)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Chorvatština"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Česky"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Dánština"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Nizozemština"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonština"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finština"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francouzština"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galicijština"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Němčina"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Řečtina"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebrejština"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Maďarština"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italština"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italština (švýcarská)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonština"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Korejština"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litevština"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norština"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polština"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugalština"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalština (brazilská)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Rumunština"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Ruština"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovinština"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Španělština"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Švédština"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turečtina"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukrajinština"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Změnit jazyk"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Nedostupný"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "není dostupné žádné nastavení"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Nalezena neplatná kategorie, přeskakuji"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port nemůže být vyšší než 65532, protože UDP port je TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bude použit výchozí port (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Připojení"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servery"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Soubory"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Bezpečnost"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Rozhraní"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Vzdálené ovládání"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Online podpis"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Události"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Debugování"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5155,26 +5173,26 @@ msgstr ""
 "aMule poběží v pohodě bez změny\n"
 "nastavení na tomto tabu."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Typ proxy, ke které se připojujete"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5182,65 +5200,70 @@ msgstr ""
 "Restartujte aMule, aby se projevily následující změny:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Externí připojení uzavřeno."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nové externí připojení přijato"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Zatemnění protokolu"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Jazyk byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Dočasný adresář byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Síť eD2k povolena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5248,7 +5271,7 @@ msgstr ""
 "Kad se nespustí, když máte zakázaný UDP port.\n"
 "Povolte UDP port, nebo zakažte připojování na Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5258,61 +5281,61 @@ msgstr ""
 "Nyní MUSÍTE restartovat aMule.\n"
 "Pokud to neuděláte, tak si pak nestěžujte, když se přihodí něco špatného.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatické obnovování spuštěno"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Dočasné soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Příchozí soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Online podpisy"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zvolte adresář pro %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Zvolit přehrávač videa"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Výběr prohlížeče"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Spustitelný soubor %s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Upravit seznam serverů"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5320,42 +5343,42 @@ msgstr ""
 "Sem přidejte URL pro stažení server.met souborů.\n"
 "Pouze jedno URL na každý řádek."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletní zdroje"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -5363,7 +5386,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -5371,12 +5394,12 @@ msgstr[0] "Čas pro průměrný graf: %d minut"
 msgstr[1] "Čas pro průměrný graf: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5384,7 +5407,7 @@ msgstr[0] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[1] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -5392,7 +5415,7 @@ msgstr[0] "Velikost fronty pro odesílání: %d klientů"
 msgstr[1] "Velikost fronty pro odesílání: %d klientů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -5400,74 +5423,74 @@ msgstr[0] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[1] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval pro obnovení připojení k serveru: Zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Spustí příkaz při událost `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Povolit jaderné příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Příkaz jádra:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Povolit GUI příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Příkaz GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Následující proměnné budou nahrazeny:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Znovu načte seznam sdílených souborů."

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -200,8 +200,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -246,37 +246,42 @@ msgstr "Ukončení aMule dokončeno."
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše nastavení locale bylo změněno na výchozí systémové nastavení kvůli změně v konfiguraci. Pardon."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -284,54 +289,54 @@ msgstr ""
 "\n"
 "Konfigurace EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "VAROVÁNÍ"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sítě"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u je nedostupný. Budete mít LowID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -346,184 +351,184 @@ msgstr ""
 "\n"
 "Zkontrolujte nastavení vaší sítě a ujistěte se, že je port v obou směrech otevřený."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Selhalo vytvoření OnlineSig souboru"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Selhalo vytvoření aMule OnlineSig souboru"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Toto je vaše první spuštění aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Toto je testovací verze, která je denně aktualizovaná a\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "my nezaručujeme, že nemůže nic pokazit, zapálit váš dům,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nebo zabít vašeho psa. Nicméně i tak by *mělo* být její používání bezpečné.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Více informací, podporu a nová vydání naleznete na naší domovské stránce,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, nebo na našem IRC kanálu #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Hlašte chyby na adrese https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Předalokace místa na disku pro soubor '%s' selhala: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "CHYBA: nelze otevřít logovací soubor"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROVÁNÍ: log je prázdný. Něco je špatně."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Log byl vymazán"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Zpráva od serveru: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Selhalo stahování seznamu uzlů."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Selhalo otvírání staženého kontrolního souboru s verzí"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Porušený soubor pro kontrolu verze"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Používáte zastaralou verzi aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Vaše verze aMule je %i.%i.%i a poslední verze je %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROVÁNÍ: Vaše verze aMuled je zastaralá: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Vaše verze aMule je aktuální."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Selhalo stahování kontrolního souboru s verzí"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uživatelů: %s | Souborů: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uživatelů: E: %s K: %s | Souborů: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nezvoleny žádné sítě"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "s LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "s HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Připojen k %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Připojování k %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Odpojen od eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad spuštěn."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad zastaven."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Připojen ke Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Připojen ke kad (za firewallem)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Odpojen od Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Síť Kad nelze použít, když je v nastavení zakázán UDP port."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Síť Kad je zakázána v nastavení, nepřipojuji se."
 
@@ -884,7 +889,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2239,49 +2244,49 @@ msgstr "Ne"
 msgid "Yes"
 msgstr "Ano"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Stahuji..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP stahování zrušeno"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "URL pro stahování nesmí být prázdné"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Nelze získat seznam sdílených souborů od uživatele '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Staženo %d bytů"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s vrátilo: %i - Chyba (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP stahování zrušeno"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2592,7 +2597,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Heslo pro externí připojení."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synchronizační vlákno spuštěno."

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -200,8 +200,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -246,27 +246,37 @@ msgstr "Ukončení aMule dokončeno."
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše nastavení locale bylo změněno na výchozí systémové nastavení kvůli změně v konfiguraci. Pardon."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -274,54 +284,54 @@ msgstr ""
 "\n"
 "Konfigurace EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "VAROVÁNÍ"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sítě"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u je nedostupný. Budete mít LowID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -336,184 +346,184 @@ msgstr ""
 "\n"
 "Zkontrolujte nastavení vaší sítě a ujistěte se, že je port v obou směrech otevřený."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Selhalo vytvoření OnlineSig souboru"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Selhalo vytvoření aMule OnlineSig souboru"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Toto je vaše první spuštění aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Toto je testovací verze, která je denně aktualizovaná a\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "my nezaručujeme, že nemůže nic pokazit, zapálit váš dům,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nebo zabít vašeho psa. Nicméně i tak by *mělo* být její používání bezpečné.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Více informací, podporu a nová vydání naleznete na naší domovské stránce,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, nebo na našem IRC kanálu #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Hlašte chyby na adrese https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Předalokace místa na disku pro soubor '%s' selhala: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "CHYBA: nelze otevřít logovací soubor"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROVÁNÍ: log je prázdný. Něco je špatně."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Log byl vymazán"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Zpráva od serveru: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Selhalo stahování seznamu uzlů."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Selhalo otvírání staženého kontrolního souboru s verzí"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Porušený soubor pro kontrolu verze"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Používáte zastaralou verzi aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Vaše verze aMule je %i.%i.%i a poslední verze je %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROVÁNÍ: Vaše verze aMuled je zastaralá: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Vaše verze aMule je aktuální."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Selhalo stahování kontrolního souboru s verzí"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uživatelů: %s | Souborů: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uživatelů: E: %s K: %s | Souborů: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nezvoleny žádné sítě"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "s LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "s HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Připojen k %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Připojování k %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Odpojen od eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad spuštěn."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad zastaven."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Připojen ke Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Připojen ke kad (za firewallem)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Odpojen od Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Síť Kad nelze použít, když je v nastavení zakázán UDP port."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Síť Kad je zakázána v nastavení, nepřipojuji se."
 
@@ -2582,7 +2592,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Heslo pro externí připojení."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synchronizační vlákno spuštěno."

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -20,82 +20,82 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Omking wxCas"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Du bruger en forældet version af aMule"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ikke tilgængelig"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -189,8 +189,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -206,102 +206,112 @@ msgstr "Kunne ikke åbne %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Fejlede"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Bekræft afslut"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i Serverer fundet i server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -311,185 +321,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "Vi giver ikke garanti for at det ikke vil ødelægge noget, brænde dit hus,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Servernavn :"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "FEJL: Kan ikke åbne logfil"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FARE: logfilen er tom. Noget er galt"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Log nulstillet"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerBesked: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Fejl ved hentning af node listen"
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Fejl ved åbning af den hentet version check filen"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Korrupt version check fil"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Du bruger en forældet version af aMule"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMule version er %i.%i.%i og den sisdte nye version er %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FARE: Din aMule version er forældet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Din kopi af aMule er op til dato"
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Fejl ved hentning af version check filen"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Forbundet til %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Forbundet til %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad startet."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad stoppet."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Forbundet til Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Forbundet til Kad (med firewall)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Afbrudt fra Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad netværk kan ikke bruges hvis UDP port er fravalgt i instillinger, starter ikke."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad netværk fravalgt i instillinger, forbinder ikke."
 
@@ -528,15 +538,15 @@ msgstr ""
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -546,229 +556,229 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Ikke tilgængelig"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "firewalled"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Forbundet"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Stop de nuværende forbindelses forsøg"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Afbryd fra nuvÃŠrende server"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Forbind"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Op: %.1f | Ned: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du virkelig afslutte aMule?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Bekræft afslut"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Søg"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Søge Vindue"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Henter"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Beskeder"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Besked Vindue"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Indstillinger"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -860,8 +870,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Ukendt"
@@ -1225,19 +1235,19 @@ msgstr "Auto [Hø]"
 msgid "Very low"
 msgstr "Meget lav"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Lav"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1269,7 +1279,7 @@ msgid "On Queue"
 msgstr "I Kø"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Henter"
 
@@ -1329,7 +1339,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr ""
@@ -1400,7 +1410,7 @@ msgstr ""
 msgid "Size"
 msgstr "Størrelse"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1413,7 +1423,7 @@ msgid "Progress"
 msgstr "Forløb"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Kilder"
 
@@ -1423,7 +1433,7 @@ msgstr "Kilder"
 msgid "Priority"
 msgstr "Priotet"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Status"
 
@@ -1456,7 +1466,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2082,7 +2092,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Venner"
 
@@ -2366,8 +2376,8 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr ""
 
@@ -2439,7 +2449,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2473,30 +2483,30 @@ msgstr "Ukendt: %i"
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Hasher"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Færdiggør"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Færdig"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pause"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Beskadiget"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Venter"
 
@@ -2543,7 +2553,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synkroniserings tråd startet."
@@ -2565,7 +2575,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Luk"
 
@@ -2680,7 +2690,7 @@ msgstr "Afslut"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2920,7 +2930,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -2990,7 +3000,7 @@ msgstr ""
 msgid "File sources:"
 msgstr "Fundne Kilder :"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "General"
 
@@ -3011,7 +3021,7 @@ msgstr "Navn :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3185,7 +3195,7 @@ msgstr "Brugernavn :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Tilføj"
@@ -3194,15 +3204,15 @@ msgstr "Tilføj"
 msgid "Download-Speed"
 msgstr "Download-Hastighed"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Nuværende"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Nuværende Gennemsnit"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Sessions Gennemsnit"
 
@@ -3214,7 +3224,7 @@ msgstr "Upload-Hastighed"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3222,7 +3232,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Forbindelser (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3424,8 +3434,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3499,747 +3509,755 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Genforbind ved fejl"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Fjern ikke tilgængelige servere, efter"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "forsøg"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Brug prioterings system"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Brug smart LavID tjek ved forbindelse"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Sikker forbindelse"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoforbind kun til servere i statik liste"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Sæt manuelt tilføjede servere til Høj Priotet"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Tilføj filer til download i pause tilstand"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Tilføj filer til download med auto priotet"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Prøv at download første og sidste del først"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Tilføj nye delte filer med auto priotet"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafer"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Opdaterings interval : 5 sek"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gennemsnitlig graf: 100 min"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Baggrund"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Download nu"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Upload nu"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktive Forbindelser"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Vælg"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! Advarsel !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Max nye forbindelser / 5 sekunder"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fil Buffer Størrelse"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Flad"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Accepter ydre forbindelser"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Fuld rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Aktiver lav rettigheds brugere"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Lav rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Side Opdaterings Tid (i sek)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Aktiver Gzip komprimering"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titel :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Indkommende Mappe :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Reset"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Tryk på denne knap for at opdatere serverlisten fra URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Server Info"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Aktiver online-signatur"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Kilder"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4247,11 +4265,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4261,232 +4279,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Brug gzip komprimering"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Åben filen"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Venter..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Antal Filer Total"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Delte Filer"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Slettede Servere"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "Opdater"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Delte Filer"
 
@@ -4565,7 +4583,7 @@ msgstr "alt andet"
 msgid "Incomplete"
 msgstr "Mangelfuld"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "stoppet"
 
@@ -4756,359 +4774,359 @@ msgstr ""
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Kunne ikke hente serverlist fra %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "System standard"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabic"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgarian"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danish"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Dutch"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finnish"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "French"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "German"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italian"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr ""
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Korean"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lithuanian"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polish"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portuguese"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Russian"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "Sprog"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikke tilgængelig"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Forbindelse"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Mapper"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servere"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Fjern Kontrol"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5118,157 +5136,162 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Ydre Forbindelses Parametre"
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Opdatering startet"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Gennemse efter Video Afspiller"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5276,148 +5299,148 @@ msgstr ""
 "Tilføj URLer hvor der kan hentes server.met filer.\n"
 "Kun en URL på hver linje."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Hele kilder"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Opdaterings interval : 5 sek"
 msgstr[1] "Opdaterings interval : 5 sek"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gennemsnitlig graf: 100 min"
 msgstr[1] "Tid for gennemsnitlig graf: 100 min"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fil Buffer StÃžrrelse %i bytes"
 msgstr[1] "Fil Buffer StÃžrrelse %i bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server forbindelses opdaterings interval %i min"
 msgstr[1] "Server forbindelses opdaterings interval %i min"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server forbindelses opdaterings interval: Inaktiv"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "deaktiver"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Fandt %i kendte delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -189,8 +189,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -236,92 +236,97 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Bekræft afslut"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i Serverer fundet i server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -331,185 +336,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "Vi giver ikke garanti for at det ikke vil ødelægge noget, brænde dit hus,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Servernavn :"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "FEJL: Kan ikke åbne logfil"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FARE: logfilen er tom. Noget er galt"
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Log nulstillet"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerBesked: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Fejl ved hentning af node listen"
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Fejl ved åbning af den hentet version check filen"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Korrupt version check fil"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Du bruger en forældet version af aMule"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMule version er %i.%i.%i og den sisdte nye version er %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FARE: Din aMule version er forældet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Din kopi af aMule er op til dato"
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Fejl ved hentning af version check filen"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Forbundet til %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Forbundet til %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad startet."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad stoppet."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Forbundet til Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Forbundet til Kad (med firewall)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Afbrudt fra Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad netværk kan ikke bruges hvis UDP port er fravalgt i instillinger, starter ikke."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad netværk fravalgt i instillinger, forbinder ikke."
 
@@ -879,7 +884,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2217,50 +2222,50 @@ msgstr "Nej"
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Downloader..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 #, fuzzy
 msgid "HTTP download cancelled"
 msgstr "Max download grÃŠnse"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Hentelse af delte fier fra bruger '%s' fejlede"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Downloaded:"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Max download grÃŠnse"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2563,7 +2568,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synkroniserings tråd startet."

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -189,8 +189,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -236,82 +236,92 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Bekræft afslut"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i Serverer fundet i server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -321,185 +331,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "Vi giver ikke garanti for at det ikke vil ødelægge noget, brænde dit hus,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Servernavn :"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "FEJL: Kan ikke åbne logfil"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FARE: logfilen er tom. Noget er galt"
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Log nulstillet"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerBesked: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Fejl ved hentning af node listen"
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Fejl ved åbning af den hentet version check filen"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Korrupt version check fil"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Du bruger en forældet version af aMule"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMule version er %i.%i.%i og den sisdte nye version er %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FARE: Din aMule version er forældet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Din kopi af aMule er op til dato"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Fejl ved hentning af version check filen"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Forbundet til %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Forbundet til %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad startet."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad stoppet."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Forbundet til Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Forbundet til Kad (med firewall)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Afbrudt fra Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad netværk kan ikke bruges hvis UDP port er fravalgt i instillinger, starter ikke."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad netværk fravalgt i instillinger, forbinder ikke."
 
@@ -2553,7 +2563,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synkroniserings tråd startet."

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -24,20 +24,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Lokalize 26.04.0\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Zeige aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule-Fernbedienung "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Schnappschuss:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -45,7 +45,7 @@ msgstr ""
 "'All-Plattform' p2p Client basierend auf eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -53,59 +53,59 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Teile von aMule basieren auf \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer Weiterleitung basierend auf der XOR Funktion.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr "Probleme:"
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Beim Start auf neue Version prüfen"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Verbinde mit Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Du benutzt eine veraltete aMule-Version!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nicht verfügbar"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -207,8 +207,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Konnte %u Link aus ED2KLinks nicht hinzufügen (Details: siehe Log)"
 msgstr[1] "Konnte %u Links aus ED2KLinks nicht hinzufügen (Details: siehe Log)"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -223,47 +223,57 @@ msgstr "Fehler beim Öffnen der ED2KLinks-Datei."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WARNUNG: Man kann sich nicht als Quelle für einen eD2k-Verweis hinzufügen während man eine niedrige ID hat."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Beende nun Hauptanwendung ..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Beende amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Erzwinge Beenden der amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Beende Programmkern."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule-Herunterfahren abgeschlossen."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Speicherfehlerbehebungsresultate für aMule-Beendung:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Deine Locale wurde wegen einer Konfigurationsänderung auf Systemstandard geändert. Sorry."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -271,20 +281,20 @@ msgstr ""
 "\n"
 "EC-Konfiguration"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "Netzwerk-Bootstrap"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -292,34 +302,34 @@ msgstr ""
 "aMule hat fehlende Netzwerk-Bootstrap-Dateien erkannt.\n"
 "Wählen Sie aus, welche heruntergeladen werden sollen:"
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "eD2k-Serverliste (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad-Bootstrap-Knoten (nodes.dat)"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kann Ports nicht mit der festgelegten Adresse verbinden: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ist nicht erreichbar. Du wirst eine niedrige ID erhalten\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -334,48 +344,48 @@ msgstr ""
 "\n"
 "Bitte überprüfe deine Netzwerkeinstellungen, um sicherzugehen, dass der Port für ein- und ausgehenden Traffic geöffnet ist."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Erstellen der OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erstellen der aMule OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Die ausgewählte Locale scheint nicht auf dem System installiert zu sein.(INFO: Ich werde trotzdem versuchen, sie zu setzen)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dies ist das erste Mal, dass du aMule %s startest"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dies ist eine Testversion, täglich aktualisiert, und\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "wir garantieren nicht, dass sie keine Daten zerstört, dein Haus anzündet\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "oder deinen Hund tötet. Aber es *sollte* sicher sein, sie zu benutzen.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mehr Informationen und neue Releases können auf unserer Homepage gefunden werden\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "unter https://amule-org.github.io, oder in unserem IRC-Channel #amule auf irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bitte melde Fehler unter https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -383,137 +393,137 @@ msgstr ""
 "Das angegebene Verzeichnis für die Online-Signaturdateien ist UNGÜLTIG!\n"
 "Online-Signatur wird bis zur Fehlerbehebung in den Einstellungen DEAKTIVIERT."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Server Hostname benachrichtigt"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Speicherplatzvorbelegung für Datei '%s' fehlgeschlagen: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "FEHLER: kann Logdatei nicht öffnen"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WARNUNG: Logdatei ist leer. Etwas ist falsch."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Das Log wurde zurückgesetzt"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servernachricht: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Lade %s nicht herunter, weil die angeforderte Datei nicht neuer ist."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Knotenliste kann nicht geholt werden."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Konnte heruntergeladene Datei zur Versionsprüfung nicht öffnen"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Fehlerhafte Versionsprüfungsdatei"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Du benutzt eine veraltete aMule-Version!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Diese Version von aMule ist %i.%i.%i und die aktuelle Version ist %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WARNUNG: Diese Version von aMuled ist veraltet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Deine Kopie von aMule ist aktuell."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Konnte die Versionsprüfungsdatei nicht herunterladen"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Benutzer: %s | Dateien: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Benutzer: E: %s K: %s | Dateien: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Keine Netzwerke ausgewählt"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "mit niedriger ID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "mit hoher ID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbunden zu %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinde zu %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "eD2k getrennt"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad gestartet."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad beendet."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Kad verbunden (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad verbunden (firewalled)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Kad getrennt"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-Netzwerk kann mit deaktiviertem UDP-Port nicht benutzt werden, nicht gestartet."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-Netzwerk ist in den Voreinstellungen deaktiviert, kein Verbindungsversuch."
 
@@ -552,15 +562,15 @@ msgstr "Dies ist aMule %s, basierend auf eMule."
 msgid "Running on %s"
 msgstr "Läuft auf %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besuche https://github.com/amule-org/amule/releases/latest um zu sehen, ob eine neue Version verfügbar ist."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "UNBEHEBBARER FEHLER: Es konnte kein Zeitgeber erstellt werden."
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -570,222 +580,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Nicht verfügbar"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMule Dialog zerstört."
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Verbindung getrennt"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Verbunden"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: aus"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Beendet die derzeitigen Verbindungsversuche"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Trennen"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Von den momentan verbundenen Netzwerken trennen."
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Mit den aktuell aktivierten Netzwerken verbinden."
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbunden)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Getrennt)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s wirklich beenden?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Beenden bestätigen"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Startbefehl: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- Voreinstellung -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-Verzeichnis '%s' existiert nicht"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WARNUNG: Öffnen der Skin-Datei '%s' zum Lesen nicht möglich"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Netzwerke"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Übersicht der verwendeten Netzwerke"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Suchen"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Dateisuche in den verbundenen Netzwerken"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Download-Fenster"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Freigegebene Dateien"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Übersicht der freigegebenen Dateien"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Nachrichten, Chat, Freundesliste"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Diverse Statistiken über Up- und Download, Verbindungen, Clients usw."
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Fenster für Einstellungen"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importiere"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Das Importierwerkzeug für Part-Dateien"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Über"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Über/Hilfe - Hinweise zur Version usw."
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k-Netzwerk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad-Netzwerk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Kein Netzwerk"
 
@@ -875,8 +885,8 @@ msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nut
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Unbekannt"
@@ -1239,19 +1249,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Niedrig"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1283,7 +1293,7 @@ msgid "On Queue"
 msgstr "in Warteschlange"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Herunterladen"
 
@@ -1343,7 +1353,7 @@ msgstr "Lokaler Server"
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1414,7 +1424,7 @@ msgstr "Teil"
 msgid "Size"
 msgstr "Größe"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Übertragen"
 
@@ -1427,7 +1437,7 @@ msgid "Progress"
 msgstr "Fortschritt"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Quellen"
 
@@ -1437,7 +1447,7 @@ msgstr "Quellen"
 msgid "Priority"
 msgstr "Priorität"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Status"
 
@@ -1470,7 +1480,7 @@ msgstr ""
 "Rückmeldung von: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automatisch"
@@ -2121,7 +2131,7 @@ msgstr "Konnte Freundes-Liste 'emfriends.met' nicht schreiben!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISCH - kein Client bei StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Freunde"
 
@@ -2405,8 +2415,8 @@ msgstr "Ungültiger Bootstrap-Port"
 msgid "Please fill all fields required"
 msgstr "Bitte alle erforderlichen Felder ausfüllen"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Nachricht"
 
@@ -2478,7 +2488,7 @@ msgstr "Tauschverhältnis"
 msgid "Uploaded"
 msgstr "Hochgeladen"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Angefordert"
 
@@ -2512,30 +2522,30 @@ msgstr "Unbekannter Fehler %d"
 msgid "Unable to get error description for error %d"
 msgstr "Kann Fehlerbeschreibung für Fehler %d nicht erhalten"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Prüfsumme erstellen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Wird abgeschlossen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Vollständig"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pausiert"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Fehlerhaft"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Warten"
 
@@ -2579,7 +2589,7 @@ msgstr "Externe Verbindungen: Zugriff verweigert wegen:"
 msgid "External Connection: Handshake failed."
 msgstr "Externe Verbindungen: Verhandlung fehlgeschlagen."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-Thread %d gestartet"
@@ -2601,7 +2611,7 @@ msgid "WARNING: "
 msgstr "WARNUNG: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Schließen"
 
@@ -2710,7 +2720,7 @@ msgstr "Schließen"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2950,7 +2960,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3019,7 +3029,7 @@ msgstr "Vollständige Downloads entfernen"
 msgid "File sources:"
 msgstr "Dateiquellen:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Allgemein"
 
@@ -3040,7 +3050,7 @@ msgstr "Name:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "Nicht verfügbar"
 
@@ -3216,7 +3226,7 @@ msgstr "Benutzername:"
 msgid "Userhash :"
 msgstr "Benutzerprüfsumme:"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hinzufügen"
@@ -3225,15 +3235,15 @@ msgstr "Hinzufügen"
 msgid "Download-Speed"
 msgstr "Download-Geschwindigkeit"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "gleitender Mittelwert"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Sitzungsdurchschnitt"
 
@@ -3245,7 +3255,7 @@ msgstr "Upload-Geschwindigkeit"
 msgid "Connections"
 msgstr "Verbindungen"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3253,7 +3263,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Verbindungen (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3454,8 +3464,8 @@ msgstr "Browser-Wahl"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Gib den Namen des gewünschten Browsers hier ein. Bei einem leeren Feld wird der voreingestellte Systembrowser benutzt."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3529,147 +3539,156 @@ msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Nur für fortgeschrittene Benutzer: Wenn es mehrere Netzwerkverbindungen gibt, hier die Adresse der Verbindung, mit der aMule verknüpft werden soll, eingeben."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Maximale Anzahl Quellen pro heruntergeladener Datei:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Maximale gleichzeitige Verbindungen:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Automatisches Verbinden beim Start"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Wiederverbinden nach Trennung"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Lösche tote Server nach"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "Versuchen"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Serverliste beim Programmstart aktualisieren"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Serverliste von verbundenem Server beziehen"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Serverliste beim Verbinden zu einem Client beziehen"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Benutze Prioritätssystem"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Benutze intelligente Prüfung für niedrige ID beim Verbinden"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Sicheres/langsames Verbinden zu Servern"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatisches Verbinden nur zu Servern aus der statischen Liste"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Setze manuell hinzugefügte Server auf hohe Priorität"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente Korruptionsverarbeitung (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Aktiviere"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Advanced I.C.H vertraut jeder Prüfsumme (nicht empfohlen)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Neue Dateien dem Download pausiert hinzufügen"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Neu hinzugefügte Dateien im Download auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Versuche, zuerst die ersten und letzten Dateiteile herunterzuladen"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Starte nächste pausierte Datei, wenn eine Datei fertiggestellt wird"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Aus der selben Kategorie"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "In alphabetischer Reihenfolge"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Reserviere Speicherplatz für neue Dateien"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserviert für neue Dateien Speicherplatz für die ganze Datei und reduziert so Fragmentierung."
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe Downloads wenn freier Speicherplatz folgenden Wert erreicht:"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Wähle dies aus, wenn aMule deinen Festplattenplatz prüfen soll"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Hier den minimalen erwünschten Festplattenplatz angeben."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bei seltenen (< 20 Quellen) Dateien zehn Quellen speichern"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Neue freigegebene Dateien auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Zielverzeichnis für Downloads."
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3677,601 +3696,601 @@ msgstr ""
 "Vollständige Downloads werden hier gespeichert. Alle Dateien in diesem Ordner werden automatisch geteilt\n"
 ". Falls dieser Ordner Dateien enthält die du nicht teilen willst, wähle einen eigenen Ordner nur für aMule aus."
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Wähle einen Ordner in dem vollständige Downloads gepeichert werden sollen. Dieser Ordner wird automatisch geteilt."
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Alle Dateien in diesem Ordner werden mit anderen Nutzern geteilt)"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Verzeichnis für temporäre Downloaddateien"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Freigegebene Ordner"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtsklick auf das Symbol des rekursiv freizugebenden Verzeichnisses)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Versteckte Dateien freigeben"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ornder automatisch auf Änderungen überwachen"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr "Symbolischen Links in geteilten Ordnern folgen"
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Graphen"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Aktualisierungsverzögerung: 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Durchschnittsgraphen in Minuten berechnen: 100 min"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Verbindungsgraphenskalierung: 100"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Downloadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Uploadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Farben: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Hintergrund"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Gitter"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Aktueller Download"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Download: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Download: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Aktueller Upload"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Upload: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Upload: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktive Verbindungen"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "Transferbalken des Symbols im Infobereich"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Momentane Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Laufende Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kad-Knoten Sitzung"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Auswahl"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Baum"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Anzahl angezeigter Client-Versionen (0=unbegrenzt)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! WARNUNG !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Maximale neue Verbindungen pro 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dateipuffergröße: 240000 Bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Upload-Warteschlangengröße: 5000 Clients"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Zeitgesteuerten Bereitschaftsmodus des Computers deaktivieren"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "benutztes Aussehen:"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Zeige \"schnelle eD2k-Linkverarbeitung\" in jedem Fenster"
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Zeige erweiterte Informationen auf Kategorie-Reitern"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Zeige Programmversion im Titel"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Zeige Transferraten im Titel"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Vor dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Nach dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Zeige Overhead-Bandbreite"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Toolbar senkrecht ausrichten"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Downloadwarteschlangendateien"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Zeige Prozent des Fortschritts"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Zeige Fortschrittsbalken"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Flach"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "sortiere Dateien automatisch (hohe CPU-Auslastung)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule sortiert automatisch die Spalten der Downloadliste"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parameter für externe Verbindungen"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Externe Verbindungen annehmen"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP der lauschenden Schnittstelle:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Hier eine gültige IP im Format a.b.c.d für das lauschende EC-Interface eingeben. Ein leeres Feld oder 0.0.0.0 bedeutet ein beliebiges Interface."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung zu EC-Port"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passwort"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Starte Webserver mit aMule"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Webvorlage"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Kennwort für Vollzugriff"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Eingeschränkten Benutzer aktivieren"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Kennwort für eingeschränkten Zugriff"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung des Webserverports"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserver UPnP-TCP-Port (optional)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Aktualisierungsintervall in Sekunden"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Gzip-Kompression an"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hier klicken, um alle Einstellungsänderungen zu übernehmen."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Alle Änderungen zu den Einstellungen zurücksetzen."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titel:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Kommentar:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Verzeichnis für eingehende Dateien:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Priorität bei neu zugewiesenen Dateien ändern:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Nicht ändern"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Farbe für diese Kategorie wählen (momentan ausgewählt):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Drücke diesen Knopf, um das Log zurückzusetzen."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Hier klicken, um die Serverliste über die angegebene URL zu aktualisieren"
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Serverliste"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Hier die URL einer server.met eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Serverliste zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Server manuell hinzufügen: Name"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Gib den Namen das neuen Servers hier ein"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Hier die IP des Servers im Format x.x.x.x eingeben."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Hier den Serverport eingeben."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Einen Server manuell hinzufügen (vorher bitte links die Felder ausfüllen)..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule-Log"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "eD2k-Info"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad-Info"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Zum Aktualisieren der nodes.dat von URL diese Schaltfläche drücken."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Knoten (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Hier die URL einer nodes.dat eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Liste der bekannten Knoten zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Knotenstatistik"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Neuer Knoten"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap von bekannten Clients"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Kad trennen"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Benutze sichere Benutzeridentifikation"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es wird empfohlen diese Option zu aktivieren. Du wirst keine Credits erhalten, wenn SUI nicht aktiviert ist."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Unterstütze Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Diese Option aktiviert die Protokollverschleierung und verfügt aMule, verschleierte Verbindungen von anderen Clients anzunehmen."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Verschleiere ausgehende Verbindungen"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Diese Option verfügt aMule, Protokollverschleierung zu verwenden bei der Verbindung zu anderen Clients und/oder Servern."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Akzeptiere ausschließlich verschleierte Verbindungen"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Diese Option verfügt aMule, ausschließlich verschleierte Verbindungen zu akzeptieren. Das führt zu weniger Quellen, jedoch ist sämtlicher Verkehr verschleiert."
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Jeder"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Wer kann freigegebene Dateien sehen:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wähle, wer deine freigegebenen Dateien einsehen darf."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP-Filterung"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtere Clients"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere die Filterung von Client-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtere Server"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere das Filtern von Server-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Aktualisieren der Liste"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Aktualisiert die Liste der zu filternden IPs in der ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Jetzt aktualisieren"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Filterstufe:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "LAN-IP-Adressen immer filtern"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoides Handhaben nicht-passender IP-Adressen"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Weise Paket zurück, wenn die Client-IP abweicht von der IP, von der das Paket empfangen wurde. Mit Vorsicht zu benutzen."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Benutze systemweite ipfilter.dat, wenn verfügbar."
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Erlaube die Benutzung der systemweiten ipfilter-Datei, falls keine lokale ipfilter.dat gefunden wird."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Online-Signatur aktivieren"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiviert das Schreiben der Online-Signaturdatei, die von externen Programmen verwendet werden kann, um Signaturen o.ä. zu erstellen."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Aktualisierungsintervall (Sekunden):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändern des Online-Signatur-Aktualisierungsintervalls (in Sekunden)."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Speichere Online-Signatur-Datei in:"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Hier klicken, um das Verzeichnis mit den Dateien für die Online-Signatur auszuwählen."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Landesflaggen für Clients anzeigen"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Datenrate:"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Quellen"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4279,11 +4298,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4293,224 +4312,224 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Eingehende Nachrichten filtern (außer momentanen Chats):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtere alle Nachrichten"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtere Nachrichten von Benutzern, die nicht auf deiner Freundesliste stehen"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtere Nachrichten von unbekannten Clients"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtere Nachrichten, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Hier die Worte eingeben, die aMule filtern soll, und um Nachrichten abzuweisen, in denen sie vorkommen"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Zeige empfangene Nachrichten im Log an"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Kommentare"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtere Komentare, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Authentifizierung aktivieren"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Aktiviere/Deaktiviere Authentifizierung mit Benutzername/Passwort"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Benutzername:"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Der Benutzername, um sich beim Proxy anzumelden"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Passwort:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-Verbindungspasswort"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Proxy aktivieren"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Aktiviere/Deaktiviere Proxy-Unterstützung"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Proxy-Typ:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Proxy-Host:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Der Hostname des Proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Proxy-Port:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Der Port des Proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Verbinde zu:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Beim entfernten aMule anmelden"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Benutzername"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Diese Einstellungen speichern"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr "ZLIB-Kompression erzwingen"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktiviere ausführliche Debug-Protokollierung"
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Nur in Logdatei"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Nachrichtenkategorien:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wartend..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Füge Importe hinzu"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Versuche Ausgewähltes noch einmal"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Auswahl entfernen"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Ereignisarten"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiken und Clients in der Warteschlange für ausgewählte Datei(en): Sitzung / Insgesamt"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Prozent aller Dateien"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Ausgewählte Dateien"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Nur aktive Uploads"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Aktualisieren:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Freigegebene Dateien neu laden"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Senden"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Sendet die angegebene Nachricht."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Schließe diese Chat-Sitzung."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Mit irgendeinem Server und/oder Kad verbinden"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Freigaben"
 
@@ -4587,7 +4606,7 @@ msgstr "alle anderen"
 msgid "Incomplete"
 msgstr "Unvollständig"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Angehalten"
 
@@ -4776,34 +4795,34 @@ msgstr "Konnte Seed-Datei für Part-Datei %s (%s) nicht lesen"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Fehler beim Lesen der Partfile-Einstiegsquellendatei (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "korrumpierter Teil (%d) in %d-teiliger Datei %s gefunden - Dateiergebnishash |%s| Dateihash |%s|"
 msgstr[1] "korrumpierter Teil (%d) in %d-teiliger Datei %s gefunden - Dateiergebnishash |%s| Dateihash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Vollständigen Teil (%i) in %s gefunden"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Prüfsumme für %s neu erstellt"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Unerwarteter Fehler beim Abschließen des Herunterladens von %s. Datei pausiert."
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Herunterladen abgeschlossen: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4812,307 +4831,307 @@ msgstr ""
 "Herunterladen abgeschlossen:\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Lösche Datei: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "WARNUNG: Konnte für heruntergeladenen Teil die Prüfsumme nicht berechnen - Prüfsummensatz unvollständig für '%s'."
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "FEHLER: Prüfsumme für einen Teil konnte nicht erstellt werden - Prüfsumme unvollständig (%s). Dies dürfte eigentlich nie passieren."
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Teil %u von '%s' als vollständig markiert aber das Partfile ist kürzer als erwartet (%llu Bytes statt %llu); öffne Lücke für wiederholten Download."
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF beim Hashen des %u. heruntergeladenen Teils, mit der Länge %u (max %u), für die Part-Datei '%s', mit der Länge %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "WARNUNG: Nicht genügend freier Festplattenplatz! Pausiere Datei: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Heruntergeladener Teil %i in Datei '%s' ist defekt"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Defekter Teil %i in %s wiederhergestellt -> Gesparte Bytes: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Reserviere"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Zu wenig Festplattenplatz"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Heruntergeladen"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEHLER: Öffnen von Partfile '%s' fehlgeschlagen"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Systemvorgabe"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanisch"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgarisch"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalanisch"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chinesisch (vereinfacht)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chinesisch (traditionell)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Tschechisch"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Dänisch"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holländisch"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estnisch"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finnisch"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Französisch"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galizisch"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Deutsch"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Griechisch"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebräisch"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italienisch"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italienisch (Schweiz)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japanisch"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Koreanisch"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litauisch"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norwegisch"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polnisch"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugiesisch"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugiesisch (Brasilianisch)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Rumänisch"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slowenisch"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spanisch"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Schwedisch"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Sprache ändern"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Für aMule sind keine Übersetzungen installiert"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Keine Sprachen verfügbar"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "keine Optionen verfügbar"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Ungültige Kategorie gefunden, überspringe."
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-Port kann nicht größer als 65532 sein, da der Server-UDP-Port=TCP-Port+3 ist"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standard-Port wird verwendet (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Verbindung"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Verzeichnisse"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Server"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Sicherheit"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Aussehen"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filter"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Fernsteuerung"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Onlinesignatur"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Fortgeschritten"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Ereignisse"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Fehlersuche (Debugging)"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5122,15 +5141,15 @@ msgstr ""
 "    %PARTFILE - ganzer Pfad zur Datei\n"
 "    %PARTNAME - nur der Dateiname"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Tray-Icon unterstützung benötigt libayatana-appindicator3 beim kompilieren."
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Auf Wayland nicht verfügbar: Das Protokoll meldet nicht wenn ein Fenster minimiert is, sodass diese Option nicht auf die Minimieren Schaltfläche des System reagieren kann. Workaround: aMule mit `GDK_BACKEND=x11 starten um XWayland zu verwenden."
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5146,26 +5165,26 @@ msgstr ""
 "aMule funktioniert auch hervorragend, ohne\n"
 "dass diese Einstellungen verändert werden."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Verbindung von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datentransfer von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Der Typ des Proxy, zu dem du verbindest"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datentransfer von Steuerelement zu Einstellung mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5173,31 +5192,36 @@ msgstr ""
 "aMule muss neu gestartet werden, um diese Änderungen zu übernehmen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Schnittstelle der externen Verbindung geändert.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Port externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Akzeptanz externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Unterstützung für Protokollverschleierung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5205,7 +5229,7 @@ msgstr ""
 "Die Auto-Update-Serverliste ist leer.\n"
 "'Serverliste beim Programmstart aktualisieren' wird deaktiviert."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5213,19 +5237,19 @@ msgstr ""
 "Du hast die externen Verbindungen aktiviert, aber kein Passwort angegeben.\n"
 "Externe Verbindungen können nur aktiviert werden, wenn ein gültiges Passwort angegeben wird."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Sprache geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Temp-Verzeichnis geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2k-Netzwerk aktiviert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5233,7 +5257,7 @@ msgstr ""
 "Beide Netzwerke, eD2k und Kad, sind deaktiviert.\n"
 "Mindestens eins davon muss aktiviert sein, um sich verbinden zu können."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5241,7 +5265,7 @@ msgstr ""
 "Kad wird nicht starten, solange der UDP-Port deaktiviert ist.\n"
 "Bitte UDP-Port aktivieren, oder Kad ausschalten."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5251,19 +5275,19 @@ msgstr ""
 "aMule MUSS jetzt neu gestartet werden.\n"
 "Wenn du jetzt nicht neu startest, beklage dich nicht, wenn irgendwas übles passiert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr "Autostart"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5273,41 +5297,41 @@ msgstr ""
 "Bitte gib mindestens eine URL zu einer gültigen server.met ein.\n"
 "Drücke dazu den Knopf \"Liste\" neben diesem Kontrollkästchen."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Temporäre Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Fertige Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Online-Signaturen"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wähle einen Ordner für %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Suche nach einem Videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Browser-Wahl"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Ausführbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Serverliste bearbeiten"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5315,115 +5339,115 @@ msgstr ""
 "Hier URL's für server.met-Dateien eintragen.\n"
 "Nur eine URL pro Zeile!"
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "vollständige Quellen"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Aktualisierungsverzögerung: %d Sekunde"
 msgstr[1] "Aktualisierungsverzögerung: %d Sekunden"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Zeit für Durchschnittslinie: %d Minute"
 msgstr[1] "Zeit für Durchschnittslinie: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Verbindungsgraphenskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dateipuffergröße: %d Byte"
 msgstr[1] "Dateipuffergröße: %d Bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Upload-Warteschlangengröße: %d Client"
 msgstr[1] "Upload-Warteschlangengröße: %d Clients"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-Wiederverbindungsintervall: %d Minute"
 msgstr[1] "Server-Wiederverbindungsintervall: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "deaktiviert"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Führe Kommando beim '%s' Ereignis aus"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Aktiviere Befehlsausführung im Kern"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Kern-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Aktiviere Befehlsausführung in GUI"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "GUI-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Die folgenden Variablen werden ersetzt:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -5431,32 +5455,32 @@ msgstr ""
 "Die folgenden Ordner sehen nach System oder Sensiblen Daten aus.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Rekursives Teilen würde jede Datei im eD2k/Kad Netzwerk verfügbar machen. Willst du das wirklich?"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr "Freigegebene Ordner bestätigen"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr "Freigegebene Dateien neu laden..."
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr "Suche nach Unterverzeichnissen..."
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr "Freigegebene Ordner werden aktualisiert"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr "%u Verzeichnisse durchsucht..."
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -207,8 +207,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Konnte %u Link aus ED2KLinks nicht hinzufügen (Details: siehe Log)"
 msgstr[1] "Konnte %u Links aus ED2KLinks nicht hinzufügen (Details: siehe Log)"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -253,27 +253,37 @@ msgstr "aMule-Herunterfahren abgeschlossen."
 msgid "Memory debug results for aMule exit:"
 msgstr "Speicherfehlerbehebungsresultate für aMule-Beendung:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Deine Locale wurde wegen einer Konfigurationsänderung auf Systemstandard geändert. Sorry."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -281,20 +291,20 @@ msgstr ""
 "\n"
 "EC-Konfiguration"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "Netzwerk-Bootstrap"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -302,34 +312,34 @@ msgstr ""
 "aMule hat fehlende Netzwerk-Bootstrap-Dateien erkannt.\n"
 "Wählen Sie aus, welche heruntergeladen werden sollen:"
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "eD2k-Serverliste (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad-Bootstrap-Knoten (nodes.dat)"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kann Ports nicht mit der festgelegten Adresse verbinden: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ist nicht erreichbar. Du wirst eine niedrige ID erhalten\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,48 +354,48 @@ msgstr ""
 "\n"
 "Bitte überprüfe deine Netzwerkeinstellungen, um sicherzugehen, dass der Port für ein- und ausgehenden Traffic geöffnet ist."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Erstellen der OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erstellen der aMule OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Die ausgewählte Locale scheint nicht auf dem System installiert zu sein.(INFO: Ich werde trotzdem versuchen, sie zu setzen)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dies ist das erste Mal, dass du aMule %s startest"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dies ist eine Testversion, täglich aktualisiert, und\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "wir garantieren nicht, dass sie keine Daten zerstört, dein Haus anzündet\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "oder deinen Hund tötet. Aber es *sollte* sicher sein, sie zu benutzen.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mehr Informationen und neue Releases können auf unserer Homepage gefunden werden\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "unter https://amule-org.github.io, oder in unserem IRC-Channel #amule auf irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bitte melde Fehler unter https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -393,137 +403,137 @@ msgstr ""
 "Das angegebene Verzeichnis für die Online-Signaturdateien ist UNGÜLTIG!\n"
 "Online-Signatur wird bis zur Fehlerbehebung in den Einstellungen DEAKTIVIERT."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Server Hostname benachrichtigt"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Speicherplatzvorbelegung für Datei '%s' fehlgeschlagen: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "FEHLER: kann Logdatei nicht öffnen"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WARNUNG: Logdatei ist leer. Etwas ist falsch."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Das Log wurde zurückgesetzt"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servernachricht: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Lade %s nicht herunter, weil die angeforderte Datei nicht neuer ist."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Knotenliste kann nicht geholt werden."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Konnte heruntergeladene Datei zur Versionsprüfung nicht öffnen"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Fehlerhafte Versionsprüfungsdatei"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Du benutzt eine veraltete aMule-Version!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Diese Version von aMule ist %i.%i.%i und die aktuelle Version ist %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WARNUNG: Diese Version von aMuled ist veraltet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Deine Kopie von aMule ist aktuell."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Konnte die Versionsprüfungsdatei nicht herunterladen"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Benutzer: %s | Dateien: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Benutzer: E: %s K: %s | Dateien: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Keine Netzwerke ausgewählt"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "mit niedriger ID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "mit hoher ID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbunden zu %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinde zu %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "eD2k getrennt"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad gestartet."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad beendet."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Kad verbunden (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad verbunden (firewalled)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Kad getrennt"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-Netzwerk kann mit deaktiviertem UDP-Port nicht benutzt werden, nicht gestartet."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-Netzwerk ist in den Voreinstellungen deaktiviert, kein Verbindungsversuch."
 
@@ -2589,7 +2599,7 @@ msgstr "Externe Verbindungen: Zugriff verweigert wegen:"
 msgid "External Connection: Handshake failed."
 msgstr "Externe Verbindungen: Verhandlung fehlgeschlagen."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-Thread %d gestartet"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:06+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -207,8 +207,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Konnte %u Link aus ED2KLinks nicht hinzufügen (Details: siehe Log)"
 msgstr[1] "Konnte %u Links aus ED2KLinks nicht hinzufügen (Details: siehe Log)"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -253,37 +253,42 @@ msgstr "aMule-Herunterfahren abgeschlossen."
 msgid "Memory debug results for aMule exit:"
 msgstr "Speicherfehlerbehebungsresultate für aMule-Beendung:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Deine Locale wurde wegen einer Konfigurationsänderung auf Systemstandard geändert. Sorry."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -291,20 +296,20 @@ msgstr ""
 "\n"
 "EC-Konfiguration"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "Netzwerk-Bootstrap"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -312,34 +317,34 @@ msgstr ""
 "aMule hat fehlende Netzwerk-Bootstrap-Dateien erkannt.\n"
 "Wählen Sie aus, welche heruntergeladen werden sollen:"
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "eD2k-Serverliste (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad-Bootstrap-Knoten (nodes.dat)"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kann Ports nicht mit der festgelegten Adresse verbinden: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ist nicht erreichbar. Du wirst eine niedrige ID erhalten\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -354,48 +359,48 @@ msgstr ""
 "\n"
 "Bitte überprüfe deine Netzwerkeinstellungen, um sicherzugehen, dass der Port für ein- und ausgehenden Traffic geöffnet ist."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Erstellen der OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erstellen der aMule OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Die ausgewählte Locale scheint nicht auf dem System installiert zu sein.(INFO: Ich werde trotzdem versuchen, sie zu setzen)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dies ist das erste Mal, dass du aMule %s startest"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dies ist eine Testversion, täglich aktualisiert, und\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "wir garantieren nicht, dass sie keine Daten zerstört, dein Haus anzündet\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "oder deinen Hund tötet. Aber es *sollte* sicher sein, sie zu benutzen.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mehr Informationen und neue Releases können auf unserer Homepage gefunden werden\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "unter https://amule-org.github.io, oder in unserem IRC-Channel #amule auf irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bitte melde Fehler unter https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -403,137 +408,137 @@ msgstr ""
 "Das angegebene Verzeichnis für die Online-Signaturdateien ist UNGÜLTIG!\n"
 "Online-Signatur wird bis zur Fehlerbehebung in den Einstellungen DEAKTIVIERT."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Server Hostname benachrichtigt"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Speicherplatzvorbelegung für Datei '%s' fehlgeschlagen: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "FEHLER: kann Logdatei nicht öffnen"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WARNUNG: Logdatei ist leer. Etwas ist falsch."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Das Log wurde zurückgesetzt"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servernachricht: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Lade %s nicht herunter, weil die angeforderte Datei nicht neuer ist."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Knotenliste kann nicht geholt werden."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Konnte heruntergeladene Datei zur Versionsprüfung nicht öffnen"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Fehlerhafte Versionsprüfungsdatei"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Du benutzt eine veraltete aMule-Version!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Diese Version von aMule ist %i.%i.%i und die aktuelle Version ist %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WARNUNG: Diese Version von aMuled ist veraltet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Deine Kopie von aMule ist aktuell."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Konnte die Versionsprüfungsdatei nicht herunterladen"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Benutzer: %s | Dateien: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Benutzer: E: %s K: %s | Dateien: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Keine Netzwerke ausgewählt"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "mit niedriger ID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "mit hoher ID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbunden zu %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinde zu %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "eD2k getrennt"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad gestartet."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad beendet."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Kad verbunden (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad verbunden (firewalled)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Kad getrennt"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-Netzwerk kann mit deaktiviertem UDP-Port nicht benutzt werden, nicht gestartet."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-Netzwerk ist in den Voreinstellungen deaktiviert, kein Verbindungsversuch."
 
@@ -894,7 +899,7 @@ msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nut
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2255,49 +2260,49 @@ msgstr "Nein"
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Lädt herunter..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP-Download abgebrochen"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "Die Download-URL kann nicht leer sein."
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Konnte HTTP-Anfrage für %s nicht erstellen"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP-Download: leerer Antworttext für %s"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Konnte heruntergeladene Datei nicht nach %s verschieben"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%s heruntergeladen (%llu Bytes)"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "Die URL %s antwortet mit: %i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP-Download für %s fehlgeschlagen: %s"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 Nicht autorisiert für %s"
@@ -2599,7 +2604,7 @@ msgstr "Externe Verbindungen: Zugriff verweigert wegen:"
 msgid "External Connection: Handshake failed."
 msgstr "Externe Verbindungen: Verhandlung fehlgeschlagen."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-Thread %d gestartet"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -198,8 +198,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -249,84 +249,94 @@ msgstr "Το κατέβασμα ολοκληρώθηκε"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Οι τοπικές ρυθμίσεις άλλαξαν στις προεπιλεγμένες του συστήματος λόγο μιας αλλαγής παραμέτρων. Sorry!"
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Δίκτυα"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "βρέθηκε %i διακομιστής στο server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Δεν μπόρεσε να προσδέσει τις θύρες στην προσδιορισμένη διεύθυνση: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Η θύρα %u δεν είναι διαθέσιμη. Θα σας αποδωθεί LOWID (χαμηλή προτεραιότητα)\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -341,48 +351,48 @@ msgstr ""
 "\n"
 "Ελέξτε το δίκτυο σας για να βεβαιωθήτε ότι η θύρα είναι ανοιχτή για είσοδο και έξοδο."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών του aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Οι επιλεγμένες τοπικές ρυθμίσεις δεν φαίνεται να είναι εγκατεστημένες στο σύστημά σας. (Σημ. Θα προσπαθήσω να τις θέσω ούτως ή άλλως)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Αυτή είναι η πρώτη φορά που τρέχετε το aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Αυτή η έκδοση είναι δοκιμαστική, και αναβαθμίζεται καθημερινά, και\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "δεν δίνουμε εγγύηση ότι δεν θα χαλάσει κάτι, δεν θα κάψει το σπίτι σας,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ή δεν θα σκοτώσει το σκύλο σας. Αλλά πρέπει να είναι ασφαλές στη χρήση\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Περισσότερες πληροφορίες, υποστήριξη και νέες εκδόσεις μπορούν να βρεθούν στην ιστοσελίδα μας,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "στο https://amule-org.github.io, ή στο κανάλι #aMule του IRC στο irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Παρακαλούμε αναφέρετε σφάλματα του προγράμματος στο https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -390,138 +400,138 @@ msgstr ""
 "Ο δικτυακός κατάλογος των ηλεκτρονικών αρχείων υπογραφών που προσδιορίσατε είναι ΑΚΥΡΟΣ!\n"
 "Οι ηλεκτρονικές υπογραφές θα ΑΠΕΝΕΡΓΟΠΟΙΗΘΟΥΝ μέχρι να το φτιάξετε στις προτιμήσεις."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Όνομα διακομιστή:"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Η εκχώρηση χώρου για το αρχείο '%s' απέτυχε: '%s'"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ΣΦΑΛΜΑ: το αρχείο καταγραφής δεν μπορεί να ανοίξει"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: το αρχείο καταγραφών είναι άδειο. Κάτι δεν πάει καλά."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Το αρχείο καταγραφών επαναφέρθηκε στην αρχική κατάσταση"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Μήνυμα Διακομιστή: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Αποτυχία κατεβάσματος της λίστας κόμβων."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Αποτυχία ανοίγματος του κατεβασμένου αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Φθαρμένο αρχείο ελέγχου έκδοσης"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Η παρούσα έκδοση του aMule είναι %i.%i.%i και η τελευταία %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Η έκδοση του aMuled είναι ξεπερασμένη: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Αυτό το αντίγραφο του aMule είναι σύγχρονο. "
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Αποτυχία κατεβάσματος του αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Χρήστες: %s | Αρχεία: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Χρήστες: E: %s K: %s | Αρχεία: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Δεν έχουν επιλεχθεί δίκτυα"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "με Χαμηλή Προτεραιότητα"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "με Υψηλή Προτεραιότητα"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Σύνδεση με το %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Διαδικασία σύνδεσης με %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Αποσυνδεδεμένο από το eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Το Kad ξεκίνησε."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Το Kad είναι σταματημένο."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Συνδεδεμένο στο Kad (ΟΚ)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Συνδεδεμένο στο Kad (με προστατευτικό τοίχο)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Αποσυνδεδεμένο από το Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Το δίκτυο Kad δεν μπορεί να χρησιμοποιηθεί αν η θύρα UDP είναι απενεργοποιημένη στις προτιμήσεις. Δεν έγινε εκκίνηση."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Το δίκτυο Kad είναι απενεργοποιημένο από τις προτιμήσεις. Δεν έγινε σύνδεση."
 
@@ -2608,7 +2618,7 @@ msgstr "Εξωτερική Σύνδεση: Η πρόσβαση απορρίφθ�
 msgid "External Connection: Handshake failed."
 msgstr "Εξωτερική σύνδεση: Η πρόσβαση απορρίφθηκε"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Εμφάνιση aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Τηλεχειρισμός aMule"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Στιγμιότυπο"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "Πελάτης P2P για όλες τις πλατφόρμες βασισμένος στο eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -50,59 +50,59 @@ msgstr ""
 "Πνευματικά Δικαιώματα (c) 2003-2019 η ομάδα του aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Μέρος του aMule είναι βασισμένο στο  \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Δρομολόγηση Peer-to-peer βασισμένη στην μετρική XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Ιστοσελίδα:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Συζητήσεις:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Έλεγχος για νέα έκδοση κατά την εκκίνηση"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Διαδικασία σύνδεσης στο Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -198,8 +198,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -215,108 +215,118 @@ msgstr "Αποτυχία ανοίγματος %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν μπορείτε να προσθέσετε τον εαυτό σας σαν πηγή για έναν σύνδεσμο eD2k ενώ έχετε χαμηλή προτεραιότητα."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Όλα μια χαρά, έξοδος %s...\n"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Απέτυχε"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Το κατέβασμα ολοκληρώθηκε"
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Οι τοπικές ρυθμίσεις άλλαξαν στις προεπιλεγμένες του συστήματος λόγο μιας αλλαγής παραμέτρων. Sorry!"
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Δίκτυα"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "βρέθηκε %i διακομιστής στο server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Δεν μπόρεσε να προσδέσει τις θύρες στην προσδιορισμένη διεύθυνση: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Η θύρα %u δεν είναι διαθέσιμη. Θα σας αποδωθεί LOWID (χαμηλή προτεραιότητα)\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -331,48 +341,48 @@ msgstr ""
 "\n"
 "Ελέξτε το δίκτυο σας για να βεβαιωθήτε ότι η θύρα είναι ανοιχτή για είσοδο και έξοδο."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών του aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Οι επιλεγμένες τοπικές ρυθμίσεις δεν φαίνεται να είναι εγκατεστημένες στο σύστημά σας. (Σημ. Θα προσπαθήσω να τις θέσω ούτως ή άλλως)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Αυτή είναι η πρώτη φορά που τρέχετε το aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Αυτή η έκδοση είναι δοκιμαστική, και αναβαθμίζεται καθημερινά, και\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "δεν δίνουμε εγγύηση ότι δεν θα χαλάσει κάτι, δεν θα κάψει το σπίτι σας,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ή δεν θα σκοτώσει το σκύλο σας. Αλλά πρέπει να είναι ασφαλές στη χρήση\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Περισσότερες πληροφορίες, υποστήριξη και νέες εκδόσεις μπορούν να βρεθούν στην ιστοσελίδα μας,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "στο https://amule-org.github.io, ή στο κανάλι #aMule του IRC στο irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Παρακαλούμε αναφέρετε σφάλματα του προγράμματος στο https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -380,138 +390,138 @@ msgstr ""
 "Ο δικτυακός κατάλογος των ηλεκτρονικών αρχείων υπογραφών που προσδιορίσατε είναι ΑΚΥΡΟΣ!\n"
 "Οι ηλεκτρονικές υπογραφές θα ΑΠΕΝΕΡΓΟΠΟΙΗΘΟΥΝ μέχρι να το φτιάξετε στις προτιμήσεις."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Όνομα διακομιστή:"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Η εκχώρηση χώρου για το αρχείο '%s' απέτυχε: '%s'"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ΣΦΑΛΜΑ: το αρχείο καταγραφής δεν μπορεί να ανοίξει"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: το αρχείο καταγραφών είναι άδειο. Κάτι δεν πάει καλά."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Το αρχείο καταγραφών επαναφέρθηκε στην αρχική κατάσταση"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Μήνυμα Διακομιστή: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Αποτυχία κατεβάσματος της λίστας κόμβων."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Αποτυχία ανοίγματος του κατεβασμένου αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Φθαρμένο αρχείο ελέγχου έκδοσης"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Η παρούσα έκδοση του aMule είναι %i.%i.%i και η τελευταία %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Η έκδοση του aMuled είναι ξεπερασμένη: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Αυτό το αντίγραφο του aMule είναι σύγχρονο. "
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Αποτυχία κατεβάσματος του αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Χρήστες: %s | Αρχεία: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Χρήστες: E: %s K: %s | Αρχεία: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Δεν έχουν επιλεχθεί δίκτυα"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "με Χαμηλή Προτεραιότητα"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "με Υψηλή Προτεραιότητα"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Σύνδεση με το %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Διαδικασία σύνδεσης με %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Αποσυνδεδεμένο από το eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Το Kad ξεκίνησε."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Το Kad είναι σταματημένο."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Συνδεδεμένο στο Kad (ΟΚ)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Συνδεδεμένο στο Kad (με προστατευτικό τοίχο)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Αποσυνδεδεμένο από το Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Το δίκτυο Kad δεν μπορεί να χρησιμοποιηθεί αν η θύρα UDP είναι απενεργοποιημένη στις προτιμήσεις. Δεν έγινε εκκίνηση."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Το δίκτυο Kad είναι απενεργοποιημένο από τις προτιμήσεις. Δεν έγινε σύνδεση."
 
@@ -551,15 +561,15 @@ msgstr "Αυτό το aMule %s είναι βασισμένο στο eMule."
 msgid "Running on %s"
 msgstr "Τρέχει στο %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Επισκεφτείτε το https://github.com/amule-org/amule/releases/latest για να δείτε αν υπάρχει νέα έκδοση."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ΜΟΙΡΑΙΟ ΣΦΑΛΜΑ: Αποτυχία δημιουργίας Χρονομέτρου"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -569,224 +579,224 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Συνδέοντας"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Συνδέεται"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Αποσυνδεδεμένο"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Πίσω από τοίχο προστασίας"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Συνδεδεμένο"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Σε διαδικασία σύνδεσης"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Εκτός"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Σταμάτησε τις τρέχουσες απόπειρες σύνδεσης"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Αποσύνδεση από τα συνδεδεμένα δίκτυα"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Σύνδεση"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Σύνδεση στα ενεργοποιημένα δίκτυα"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Πάνω: %.1f(%.1f) | Κάτω: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Πάνω: %.1f | Κάτω: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Συνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Αποσυνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Σίγουρα θέλετε να κλείσετε το aMule;"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- Προεπιλεγμένο -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ο κατάλογος των θεμάτων '%s'  δεν υπάρχει"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατή η ανάγνωση του αρχείου θέματος '%s' "
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Δίκτυα"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Παράθυρο δικτύων"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Αναζητήσεις"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Παράθυρο αναζητήσεων"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Κατεβασμένα"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Κατεβαίνει"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Παράθυρο κοινόχρηστων αρχείων"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Μηνύματα"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Παράθυρό μηνυμάτων"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Στατιστικές"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Παράθυρο στατιστικών διαγραμμάτων"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Παράθυρο ρυθμίσεων"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Το εργαλείο εισαγωγής ημιτελών αρχείων"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Σχετικά"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Σχετικά/Βοήθεια"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Δίκτυο eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Δίκτυο Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Κανένα δίκτυο"
 
@@ -878,8 +888,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Άγνωστο"
@@ -1243,19 +1253,19 @@ msgstr "Αυτόματη [Υψηλή]"
 msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Κανονική"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1287,7 +1297,7 @@ msgid "On Queue"
 msgstr "Εν αναμονή"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Κατεβαίνει"
 
@@ -1347,7 +1357,7 @@ msgstr "Τοπικός διακομιστής"
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1419,7 +1429,7 @@ msgstr "Μέρος"
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Μεταφέρθηκαν"
 
@@ -1432,7 +1442,7 @@ msgid "Progress"
 msgstr "Πρόοδος"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Αρ. πηγών"
 
@@ -1442,7 +1452,7 @@ msgstr "Αρ. πηγών"
 msgid "Priority"
 msgstr "Προτεραιότητα"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Κατάσταση"
 
@@ -1475,7 +1485,7 @@ msgstr ""
 "Αντίδραση από %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Αυτόματη"
@@ -2132,7 +2142,7 @@ msgstr "Αποτυχία γραψίματος στο αρχείο της λίσ�
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Φίλοι"
 
@@ -2421,8 +2431,8 @@ msgstr "Άκυρη θύρα για εκκινητήρα"
 msgid "Please fill all fields required"
 msgstr "Παρακαλώ συμπληρώστε όλα τα απαιτούμενα πεδία"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Μήνυμα"
 
@@ -2494,7 +2504,7 @@ msgstr "Λόγος μοιράσματος"
 msgid "Uploaded"
 msgstr "Ανέβηκε"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Ζητήθηκε:"
 
@@ -2528,30 +2538,30 @@ msgstr "Άγνωστη έκδοση"
 msgid "Unable to get error description for error %d"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Κατακερματισμός"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Ολοκληρώνεται"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Ολοκληρωμένο"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Σταματημένο"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Εσφαλμένο"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Εν αναμονή"
 
@@ -2598,7 +2608,7 @@ msgstr "Εξωτερική Σύνδεση: Η πρόσβαση απορρίφθ�
 msgid "External Connection: Handshake failed."
 msgstr "Εξωτερική σύνδεση: Η πρόσβαση απορρίφθηκε"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
@@ -2620,7 +2630,7 @@ msgid "WARNING: "
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -2736,7 +2746,7 @@ msgstr "Έξοδος"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2976,7 +2986,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3046,7 +3056,7 @@ msgstr "Καθάρισμα των ολοκληρωμένων κατεβασμά�
 msgid "File sources:"
 msgstr "Ολοκλήρωση πηγών"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Γενικά"
 
@@ -3067,7 +3077,7 @@ msgstr "Πλήρες Όνομα :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "Δεν υπάρχει"
 
@@ -3243,7 +3253,7 @@ msgstr "Όνομα χρήστη :"
 msgid "Userhash :"
 msgstr "Τεμάχιο χρήστη :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Προσθήκη"
@@ -3252,15 +3262,15 @@ msgstr "Προσθήκη"
 msgid "Download-Speed"
 msgstr "Ταχύτητα κατεβάσματος"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Τρέχων"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Μέσο τρεξίματος"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Μέσο περιόδου"
 
@@ -3272,7 +3282,7 @@ msgstr "Ταχύτητα ανεβάσματος"
 msgid "Connections"
 msgstr "Συνδέσεις"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Ενεργά κατεβάσματα"
 
@@ -3280,7 +3290,7 @@ msgstr "Ενεργά κατεβάσματα"
 msgid "Active connections (1:1)"
 msgstr "Ενεργές συνδέσεις (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Ενεργά ανεβάσματα"
 
@@ -3482,8 +3492,8 @@ msgstr "Επιλογή περιηγητή ιστοσελίδων"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Εισάγετε το όνομα το περιηγητή ιστολελίδων. Αφήστε αυτό το πεδίο κενό για τον προεπιλεγμένο περιηγητή."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3557,755 +3567,764 @@ msgstr "Συνέδεσε την τοπική διεύθυνση στην διε�
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Μόνο για προχωρημένους χρήστες: Αν έχετε πολλαπλά δικτυακά περιβάλλοντα, εισάγετε την διεύθυνση του περιβάλλοντος με το οποίο το aMule πρέπει να συνδεθεί."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Μέγιστος αριθμός πηγών ανά εισερχόμενο αρχείο:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Μέγιστος αριθμός παράλληλων συνδέσεων:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Αυτόματη σύνδεση κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Επανασύνδεση σε περίπτωση διακοπής"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Αφαίρεση του νεκρού διακομιστή ύστερα από"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "προσπάθειες"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Λίστα"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Ενημέρωση της λίστας διακομιστών κατά τη σύνδεση σε διακομιστή"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Ενημέρωση της λίστας διακομιστών κατά τη σύνδεση σε πελάτη"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Χρήση συστήματος προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Χρήση έξυπνου ελέγχου LowID κατά τη σύνδεση"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Ασφαλής σύνδεση"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Αυτόματη σύνδεση μόνο με τους διακομιστές της στατικής λίστας"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Υψηλή προτεραιότητα στους διακομιστές που προστέθηκαν με το χέρι"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Έξυπνη διαχείριση φθοράς (Ε.Δ.Φ.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Ενεργοποιήση"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Προχωρημένη Ε.Δ.Φ. εμπιστεύεται κάθε κατακερματισμό (δεν συνιστάται)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Προσθήκη αρχείων προς κατέβασμα κατά τη διάρκεια παύσης"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Προσθήκη αρχείων προς κατέβασμα με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Προσπάθησε να κατεβάσεις πρώτα τα αρχικά και τελικά κομμάτια"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Εκκίνηση του επόμενου σταματημένου αρχείου όταν ένα αρχείο ολοκληρωθεί"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Από την ίδια κατηγορία"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Δέσμευση χώρου στο δίσκο για καινούρια αρχεία"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Δεσμεύει χώρο στο δίσκο για καινούρια αρχεία και έτσι μειώνει τον κατακερματισμό"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Σταμάτημα του κατεβάσματος όταν ο ελεύθερος δίσκος φτάσει τα"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Επιλέξτε αυτό αν θέλετε το aMule να ελέγξει τον χώρο στον δίσκο σας"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Γράψτε εδώ των ελάχιστο επιθυμητό χώρο στον δίσκο."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Αποθήκευση 10 πηγών σε σπάνια αρχεία (<20 πηγές)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Ανεβασμένα"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Προσθήκη νέων κοινόχρηστων αρχείων με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Δεξί κλικ στην εικόνα του καταλόγου για να γίνουν κοινόχρηστοι οι υποκατάλογοι)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Κάνε τα κρυφά αρχεία κοινόχρηστα"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Γραφικές Παραστάσεις"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Χρόνος καθυστέρηση ενημέρωσης : 5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Χρόνος μέσου γραφήματος: 100 λεπτά"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Κλίμακα διαγράμματος συνδέσεων: 100"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Κλιματα του γραφήματος εισερχομένων:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Κλιμακα του γραφήματος εξερχομένων"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Χρώματα:"
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Υπόβαθρο"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Πλέγμα"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Κατέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Μέσο τρέξιμο κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Μέσο συνεδρίας κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Ανέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Μέσο τρέξιμο ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Μέσο συνεδρίας ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Ενεργές συνδέσεις"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Εικόνα για την μπάρα ταχείας πρόσβασης του Systray"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Σύνδεσμοι-Kad παρόντες"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Σύνδεσμοι-Kad τρέχοντες"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Σύνδεσμοι-Kad συνεδρία"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Επέλεξε"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Δέντρο"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Αριθμός των εμφανιζόμενων εκδόσεων πελάτη (0=απεριόριστος)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! Προειδοποίηση !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Μέγιστος αρ. νέων συνδέσεων /5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Χώρος προσωρινής αποθήκευσης αρχείου: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Λίστα αναμονής ανεβάσματος: 5000 πελάτες"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποίηση"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Θέμα:"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Εμφάνιση \"Γρήγορου διαχειριστή συνδέσμων eD2k\" σε όλα τα παράθυρα."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Εμφάνιση εκτεταμένων πληροφοριών στην καρτέλα κατηγοριών"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Πριν απο το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Μετά το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Εμφάνιση επιβάρυνσης στο εύρος ζώνης"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Κατακόρυφος προσανατολισμός της γραμμής εντολών"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Ουρά εισερχομένων αρχείων"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Εμφάνιση ποσοστού προόδου"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Εμφάνιση μπάρας προόδου"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Επίπεδη"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Στρογγυλή"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Αυτόματη ταξινόμηση αρχείων (υψηλή απαίτηση σε υπολογική ισχύη)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "Το aMule θα ταξινομήσει τις στήλες τις λίστας κατεβασμάτων αυτόματα."
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Παράμετροι εξωτερικών συνδέσεων"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Να γίνονται αποδεκτές οι εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "Η διεύθυνση του εισακούοντος περιβάλλοντος:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Εισάγετε μία έγκυρη διεύθυνση με φόρμα a.b.c.d για σύνδεση με το περιβάλλον EC. Άδειο πεδίου ή 0.0.0.0 συμβολίζει όλα τα περιβάλλοντα."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας UPnP στην θύρα EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Κωδικός"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Έναρξη του εξυπηρετητή ιστού κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Πρότυπη σελίδα"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Κωδικός πλήρων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Ενεργοποίηση χρήστη μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Κωδικός μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας του εξηπηρετητή ιστού στη θύρα UPnP"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Θύρα UPnP TCP του εξυπηρετητή (Προαιρετική)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Χρόνος ανανέωσης σελίδας (σε δευτερόλεπτα)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Ενεργοποίηση συμπίεσης Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Εντάξει"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Κλικ εδώ για εφαρμογή των αλλαγών που έγιναν στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Επαναφορά κάθε αλλαγής που έγινε στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Τίτλος:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Σχόλιο:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Κατάλογος εισερχομένων :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Αλλαγή προτεραιότητας για τα νέα προσδιορισμένα αρχεία :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "Να μην αλλάξει"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Επιλογή χρώματος για τη συγκεκριμένη κατηγορία (τρέχουσα επιλογή) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Καθαρισμός"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Πατήστε αυτό το κουμπί για το καθάρισμα του αρχείου καταγραφής."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Πατήστε αυτό το αρχείο για να ανανεώσετε την λίστα διακομιστών από την URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Λίστα διακομιστών"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Εισάγετε την url ενός αρχείου server.met και πατήστε το κουμπί στα αριστερά για να ανανεώσετε τη λίστα με τους γνωστούς διακομιστές"
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Προσθήκη διακομιστή: Όνομα"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Γράψτε το όνομα του νέου διακομιστή εδώ"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "Διεύθυνση:Θύρα"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Γράψτε την IP του διακομιστή εδώ, σε μορφή x.x.x.x"
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Βάλτε τον διακομιστή με το χέρι (γεμίστε πρώτα τα πεδία στα αριστερά) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Αρχείο καταγραφής aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Πληροφορίες διακομιστή"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Πληροφορίες ED2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Πληροφορίες Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Πατήστε το κουμπί για να ανανεώσετε την λίστα των κόμβων από την URL ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Κόμβοι (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Βάλτε εδώ την url ενός αρχείου nodes.dat και πατήστε το κουμπί στα αριστερά για να ανανεώσετε την λίστα των γνωστών κόμβων."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Στατιστικές κόμβων"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Εκκινητήρας"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Καινούριος κόμβος"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Θύρα:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Εκκίνηση από\n"
 "γνωστούς πελάτες"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Αποσυνδεδεμένο Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Χρήση Ασφαλούς Ταυτοποίησης χρήστη"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ενδείκνυται να ενεργοποιήσετε αυτήν την προτίμηση. Δεν θα λάβετε πίστωση αν το SUI δεν είναι ενεργοποιημένο."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Υποστήριξη συσκότισης πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Αυτή η επιλογή ενεργοποίησε την συσκότιση πρωτοκόλλου και κάνει το aMule να δέχεται συσκοτισμένες συνδέσεις από άλλους πελάτες"
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Χρήση συσκότισης για εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Αυτή η επιλογή κάνει το aMule να χρησιμοποιεί συσκότιση πρωτοκόλλου όταν συνδέεται σε άλλους πελάτες/διακομιστές."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Να γίνονται δεκτές μόνο συσκοτισμένες συνδέσεις"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Αυτή η επιλογή κάνει το aMule να δέχεται μόνο συσκοτισμένες συνδέσεις. Θα υπάρχουν λιγότερες πηγές αλλά όλη η κυκλοφορία θα είναι συσκοτισμένη"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Οι πάντες"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Κανείς"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Ποίος μπορεί να δεί τα κοινόχρηστα αρχεία μου:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Επιλέξτε ποίος μπορεί να ζητήσει να δει τη λίστα με τα κοινόχρηστα αρχεία σας."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Φίλτρο IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Φιλτράρισμα πελατών"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των πελατών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Φιλτράρισμα διακομιστών"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των διακομιστών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Επαναφόρτωση για φιλτράρισμα της λίστας των IP από το ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Ανανέωσε τώρα"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Επίπεδο φιλτραρίσματος:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Πάντα φίλτραρε τις IP του τοπικού δικτύου"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Παρανοϊκή διαχείριση των αταίριαστων διευθύνσεων IP"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Απορρίπτει τα πακέτα αν η IP του πελάτη είναι διαφορετική από την IP από την οποία ελήφθη το πακέτο. Χρήση με προσοχή."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Χρήση του ipfilter.dat όλου του συστήματος αν αυτό υπάρχει"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Αν δεν βρεθεί τοπικό ipfilter.dat, να γίνει επιτρεπτή η χρήση του αρχείου ipfilter (φίλτρο διευθύνσεων) όλου του συστήματος."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Ενεργοποίηση συνδεδεμένων υπογραφών"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ενεργοποίηση γραψίματος του αρχείου συστήματος, το οποίο μπορεί να χρησιμοποιηθεί από εξωτερικές εφαρμογές για τη δημιουργία υπογραφών κτλ."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Συχνότητα ανανέωσης (δευτερόλεπτα):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Αλλαγή της συχνότητας (σε δευτερόλεπτα) για την ενημέρωση Συνδεδεμένων υπογραφών."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Αποθύκευση του αρχείου συνδεδεμένων υπογραφών σε:"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Κλικ εδώ για την επιλογή του καταλόγου που περιέχει τα αρχεία Συνδεδεμένων Υπογραφών."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Ρυθμός ροής δεδομένων :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Αρ. πηγών"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4313,11 +4332,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4327,232 +4346,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Μεταφόρτωση"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Φιλτράρισμα εισερχομένων μηνυμάτων (εκτός από την τρέχουσα συνομιλία):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Διήθηση όλων των μηνυμάτων"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Διήθηση των μηνυμάτων από μέλη εκτός της λίστας φίλων"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Διήθηση των μηνυμάτων που περιέχουν (χρήση ',' ως διαχωριστικού):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "προσθήκη σε αυτό το σημείο των λέξεων που το aMule πρέπει να φιλτράρει και μπλοκάρισμα μηνυμάτων που το περιέχουν"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Εμφάνιση των ληφθέντων μηνυμάτων στο αρχείο καταγραφής"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Σχόλια"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Φιλτράρισμα σχολίων που περιέχουν (χρησιμοποίηση ',' ως διαχωριστή):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Ενεργοποίηση πιστοποίησης"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Ενεργοποίηση/Απενεργοποίηση πιστοποίησης ονόματος χρήστη/κωδικού"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Όνομα χρήστη:"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Το όνομα χρήστη για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Κωδικός:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Ο κωδικός που χρειάζεται για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Ενεργοποίηση διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Ενεργοποίηση/Απενεργοποίηση υποστήριξης διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Τύπος διαμεσολάβησης"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Διεύθυνση διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Όνομα του διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Θύρα διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Η θύρα διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Σύνδεση με:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Σύνδεση σε απομακρυσμένο amule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Όνομα χρήστη"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Χρήση συμπίεσης τύπου gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ενεργοποίηση λεπτομερούς καταγραφής για έλεγχο σφαλμάτων"
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Άνοιγμα αρχείου"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Κατηγορίες μηνυμάτων:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Αναμονή..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Προσθήκη εισακτέων"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Επαναπροσπάθεια των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Αφαίρεση των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Τύποι συμβάντων"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Κρύψιμο των κοινόχρηστων αρχείων "
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Επιλογή φίλτρου εμφάνισης"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ενεργά ανεβάσματα"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Αποστολή"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Αποστολή του προσδιορισμένου μηνύματος."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Κλείσιμο της συνομιλίας."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Κοινόχρηστα αρχεία"
 
@@ -4629,7 +4648,7 @@ msgstr "όλα τα άλλα"
 msgid "Incomplete"
 msgstr "Ημιτελές"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Σταματημένο"
 
@@ -4821,360 +4840,360 @@ msgstr "Σώθηκε %i σπόρος πηγής για το ημιτελές α�
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου σπόρου του ημιτελούς αρχείου (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Βρέθηκε φθαρμένο τμήμα (%d) στο %d μέρος αρχείου %s -  FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Βρέθηκε φθαρμένο τμήμα (%d) στα %d μέρη αρχείου %s -  FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Βρέθηκε ολοκληρωμένο μέρος (%i) στο %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Τελείωσε ο επανακατακερματισμός του %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Απρόσμενο σφάλμα κατά την ολοκλήρωση του %s. Το αρχεί έπαψε"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Ολοκλήρωση του κατεβάσματος: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Ολοκλήρωση του κατεβάσματος: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Σβήσιμο αρχείου: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατός ο κατακερματισμός του κατεβασμένου τμήματος - του σύνολο κατακερματισμού για το '%s' είναι ημιτελές"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ΣΦΑΛΜΑ: Δεν είναι δυνατός ο κατακερματισμός του κατεβασμένου τμήματος - του σύνολο κατακερματισμού για το '%s' είναι ημιτελές. Αυτό δεν πρέπει να ξανασυμβεί ποτέ"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Μη αρκετός χώρος στο δίσκο! Παύση αρχείου: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Το κατεβασμένο τμήμα υπ. αρ. %i είναι φθαρμένο στο αρχείο: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Ανακτήθηκε φθαρμένο τεμάχιο %i για το %s -> Σωσμένα bytes: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Κατανέμει"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Ανεπαρκής χώρος στο δίσκο"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Έχει κατεβεί"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία ανοίγματος του ημιτελούς αρχείου '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Αραβικά"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Βάσκικα"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Βουλγάρικα"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Καταλανικά"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Κινέζικα (απλοποιημένα)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Κινέζικα (Παραδοσιακά)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Κροατικά"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Τσέχικα"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Δανέζικα"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Ολλανδικά"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Φιλανδικά"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Γαλλικά"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Γαλικιακά"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Γερμανικά"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Ελληνικά"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Εβραϊκά"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Ουγγαρέζικα"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Ιταλικά"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Ιταλικά (Ελβετίας)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Γιαπωνέζικα"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Κορεάτικα"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Λιθουανικά"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Νορβηγικά"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Πολωνέζικα"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Πορτογαλλικά"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Πορτογαλλικά (Βραζιλίας)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Ρωσικά"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Σλοβένικα"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Ισπανικά"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Σουηδικά"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Τούρκικα"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "Γλώσσα"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "Δεν υπάρχουν επιλογές"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Η θύρα TCP δεν μπορεί να είναι μεγαλύτερη από 65532, διότι η θύρα UDP του διακομιστή είναι TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Θα χρησιμοποιηθεί η στάνταρ θύρα (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Σύνδεση"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Κατάλογοι Αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Διακομιστές"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Ασφάλεια"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Περιβάλλον"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Διακομιστής διαμεσολάβησης"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Φίλτρα"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Τηλεχειρισμός"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Διασυνδεδεμένη υπογραφή"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Προχωρημένες"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Γεγονότα"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Έλεγχος σφαλμάτων προγράμματος"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5189,26 +5208,26 @@ msgstr ""
 "Το aMule θα τρέχει μια χαρά χωρίς την αλλαγή καμιάς από αυτές\n"
 " τις ρυθμίσεις."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Ο τύπος του διακομιστή μεσολάβησης στον οποίον συνδέεστε"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5216,35 +5235,40 @@ msgstr ""
 "το aMule πρέπει να επανεκινηθεί για να ενεργοποιηθούν αυτές οι αλλαγές: \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- Άλλαξε η θύρα TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- Άλλαξε η θύρα UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Η εξωτερική σύνδεση έκλεισε."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5252,7 +5276,7 @@ msgstr ""
 "Η λίστα αυτόματης ενημέρωσης διακομιστών είναι κενή.\n"
 "Θα απενεργοποιηθεί η επιλογή: 'Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση' "
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5260,20 +5284,20 @@ msgstr ""
 "Έχετε ενεργοποιήσει τις εξωτερικές συνδέσεις αλλά δεν έχετε προσδιορίσει κωδικό.\n"
 "Οι εξωτερικές συνδέσεις δεν μπορούν να ενεργοποιηθούν μέχρι να προσδιοριστεί ένας έγκυρος κωδικός."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Η γλώσσα άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Ο προσωρινός κατάλογος άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Όλα τα δίκτυα είναι απενεργοποιημένα."
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5281,7 +5305,7 @@ msgstr ""
 "Και το δίκτυο eD2k και το Kad είναι απενεργοποιημένα.\n"
 "Δεν θα μπορέσετε να συνδεθείτε μέχρι να ενεργοποιήσετε τουλάχιστον ένα από αυτα."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5289,7 +5313,7 @@ msgstr ""
 "Το δίκτυο Kad δεν θα ξεκινήσει αν η θύρα UDP είναι απενεργοποιημένη.\n"
 "Ενεργοποιήστε τη θύρα UDP ή απενεργοποιήστε το Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5299,20 +5323,20 @@ msgstr ""
 "Τώρα πρέπει να επανεκινήσετε το aMule.\n"
 "Διαφορετικά μην διαμαρτυρηθείτε αν συμβεί κάτι κακό.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5322,41 +5346,41 @@ msgstr ""
 "Παρακαλώ βάλτε τουλάχιστον μία URL που να δείχνει σε ένα έγκυρο αρχείο sever.met.\n"
 "Πατήστε το διπλανό κουμπί \"List\" για να βάλετε ένα URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Προσωρινά αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Εισερχόμενα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Συνδεδεμένες υπογραφές"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Επιλέξτε κατάλογο για %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Αναζήτηση του προγράμματος για βίντεο"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Επιλογή περιηγητή"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Εκτελέσιμο%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Επεξεργασία λίστας διακομιστών"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5364,150 +5388,150 @@ msgstr ""
 "Βάλτε εδώ τη διεύθυνση για το κατέβασμα των αρχείων server.met. \n"
 "Μία διεύθυνση σε κάθε γραμμή"
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Ολοκλήρωση πηγών"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτο"
 msgstr[1] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτα"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Χρόνος για μέσο γράφημα: %d λεπτό"
 msgstr[1] "Χρόνος για μέσο γράφημα: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Κλίμακα γραφήματος συνδέσεων: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byte"
 msgstr[1] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byteς"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Μέγεθος λίστας αναμονής αποστελλόμενων: %d πελάτης"
 msgstr[1] "Μέγεθος λίστας αναμονής ανεβασμάτων: %d πελάτες"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτό"
 msgstr[1] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποιημένο"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "απενεργοποίηση"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Εκτέλεση εντολής κατά το γεγονός `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στον πυρήνα"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Εντολή πυρήνα:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στο γραφικό περιβάλλον"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Εντολή γραφικού περιβάλλοντος:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Οι παρακάτω μεταβλητές θα αντικατασταθούν:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -198,8 +198,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -249,94 +249,99 @@ msgstr "Το κατέβασμα ολοκληρώθηκε"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Οι τοπικές ρυθμίσεις άλλαξαν στις προεπιλεγμένες του συστήματος λόγο μιας αλλαγής παραμέτρων. Sorry!"
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Δίκτυα"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "βρέθηκε %i διακομιστής στο server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Δεν μπόρεσε να προσδέσει τις θύρες στην προσδιορισμένη διεύθυνση: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Η θύρα %u δεν είναι διαθέσιμη. Θα σας αποδωθεί LOWID (χαμηλή προτεραιότητα)\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -351,48 +356,48 @@ msgstr ""
 "\n"
 "Ελέξτε το δίκτυο σας για να βεβαιωθήτε ότι η θύρα είναι ανοιχτή για είσοδο και έξοδο."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών του aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Οι επιλεγμένες τοπικές ρυθμίσεις δεν φαίνεται να είναι εγκατεστημένες στο σύστημά σας. (Σημ. Θα προσπαθήσω να τις θέσω ούτως ή άλλως)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Αυτή είναι η πρώτη φορά που τρέχετε το aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Αυτή η έκδοση είναι δοκιμαστική, και αναβαθμίζεται καθημερινά, και\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "δεν δίνουμε εγγύηση ότι δεν θα χαλάσει κάτι, δεν θα κάψει το σπίτι σας,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ή δεν θα σκοτώσει το σκύλο σας. Αλλά πρέπει να είναι ασφαλές στη χρήση\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Περισσότερες πληροφορίες, υποστήριξη και νέες εκδόσεις μπορούν να βρεθούν στην ιστοσελίδα μας,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "στο https://amule-org.github.io, ή στο κανάλι #aMule του IRC στο irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Παρακαλούμε αναφέρετε σφάλματα του προγράμματος στο https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -400,138 +405,138 @@ msgstr ""
 "Ο δικτυακός κατάλογος των ηλεκτρονικών αρχείων υπογραφών που προσδιορίσατε είναι ΑΚΥΡΟΣ!\n"
 "Οι ηλεκτρονικές υπογραφές θα ΑΠΕΝΕΡΓΟΠΟΙΗΘΟΥΝ μέχρι να το φτιάξετε στις προτιμήσεις."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Όνομα διακομιστή:"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Η εκχώρηση χώρου για το αρχείο '%s' απέτυχε: '%s'"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ΣΦΑΛΜΑ: το αρχείο καταγραφής δεν μπορεί να ανοίξει"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: το αρχείο καταγραφών είναι άδειο. Κάτι δεν πάει καλά."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Το αρχείο καταγραφών επαναφέρθηκε στην αρχική κατάσταση"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Μήνυμα Διακομιστή: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Αποτυχία κατεβάσματος της λίστας κόμβων."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Αποτυχία ανοίγματος του κατεβασμένου αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Φθαρμένο αρχείο ελέγχου έκδοσης"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Η παρούσα έκδοση του aMule είναι %i.%i.%i και η τελευταία %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Η έκδοση του aMuled είναι ξεπερασμένη: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Αυτό το αντίγραφο του aMule είναι σύγχρονο. "
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Αποτυχία κατεβάσματος του αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Χρήστες: %s | Αρχεία: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Χρήστες: E: %s K: %s | Αρχεία: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Δεν έχουν επιλεχθεί δίκτυα"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "με Χαμηλή Προτεραιότητα"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "με Υψηλή Προτεραιότητα"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Σύνδεση με το %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Διαδικασία σύνδεσης με %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Αποσυνδεδεμένο από το eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Το Kad ξεκίνησε."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Το Kad είναι σταματημένο."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Συνδεδεμένο στο Kad (ΟΚ)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Συνδεδεμένο στο Kad (με προστατευτικό τοίχο)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Αποσυνδεδεμένο από το Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Το δίκτυο Kad δεν μπορεί να χρησιμοποιηθεί αν η θύρα UDP είναι απενεργοποιημένη στις προτιμήσεις. Δεν έγινε εκκίνηση."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Το δίκτυο Kad είναι απενεργοποιημένο από τις προτιμήσεις. Δεν έγινε σύνδεση."
 
@@ -897,7 +902,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2270,49 +2275,49 @@ msgstr "Όχι"
 msgid "Yes"
 msgstr "Ναι"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Μεταφόρτωση..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Αποτυχία λήψης των κοινόχρηστων αρχείων του χρήστη '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Έχει κατεβεί"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Κατεβασμένα (%i)"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2618,7 +2623,7 @@ msgstr "Εξωτερική Σύνδεση: Η πρόσβαση απορρίφθ�
 msgid "External Connection: Handshake failed."
 msgstr "Εξωτερική σύνδεση: Η πρόσβαση απορρίφθηκε"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -18,80 +18,80 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -185,8 +185,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -201,99 +201,109 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -303,184 +313,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -519,15 +529,15 @@ msgstr ""
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -537,221 +547,221 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -839,8 +849,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr ""
@@ -1203,19 +1213,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1247,7 +1257,7 @@ msgid "On Queue"
 msgstr ""
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr ""
 
@@ -1307,7 +1317,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr ""
@@ -1378,7 +1388,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr ""
 
@@ -1391,7 +1401,7 @@ msgid "Progress"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr ""
 
@@ -1401,7 +1411,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr ""
 
@@ -1432,7 +1442,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr ""
@@ -2056,7 +2066,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr ""
 
@@ -2334,8 +2344,8 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr ""
 
@@ -2407,7 +2417,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2441,30 +2451,30 @@ msgstr ""
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr ""
 
@@ -2508,7 +2518,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2530,7 +2540,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr ""
 
@@ -2639,7 +2649,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -2879,7 +2889,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr ""
@@ -2948,7 +2958,7 @@ msgstr ""
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr ""
 
@@ -2969,7 +2979,7 @@ msgstr ""
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr ""
 
@@ -3143,7 +3153,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3152,15 +3162,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr ""
 
@@ -3172,7 +3182,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr ""
 
@@ -3180,7 +3190,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr ""
 
@@ -3381,8 +3391,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3456,745 +3466,753 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4202,11 +4220,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4216,222 +4234,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr ""
 
@@ -4508,7 +4526,7 @@ msgstr ""
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr ""
 
@@ -4697,355 +4715,355 @@ msgstr ""
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr ""
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5055,296 +5073,300 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+msgid "- Network interface binding changed.\n"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -185,8 +185,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -231,89 +231,94 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -323,184 +328,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -858,7 +863,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2186,49 +2191,49 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr ""
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2528,7 +2533,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -185,8 +185,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -231,79 +231,89 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -313,184 +323,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -2518,7 +2528,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -28,20 +28,20 @@ msgstr ""
 "X-Language: es_ES\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Control remoto de aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Versión:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -49,7 +49,7 @@ msgstr ""
 "Cliente p2p multiplataforma basado en eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -57,59 +57,59 @@ msgstr ""
 "Copyright (c) 2003-2026 El equipo de aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Parte de aMule está basada en \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: direccionamiento P2P basado en la métrica XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov (petar@maymounkov.org)\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Web:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Foro:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr "Documentación:"
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr "Problemas:"
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprobar si hay una nueva versión al inicio"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Conectando a Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "¡Estás usando una versión desactualizada de aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "No disponible"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -211,8 +211,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "No se pudo añadir %u enlace del archivo ED2KLinks (consulte el registro para más detalles)"
 msgstr[1] "No se pudieron añadir %u enlaces del archivo ED2KLinks (consulte el registro para más detalles)"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -227,47 +227,57 @@ msgstr "Error al abrir el archivo de enlaces ED2K."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: no puede añadirse a sí mismo como fuente para un enlace eD2k teniendo Id Baja."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Ahora, saliendo de la aplicación principal..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Cerrando la instancia de amuleweb con pid '%d'... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando la instancia de amuleweb con pid '%d'... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Falló"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: terminando el núcleo."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Cierre de aMule completado."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados de depuración de memoria en la salida de aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Su configuración regional se ha cambiado a la predefinida del sistema debido a un cambio en la configuración. Disculpe."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -275,20 +285,20 @@ msgstr ""
 "\n"
 "Configuración de la EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fijada y conexiones externas habilitadas."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "Bootstrap de red"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -296,34 +306,34 @@ msgstr ""
 "aMule ha detectado archivos de bootstrap de red faltantes.\n"
 "Seleccione cuáles descargar:"
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se pueden asociar los puertos con la dirección especificada: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puerto %u no está disponible. Tendrás Id Baja\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -338,48 +348,48 @@ msgstr ""
 "\n"
 "Comprueba la red y asegúrate de que el puerto está abierto para salida y entrada."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Error al crear el archivo de firma online"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Error al crear el archivo de firma online de aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "El idioma seleccionado no parece estar instalado en tu sistema. (Nota: intentaré configurarlo de todos modos)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Es la primera vez que inicias aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta es una versión de prueba, actualizada diariamente, y\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no garantizamos que no rompa nada, no queme su casa,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o no mate a su perro. Pero *debería* ser seguro usarla de todas formas.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "En nuestra web podrá encontrar más información, soporte y nuevas versiones,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o en nuestro canal de IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Envíenos cualquier fallo a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -387,137 +397,137 @@ msgstr ""
 "¡El directorio que ha especificado para archivos de firma digital no es válido!\n"
 "La firma digital se ha deshabilitado hasta que lo arregle en las preferencias."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Nombre de servidor notificado"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espacio en disco para el archivo '%s' ha fallado: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no se puede abrir el archivo de registro"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: el archivo de registro está vacío. Algo está mal."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "El registro se ha borrado"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaje del servidor: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se ha descartado la descarga de %s, porque el archivo solicitado no es más nuevo."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Error al descargar la lista de nodos."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Error al abrir el archivo de comprobación de versión descargado"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Archivo de comprobación de versión dañado"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Estás usando una versión desactualizada de aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Su versión de aMule es %i.%i.%i y la última versión es %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La última versión siempre se puede encontrar en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: su versión de aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Su copia de aMule está actualizada."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Error al descargar el archivo de comprobación de la versión"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Archivos: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Archivos: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "No hay redes seleccionadas"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con Id Baja"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con Id Alta"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad detenido."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (correcto)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (tras cortafuegos)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La red Kad no se puede usar si el puerto UDP está deshabilitado en las preferencias, no se inicia."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada en las preferencias, no se conecta."
 
@@ -556,15 +566,15 @@ msgstr "Esto es aMule %s basado en eMule."
 msgid "Running on %s"
 msgstr "Ejecutándose en %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para comprobar si hay una nueva versión disponible."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR FATAL: no se ha podido crear el temporizador"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -574,222 +584,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "La última versión siempre se puede encontrar en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "No disponible"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Diálogo de aMule destruido"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: tras cortafuegos"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: conectado"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: conectando"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: apagado"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexión actuales"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectarse de las redes conectadas"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Conectarse a las redes habilitadas"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Su: %.1f%s (%.1f) | De: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Su: %.1f%s | De: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "¿Realmente desea cerrar %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Confirmación de salida"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Ejecutar comando: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- predeterminado -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directorio de tema '%s' no existe"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: no se puede abrir el archivo de tema '%s' para lectura"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Búsquedas"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Ventana de búsquedas"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Ventana de descargas"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Compartidos"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Ventana de archivos compartidos"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Mensajes"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Ventana de mensajes"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Ventana de preferencias de configuración"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "La herramienta para importar archivos de partes"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca de"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Acerca de/Ayuda"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Red eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "No hay red"
 
@@ -879,8 +889,8 @@ msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantien
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Desconocido"
@@ -1243,19 +1253,19 @@ msgstr "Automática [Al]"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Baja"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1287,7 +1297,7 @@ msgid "On Queue"
 msgstr "En cola"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Descargando"
 
@@ -1347,7 +1357,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1418,7 +1428,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1431,7 +1441,7 @@ msgid "Progress"
 msgstr "Progreso"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Fuentes"
 
@@ -1441,7 +1451,7 @@ msgstr "Fuentes"
 msgid "Priority"
 msgstr "Prioridad"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Estado"
 
@@ -1474,7 +1484,7 @@ msgstr ""
 "Reacción desde: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automática"
@@ -2125,7 +2135,7 @@ msgstr "¡Error al abrir el archivo de amigos 'emfriends.met' para escritura!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - no hay clientes en el inicio de sesión chat"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2409,8 +2419,8 @@ msgstr "Puerto no válido para la inicialización"
 msgid "Please fill all fields required"
 msgstr "Por favor, rellene todos los campos requeridos"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Mensaje"
 
@@ -2482,7 +2492,7 @@ msgstr "Media de compartición"
 msgid "Uploaded"
 msgstr "Subido"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2516,30 +2526,30 @@ msgstr "Error desconocido %d"
 msgid "Unable to get error description for error %d"
 msgstr "No se puede obtener la descripción del error para el error %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Creando el hash"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Completando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Completado"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pausado"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Erróneo"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Esperando"
 
@@ -2583,7 +2593,7 @@ msgstr "Conexión externa: acceso denegado, razón: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: error al establecer la comunicación."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Hilo Asio %d iniciado"
@@ -2605,7 +2615,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Cerrar"
 
@@ -2714,7 +2724,7 @@ msgstr "Salir"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2954,7 +2964,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3023,7 +3033,7 @@ msgstr "Quita de la lista las descargas completadas"
 msgid "File sources:"
 msgstr "Fuentes del archivo:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "General"
 
@@ -3044,7 +3054,7 @@ msgstr "Nombre completo:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/D"
 
@@ -3220,7 +3230,7 @@ msgstr "Nombre del usuario:"
 msgid "Userhash :"
 msgstr "Hash del usuario:"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Añadir"
@@ -3229,15 +3239,15 @@ msgstr "Añadir"
 msgid "Download-Speed"
 msgstr "Velocidad de descarga"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Media de ejecución"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3249,7 +3259,7 @@ msgstr "Velocidad de subida"
 msgid "Connections"
 msgstr "Conexiones"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3257,7 +3267,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexiones activas (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Subidas activas"
 
@@ -3458,8 +3468,8 @@ msgstr "Selección del navegador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduzca el nombre de su navegador. Déjelo en blanco si quiere usar el predefinido del sistema."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3533,147 +3543,156 @@ msgstr "Dirección IP local de enlace (vacía para cualquiera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo usuarios avanzados: si tiene varias tarjetas de red, introduzca la dirección de la tarjeta que debe usar aMule."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Dirección IP local de enlace (vacía para cualquiera):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Número máximo de fuentes descargando un archivo:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Número máximo de conexiones simultáneas:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Autoconectar al iniciar"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Reconectar al perder la conexión"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Eliminar los servidores caídos tras"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "reintentos"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Autoactualizar la lista de servidores al inicio"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar la lista de servidores al conectar a un servidor"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Actualizar la lista de servidores cuando se conecte un cliente"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Usar el sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Usar el control inteligente de Id Baja al conectar"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Conexión segura"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconectar sólo a servidores fijos"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar la prioridad alta a los servidores añadidos manualmente"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestión inteligente de corrupción (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "El I.C.H. avanzado confía en todos los hash (no recomendado)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Añadir los archivos a descargar en modo pausado"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Añadir las nuevas descargas con prioridad automática"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Intentar descargar antes el primer y último trozo"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Descargar el siguiente archivo pausado cuando otro se complete"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Solo de la misma categoría"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "En orden alfabético"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Reservar el espacio en disco para los archivos nuevos"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva en disco el espacio para los archivos nuevos enteros, reduciendo asíla fragmentación"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener las descargas cuando el espacio libre en disco alcance "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción si quiere que aMule compruebe el espacio en disco"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Introduzca el espacio mínimo de disco deseado."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fuentes para archivos raros (< 20 fuentes)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Subidas"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Añadir los nuevos archivos compartidos con prioridad automática"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destino para las descargas"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3681,284 +3700,284 @@ msgstr ""
 "Las descargas completadas se guardan aquí. Todos los archivos de esta carpeta se compartirán automáticamente con otros usuarios.\n"
 "Si esta carpeta contiene archivos que no quiere compartir, apúntelo a un sub-directorio exclusivo para aMule."
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Elija la carpeta donde se guardarán las descargas terminadas. Todos los archivos de esa carpeta se compartirán con otros usuarios."
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos los archivos de esta carpeta se comparten con otros usuarios)"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Carpeta para los archivos temporales de las descargas"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Haga clic derecho en los iconos de carpetas para compartirlas recursivamente)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Compartir los archivos ocultos"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "Buscar cambios automáticamente en los directorios compartidos"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr "Seguir enlaces simbólicos en las carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 s"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempo de promedio del gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráfico de las conexiones: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Escala de la gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Escala de la gráfica de subida:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Rejilla"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Promedio de descarga en ejecución"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Promedio de descarga en la sesión"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Promedio de subida en ejecución"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Promedio de subida en la sesión"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Conexiones activas"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidad en el icono de la bandeja del sistema"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuales"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Nodos Kad activos"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Nodos Kad de la sesión"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versiones de clientes a mostrar (0=sin límite)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISO !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Número máximo de nuevas conexiones cada 5 segundos"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño del búfer de archivo: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño de cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de la conexión al servidor: desactivado"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Deshabilitar el modo de reposo del ordenador"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar el \"Gestor rápido de enlaces eD2k\" en todas las ventanas."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información adicional en las pestañas de las categorías"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Mostrar la versión de la aplicación en el título"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Mostrar las tasas de transferencia en el título"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Antes del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Después del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Mostrar el ancho de banda adicional usado"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de herramientas"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Archivos de la cola de descarga"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Mostrar el porcentaje de progreso"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Mostrar la barra de progreso"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Redondeada"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Autoordenar los archivos (uso alto de CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule ordenará automáticamente las columnas en la lista de descargas"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parámetros de la conexión externa"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Aceptar conexiones externas"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP de la interfaz que está escuchando:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduzca aquí una IP válida en la forma a.b.c.d para la interfaz EC que está escuchando. Un campo vacío o 0.0.0.0 significará cualquier interfaz."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Puerto TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar la redirección de puertos UPnP en el puerto EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parámetros del servidor web"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Arrancar el servidor web al inicio"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Contraseña de administrador"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Permitir un invitado"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Contraseña del invitado"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar el reenvío de puertos UPnP en el puerto del servidor web"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puerto TCP del servidor web para UPnP (opcional)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalo de actualización de la página (en segundos)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Activar la compresión gzip"
 
@@ -3966,318 +3985,318 @@ msgstr "Activar la compresión gzip"
 # botón para cerrar el diálogo de Preferencias guardando los cambios. La
 # traducción sería distinta en cada caso, así que hay que dejar el OK
 # original.
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Haga clic aquí para aplicar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Cancelar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Título:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Comentario:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Directorio entrante:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar la prioridad de los nuevos archivos asignados:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "No cambiar"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccione el color para esta categoría (actualmente seleccionado):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Borrar"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Pulse este botón para borrar el registro."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de servidores desde un URL..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduzca la URL de un archivo server.met y pulse el botón de la izquierda para actualizar la lista de servidores conocidos."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Añadir servidor manualmente: Nombre"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Introduzca aquí el nombre del nuevo servidor"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Puerto"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduzca aquí la IP del servidor, usando el formato \"x.x.x.x\"."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Introduzca el puerto del servidor."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Añadir manualmente un servidor (rellene antes los campos de la izquierda)..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Registro de aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Información del servidor"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Información sobre ED2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Información sobre Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de nodos desde el URL..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduzca la URL del archivo nodes.dat y pulse el botón de la izquierda para actualizar la lista de nodos conocidos."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Estadísticas de nodos"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Inicialización"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nuevo nodo"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Puerto:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Inicializar desde clientes conocidos"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Usar la Identificación Segura de Usuario (ISU)"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Se recomienda activar esta opción. No recibirá créditos si la ISU no está habilitada."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Permitir la ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolo y hace que aMule acepte conexiones ofuscadas de otros clientes."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar la ofuscación para las conexiones salientes"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción hace que aMule use la ofuscación de protocolo cuando se conecta a otros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar sólo conexiones ofuscadas"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción hace que aMule sólo acepte conexiones ofuscadas. Tendrá menos fuentes, pero todo su tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Nadie"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Quién puede ver mis archivos compartidos:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quién puede solicitar ver la lista de sus archivos compartidos."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtrado de direcciones IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtrar los clientes"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de clientes definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtrar los servidores"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de servidores definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Recargar la lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar la lista de filtrado de IP desde el archivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Actualizar ahora"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Autoactualizar el filtro de IP al inicio"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filtrar siempre las IP de LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestión paranoica de las IP que no coincidan"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Rechaza los paquetes para los que la IP del cliente es diferente de la IP desde donde se ha recibido el paquete. Úselo con cautela."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat del sistema si está disponible"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no hay un archivo ipfilter.dat local, permitir el uso de un archivo ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Habilitar la firma digital"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita la escritura de archivos de firma digital, algo que puede ser usado por las aplicaciones externas para crear firmas y cosas parecidas."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segundos):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de actualización de la firma digital."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Guardar el archivo de firma digital en: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Pulse aquí para seleccionar el directorio que contiene los archivos de firmas digitales."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Mostrar las banderas de los países para los clientes"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostrar la columna de la bandera del país en las vistas de transferencias, cola y búsqueda. Requiere una base de datos MMDB GeoIP válida (ver más abajo)."
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr "Base de datos"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr "Fuente:"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratis, sin crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, requiere crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr "URL personalizada"
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Elige qué proveedor ofrece la base de datos GeoIP MMDB. DB-IP es la opción predeterminada; no se necesita cuenta. MaxMind requiere una cuenta gratuita y una clave de licencia. Utiliza la opción 'URL personalizada' para indicar cualquier otro servidor MMDB (por ejemplo, un servidor espejo local)."
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4289,11 +4308,11 @@ msgstr ""
 "Datos IP-País de DB-IP.com - https://db-ip.com\n"
 "Licencia: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr "Clave de licencia:"
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4309,11 +4328,11 @@ msgstr ""
 "Licencia: EULA de MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Requiere la atribución de la fuente y el registro de una cuenta; actualizar al menos cada 30 días."
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr "URL de descarga:"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4323,211 +4342,211 @@ msgstr ""
 "La URL puede incluir credenciales (https://user:pass@host/...).\n"
 "Las condiciones de licencia y atribución dependen de la URL de descarga; la responsabilidad recae en ti."
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr "Descarga la base de datos GeoIP de la fuente seleccionada."
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr "Autoactualizar al inicio"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Vuelve a descargar la base de datos GeoIP desde la fuente seleccionada cada vez que se inicie aMule."
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar los mensajes entrantes (salvo la conversación actual):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtrar todos los mensajes"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar los mensajes de gente que no esté en su lista de amigos"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar los mensajes de clientes desconocidos"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar los mensajes que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "añada aquí las palabras que amule debe filtrar para bloquear los mensajes que las incluyan"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Mostrar los mensajes recibidos en el registro"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar los comentarios que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Habilitar la autentificación"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Habilitar/deshabilitar la autenticación mediante usuario/contraseña"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Nombre de usuario: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "El nombre de usuario a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Habilitar el proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/deshabilitar el soporte para proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Servidor proxy:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Nombre del host del proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Puerto del proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "El puerto del proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Conexión a aMule remoto"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nombre de usuario"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Recordar estas opciones"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr "Forzar compresión ZLIB"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilitar el modo detallado de depuración."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Sólo al archivo de registro"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Categorías de mensajes:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Añadir lo importado"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Reintentar seleccionado"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Borrar seleccionado"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tipos de evento"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas y clientes en la cola para los archivos seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Subidas activas"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Porcentaje del total de archivos"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Archivos seleccionados"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Solo las subidas activas"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Recargar los archivos compartidos"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Envía el mensaje especificado."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Cerrar esta sesión de chat."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a cualquier servidor y/o a Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Compartidos"
 
@@ -4604,7 +4623,7 @@ msgstr "El resto"
 msgid "Incomplete"
 msgstr "Incompleto"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Detenido"
 
@@ -4793,34 +4812,34 @@ msgstr "No se puede leer el archivo de semillas para el archivo de partes %s (%s
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Error al leer el archivo de semillas del archivo de partes (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Parte corrupta encontrada (%d) en %d archivo de partes %s - Resultado del hash del archivo |%s| Hash del archivo |%s|"
 msgstr[1] "Parte corrupta encontrada (%d) en %d partes del archivo %s - Resultado del hash del archivo |%s| Hash del archivo |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Parte completada encontrada (%i) en %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Recálculo del hash terminado %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Error imprevisto mientras se completaba %s. Archivo pausado"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Descarga terminada: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4829,306 +4848,306 @@ msgstr ""
 "Descarga terminada: \n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Borrando archivo: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVISO: no se puede crear el hash de la parte descargada - hashset incompleto para '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERROR: no se puede crear el hash de la parte descargada - hashset incompleto (%s). Esto no debería pasar nunca"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Parte %u de '%s' marcada completa, pero el archivo de partes es más corto de lo esperado (tiene %llu bytes, necesita %llu); reabriendo hueco para re-descargarlo."
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Se ha alcanzado el final del fichero al crear el hash de la parte descargada %u con longitud %u (máximo %u) del archivo de partes '%s' con longitud %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISO: ¡no hay suficiente espacio libre en el disco! Se pausa el archivo: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Parte descargada %i corrupta en el archivo: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: recuperada parte corrupta %i de %s -> Bytes salvados: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Asignando"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Espacio en disco insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descargado"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: no se ha podido abrir el archivo de partes '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Por defecto"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chino (simplificado)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chino (tradicional)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Inglés (Reino Unido)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr "Inglés (EE.UU.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finés"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Gallego"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Griego"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiano (suizo)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonés"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruego (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (brasileño)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Cambiar el idioma"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "No hay traducciones instaladas para aMule"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "No hay idiomas disponibles"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "no hay opciones disponibles"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida encontrada, se omite"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El puerto TCP no puede ser mayor que 65532 debido a que el socket del servidor UDP es TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puerto por defecto que será usado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Conexión"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Directorios"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Archivos"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Seguridad"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interfaz"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Firma digital"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Depurando"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5138,15 +5157,15 @@ msgstr ""
 "    %PARTFILE - ruta completa al archivo\n"
 "    %PARTNAME - nombre del archivo"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "El icono de la bandeja requiere libayatana-appindicator3 en tiempo de compilación."
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "No disponible en Wayland: el protocolo no informa cuando una ventana es minimizada, por lo que esta opción no puede interceptar el botón de minimizar del sistema. Como alternativa: lanzar aMule con `GDK_BACKEND=x11` para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5162,26 +5181,26 @@ msgstr ""
 "aMule funciona bien sin cambiar ninguno de\n"
 "estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al conectar configuración con programa, con el ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al transferir datos desde la configuración al programa, con el ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "El tipo de proxy al que se está conectando"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al transferir datos desde el programa a la configuración, con el ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5189,31 +5208,36 @@ msgstr ""
 "aMule debe reiniciarse para aplicar los cambios:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- El puerto TCP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- El puerto UDP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- La interfaz de conexión externa ha cambiado.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- El puerto para la conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- La aceptación de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- La interfaz de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- El soporte de ofuscación de protocolo ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5221,7 +5245,7 @@ msgstr ""
 "Su lista autoactualizable de servidores esta vacía.\n"
 "Se desactivará 'Autoactualizar la lista de servidores al inicio'."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5229,19 +5253,19 @@ msgstr ""
 "Tiene habilitadas las conexiones externas, pero no ha especificado ninguna contraseña.\n"
 "Las conexiones externas no pueden ser habilitadas a menos que especifique una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Carpeta temporal cambiada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Red ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5249,7 +5273,7 @@ msgstr ""
 "eD2k y Kad están desactivados.\n"
 "No podrá conectarse hasta que active al menos uno de ellos."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5257,7 +5281,7 @@ msgstr ""
 "Kad no se inicia si el puerto UDP está deshabilitado.\n"
 "Habilite un puerto UDP o deshabilite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5267,19 +5291,19 @@ msgstr ""
 "DEBE reiniciar aMule ahora.\n"
 "Si no reinicia ahora, no se queje si sucede algo malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "No se pudo registrar aMule para arrancar automáticamente al iniciar sesión. El almacén de arranque automático podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr "No se pudo eliminar la entrada de arranque automático."
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr "Arranque automático"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5289,41 +5313,41 @@ msgstr ""
 "Por favor, introduzca al menos un URL que apunte a un archivo server.met válido.\n"
 "Haga clic en el botón \"Lista\" junto a esta casilla para introducir un URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Archivos temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Archivos entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Firmas digitales"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Elija una carpeta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Buscar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Seleccione el navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Ejecutable %s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Editar la lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5331,114 +5355,114 @@ msgstr ""
 "Añada aquí los URL para descargar los archivos server.met.\n"
 "Sólo un URL por línea."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr "Error al actualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr "Datos de MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr "Fuente personalizada"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr "Datos de DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado: Cargado%s"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado: Cargado%s -%s"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: No se ha podido cargar. Haz clic en 'Actualizar ahora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: No encontrado. Haz clic en 'Actualizar ahora' para descargarlo."
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualización: %d segundo"
 msgstr[1] "Intervalo de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempo medio del gráfico: %d minuto"
 msgstr[1] "Tiempo medio del gráfico: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexiones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño del búfer de archivo: %d byte"
 msgstr[1] "Tamaño del búfer de archivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño de la cola de subida: %d cliente"
 msgstr[1] "Tamaño de la cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización de la conexión al servidor: %d minuto"
 msgstr[1] "Intervalo de actualización de la conexión al servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización de la conexión al servidor: deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ejecutar comando en el evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Habilitar la ejecución de comandos en el núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Comando del núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Habilitar la ejecución de comandos en la interfaz"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Comando de la interfaz:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Las siguientes variables serán sustituidas:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -5446,32 +5470,32 @@ msgstr ""
 "Estas carpetas parecen ubicaciones sensibles o de sistema:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartirlas recursivamente publicará todos los archivos en las redes eD2k/Kad. ¿Realmente quiere hacerlo?"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr "Confirmar carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr "Recargando los archivos compartidos..."
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr "Escaneando por subcarpetas..."
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr "Actualizando carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr "Escaneadas %u carpetas…"
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargando archivos compartidos: %u archivos escaneados"

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -211,8 +211,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "No se pudo añadir %u enlace del archivo ED2KLinks (consulte el registro para más detalles)"
 msgstr[1] "No se pudieron añadir %u enlaces del archivo ED2KLinks (consulte el registro para más detalles)"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -257,27 +257,37 @@ msgstr "Cierre de aMule completado."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados de depuración de memoria en la salida de aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Su configuración regional se ha cambiado a la predefinida del sistema debido a un cambio en la configuración. Disculpe."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -285,20 +295,20 @@ msgstr ""
 "\n"
 "Configuración de la EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fijada y conexiones externas habilitadas."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "Bootstrap de red"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -306,34 +316,34 @@ msgstr ""
 "aMule ha detectado archivos de bootstrap de red faltantes.\n"
 "Seleccione cuáles descargar:"
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se pueden asociar los puertos con la dirección especificada: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puerto %u no está disponible. Tendrás Id Baja\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -348,48 +358,48 @@ msgstr ""
 "\n"
 "Comprueba la red y asegúrate de que el puerto está abierto para salida y entrada."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Error al crear el archivo de firma online"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Error al crear el archivo de firma online de aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "El idioma seleccionado no parece estar instalado en tu sistema. (Nota: intentaré configurarlo de todos modos)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Es la primera vez que inicias aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta es una versión de prueba, actualizada diariamente, y\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no garantizamos que no rompa nada, no queme su casa,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o no mate a su perro. Pero *debería* ser seguro usarla de todas formas.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "En nuestra web podrá encontrar más información, soporte y nuevas versiones,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o en nuestro canal de IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Envíenos cualquier fallo a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -397,137 +407,137 @@ msgstr ""
 "¡El directorio que ha especificado para archivos de firma digital no es válido!\n"
 "La firma digital se ha deshabilitado hasta que lo arregle en las preferencias."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Nombre de servidor notificado"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espacio en disco para el archivo '%s' ha fallado: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no se puede abrir el archivo de registro"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: el archivo de registro está vacío. Algo está mal."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "El registro se ha borrado"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaje del servidor: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se ha descartado la descarga de %s, porque el archivo solicitado no es más nuevo."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Error al descargar la lista de nodos."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Error al abrir el archivo de comprobación de versión descargado"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Archivo de comprobación de versión dañado"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Estás usando una versión desactualizada de aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Su versión de aMule es %i.%i.%i y la última versión es %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La última versión siempre se puede encontrar en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: su versión de aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Su copia de aMule está actualizada."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Error al descargar el archivo de comprobación de la versión"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Archivos: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Archivos: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "No hay redes seleccionadas"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con Id Baja"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con Id Alta"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad detenido."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (correcto)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (tras cortafuegos)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La red Kad no se puede usar si el puerto UDP está deshabilitado en las preferencias, no se inicia."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada en las preferencias, no se conecta."
 
@@ -2593,7 +2603,7 @@ msgstr "Conexión externa: acceso denegado, razón: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: error al establecer la comunicación."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Hilo Asio %d iniciado"

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -211,8 +211,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "No se pudo añadir %u enlace del archivo ED2KLinks (consulte el registro para más detalles)"
 msgstr[1] "No se pudieron añadir %u enlaces del archivo ED2KLinks (consulte el registro para más detalles)"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -257,37 +257,42 @@ msgstr "Cierre de aMule completado."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados de depuración de memoria en la salida de aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Su configuración regional se ha cambiado a la predefinida del sistema debido a un cambio en la configuración. Disculpe."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -295,20 +300,20 @@ msgstr ""
 "\n"
 "Configuración de la EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fijada y conexiones externas habilitadas."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "Bootstrap de red"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -316,34 +321,34 @@ msgstr ""
 "aMule ha detectado archivos de bootstrap de red faltantes.\n"
 "Seleccione cuáles descargar:"
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se pueden asociar los puertos con la dirección especificada: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puerto %u no está disponible. Tendrás Id Baja\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -358,48 +363,48 @@ msgstr ""
 "\n"
 "Comprueba la red y asegúrate de que el puerto está abierto para salida y entrada."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Error al crear el archivo de firma online"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Error al crear el archivo de firma online de aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "El idioma seleccionado no parece estar instalado en tu sistema. (Nota: intentaré configurarlo de todos modos)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Es la primera vez que inicias aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta es una versión de prueba, actualizada diariamente, y\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no garantizamos que no rompa nada, no queme su casa,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o no mate a su perro. Pero *debería* ser seguro usarla de todas formas.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "En nuestra web podrá encontrar más información, soporte y nuevas versiones,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o en nuestro canal de IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Envíenos cualquier fallo a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -407,137 +412,137 @@ msgstr ""
 "¡El directorio que ha especificado para archivos de firma digital no es válido!\n"
 "La firma digital se ha deshabilitado hasta que lo arregle en las preferencias."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Nombre de servidor notificado"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espacio en disco para el archivo '%s' ha fallado: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no se puede abrir el archivo de registro"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: el archivo de registro está vacío. Algo está mal."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "El registro se ha borrado"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaje del servidor: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se ha descartado la descarga de %s, porque el archivo solicitado no es más nuevo."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Error al descargar la lista de nodos."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Error al abrir el archivo de comprobación de versión descargado"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Archivo de comprobación de versión dañado"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Estás usando una versión desactualizada de aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Su versión de aMule es %i.%i.%i y la última versión es %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La última versión siempre se puede encontrar en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: su versión de aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Su copia de aMule está actualizada."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Error al descargar el archivo de comprobación de la versión"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Archivos: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Archivos: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "No hay redes seleccionadas"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con Id Baja"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con Id Alta"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad detenido."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (correcto)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (tras cortafuegos)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La red Kad no se puede usar si el puerto UDP está deshabilitado en las preferencias, no se inicia."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada en las preferencias, no se conecta."
 
@@ -898,7 +903,7 @@ msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantien
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2259,49 +2264,49 @@ msgstr "No"
 msgid "Yes"
 msgstr "Sí"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Descarga HTTP cancelada"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "El URL a descargar no puede estar en blanco"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "No se ha podido crear la petición HTTP para %s"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "Descarga HTTP: cuerpo de respuesta vacío para %s"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "No se ha podido mover el archivo descargado a %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Descargado %s (%llu bytes)"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "La URL %s ha devuelto: %i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Descarga HTTP fallida para %s: %s"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 No autorizado para %s"
@@ -2603,7 +2608,7 @@ msgstr "Conexión externa: acceso denegado, razón: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: error al establecer la comunicación."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Hilo Asio %d iniciado"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -199,8 +199,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,27 +245,37 @@ msgstr "aMule seiskamine lõpetatud."
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule väljumise mälu veajälituse tulemus:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Sinu keelelokaat muudeti süsteemi vaikeväärtuseks seoses konfiguratsiooni muudatustega. Sorry."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -273,56 +283,56 @@ msgstr ""
 "\n"
 "EC seadistused"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "HOIATUS"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Võrgud"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Failis server.met on %i serverit"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei suuda siduda porti määratud aadressiga: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ei ole kasutatav. Sa saad LOWID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -337,48 +347,48 @@ msgstr ""
 "Kasuta netstat programmi kontrollimaks kuna port vabaneb\n"
 "ja proovi amule uuesti käivitada."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Ei suutnud luua OnlineSig Faili"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ei suutnud luua aMule OnlineSig Faili"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Tundub et valitud keelelokaat pole sinu karpi installeritud. (Märkus: Ma proovin seda seada sellest hoolimata)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "See on aMule %s käivitamise esimene kord"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "See on testversioon, mida igapäevaselt uuendatakse ja\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "me ei anna mingit garantiid, et see ei lõhu midagi, ei süüta sinu elamist\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ega tapa sinu koera. Sellest hoolimata peaks see olema *turvaline* kasutada.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Rohkem informatsiooni, tuge ja uusi programmi versioone leiad meie kodulehelt,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "aadressil https://amule-org.github.io või meie IRC kanalis #aMule aadressil irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Tunne ennast vabalt suvaliste vigade leidmisest teavitamisel aadressil https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -386,137 +396,137 @@ msgstr ""
 "Online Allkirja kataloog on VIGANE!\n"
 " Online Allkirja ei kasutata, kuni parandad vea seadetes."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Teatatud serveri nimi"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Kettaruumi eraldamine faili '%s' jaoks ebaõnnestus: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "VIGA: Ei suutnud avada logifaili"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "HOIATUS: logifail on tühi, miskit on kapitaalselt viltu."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Log on nullitud"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serveri teade: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Fail %s jäeti vahele, sest soovitud fail pole uuem."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Ebaõnnestus sõlmede nimekirja tõmbamine."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Ebaõnnestus tõmmatud versiooni kotrollfaili avamine"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Versiooni kontrollfail on korrumpeerunud"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Kasutad aegunud aMule versiooni!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sinu aMule versioon on %i.%i.%i ja uusim versioon on %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "HOAITUS: Sinu aMuled versioon on vananenud: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Sinu aMule koopia on ajakohane."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Versiooni kontrollfaili tõmbamine ebaõnnestus"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kasutajaid: %s | Faile: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kasutajaid: E: %s K: %s | Faile E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ühtegi võrku pole valitud"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "koos LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "koos HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ühendatud %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ühendun %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "eD2k ühendus katkestatud."
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad käivitatud."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad peatatud."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Ühendus Kad võrk (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Ühendus Kad võrku (tulemüüriga)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Ühendus Kad võrguga katkestatud"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad võrku ei saa kasutada kui seadetes on UDP port väljalülitatud, ei ühendu."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad on seadetes väljalülitatud, ei ühenda."
 
@@ -2587,7 +2597,7 @@ msgstr "Väline Ühendus: Ligipääs keelatud sest: "
 msgid "External Connection: Handshake failed."
 msgstr "Väline Ühendus: Kätlemine ebaõnnestus."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automaatne värskendamine on käivitatud"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -199,8 +199,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,37 +245,42 @@ msgstr "aMule seiskamine lõpetatud."
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule väljumise mälu veajälituse tulemus:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Sinu keelelokaat muudeti süsteemi vaikeväärtuseks seoses konfiguratsiooni muudatustega. Sorry."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -283,56 +288,56 @@ msgstr ""
 "\n"
 "EC seadistused"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "HOIATUS"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Võrgud"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Failis server.met on %i serverit"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei suuda siduda porti määratud aadressiga: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ei ole kasutatav. Sa saad LOWID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -347,48 +352,48 @@ msgstr ""
 "Kasuta netstat programmi kontrollimaks kuna port vabaneb\n"
 "ja proovi amule uuesti käivitada."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Ei suutnud luua OnlineSig Faili"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ei suutnud luua aMule OnlineSig Faili"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Tundub et valitud keelelokaat pole sinu karpi installeritud. (Märkus: Ma proovin seda seada sellest hoolimata)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "See on aMule %s käivitamise esimene kord"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "See on testversioon, mida igapäevaselt uuendatakse ja\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "me ei anna mingit garantiid, et see ei lõhu midagi, ei süüta sinu elamist\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ega tapa sinu koera. Sellest hoolimata peaks see olema *turvaline* kasutada.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Rohkem informatsiooni, tuge ja uusi programmi versioone leiad meie kodulehelt,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "aadressil https://amule-org.github.io või meie IRC kanalis #aMule aadressil irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Tunne ennast vabalt suvaliste vigade leidmisest teavitamisel aadressil https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -396,137 +401,137 @@ msgstr ""
 "Online Allkirja kataloog on VIGANE!\n"
 " Online Allkirja ei kasutata, kuni parandad vea seadetes."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Teatatud serveri nimi"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Kettaruumi eraldamine faili '%s' jaoks ebaõnnestus: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "VIGA: Ei suutnud avada logifaili"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "HOIATUS: logifail on tühi, miskit on kapitaalselt viltu."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Log on nullitud"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serveri teade: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Fail %s jäeti vahele, sest soovitud fail pole uuem."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Ebaõnnestus sõlmede nimekirja tõmbamine."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Ebaõnnestus tõmmatud versiooni kotrollfaili avamine"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Versiooni kontrollfail on korrumpeerunud"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Kasutad aegunud aMule versiooni!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sinu aMule versioon on %i.%i.%i ja uusim versioon on %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "HOAITUS: Sinu aMuled versioon on vananenud: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Sinu aMule koopia on ajakohane."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Versiooni kontrollfaili tõmbamine ebaõnnestus"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kasutajaid: %s | Faile: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kasutajaid: E: %s K: %s | Faile E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ühtegi võrku pole valitud"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "koos LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "koos HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ühendatud %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ühendun %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "eD2k ühendus katkestatud."
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad käivitatud."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad peatatud."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Ühendus Kad võrk (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Ühendus Kad võrku (tulemüüriga)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Ühendus Kad võrguga katkestatud"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad võrku ei saa kasutada kui seadetes on UDP port väljalülitatud, ei ühendu."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad on seadetes väljalülitatud, ei ühenda."
 
@@ -887,7 +892,7 @@ msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' katal
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2252,49 +2257,49 @@ msgstr "Ei"
 msgid "Yes"
 msgstr "Jah"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Tõmban..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP allalaadimine katkestatud"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "Tõmbamise URL ei saa olla tühi."
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Ei suuda tõmmata kasutaja '%s' jagatud faili"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Tõmmatud %d baiti"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s ütles: %i - VIGA (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP allalaadimine katkestatud"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2597,7 +2602,7 @@ msgstr "Väline Ühendus: Ligipääs keelatud sest: "
 msgid "External Connection: Handshake failed."
 msgstr "Väline Ühendus: Kätlemine ebaõnnestus."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automaatne värskendamine on käivitatud"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -21,20 +21,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Näita aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule kaugjuhtimine "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Piiluvaade:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -42,7 +42,7 @@ msgstr ""
 " eMulel põhinev, platvormist sõltumatu, p2p klient \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -51,59 +51,59 @@ msgstr ""
 "Copyright (c) 2003-2019 aMule Meeskond \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Osa aMule põhineb \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Sõlmest-Sõlmeni ruutimine põhineb XOR meetrikal.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (C) 2002-2011 Petar Maymounkov <petar@maymounkov.org>\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Web:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Foorum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kontrolli käivitumisel uue versiooni olemasolu"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Ühendun Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Kasutad aegunud aMule versiooni!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Info puudub"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -199,8 +199,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -215,47 +215,57 @@ msgstr "Ei suuda avada ED2KLinks faili."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "HOIATUS: Sa ei saa ennast eD2k lingi jaoks allikana lisada ajal kui omad lowid'd."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Ok, lahkun põhiprogrammist..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Nurjunud"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Peatan tuuma."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule seiskamine lõpetatud."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule väljumise mälu veajälituse tulemus:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Sinu keelelokaat muudeti süsteemi vaikeväärtuseks seoses konfiguratsiooni muudatustega. Sorry."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -263,56 +273,56 @@ msgstr ""
 "\n"
 "EC seadistused"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "HOIATUS"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Võrgud"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Failis server.met on %i serverit"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei suuda siduda porti määratud aadressiga: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ei ole kasutatav. Sa saad LOWID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -327,48 +337,48 @@ msgstr ""
 "Kasuta netstat programmi kontrollimaks kuna port vabaneb\n"
 "ja proovi amule uuesti käivitada."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Ei suutnud luua OnlineSig Faili"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ei suutnud luua aMule OnlineSig Faili"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Tundub et valitud keelelokaat pole sinu karpi installeritud. (Märkus: Ma proovin seda seada sellest hoolimata)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "See on aMule %s käivitamise esimene kord"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "See on testversioon, mida igapäevaselt uuendatakse ja\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "me ei anna mingit garantiid, et see ei lõhu midagi, ei süüta sinu elamist\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ega tapa sinu koera. Sellest hoolimata peaks see olema *turvaline* kasutada.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Rohkem informatsiooni, tuge ja uusi programmi versioone leiad meie kodulehelt,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "aadressil https://amule-org.github.io või meie IRC kanalis #aMule aadressil irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Tunne ennast vabalt suvaliste vigade leidmisest teavitamisel aadressil https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -376,137 +386,137 @@ msgstr ""
 "Online Allkirja kataloog on VIGANE!\n"
 " Online Allkirja ei kasutata, kuni parandad vea seadetes."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Teatatud serveri nimi"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Kettaruumi eraldamine faili '%s' jaoks ebaõnnestus: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "VIGA: Ei suutnud avada logifaili"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "HOIATUS: logifail on tühi, miskit on kapitaalselt viltu."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Log on nullitud"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serveri teade: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Fail %s jäeti vahele, sest soovitud fail pole uuem."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Ebaõnnestus sõlmede nimekirja tõmbamine."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Ebaõnnestus tõmmatud versiooni kotrollfaili avamine"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Versiooni kontrollfail on korrumpeerunud"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Kasutad aegunud aMule versiooni!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sinu aMule versioon on %i.%i.%i ja uusim versioon on %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "HOAITUS: Sinu aMuled versioon on vananenud: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Sinu aMule koopia on ajakohane."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Versiooni kontrollfaili tõmbamine ebaõnnestus"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kasutajaid: %s | Faile: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kasutajaid: E: %s K: %s | Faile E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ühtegi võrku pole valitud"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "koos LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "koos HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ühendatud %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ühendun %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "eD2k ühendus katkestatud."
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad käivitatud."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad peatatud."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Ühendus Kad võrk (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Ühendus Kad võrku (tulemüüriga)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Ühendus Kad võrguga katkestatud"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad võrku ei saa kasutada kui seadetes on UDP port väljalülitatud, ei ühendu."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad on seadetes väljalülitatud, ei ühenda."
 
@@ -546,15 +556,15 @@ msgstr "See on eMulel põhinev aMule %s."
 msgid "Running on %s"
 msgstr "Jookseb %s peal"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Külasta https://github.com/amule-org/amule/releases/latest ja vaata ehk on uuem versioon saadaval."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua stopperit."
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -564,223 +574,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Info puudub"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoog hävitatud"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Ühendun"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ühendun"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Lahutatud"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Tulemüüriga"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Ühendatud"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Ühendun"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Väljas"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Loobu"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Lõpeta käimasolevad ühenduskatsed"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Lõpeta ühendus ühendatud võrkudega"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Ühenda"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Ühendu olemasolevate, aktiivsete võrkudega"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Üles: %.1f(%.1f) | Alla: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Üles: %.1f | Alla: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ühendatud)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ühenduseta)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Kas sa tõesti tahad %s'st väljuda?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Kinnitan väljumise"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Käivitamise korraldus: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- vaikimisi -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Rüüde kataloogi  '%s' ei eksiteeri"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "HOIATUS: Ei suuda rüüfaili '%s' lugemiseks avada"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Otsingud"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Otsingu aken"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Jagatud failid"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Jagatud failide Aken"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Teated"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Teadete Aken"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Statistiliste graafikute aken"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Seaded"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Seadete aken"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Impordi"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Osafailide importimise tööriist"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Info"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Info/Appi"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k võrk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad võrk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Võrk puudub"
 
@@ -868,8 +878,8 @@ msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' katal
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Teadmata"
@@ -1232,19 +1242,19 @@ msgstr "Auto [Kõrge]"
 msgid "Very low"
 msgstr "Väga madal"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Madal"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Keskmine"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1276,7 +1286,7 @@ msgid "On Queue"
 msgstr "Järjekorras"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Tõmban"
 
@@ -1336,7 +1346,7 @@ msgstr "Kohalik server"
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1408,7 +1418,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Suurus"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Siiratud"
 
@@ -1421,7 +1431,7 @@ msgid "Progress"
 msgstr "Edenemine"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Allikaid"
 
@@ -1431,7 +1441,7 @@ msgstr "Allikaid"
 msgid "Priority"
 msgstr "Prioriteet"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Olek"
 
@@ -1464,7 +1474,7 @@ msgstr ""
 "Tagasiside : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2117,7 +2127,7 @@ msgstr "Sõprade faili 'emfriends.met' avamine kirjutamiseks ebaõnnestus!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITILINE - StartChatSession puudub klient"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Sõbrad"
 
@@ -2402,8 +2412,8 @@ msgstr "Bootstrapil vigane port"
 msgid "Please fill all fields required"
 msgstr "Palun täida kõik nõutud väljad"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Teade"
 
@@ -2475,7 +2485,7 @@ msgstr "Üles- ja allalaadimise suhe"
 msgid "Uploaded"
 msgstr "Üleslaaditud"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Küsitud"
 
@@ -2509,30 +2519,30 @@ msgstr "Versioon teadmata"
 msgid "Unable to get error description for error %d"
 msgstr "Ei suuda luua sihtkoha faili %s."
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Räsin"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Lõpetatud"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Valmis"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Peatatud"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Vigane"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Ootan"
 
@@ -2577,7 +2587,7 @@ msgstr "Väline Ühendus: Ligipääs keelatud sest: "
 msgid "External Connection: Handshake failed."
 msgstr "Väline Ühendus: Kätlemine ebaõnnestus."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automaatne värskendamine on käivitatud"
@@ -2599,7 +2609,7 @@ msgid "WARNING: "
 msgstr "HOIATUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Sulge"
 
@@ -2715,7 +2725,7 @@ msgstr "Välju"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2955,7 +2965,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3024,7 +3034,7 @@ msgstr "Puhastab lõpetatud tõmbamised"
 msgid "File sources:"
 msgstr "Faili allikad:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Üldine"
 
@@ -3045,7 +3055,7 @@ msgstr "Täis nimi :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3221,7 +3231,7 @@ msgstr "Kasutajanimi :"
 msgid "Userhash :"
 msgstr "Kasutaja kontrollsumma :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisa"
@@ -3230,15 +3240,15 @@ msgstr "Lisa"
 msgid "Download-Speed"
 msgstr "Tõmbamise kiirus"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Hetkel"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Hetke keskmine"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Seansi keskmine"
 
@@ -3250,7 +3260,7 @@ msgstr "Saatmise kiirus"
 msgid "Connections"
 msgstr "Ühendused"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktiivsed tõmbamised"
 
@@ -3258,7 +3268,7 @@ msgstr "Aktiivsed tõmbamised"
 msgid "Active connections (1:1)"
 msgstr "Aktiivseid ühendusi (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktiivsed saatmised"
 
@@ -3459,8 +3469,8 @@ msgstr "Lehitseja valik"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sisesta siia lehitsejaprogrammi nimi. Jättes välja tühjaks, kasutab süsteem vaikimisi määratud lehitsejat."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3534,751 +3544,760 @@ msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Ainult edasijõudnud kasutajatele: Kui sul on kasutada mitu võrguliidest, siis sisesta selle liidese aadress millega aMule võib ennast siduda."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Maksimaalseid allikaid tõmmatava faili kohta:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Maksimaalselt samaaegseid ühendusi:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Automaatne ühendumine käivitumisel"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Ühenduse kadumisel taasta ühendus"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Eemalda surnud server peale"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "katset"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Käivitamisel värskenda automaatselt serverite nimekirja"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Loend"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Värskenda serverite nimekirja serveriga ühendumisel"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Värskenda serverite nimekirja kliendi ühendumisel"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Kasuta prioriteedisüsteemi"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Ühendumisel kasuta nutikat LowID kontrolli "
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Ohutu ühendumine"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Automaatne ühendumine ainult staatilises serverinimekirjas olevate serveritega"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Määra käsitsi lisatud serveritel Kõrge Prioriteet"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligentne Riknemise Vältimine (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Luba"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Laiendatud I.C.H. usaldab suvalist kontrollsummat (pole soovitatav valik)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Lisa failid tõmbamiseks peatatud olekus"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Lisa failid tõmbamiseks automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Proovi alustuseks tõmmata esimene ja viimane tükk"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Alusta järgmise peatatud failiga, kui fail lõpetab"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Samast kategooriast"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "Tähestikulises järjekorras"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Eralda kettaruum uute failide jaoks"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Eraldab uuet failide jaoks vajamineva kettaruumi, seeläbi väheneb faili fragmenteerumine"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Lõpeta tõmbamine, kui vaba kettaruumi on jäänud "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vali see kui soovid et aMule sinu kettaruumi kontrolliks"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Sisesta siia vähim soovitud kettaruum"
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvesta haruldaste failide 10 allikat (< 20 allikat)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Saatmised"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Lisa uued jagatud failid automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Tõmmatavate failide kataloog"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rekursiivseks jagamiseks tee paremklikk kataloogi ikoonil)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Jaga peidetud failid"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Graafikud"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Värskenduste vahe : 5 sekundit"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Keskmine graafiku aeg: 100 minutit"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Ühenduse graafiku skaala: 100"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Tõmbamise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Saatmise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Värvid: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Taust"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Alusvõrk"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Allalaadimine, jooksev"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Allalaadimine, jooksev keskmine"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Allalaadimine, seansi keskmine"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Saatmine hetkel"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Hetke saatmise keskmine"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Seansi keskmine saatmine"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktiivseid ühendusi"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Süsteemiriba Kiirvaliku Ikoon"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Kad-sõlmi hetkel"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kad-sõlmi jooksvalt"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kad-sõlmi seansis"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Vali"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Kuvatavate Kliendi Versioonide arv (0=piiramatu)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! HOIATUS !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Maksimaalne arv uusi ühendusi / 5 sek."
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Faili puhvri suurus: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Saatmise saba suurus: 5000 klienti"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveriühenduse värskenadamise intervall: Ei kasuta"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Keela arvuti ajastatud uinumine"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Kasutatav rüü: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näita igas aknas \"Kiiret eD2k lingi käsitlejat\". "
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Näita kategooria juures laiendatud infot"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Eelmise rakenduse nimi"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Järgneva rakenduse nimi"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Näita raisatud ribalaiust"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Vertikaalne tööriistariba paigutus"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Tõmbamise Järjekorrafailid"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Näita edenemist protsentuaalselt"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Näita edenemise riba"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Lame"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Ümar"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Sorteeri failid automaatselt (high CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule sorteerib tulbad tõmbamise sabas automaatselt"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Välisühenduse parameetrid"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Aksepteeri väliseid ühendusi"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "Kuulava liidese IP aadress:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sisesta siia välisühenduse liidese kehtiv ip aadress a.b.c.d formaadis. Tühi väli või 0.0.0.0 tähendab suvalist liidest."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Luba UPnP pordisuunamist EC pordile"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parool"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Käivita WEBserver koos aMulega"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "WEB näidis/mall"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Täisõiguste parool"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Luba madalate õigustega kasutaja"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Madalate õiguste parool"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Luba webservri portide UPnP pordisuunamist"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserveri UPnP TCP port (Valikuline)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Lehekülje värskendusaeg (sekundites)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Luba Gzip pakkimine"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Sobib"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Seadetes tehtud muudatuste jõustamiseks klikka siia."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Tühista kõik seadetes tehtud muudatused."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Tiitel :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Kommentaar :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Tõmmatud failide kataloog :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Muuda uute failide prioriteeti :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Ära muuda"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vali praegu valitud kategooriale värv :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Algväärtusta"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Klikates seda nuppu tühjendad logi."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sellele nupule klikates värskendad serverite loetelu URL ilt ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Serverite nimekiri"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Sisesta siia server.met faili asukoha URL ja pressi vasakul olevat nuppu tuntud serverite nimekirja värskendamiseks."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Lisa server käsitsi: Nimi"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Sisesta siia uue serveri nimi"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sisesta siia serveri IP aadrdess, kasutades x.x.x.x formaati."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Sisesta siia serveri port."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Täites esiteks vasakul olevad väljad, lisa server käsitsi ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule Logi"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Serveri info"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikates sellele nupule värskendad sõlmede loetelu URL'ilt ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Sõlmed (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Sisesta siia nodes.dat faili url ja pressi vasakul olevat nuppu, et tuntud sõlmede loetelu täiendada."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Sõlmede statistika"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Uus sõlm"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Tuntud klientide Bootstrap"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Lõpeta Kad ühendus"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Kasuta Turvalist Kasutaja tuvastamist"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "On soovitatav see omadus lubada. Sa ei saa krediiti kui SUI on välja lülitatud."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokolli Hämamine"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Protokolli Hämamine lubatud"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "See valik lülitab Protokolli Hämamise sisse ja sunnib aMule aksepteerima ainult teiste klientide hämatud ühendusi."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kasuta väljuvatel ühendustel hämamist"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "See valik sunnib aMule kasutama teiste serverite/klientidega ühendumisel Protokolli Hämamist."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Aksepteeri ainult hämatud ühendusi"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "See valik sunnib aMule aksepteerima ainult hämatud ühendusi. Sul on vähem allikaid aga kogu liiklus on hämatud."
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Igaüks"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Mitte keegi"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Kes näeb minu jagatud faile:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vali, kes võib vaatamiseks küsida sinu jagatud falide nimekira."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP-Filtreerimine"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtreeri kliente"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda klientide IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtreeri servereid"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda serverite IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Lae loetelu uuesti"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Taaslae filtreeritavad IP aadressid failist ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Värskenda"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Filtreerimise tase:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filtreeri alati LAN IP aadresse"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Mitteklappivate IP aadresside paranoiline käitlemine"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Viskab paketi minema kui kliendi IP erineb paketi saatja IP aadressist. Kasuta ettevaatlikult."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Kasuta süsteemi ipfilter.dat kui see on saadaval"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Kui kohalik ipfilter.dat fail puudub, kasuta süsteemi globaalset ipfilter faili."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Luba Online-Allkiri"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Võimaldab kirjutada OS faile, mida saavad kasutada välised rakendused kasvõi allkirja loomiseks."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Värskenduse sagedus (Sek):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuda Online Allkirja värskendamise (sekundites) sagedust."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Salvesta online ollkirja fail: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Siin saad valida kataloogi kus asub sinu Online Allkirja fail."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Näita klientide riigi lippe"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Andmekiirus :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Allikaid"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4286,11 +4305,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4300,226 +4319,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Tõmbamine: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtreeri saabuvaid teateid (va. käimasolev vestlus):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtreeri kõiki teateid"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtreeri sinu sõbralistiväliste kodanike teateid"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtreeri tundmatute klientide teateid"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "lisa siia sõnad mille amule peab väljafiltreerima ja bloki teated mis seda sisaldavad"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Näita logis saabunud teateid"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Kommentaarid"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Nõua autoriseerimist"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Autoriseerimisel Kasuta/Ära kasuta kasutajanime/parooli"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Kasutajanimi: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Puhverserveriga ühenduseks vajalik kasutajanimi"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Parool:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Puhverserveri kasutamiseks vajalik parool"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Kasuta puhverserverit"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Kasuta/ärakasuta puhverserveri tuge"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Puhverserveri tüüp:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Puhverserveri nimi:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Selle puhverserveri/hosti nimi "
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Puhverserveri port:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Selle puhverserveri pordi number"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Ühendu :"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Logi sisse eemalasuvasse amuula"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Kasutaja nimi"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Pea need seaded meeles"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Kasuta gzip pakkimist"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Võimalda inimkieelne Veajälitus-Logimine"
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Ava Fail"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Saadetav teade:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ootan..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Lisa imporditavad"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Proovi valitutega uuesti"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Eemalda valitud"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Sündmuse tüübid"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika ja järjekorras kliendid valitud faili(de) kohta : Sessioon / Kokku"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Protsenti kogufailidest"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Kõik failid"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Valitud failid"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Ainult aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Taaslae:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Saada"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Saada määratud teade."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Sulge see vestlus-seanss."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Ühendu suvalise serveri ja/või Kad võrguga"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Jagatud failid"
 
@@ -4596,7 +4615,7 @@ msgstr "kõik teised"
 msgid "Incomplete"
 msgstr "Poolik"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Peatatud"
 
@@ -4786,342 +4805,342 @@ msgstr "Salvestatud %i allikat osafailile: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "VIGA osafaili toitefaili lugemisel (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Leidsin riknenud osa (%d) %d osast fail '%s' - Arvutatud Kontrollsumma |%s| Saadetud Kontrollsumma |%s|"
 msgstr[1] "Leidsin riknenud osa (%d) %d osast fail '%s' - Arvutatud Kontrollsumma |%s| Saadetud Kontrollsumma |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Leitud lõpetatud osa (%i)  %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "'%s' faili kontrollsumma arvutamine lõpetatud"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Ootamatu viga %s lõpetamisel. Fail peatatud"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Faili '%s' tõmbamine lõpetatud"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Faili '%s' tõmbamine lõpetatud"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Kustutan faili: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "HOIATUS: Ei suuda tõmmatud osale arvutada kontrollsummat - kontrollsumma on mittetäielik '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "VIGA: ei suuda tõmmatud osale arvutada kontrollsummat- kontrollsumma on mittetäielik(%s). Seda ei tohiks kunagi juhtuda."
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "HOIATUS: Pole piisavalt vaba kettaruumi! Pausin faili: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Tõmmatud osa %i on failis %s vigane"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Taastatud riknenud osa %i %s jaoks -> Päästsin: %s baiti"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Eraldamine"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Ebapiisav kettaruum"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Allalaetud"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIGA: Osafaili '%s' avamine ebaõnnestus"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albaania"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Araabia"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgaaria"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Kataloonia"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Hiina (Lihtsustatud)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Hiina (Traditsiooniline)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Kroaatia"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Tšehhi"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Taani"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Hollandi"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Eesti"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Soome"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Prantsuse"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galiitsia"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Kreeka"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Heebrea"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Ungari"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Itaalia"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Itaalia (Shveits)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Jaapani"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Leedu"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norra"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Poola"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brasiilia)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Rumeenia"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Vene"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Sloveenia"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Hispaania"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Rootsi"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Türgi"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Muuda keel"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Info puudub"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "valikud puuduvad"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Leidsin vigase kategooria, ignoreerin"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port ei saa olla suuerm kui 65532, sest serveri UDP soket on TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Kasutan vaikimisi porti (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Ühendus"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Serverid"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Failid"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Turvalisus"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Liides"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Puhverserver"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtrid"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Kaugjuhtimine"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Online Allkiri"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Muud"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Sündmused"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Veajälitus"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5131,15 +5150,15 @@ msgstr ""
 "   %PARTFILE - fail täis rada\n"
 "   %PARTNAME - faili nimi"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5155,26 +5174,26 @@ msgstr ""
 "aMule toimib ilusasti ilma siinolevaid seadeid muutmata\n"
 "You Are WARNED!!."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Widgeti ühendamine Cfg'a, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Andmete ülekandmine Cfg'st Widget'isse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Selle puhverserveri tüüp kuhu sa ühendud"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Andmete ülekandmine Widgetist Cfg'sse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5182,32 +5201,37 @@ msgstr ""
 "Nende muudatuste jõustamiseks pead aMUle taaskäivitama:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Välisühenduse liides muutunud.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Välisühenduse port on muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Välisühenduse luba on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Välisühenduse liides muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli Hämamine"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5215,7 +5239,7 @@ msgstr ""
 "Sinu automaane serverinimekirja värskendamise loetelu on tühi.\n"
 "Käivitamisel serverinimekirja automaatselt ei uuendata."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5223,19 +5247,19 @@ msgstr ""
 "Lülitasid sisse välised ühendused kuid ei määranud parooli.\n"
 "Väliseid ühendusi ei saa enne kehtiva parooli määramist kasutada."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Keel on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Ajutiste failide kataloog on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K võrk on lubatud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5243,7 +5267,7 @@ msgstr ""
 "Mõlemad, nii eD2k kui ka Kad võrgud on mitteaktiivsed.\n"
 "Sa ei saa ühenduda enne, kui vähemalt üks neist on aktiivne."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5251,7 +5275,7 @@ msgstr ""
 "Kad ei saa käivitada kuni UDP port on väljalülitatud.\n"
 "Lülita UDP port sisse, või Kad välja."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5261,20 +5285,20 @@ msgstr ""
 "Sa PEAD aMule nüüd taaskäivitama.\n"
 "Kui sa seda ei tee siis ära tänita kui midagi paha juhtub.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaatne värskendamine on käivitatud"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5284,41 +5308,41 @@ msgstr ""
 "Palun sisesta vähemalt üks server.met faili asukoha kehtiv URL.\n"
 "URL sisestamiseks kliki nupule 'Loend'."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Ajutised failid"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Saabuvad failid"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Online Allkirjad"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vali %s kataloog"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Otsi filmi taasesitamise programmi"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Vali lehitseja (browser)"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Käivitusprogramm%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Muuda serverite nimekirja"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5326,149 +5350,149 @@ msgstr ""
 "Lisa siia server.met faili(de) laadimise URL.\n"
 "Üks URL rea kohta."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Täielikke allikaid"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Värskenduse viide: %d sekundit"
 msgstr[1] "Värskenduse viide: %d sekundit"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskmiste graafiku aeg: %d minutit"
 msgstr[1] "Keskmiste graafiku aeg: %d  minutit"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ühenduse graafiku skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Failipuhvri suurus: %d baiti"
 msgstr[1] "Failipuhvri suurus: %d baiti"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Saatmise Saba suurus: %d klienti"
 msgstr[1] "Saatmise Saba suurus: %d klienti"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveri ühenduse värskendamise intervall: %d minutit"
 msgstr[1] "Serveri ühenduse värskendamise intervall: %d minutit"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveri ühenduse värskendamise intervall: Ei kasuta"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "keelatud"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Käivita käsk peale '%s' sündmust"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Luba käskude käivitamine tuumas"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Tuumkäsk:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Luba käskude käivitamine GUI's"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "GUI Käsk:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Järgnevad muutujad asendatakse:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Jagatud failide loetelu taaslaadimine."

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -200,8 +200,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -246,27 +246,37 @@ msgstr "aMule itzaltzea osaturik."
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule ixtearen memoria arazte irteera:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Zure lokalak sistemako lehenetsira aldatu dira konfigurazio aldaketa bat dela eta. Barkatu."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Argb"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -274,56 +284,56 @@ msgstr ""
 "\n"
 "EC konfigurazioa"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "OHARRA"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sareak"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "zerbitzari %i aurkiturik server.met fitxategian"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ezin da atakak ezarritako helbidean ireki: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "%u ataka ez dago eskuragarri. IDBaxua izango duzu\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -338,48 +348,48 @@ msgstr ""
 "\n"
 "Egiaztatu zure sarea ataka sarrera eta irteerarako irekirik dagoela ziurtatzeko."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Huts online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Huts aMule online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Aukeratutako lokalak ez dirudi zure sisteman instalaturik. (Oharra: Hala ere erabiltzen saiatuko da)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule %s abiarazten duzun lehen aldia da"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bertsioa hau beta bertsio bat da, egunero eguneratzen da, eta\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ez gara ezer apurtu, zure etxea erre, edo zure zakurra akatzen\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "badu ere kargu egingo. Baina erabiltzeko ziurra izan *beharko* litzateke.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Argibide gehiago, laguntza eta bertsio berriak gure webgunean aurki ditzakezu,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io -en, edo irc.libera.chat IRC sareko #aMule kanalean.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Edozein akatsen berri emateko:https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -387,137 +397,137 @@ msgstr ""
 "Zuk aukeratutako sinadura karpeta BALIOGABEA da!\n"
 " Lehenespenak konpondu artean lineako sinadura EZGAITU egingo da."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Zerbitzari ostalari-izena notifikatua"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Disko aurresleipenak huts egin du '%s' fitxategiarentzat: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ERROREA: ezin da erregistro fitxategia ireki"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ABISUA: erregistro fitxategia hutsik dago. Zerbait oker dago."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Erregistroa berrezarri egin da"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ZerbitzariMezua: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s-ren deskarga baztertua, eskatutako fitxategia ez da berria eta."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Huts egin du nodo zerrenda deskargatzerakoan."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Hondaturiko bertsio arakatze fitxategia"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Zure aMule bertsioa %i.%i.%i da eta azken bertsioa %li.%li.%li da"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OHARRA: Zure aMuled bertsioa zaharkiturik dago: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Zure aMule kopia zaharkiturik dago."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Huts bertsio arakatze fitxategia deskargatzerakoan"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Erab: %s | Fitx: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Erab: E: %s K: %s | Fitx: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ez dago sarerik hautatuta"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "IDBaxuarekin"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "IDAltuarekin"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s-ra konektaturik"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s-ra konektatzen"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "eD2k-tik deskonektatua"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad abiarazirik."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad gelditurik."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Kad-era Konektatuta (ondo)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad-era Konektatuta (suebakirik)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Kad-etik deskonektatua"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad sarea ezin da erabili hobespenetan UDP ataka ezgaiturik badago, ez da abiaraziko."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad sarea hobespenetan ezgaiturik, ez da konektatuko."
 
@@ -2588,7 +2598,7 @@ msgstr "Kanpo konexioa: Sarrera ukatze arrazoia: "
 msgid "External Connection: Handshake failed."
 msgstr "Kanpo Konexioa: Esku-emateak huts egin du."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP deskarga haria hasia"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -22,20 +22,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "aMule erakutsi"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule urruneko kontrola "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Argazkia:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -43,7 +43,7 @@ msgstr ""
 "'Plataforma-orotarako' p2p bezeroa eMulen oinarritua \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -52,59 +52,59 @@ msgstr ""
 "Copyright (c) 2003-2019 aMule taldea \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "aMuleren zati bat \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Parez-pareko routing-a XOR metrikan oinarritua.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Webgunea:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Foroa:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Arakatu bertsio berrien bila abiaraztean"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kad-era konektatzen..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ez dago erabilgarri"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -200,8 +200,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -216,47 +216,57 @@ msgstr "Huts ED2KLinks fitxategia irekitzerakoan."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "KONTUZ: Ezin duzu zure burua ezarri eD2k lotura batean Id baxua duzunean."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Orain, aplikazio nagusia ixten..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia amaitzen ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia hiltzen ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule irteten: Muina ixten."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule itzaltzea osaturik."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule ixtearen memoria arazte irteera:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Zure lokalak sistemako lehenetsira aldatu dira konfigurazio aldaketa bat dela eta. Barkatu."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Argb"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -264,56 +274,56 @@ msgstr ""
 "\n"
 "EC konfigurazioa"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "OHARRA"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sareak"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "zerbitzari %i aurkiturik server.met fitxategian"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ezin da atakak ezarritako helbidean ireki: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "%u ataka ez dago eskuragarri. IDBaxua izango duzu\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -328,48 +338,48 @@ msgstr ""
 "\n"
 "Egiaztatu zure sarea ataka sarrera eta irteerarako irekirik dagoela ziurtatzeko."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Huts online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Huts aMule online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Aukeratutako lokalak ez dirudi zure sisteman instalaturik. (Oharra: Hala ere erabiltzen saiatuko da)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule %s abiarazten duzun lehen aldia da"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bertsioa hau beta bertsio bat da, egunero eguneratzen da, eta\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ez gara ezer apurtu, zure etxea erre, edo zure zakurra akatzen\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "badu ere kargu egingo. Baina erabiltzeko ziurra izan *beharko* litzateke.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Argibide gehiago, laguntza eta bertsio berriak gure webgunean aurki ditzakezu,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io -en, edo irc.libera.chat IRC sareko #aMule kanalean.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Edozein akatsen berri emateko:https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -377,137 +387,137 @@ msgstr ""
 "Zuk aukeratutako sinadura karpeta BALIOGABEA da!\n"
 " Lehenespenak konpondu artean lineako sinadura EZGAITU egingo da."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Zerbitzari ostalari-izena notifikatua"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Disko aurresleipenak huts egin du '%s' fitxategiarentzat: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ERROREA: ezin da erregistro fitxategia ireki"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ABISUA: erregistro fitxategia hutsik dago. Zerbait oker dago."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Erregistroa berrezarri egin da"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ZerbitzariMezua: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s-ren deskarga baztertua, eskatutako fitxategia ez da berria eta."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Huts egin du nodo zerrenda deskargatzerakoan."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Hondaturiko bertsio arakatze fitxategia"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Zure aMule bertsioa %i.%i.%i da eta azken bertsioa %li.%li.%li da"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OHARRA: Zure aMuled bertsioa zaharkiturik dago: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Zure aMule kopia zaharkiturik dago."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Huts bertsio arakatze fitxategia deskargatzerakoan"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Erab: %s | Fitx: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Erab: E: %s K: %s | Fitx: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ez dago sarerik hautatuta"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "IDBaxuarekin"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "IDAltuarekin"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s-ra konektaturik"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s-ra konektatzen"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "eD2k-tik deskonektatua"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad abiarazirik."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad gelditurik."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Kad-era Konektatuta (ondo)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad-era Konektatuta (suebakirik)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Kad-etik deskonektatua"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad sarea ezin da erabili hobespenetan UDP ataka ezgaiturik badago, ez da abiaraziko."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad sarea hobespenetan ezgaiturik, ez da konektatuko."
 
@@ -547,15 +557,15 @@ msgstr "Hau eMulen oinarrituriko aMule %s da."
 msgid "Running on %s"
 msgstr "%s-n abiarazirik"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bisitatu https://github.com/amule-org/amule/releases/latest gunea bertsio berriagorik eskuragarri dagoen jakiteko."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE KONPONEZINA: Huts kronometroa sortzean"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -565,223 +575,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Ez dago erabilgarri"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMule elkarrizketa suntsitua"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Konektatzen"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Konektatzen"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deskonektatua"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Suebakirik"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Konektaturik"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Konektatzen"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Itzalia"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Utzi"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Geratu uneko konexio saiakerak"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Deskonektatu konektatutako sareetatik"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Konektatu"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Konektatu gaituriko sareetara"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gora: %.1f(%.1f) | Behera: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gora: %.1f | Behera: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Konektaturik)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ez konektaturik)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Benetan %s utzi egin nahi duzu?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Irteera berrespena"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Abiarazi komandoa: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- lehenetsia -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ez dago '%s' itxura direktorioa"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ABISUA: Ezin da '%s' azal fitxategia irakurri"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Sareak"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Sare leihoa"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Bilaketak"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Bilaketa leihoa"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Deskargak"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Deskargak leihoa"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Partekatutako fitxategiak"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Partekatutako fitxategi leihoa"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Mezuak"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Mezu leihoa"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estatistikak"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Estatistika grafiko leihoa"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Hobespenak"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Hobespen ezarpen leihoa"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Inportatu"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Zati fitxategi inportazio tresna"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Honi buruz"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Honi buruz/Laguntza"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k sarea"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad sarea"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Sarerik ez"
 
@@ -869,8 +879,8 @@ msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa m
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Ezezaguna"
@@ -1233,19 +1243,19 @@ msgstr "Auto[Alt]"
 msgid "Very low"
 msgstr "Oso txikia"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Baxua"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normala"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1277,7 +1287,7 @@ msgid "On Queue"
 msgstr "Ilaran"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Deskargatzen"
 
@@ -1337,7 +1347,7 @@ msgstr "Zerbitzari lokala"
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1409,7 +1419,7 @@ msgstr "Zatia"
 msgid "Size"
 msgstr "Tamaina"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Transferituta"
 
@@ -1422,7 +1432,7 @@ msgid "Progress"
 msgstr "Egoera"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Jatorriak"
 
@@ -1432,7 +1442,7 @@ msgstr "Jatorriak"
 msgid "Priority"
 msgstr "Lehentasuna"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Egoera"
 
@@ -1465,7 +1475,7 @@ msgstr ""
 "Erantzuna hemendik: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2118,7 +2128,7 @@ msgstr "Huts 'emfriends.met' lagun zerrenda fitxategia idazteko irekitzean!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKOA - ez dago bezerorik StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Lagunak"
 
@@ -2403,8 +2413,8 @@ msgstr "Abiarazteko ataka baliogabea"
 msgid "Please fill all fields required"
 msgstr "Beharrezko eremu guztiak bete"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Mezua"
 
@@ -2476,7 +2486,7 @@ msgstr "Partekatze erlazioa"
 msgid "Uploaded"
 msgstr "Igoa"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Eskatutakoa"
 
@@ -2510,30 +2520,30 @@ msgstr "%d errore ezezaguna"
 msgid "Unable to get error description for error %d"
 msgstr "Ezin da %d errorearen azalpena eskuratu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Aztertzen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Osotzen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Amaitua"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Geraturik"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Akasdun"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Zain"
 
@@ -2578,7 +2588,7 @@ msgstr "Kanpo konexioa: Sarrera ukatze arrazoia: "
 msgid "External Connection: Handshake failed."
 msgstr "Kanpo Konexioa: Esku-emateak huts egin du."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP deskarga haria hasia"
@@ -2600,7 +2610,7 @@ msgid "WARNING: "
 msgstr "OHARRA: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Itxi"
 
@@ -2716,7 +2726,7 @@ msgstr "Irten"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2956,7 +2966,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3025,7 +3035,7 @@ msgstr "Garbitu amaituriko deskargak"
 msgid "File sources:"
 msgstr "Fitxategiaren iturburua:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Orokorra"
 
@@ -3046,7 +3056,7 @@ msgstr "Izen osoa :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "E/G"
 
@@ -3222,7 +3232,7 @@ msgstr "Erabiltzaile-izena :"
 msgid "Userhash :"
 msgstr "Erabiltzaile aztertze zenbakia :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Gehitu"
@@ -3231,15 +3241,15 @@ msgstr "Gehitu"
 msgid "Download-Speed"
 msgstr "Deskarga abiadura"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Unekoa"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Funtzionamendu bataz bestekoa"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "saio batez bestekoa"
 
@@ -3251,7 +3261,7 @@ msgstr "Igoera abiadura"
 msgid "Connections"
 msgstr "Konexioak"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Deskarga aktiboak"
 
@@ -3259,7 +3269,7 @@ msgstr "Deskarga aktiboak"
 msgid "Active connections (1:1)"
 msgstr "konexio aktiboak (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Igoera aktiboak"
 
@@ -3460,8 +3470,8 @@ msgstr "Nabigatzaile hautaketa"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Idatzi zure nabigatzaile izena hemen. Zurian utzi sisteman lehenetsitako nabigatzailea erabiltzeko."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3535,750 +3545,759 @@ msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Erabiltzaile aurreratuak bakarrik: Sare interfaze anitz badituzu idatzi amulek erabili behar duen sare interfazearen helbidea."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Jatorri muga deskarga bakoitzerako:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Aldibereko konexioa muga:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Konektatu abiaraztekoan"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "birkonektatu konexioa galtzean"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Ezabatu hildako zerbitzaria geroago"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "saiakerak"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Auto-eguneratu zerbitzari zerrenda abioan"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Zerrenda"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Eguneratu zerbitzari zerrenda zerbitzari batetara konektatzean"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Eguneratu zerbitzari zerrenda bezero bat konektatzean"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Erabili lehentasun sistema"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Erabili IDbaxu egiaztapena konektatzerakoan"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Konexio ziurra"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Estatiko zerbitzarietara bakarrik auto-konektatu"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Ezarri eskuz gehitutako zerbitzariak lehentasun altuan"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Hondatze kudeaketa adimentsua (I.C.H)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Gaitu"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H aurreratuak, egiaztapen bakoitza egiaztatzen du (ez da gomendatzen)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Gehitu fitxategiak deskargetara geldirik"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Gehitu fitxategiak deskarga zerrendara auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Saiatu lehen eta azken zatiak hasieran deskargatzen"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Abiarazi lehen pausaturiko fitxategia fitxategi bat osatzean"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Kategoria berdinekoa"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "Orden alfabetikoan"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Aurresleitu disko lekua fitxategi berrientzat"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Fitxategi berrientzat fitxategi bakoitzarentzat disko leku osoa aurresleitzen du, honek fragmentazioa murrizten du"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Gelditu deskargak disko-leku librea hona iristean "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Aukera hau hautatu aMulek zure disko-lekua egiaztatzea nahi baduzu"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Ezarri hemen nahi duzu disko toki txikiena."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "10 jatorri gorde fitxategi arraroentzat (< 20 jatorri)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Igoerak"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Gehitu partekatutako fitxategi berriak auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Deskargentzat helburu karpeta"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Egin klik eskuineko botoiaz karpeta ikono batean barnekoak ere partekatzeko)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Partekatu ezkutatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafikak"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Eguneratze atzerapena : 5 seg"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Bataz besteko grafiko denbora : 100 min"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Konexio graf eskala: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Deskarga grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Igoera grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Koloreak: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Atzeko planoa"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Sareta"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Uneko deskargak"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Martxan deskargak bataz bestean"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Saioaren bataz besteko deskargak"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Uneko igoerak"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Martxan igoerak bataz bestean"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Saioaren bataz besteko igoerak"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Konexio aktiboak"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistema-barra abiadura-barra ikonoa"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Uneko Kad-nodoak"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kad-nodoak martxan"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kad-nodo saioa"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Hautatu"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Zuhaitza"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Erakutsiko diren bezero kopurua (0=mugagabea)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! KONTUZ !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Gehienezko konexio berri / 5 seg"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fitxategia buffer tamaina: 240000 byte"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Igoera ilara tamaina: 5000 bezero"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Zerbitzari konexio berritze aldia: Ezgaiturik"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Ezgaitu ordenagailu ordulariaren bigarren planoko modua"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Erabiltzeko azala: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Erakutsi \"eD2k lotura kudeatzaile azkarra\" leiho bakoitzean."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Erakutsi argibide hedatuak kategoria fitxetan"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Erakutsi aplikazio bertsioa izenburuan"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Erakutsi transferentziak izenburuan"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Aplikazio izenaren aurretik"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Aplikazio izenaren ondoren"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Erakutsi goiburu erabilpena"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Tresna-barra bertikal orientazioa"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Deskargatu ilara fitxategiak"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Erakutsi aurrerapen ehunekoa"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Erakutsi aurrerapen barra"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Laua"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Biribildu"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Auto-ordenatu fitxategiak (PUZ handia)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "Amule-k zure deskarga zerrendako zutabeak automatikoki sailkatuko ditu"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Urruneko konexio ezarpenak"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Onartu urruneko konexioak"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "Entzunean dagoen interfazearen IPa:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Idatzi hemen a.b.c.d formatuan entzun behar den interfazearen baliozko ip helbidea. Eremu huts batek edo 0.0.0.0 ezartzeak edozein interfazetan entzutea eragingo du."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP berbideraketa gaitu EC atakan"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Pasahitza"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Exekutatu web-zerbitzaria abioan"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Web txantiloia"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Baimen osorako pasahitza"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Gaitu baimen gutxiko erabiltzailea"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Baimen baxuko pasahitza"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Gaitu web zerbitzari atakaren UPnP ataka birbidalketa"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web zerbitzari UPnP ataka (aukerakoa)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Orrialdea berritzeko denbora (segundotan)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Gaitu Gzip konpresioa"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Ados"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hemen klik egin hobespenetan eginiko edozein aldaketa ezartzeko."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Berrezarri hobespenetan eginiko edozein aldaketa."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titulua :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Iruzkina :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Deskarga direktorioa :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Aldatu lehentasuna fitxategi berrientzat :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Ez aldatu"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Hautatu kolorea kategoria honentzat (unean aukeratutakoa) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Garbitu"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Botoi hau klikatu erregistroa garbitzeko."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik egin botoi honetan zerbitzari zerrenda URL-tik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Zerbitzari zerrenda"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Idatzi server.met fitxategiaren URL bat hemen eta gero ezkerreko botoia sakatu zerbitzari ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Gehitu zerbitzaria eskuz: Izena"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Idatzi zerbitzari berriaren izen hemen"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP ataka"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Idatzi x.x.x.x formatua erabiliaz zerbitzariaren ip helbidea."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Gehitu zerbitzari bat eskuz (sar datuak ezkerrean lehenik) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule erregistroa"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Zerbitzari argibideak"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Argb"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad Argb"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikatu botoi honetan nodo zerrenda URL honetatik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nodoak (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "nodes.dat fitxategi baten URL-a idatzi eta ezkerreko botoia sakatu nodo ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Nodo estatistikak"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Autoabioa"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nodo berria"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Ataka:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Bezero ezagunetarik abiarazi"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Kad deskonektatu"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Erabili erabiltzaile identifikazio segurua"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Gomendagarri da aukera hau gaitzea. Ez duzu krediturik jasoko EIS erabiltzen ez baduzu."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Gaitu protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Aukera honek protokolo nahastea gaitzen du eta aMule-k beste bezeroetako konexio nahastuak onartzea eragite du."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Erabili nahastea kanporako konexioetan"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Aukera honek Amulek beste bezero/zerbitzarietara konektatzerakoan protokolo nahastea erabiltzea eragiten du."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Onartu nahasitako konexioak bakarrik"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Aukera honek Amulek nahasitako konexioak bakarrik onartzea eragiten du. Jatorri gutxiago izango dituzu baina zure trafiko guztia nahasia egongo da"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Edozeini"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Bat ere ez"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Nork ikusi ditzaken nire partekatutako fitxategiak:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Hautatu zure partekatutako fitxategiak nork ikus ditzakeen."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP-Iragazkia"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Bezeroak iragazi"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako bezero IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Zerbitzariak iragazi"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako zerbitzari IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Berritu zerrenda"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Berritu ~/.aMule/ipfilter.dat fitxategian ezarritako IP helbideen iragazkia"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL-a:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Eguneratu orain"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Iragazki maila:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Beti iragazi LAN IP-ak"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoia kudeaketa pareko ez diren IP helbideentzat"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Paketea atzera bota bezero ip-a paketea jaso den ip-aren ezberdina bada. Kontu handiaz erabili."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Erabili sistemako ipfilter.dat eskuragarri badago"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ez bada ipfilter.dat fitxategi lokalik aurkitu, orduan onartu sistema ipfilter fitxategia erabiltzea."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Gaitu sinadura linean"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Gaitu sistemak fitxategiak idaztea, kanpo programek sinadurak sortu ahal izateko egiten da."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Eguneratu maiztasuna (Seg):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Aldatu linean sinadura eguneraketa aldia (segundotan)."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Gorde sare sinadura fitxategia hemen: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikatu hemen linean sinadurak dituen karpeta aukeratzeko."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Bistarazi estatu banderak bezeroentzat"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Data abiadura :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Jatorriak"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4286,11 +4305,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4300,226 +4319,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Deskargak: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "sarrera mezu iragazkia (txat honetan ezik):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Mezu guztiak iragazi"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Lagun zerrendan ez daudenen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Bezero ezezagunen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Hau duten mezuak iragazi (erabili ',' bereizle bezala):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Gehitu amulek mezuetan blokeatzea nahi dituzun hitzak"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Ikusi jasotako mezuak erregistroan"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Iruzkinak"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fitxategi iruzkinak hau du (',' erabili bereizle gisa):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Gaitu autentifikazioa"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "erabiltzaile/pasahitz autentifikazioa gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Erabiltzaile izena: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Pasahitza:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den pasahitza"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Proxy-a gaitu"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Proxy onarpena gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Proxy mota:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Proxy ostalaria:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Proxy ostalari izena"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Proxy ataka:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Proxy ataka"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Hona konektaturik:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Urruneko aMulen saioa hasi"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Ezarpen hauek gogoratu"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Erabili gzip konpresioa"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Gaitu arazten luzeko saio hasiera."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Ireki fitxategia"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Mezu kategoriak:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Zain..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Gehitu"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Berriz saiatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Ezabatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Gertaera motak"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Hautako fitxategientzat estatistika eta bezero ilara: Saioa / osotara"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "fitxategi guztien ehunekoa"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Fitxategi guztiak"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Hautatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Igoera aktiboak bakarrik"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Berritu:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Bidali"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Zehaztutako mezua bidali."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Itxi elkarrizketa saio hau."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Konektatu edozein zerbitzari eta/edo Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Partekatutako fitxategiak"
 
@@ -4596,7 +4615,7 @@ msgstr "Beste denak"
 msgid "Incomplete"
 msgstr "Amaitugabea"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Gelditua"
 
@@ -4786,341 +4805,341 @@ msgstr "jatorri ale %i bildurik zati fitxategiarentzat: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Errorea zati-fitxategi hazi fitxategia irakurtzerakoan (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Hondaturiko zatia (%d) aurkitu da %d zati %s zati fitxategian - FitxategiEgiaztapenEmaitza |%s| fitxategiEgiaztapena |%s|"
 msgstr[1] "Hondaturiko zatia (%d) aurkitu da %d zatitan %s zati fitxategian - FitxategiEgiaztapenEmaitza |%s| fitxategiEgiaztapena |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Bukatutako (%i) zatia aurkiturik %s-n"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Amaitutako berrazterketa: %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Ustekabeko errorea %s osatzean. Fitxategia gelditurik"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Deskarga amaiturik: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Deskarga amaiturik: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "fitxategia ezabatzen:%s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ABISUA: Ezinda deskargaturiko zatia egiaztatu - egiaztapen-bilduma osatugabe '%s'-rentzat"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERROREA: Ezin da deskargaturiko zatia egiaztatu - egiaztapen-bilduma osatugabea (%s). Hau ez zen inoiz gertatu beharko"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Egiaztapenean fitxategi amaiera deskargaturiko %2$u tamaina duen %1$u zatian (geh. %3$u) %5$u tamaina duen '%4$s' zati-fitxategian: %6$s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "KONTUZ: Diskoa leku askieza! Fitxategia gelditzen: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Deskargaturiko %i zatia hondaturik dago fitxategi honetan: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Hondaturiko %i zatia %s-rena -> Gordetako byte-ak: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Esleitzen"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Disko leku askieza"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Deskargatua"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROREA: Huts '%s' zati fitxategia irekitzean"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Sistema lehenetsia"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albaniera"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabiera"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Bablea"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Euskara"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgariera"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalana"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Txinatarra (Sinplea)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Txinatarra (ohizkoa)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Kroaziera"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Txekiera"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Daniera"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Nederlandera"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estoniera"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandiera"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Frantsesa"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galiziera"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Alemana"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grekoa"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebreera"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Hungariera"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiera"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiera (Suitzarra)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japoniera"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Koreera"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituaniera"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegiera (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Poloniera"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugesa"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugesa (Brasildarra)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Errumaniera"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Errusiera"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Esloveniera"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Gaztelera"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Suediera"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turkiera"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukraniera"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Aldatu hizkuntza"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Ez dago aMulerentzat itzulpen instalaturik"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Ez dago hizkuntza erabilgarririk"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "ez dago aukera erabilgarririk"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Kategoria baliogabe aurkitua, baztertzen"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP ataka ezin da 65532 baino altuagoa izan UDP socket-a TCP+3 bait da"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Lehenetsiriko ataka erabiliko da (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Konexioa"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Direktorioak"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Zerbitzariak"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Segurtasuna"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interfazea"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy-a"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Iragazkiak"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Urruneko kontrolak"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Sinadura linean"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Aurreratua"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Gertaerak"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Araztena"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5130,15 +5149,15 @@ msgstr ""
 "    %PARTFILE - fitxategiaren bide osoa\n"
 "    %PARTNAME - fitxategi-izena soilik"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5154,26 +5173,26 @@ msgstr ""
 "Amulek ondo funtzionatu beharko luke ezarpen\n"
 "hauek aldatu gabe."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara konektatzean"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara datuak bidaltzean"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Konektatzen ari zaren Proxy-aren mota"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz programatik konfiguraziora datuak bidaltzean"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5181,32 +5200,37 @@ msgstr ""
 "aMule berrabiarazi egin behar da aldaketa hauek gaitu ahal izateko:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP - ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Kanpo konexio interfazea aldatua.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Kanpo konexio ataka aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Lanpo konexio onarpena aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Kanpo konexio interfazea aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo nahastea"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5214,7 +5238,7 @@ msgstr ""
 "Auto-eguneraketa zerbitzari zerrenda hutsa dago.\n"
 "'Auto-eguneratu zerbitzari zerrenda abioan' ezgaitu egingo da."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5222,19 +5246,19 @@ msgstr ""
 "Kanpo konexioak gaiturik dituzu baina ez duzu pasahitzik ezarri.\n"
 "Kanpo konexiorik ezin da onartu baliozko pasahitza ezarri arte."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Hizkuntza aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Aldiroko karpeta aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K sarea gaiturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5242,7 +5266,7 @@ msgstr ""
 "Bai eD2k eta bai Kad sareak ezgaiturik daude.\n"
 "Ezingo zara konektatu behintzat bietako bat gaitu arte."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5250,7 +5274,7 @@ msgstr ""
 "Kad ezin da abiarazi zure UDP ataka ezgaiturik badago.\n"
 "UDP ataka gaitu edo Kad ezgaitu."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5260,20 +5284,20 @@ msgstr ""
 "aMule orain berrabiarazi BEHAR duzu.\n"
 "Orain ez berrabiaraziaz gero ez kexatu ezer txarra gertatzen bada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto berritzea abiarazirik"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5283,41 +5307,41 @@ msgstr ""
 "Mesedez bete behintzat baliozko server.met fitxategi batetara zuzenduaz.\n"
 "Klikatu \"zerrenda\" botoia URL-a sartzeko."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Aldi baterako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Sarrera fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Linean sinadurak"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Aukeratu karpeta bat %s-rentzat"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Arakatu bideo erreproduzigailua"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Hautatu nabigatzailea"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Abiarazgarria%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Editatu zerbitzari zerrenda"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5325,149 +5349,149 @@ msgstr ""
 "Gehitu hemen server.met deskargatzeko URL-a.\n"
 "URL helbide bat lerro bakoitzean."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Jatorri osoak"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Eguneratze maiztasuna: seg %d"
 msgstr[1] "Eguneratze maiztasuna: %d seg"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Batez besteko grafiko denbora: minutu %d"
 msgstr[1] "Batez besteko grafiko denbora: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Konexio grafiko eskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fitxategi buffer tamaina: byte %d"
 msgstr[1] "Fitxategi buffer tamaina: %d byte"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Igoera ilara tamaina: bezero %d"
 msgstr[1] "Igoera ilara tamaina: %d bezero"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Zerbitzari konexio berritze maiztasuna: minutu %d"
 msgstr[1] "Zerbitzari konexio berritze maiztasuna: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Zerbitzarira konexio berritze maiztasuna: Ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Gertaeran'%s' komandoa exekutatu"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Gaitu komando exekuzioa muinean"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Muin komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Gaitu komando exekuzioa urruneko interfazean"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Urruneko interfaze komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Hurrengo aldagaiak aldatuko dira:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Partekatutako fitxategi zerrenda birkargatu."

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -200,8 +200,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -246,37 +246,42 @@ msgstr "aMule itzaltzea osaturik."
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule ixtearen memoria arazte irteera:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Zure lokalak sistemako lehenetsira aldatu dira konfigurazio aldaketa bat dela eta. Barkatu."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Argb"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -284,56 +289,56 @@ msgstr ""
 "\n"
 "EC konfigurazioa"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "OHARRA"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sareak"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "zerbitzari %i aurkiturik server.met fitxategian"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ezin da atakak ezarritako helbidean ireki: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "%u ataka ez dago eskuragarri. IDBaxua izango duzu\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -348,48 +353,48 @@ msgstr ""
 "\n"
 "Egiaztatu zure sarea ataka sarrera eta irteerarako irekirik dagoela ziurtatzeko."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Huts online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Huts aMule online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Aukeratutako lokalak ez dirudi zure sisteman instalaturik. (Oharra: Hala ere erabiltzen saiatuko da)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule %s abiarazten duzun lehen aldia da"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bertsioa hau beta bertsio bat da, egunero eguneratzen da, eta\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ez gara ezer apurtu, zure etxea erre, edo zure zakurra akatzen\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "badu ere kargu egingo. Baina erabiltzeko ziurra izan *beharko* litzateke.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Argibide gehiago, laguntza eta bertsio berriak gure webgunean aurki ditzakezu,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io -en, edo irc.libera.chat IRC sareko #aMule kanalean.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Edozein akatsen berri emateko:https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -397,137 +402,137 @@ msgstr ""
 "Zuk aukeratutako sinadura karpeta BALIOGABEA da!\n"
 " Lehenespenak konpondu artean lineako sinadura EZGAITU egingo da."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Zerbitzari ostalari-izena notifikatua"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Disko aurresleipenak huts egin du '%s' fitxategiarentzat: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ERROREA: ezin da erregistro fitxategia ireki"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ABISUA: erregistro fitxategia hutsik dago. Zerbait oker dago."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Erregistroa berrezarri egin da"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ZerbitzariMezua: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s-ren deskarga baztertua, eskatutako fitxategia ez da berria eta."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Huts egin du nodo zerrenda deskargatzerakoan."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Hondaturiko bertsio arakatze fitxategia"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Zure aMule bertsioa %i.%i.%i da eta azken bertsioa %li.%li.%li da"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OHARRA: Zure aMuled bertsioa zaharkiturik dago: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Zure aMule kopia zaharkiturik dago."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Huts bertsio arakatze fitxategia deskargatzerakoan"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Erab: %s | Fitx: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Erab: E: %s K: %s | Fitx: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ez dago sarerik hautatuta"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "IDBaxuarekin"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "IDAltuarekin"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s-ra konektaturik"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s-ra konektatzen"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "eD2k-tik deskonektatua"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad abiarazirik."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad gelditurik."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Kad-era Konektatuta (ondo)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad-era Konektatuta (suebakirik)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Kad-etik deskonektatua"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad sarea ezin da erabili hobespenetan UDP ataka ezgaiturik badago, ez da abiaraziko."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad sarea hobespenetan ezgaiturik, ez da konektatuko."
 
@@ -888,7 +893,7 @@ msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa m
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2253,49 +2258,49 @@ msgstr "Ez"
 msgid "Yes"
 msgstr "Bai"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Deskargatzen..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP deskarga utzia"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "Deskargatzeko URLa ezin da hutsik egon"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Huts '%s' erabiltzailearen partekatutako fitxategiak jasotzerakoan"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%d byte deskargaturik"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "%s URL-aren erantzuna: %i - Errorea (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP deskarga utzia"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2598,7 +2603,7 @@ msgstr "Kanpo konexioa: Sarrera ukatze arrazoia: "
 msgid "External Connection: Handshake failed."
 msgstr "Kanpo Konexioa: Esku-emateak huts egin du."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP deskarga haria hasia"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -22,20 +22,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Näytä aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule etähallinta "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Tilannevedos:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -43,7 +43,7 @@ msgstr ""
 "'Kaikkien alustojen' p2p-asiakas perustuen eMuleen\n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -52,59 +52,59 @@ msgstr ""
 "Tekijänoikeudet (c) 2003-2019 aMule-Tiimi\n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Osa aMulesta perustuu\n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademliaan: Vertaisreititys perustuen XOR-metriikkaan.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Tekijänoikeudet (c) 2002-2008 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Verkkosivu:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Foorumi:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Tarkista uuden version saatavuus käynnistettäessä"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Yhdistetään Kadiin..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Käytät vanhentunutta versiota aMulesta!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ei saatavissa"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -200,8 +200,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -216,47 +216,57 @@ msgstr "ED2KLinks-tiedoston avaus epäonnistui."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROITUS: Et voi lisätä itseäsi lähteeksi eD2k-linkkiin kun sinulla on LowID."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Pääohjelmaa suljetaan..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Lopetetaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Tuhotaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Epäonnistunut"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMulen poistuessa: Lopetetaan ydin."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule sammutettu."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Muistin virheiden etsinnän tulokset aMulen sulkeutuessa:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Maa-asetuksesi vaihdettiin järjestelmän oletuksiksi asetusmuutoksen takia. Pahoittelen."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -264,56 +274,56 @@ msgstr ""
 "\n"
 "Etäyhteyksien asetukset"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "VAROITUS"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Verkot"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i palvelin tiedostossa server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei voitu sitoa portteja annettuun osoitteeseen: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portti %u ei ole saatavilla. Sinulle annetaan LowID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -328,48 +338,48 @@ msgstr ""
 "\n"
 "Tarkista yhteytesi varmistaaksesi että portti on avoinna sekä ulos että sisään."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMulen Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Valittu maa-asetus ei näytä olevan asennettuna järjestelmääsi. (Huom: Yritän asettaa sen kuitenkin)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Tämä on ensimmäinen kerta kun käynnistät aMulen version %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Tämä versio on testiversio jota päivitetään päivittäin,\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "emmekä me anna takuuta ettei se riko mitään, polta taloasi,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "tai tapa koiraasi. Mutta sen *pitäisi* olla silti turvallinen käyttää.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Lisätietoa, tukea ja uudet julkaisut löytyvät kotisivuiltamme osoitteessa\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io tai IRC-kanavaltamme #aMule palvelimella irc.libera.chat (englanniksi).\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Voit vapaasti raportoida bugeista osoitteessa https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -377,137 +387,137 @@ msgstr ""
 "Online-Signeeraukselle asettamasi kansio ei ole kelvollinen!\n"
 " Online-Signeeraus kytketään pois päältä kunnes korjaat asian asetuksista."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Palvelimen verkkonimi ilmoitettu"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Levytilan esivaraus tiedostolle '%s' epäonnistui: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "VIRHE: Lokitiedostoa ei voida avata"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROITUS: Lokitiedosto on tyhjä. Jotain on pielessä."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Loki nollattiin"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Palvelimen viesti: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Hypättiin yli latauksesta %s, koska pyydetty tiedosto ei ole uudempi."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Yhteyspisteiden listan lataus epäonnistui."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Ladatun versiotarkistustiedoston avaus epäonnistui"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Turmeltunut versiotarkistustiedosto"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Käytät vanhentunutta versiota aMulesta!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Tämän aMulen versio on %i.%i.%i ja uusin versio on %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROITUS: aMulesi versio on vanhentunut: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "aMulesi on uusinta versiota."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Versiotarkistustiedoston lataus epäonnistui"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Käyttäjiä: %s | Tiedostoja: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Käyttäjiä: E: %s K: %s | Tiedostoja: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ei valittuja verkkoja"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID:llä"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID:llä"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Yhdistetty %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Yhdistän %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Käynnistettiin Kad."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Pysäytettiin Kad."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Yhdistetty Kadiin (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Yhdistetty Kadiin (palomuurattu)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Yhteys Kadiin katkaistu"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-verkkoa ei voida käyttää mikäli UDP-portti on estetty asetuksissa, ei käynnistetä."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-verkko estetty asetuksissa, ei yhdistetä."
 
@@ -547,15 +557,15 @@ msgstr "Tämä on aMule %s ja pohjautuu eMuleen."
 msgid "Running on %s"
 msgstr "Käynnissä %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vieraile nettisivulla https://github.com/amule-org/amule/releases/latest tarkistaaksi uuden version saatavuuden."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRIITTINEN VIRHE: Ajastimen luominen epäonnistui"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -565,223 +575,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Ei saatavissa"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMulen dialogi tuhottu"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Yhdistetään"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Yhdistetään"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Ei yhdistetty"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Palomuurattu"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Yhdistety"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Yhdistetään"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Pois päältä"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Pysäytä nykyiset yhteysyritykset"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Katkaise yhteys yhdistettyihin verkkoihin"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Yhdistä"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Yhdistä sallittuihin verkkoihin"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Ylös: %.1f(%.1f) | Alas: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Ylös: %.1f | Alas: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Yhdistetty)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ei yhdistetty)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Haluatko varmasti sulkea %sn?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Lopettamisen varmistus"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Suorita komento: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- oletus -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Teemakansiota '%s' ei ole olemassa"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROITUS: Ei voida avata teematiedostoa '%s' luettavaksi"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Verkot"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Verkkoikkuna"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Haut"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Hakujen ikkuna"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Lataukset"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Latausten ikkuna"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Jaetut tiedostot"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Jaettujen tiedostojen ikkuna"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Viestit"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Viestien ikkuna"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Tilastot"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Tilastokuvaajien ikkuna"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Asetukset"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Asetuksien säätöikkuna"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Tuonti"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Osatiedostojen tuontityökalu"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tietoja"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Tietoja/Ohje"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k-verkko"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad-verkko"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Ei verkkoa"
 
@@ -869,8 +879,8 @@ msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Tuntematon"
@@ -1233,19 +1243,19 @@ msgstr "Auto [Ko]"
 msgid "Very low"
 msgstr "Erittäin matala"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Matala"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normaali"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1277,7 +1287,7 @@ msgid "On Queue"
 msgstr "Jonossa"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Lataa"
 
@@ -1337,7 +1347,7 @@ msgstr "Paikallinen Palvelin"
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1409,7 +1419,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Koko"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Siirretty"
 
@@ -1422,7 +1432,7 @@ msgid "Progress"
 msgstr "Edistyminen"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Lähteet"
 
@@ -1432,7 +1442,7 @@ msgstr "Lähteet"
 msgid "Priority"
 msgstr "Tärkeys"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Tila"
 
@@ -1465,7 +1475,7 @@ msgstr ""
 "Palaute tullut: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automaattinen"
@@ -2118,7 +2128,7 @@ msgstr "Kaverilistatiedostoa 'emfriends.met' ei saatu avattua kirjoitettavaksi!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITTINEN - ei asiakasta keskustelun aloituksessa"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Kaverit"
 
@@ -2403,8 +2413,8 @@ msgstr "Portti ei kelpaa yhdistämisavuksi"
 msgid "Please fill all fields required"
 msgstr "Ole hyvä ja täytä kaikki vaaditut kentät"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Viesti"
 
@@ -2476,7 +2486,7 @@ msgstr "Jakosuhde"
 msgid "Uploaded"
 msgstr "Lähetetty"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Pyydetty"
 
@@ -2510,30 +2520,30 @@ msgstr "Tuntematon virhe %d"
 msgid "Unable to get error description for error %d"
 msgstr "Virheelle %d ei ole virhekuvausta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Luo tarkistetta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Viimeistelee"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Valmis"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Tauotettu"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Virheellinen"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Odottaa"
 
@@ -2578,7 +2588,7 @@ msgstr "Etäyhteys: Pääsy evättiin: "
 msgid "External Connection: Handshake failed."
 msgstr "Etäyhteys: Kättely epäonnistui"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP-lataussäie käynnistetty"
@@ -2600,7 +2610,7 @@ msgid "WARNING: "
 msgstr "VAROITUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Sulje"
 
@@ -2716,7 +2726,7 @@ msgstr "Sulje"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -2956,7 +2966,7 @@ msgstr "Tavua"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3025,7 +3035,7 @@ msgstr "Siivoaa valmistuneet lataukset pois näkyvistä"
 msgid "File sources:"
 msgstr "Tiedostolähteet:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Yleiset"
 
@@ -3046,7 +3056,7 @@ msgstr "Koko nimi :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "Ei saatavilla"
 
@@ -3222,7 +3232,7 @@ msgstr "Käyttäjänimi :"
 msgid "Userhash :"
 msgstr "Käyttäjätarkiste :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisää"
@@ -3231,15 +3241,15 @@ msgstr "Lisää"
 msgid "Download-Speed"
 msgstr "Latausnopeus"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Nykyinen"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Session keskiarvo"
 
@@ -3251,7 +3261,7 @@ msgstr "Lähetysnopeus"
 msgid "Connections"
 msgstr "Yhteydet"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktiiviset lataukset"
 
@@ -3259,7 +3269,7 @@ msgstr "Aktiiviset lataukset"
 msgid "Active connections (1:1)"
 msgstr "Aktiiviset yhteydet (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktiiviset lähetykset"
 
@@ -3460,8 +3470,8 @@ msgstr "Selaimen valinta"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Syötä tähän selaimesi nimi. Jätä tyhjäksi jos haluat käyttää järjestelmän oletusselainta."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3535,750 +3545,759 @@ msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Vain edistyneille käyttäjille: mikäli sinulla on useampia verkkoliitäntöjä, syötä sen liitännän osoite johon haluat aMulen sidottavan."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Lähteitä enintään tiedostoa kohden:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Yhtäaikaisten yhteyksien enimmäismäärä:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Yhdistä automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Yhdistä uudelleen yhteyden katketessa"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Poista toimimattomat palvelimet"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "yrityksen jälkeen"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Päivitä palvelinlista käynnistettäessä"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Päivitä palvelinlista yhdistettäessä palvelimelle"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Päivitä palvelinlista asiakkaan yhdistäessä"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Käytä tärkeysjärjestystä"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Käytä älykästä LowID-tarkistusta yhdistettäessä"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Turvallinen yhdistäminen"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Yhdistä automaattisesti vain pysyville palvelimille"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Aseta käsin syötetyt palvelimet korkealle tärkeydelle"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Älykäs turmeltumien käsittely (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Käytä"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Kehittynyt I.C.H. luottaa kaikkiin tarkisteisiin (ei suositella)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Lisää tiedostot lataukseen tauotettuna"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Lisää tiedostot lataukseen tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Yritä ladata ensimmäiset ja viimeiset palat ensin"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Käynnistä seuraava tauotetty tiedosto kun tiedosto valmistuu"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Samasta luokasta"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "Aakkosellisessa järjestyksessä"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Esivaraa levytila uusille tiedostoille"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Uusia tiedostoja lisätessä varaa levytilaa koko tiedostolle, vähentää pirstaloitumista"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Pysäytä lataukset kun tyhjän levytilan määrä saavuttaa "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Valitse tämä mikäli haluat aMulen tarkistavan vapaan levytilan määrän"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Syötä tähän levytila jonka haluat jättää vapaaksi."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Tallenna 10 lähdettä harvinaisille tiedostoille (< 20 lähdettä)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Lähetykset"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Lisää uudet jaetut tiedostot tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Kansio ladatuille tiedostoille"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Klikkaa oikealla painikkeella kansion kuvaketta jakaaksesi rekursiivisesti)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Jaa piilotiedostot"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Kuvaajat"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Päivitysväli : 5 sekuntia"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Keskimääräiskuvaajan aika: 100 minuuttia"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Yhteyskuvaajan Skaala: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Latauskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Lähetyskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Värit: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Taustaväri"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Ruudukko"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Hetkittäinen lataus"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Latauksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Latauksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Hetkittäinen lähetys"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Lähetyksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Lähetyksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktiiviset yhteydet"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Järjestelmäpalkin nopeusnäyttö"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Kad-yhteyksiä tällä hetkellä"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kad-yhteyksiä aktiivisena"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kad-yhteyksiä sessiossa"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Valitse"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Näytettävien asiakasversioiden määrä (0=rajoittamattomasti)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROITUS !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Enimmäismäärä uusia yhteyksiä / 5 s"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tiedostopuskurin koko: 240000 tavua"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Lähetysjonon koko: 5000 asiakasta"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Palvelinyhteyden päivitysväli: Poissa käytöstä"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Poista käytöstä tietokoneen ajastettu siirtyminen valmiustilaan"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Käytettävä teema: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näytä \"Nopea eD2k-linkkien käsittelijä\" jokaisessa ikkunassa."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Näytä laajennetut tiedot luokitteluvälilehdillä"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Näytä sovelluksen versio otsikossa"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Näytä siirtonopeudet otsikossa"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Ennen sovelluksen nimeä"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Sovelluksen nimen perässä"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Näytä otsikkotietoihin kuluva kaista"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Pystysuuntainen työkalupalkki"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Latausjonon tiedostot"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Näytä edistyminen prosentteina"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Näytä edistymispalkki"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Tasainen"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Pyöreä"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Järjestä tiedostot automaattisesti (iso suorittimen käyttö)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule järjestää sarakkeet latauslistassasi automaattisesti"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Etäyhteyksien asetukset"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Hyväksy etäyhteydet"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "Kuunneltavan verkkoliitännän IP:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Syötä tähän sen verkkoliitännän ip jota kuunnellaan etäyhteyksiä varten. Tyhjä tai 0.0.0.0 tarkoittaa kaikkia verkkoliitäntöjä."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Kytke päälle UPnP-portinohjaus etäyhteysportissa"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Salasana"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Käynnistä web-palvelin käynnistettäessä"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Web-sapluuna"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Täysien oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Salli rajoitettujen oikeuksien käyttäjä"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Rajoitettujen oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Käytä UPnP-portinohjausta web-palvelimen portissa"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web-palvelimen UPnP TCP-portti (Valinnainen)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Sivun päivitysväli (sekunneissa)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Salli gzip-pakkaus"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Napsauta tästä saattaaksesi voimaan asetuksiin tehdyt muutokset."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Nollaa asetuksiin tekemäsi muutokset."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Otsikko :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Kommentti :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Saapuvien kansio :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Vaihda tärkeyttä uusille sijoitetuille tiedostoille :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Älä vaihda"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Valitse väri tälle luokalle (valittuna) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Tyhjennä"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Napsauta tätä painiketta nollataksesi lokin."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi palvelinlistan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Palvelinlista"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Syötä tähän server.met-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen palvelimien listan."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Palvelimen lisäys käsin: Nimi"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Syötä uuden palvelimen nimi tähän"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Portti"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Syötä uuden palvelimen IP tähän, muodossa x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Syötä palvelimen portti tähän."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lisää palvelin käsin (täytä vasemmalla olevat kentät) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule loki"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Palvelimen tiedot"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi yhteyspisteiden listan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Yhteyspisteitä (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Syötä tähän nodes.dat-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen yhteyspisteiden listan."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Yhteyspisteiden tilastot"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Yhdistämisapu"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Uusi yhteyspiste"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Katkaise Kad-yhteys"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Käytä turvattua käyttäjän tunnistusta"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Tunnistuksen käyttö on suositeltavaa. Muuten et hyödy pistejärjestelmästä."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokollan kätkeminen"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Tuki protokollan kätkemiselle"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Tämä valinta sallii aMulen ottaa vastaan kätketyn protokollan yhteyksiä muilta asiakkailta."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Käytä kätkemistä lähtevissä yhteyksissä"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Tämä valittuna aMule käyttää protokollan kätkemistä ottaessaan yhteyttä muihin asiakkaisiin/palvelimiin."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Vastaanota vain kätkettyjä yhteyksiä"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Tämä valittuna aMule hyväksyy vain kätketyt yhteydet. Lähteitä on vähemmän saatavilla mutta kaikki liikenteesi on kätketyllä protokollalla."
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Kaikki"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Ei kukaan"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Ketkä voivat nähdä jaetut tiedostoni:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Valitse ketkä voivat pyytää nähtäville sinun jaettujen tiedostojen listaasi."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP-suodatus"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Suodata asiakkaat"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli asiakas-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Suodata palvelimet"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli palvelin-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Uudelleenlataa lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Uudelleenlataa suodatettavien IP:den lista tiedostosta ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Päivitä nyt"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Suodatustaso:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Suodata aina lähiverkon IP:t"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Käsittele muut IP:t vainoharhaisesti"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Hylkää paketit mikäli asiakkaan ip on eri kuin mistä paketti saapui. Käytä varoen."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Käytä järjestelmänlaajuista ipfilter.dat-tiedostoa mikäli saatavilla"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Mikäli paikallista ipfilter.dat:ia ei löydy, käytetään järjestelmänlaajuista ipfilter.dat-tiedostoa."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Kytke Online-Signeeraus päälle"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Kytkee päälle Online-Signeeraustiedoston kirjoittamisen, jota muut ohjelmat voivat käyttää esimerkiksi signeerauksissa."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Päivitysväli (sekuntia):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuttaa Online-Signeerauksen päivitysväliä, annetaan sekunteina."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Online-signeeraus-tiedoston tallennuspaikka:"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Napsauta tästä valitaksesi kansio Online-Signeerauksen tiedostoille."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Näytä asiakkaiden valtioiden liput"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Siirtonopeus :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Lähteet"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4286,11 +4305,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4300,226 +4319,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Lataus: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Suodata saapuvat viestit (ei koske keskusteluja):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Suodata kaikki viestit"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Suodata viestit ihmisiltä jotka eivät ole kaverilistallasi"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Suodata viestit tuntemattomilta asiakkailta"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Suodata viestit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Syötä tähän suodatettavat sanat ja aMule estää viestit jotka sisältävät sellaisen"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Näytä vastaanotetut viestit lokissa"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Kommentit"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Suodata kommentit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Käytä tunnistautumista"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Kytkee päälle/pois käyttäjänimellä/salasanalla tunnistautumisen"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Käyttäjänimi: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Käyttäjänimi tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Salasana:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Salasana tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Käytä välityspalvelinta"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Kytke päälle/pois välityspalvelimen tuki"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Tyyppi:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Välityspalvelin:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Välityspalvelimen verkkonimi"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Välityspalvelimen portti"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Yhdistä:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Kirjaudu etä-aMuleen"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Käyttäjänimi"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Muista nämä asetukset"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Käytä gzip-pakkausta"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Käytä monisanaista lokiin kirjausta."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Avaa tied&osto"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Viestien luokittelut:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Odottaa..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Lisää tuonteja"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Yritä uudelleen valittuja"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Poista valitut"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tapahtumatyypit"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Tilastot ja jonottavat asiakkaat valitu(i)lle tiedosto(i)lle: Sessiossa / Yhteensä"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Prosenttia kaikista tiedostoista"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Kaikki tiedostot"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Valitut tiedostot"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Vain aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Uudelleenlataa:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Lähetä"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Lähettää annetun viestin."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Sulje tämä keskustelu."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Jaetut tiedostot"
 
@@ -4596,7 +4615,7 @@ msgstr "kaikki muut"
 msgid "Incomplete"
 msgstr "Keskeneräinen"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Pysäytetty"
 
@@ -4786,341 +4805,341 @@ msgstr "Tallennettu %i lähde osatiedostolle: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Virhe luettaessa osatiedoston lähdetiedostoa (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Turmeltunut osa (%d) %d osasta tiedostossa %s - Tiedostotulostarkiste |%s| Tiedostotarkiste |%s|"
 msgstr[1] "Turmeltunut osa (%d) %d osasta tiedostossa %s - Tiedostotulostarkiste |%s| Tiedostotarkiste |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Valmis osa (%i) kohteessa %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Tarkiste uudelleenluotu: %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Odottamaton virhe viimeistellessä %s. Tiedosto tauotettu"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Lataus suoritettu: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Lataus suoritettu: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Poistetaan tiedosto: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "VAROITUS: Ei voitu laskea tarkistetta ladatusta osasta - tarkistejoukko on puutteellinen kohteelle '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "VIRHE: Ei voitu luoda tarkistetta ladatulle osalle - tarkistejoukko on puutteellinen (%s). Näin ei pitäisi koskaan tapahtua."
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Data loppui (EOF) luotaessa tarkistetta ladatulle osalle %u jonka pituus on %u (maksimi on %u) osatiedostosta '%s' jonka pituus on %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "VAROITUS: Levytilaa ei ole tarpeeksi! Tauotan tiedoston: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Ladattu osa %i on turmeltunut tiedostossa: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Ennallistettu turmeltunut osa %i kohteessa %s -> Säästetyt tavut: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Allokoidaan"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Riittämätön levytila"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Ladattu"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIRHE: Ei voida avata osatiedostoa '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Järjestelmän vakio"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albania"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabia"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgaria"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalaani"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Kiina (Yksinkertaistettu)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Kiina (Perinteinen)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Kroatia"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Tsekki"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Tanska"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Hollanti"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Viro"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Suomi"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Ranska"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galicia (Galego)"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Kreikka"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Heprea"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Unkari"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italia"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italia (Sveitsi)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japani"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Liettua"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norja (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Puola"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brazilia)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Romanian"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Venäjä"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovenia"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Espanja"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Ruotsi"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turkki"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Vaihda kieli"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Käännöksiä ei ole asennettuna aMulelle"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Kieliä ei saatavilla"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "vaihtoehtoja ei saatavilla"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Löytyi epäkelpo luokka, hypätään yli"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-portti ei voi olla korkeampi kuin 65532 koska serverin käyttämä UDP-pistukka on TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Käytetään oletusporttia (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Yhteys"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Palvelimet"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Turvallisuus"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Käyttöliittymä"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Välityspalvelin"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Suodattimet"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Etähallinta"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Online-Signeeraus"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Laajennetut"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Tapahtumat"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Debuggaus"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5130,15 +5149,15 @@ msgstr ""
 "    %PARTFILE - koko polku tiedostoon\n"
 "    %PARTNAME - pelkästään tiedoston nimi"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5154,26 +5173,26 @@ msgstr ""
 "aMule toimii hyvin vaikka näitä ei\n"
 "säädettäisikään."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Asetuksen kytkeminen widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datan siirtäminen asetuksesta widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Yhdistettävän välityspalvelimen tyyppi"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datan siirtäminen widgetistä asetukseen epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5181,32 +5200,37 @@ msgstr ""
 "aMule on käynnistettävä uudelleen näiden muutosten voimaansaattamiseksi:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Etäyhteyden sovitin muuttui.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Etäyhteyden portti vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Etäyhteyden vastaanotto muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Etäyhteyden sovitin muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokollan kätkeminen"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5214,7 +5238,7 @@ msgstr ""
 "Palvelinlistan automaattisen päivityksen lista on tyhjä.\n"
 "'Päivitä palvelinlista käynnistettäessä' kytketään pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5222,19 +5246,19 @@ msgstr ""
 "Olet sallinut etäyhteydet mutta et ole antanut salasanaa.\n"
 "Etäyhteydet eivät ole mahdollisia ellei salasanaa ole annettu."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Kieli vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Väliaikaiskansio muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-verkko käytössä.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5242,7 +5266,7 @@ msgstr ""
 "Sekä eD2k- että Kad-verkko on pois päältä.\n"
 "Et voi yhdistää ennen kuin ainakin toinen niistä on sallittu."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5250,7 +5274,7 @@ msgstr ""
 "Kad ei käynnisty mikäli UDP-portti on pois päältä.\n"
 "Salli UDP-portti tai kytke Kad pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5260,20 +5284,20 @@ msgstr ""
 "Sinun on uudelleenkäynnistettävä aMule nyt.\n"
 "Mikäli et uudelleenkäynnistä nyt, älä valita mikäli jotain pahaa tapahtuu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaattinen Päivitys aloitettu"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5283,41 +5307,41 @@ msgstr ""
 "Ole hyvä ja syötä ainakin yksi URL joka osoittaa käypään server.met-tiedostoon.\n"
 "Klikkaa nappia \"Lista\" tämän valintaruudun vierestä syöttääksesi URLin."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Väliaikaiset tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Saapuvat tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Online-Signeeraukset"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Valitse kansio kohteelle %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Etsi videosoitin"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Valitse selain"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Suoritettava tiedosto%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Muokkaa palvelinlistaa"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5325,149 +5349,149 @@ msgstr ""
 "Syötä tähän URLit joista server.met-tiedostot haetaan.\n"
 "Vain yksi urli riville."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Täysiä lähteitä"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Päivitysväli: %d sekunti"
 msgstr[1] "Päivitysväli: %d sekuntia"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskimääräiskuvaajan aika: %d minuutti"
 msgstr[1] "Keskimääräiskuvaajan aika: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Yhteyskuvaajan skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tiedostopuskurin koko: %d tavu"
 msgstr[1] "Tiedostopuskurin koko: %d tavua"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Lähetysjonon koko: %d asiakas"
 msgstr[1] "Lähetysjonon koko: %d asiakasta"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Palvelinyhteyden päivitysväli: %d minuutti"
 msgstr[1] "Palvelinyhteyden päivitysväli: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Palvelinyhteyden päivitysväli: Ei käytössä"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "poissa käytöstä"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Suorita komento tapahtuman '%s' yhteydessä"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Mahdollista komentojen suorittaminen ytimestä"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Ytimen komento:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Mahdollista komentojen suorittaminen graafisesta käyttöliittymästä"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Graafisen käyttöliittymän komento:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Seuraavat muuttujat korvataan:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lataa uudelleen lista jaetuista tiedostoista."

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -200,8 +200,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -246,27 +246,37 @@ msgstr "aMule sammutettu."
 msgid "Memory debug results for aMule exit:"
 msgstr "Muistin virheiden etsinnän tulokset aMulen sulkeutuessa:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Maa-asetuksesi vaihdettiin järjestelmän oletuksiksi asetusmuutoksen takia. Pahoittelen."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -274,56 +284,56 @@ msgstr ""
 "\n"
 "Etäyhteyksien asetukset"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "VAROITUS"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Verkot"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i palvelin tiedostossa server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei voitu sitoa portteja annettuun osoitteeseen: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portti %u ei ole saatavilla. Sinulle annetaan LowID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -338,48 +348,48 @@ msgstr ""
 "\n"
 "Tarkista yhteytesi varmistaaksesi että portti on avoinna sekä ulos että sisään."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMulen Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Valittu maa-asetus ei näytä olevan asennettuna järjestelmääsi. (Huom: Yritän asettaa sen kuitenkin)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Tämä on ensimmäinen kerta kun käynnistät aMulen version %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Tämä versio on testiversio jota päivitetään päivittäin,\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "emmekä me anna takuuta ettei se riko mitään, polta taloasi,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "tai tapa koiraasi. Mutta sen *pitäisi* olla silti turvallinen käyttää.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Lisätietoa, tukea ja uudet julkaisut löytyvät kotisivuiltamme osoitteessa\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io tai IRC-kanavaltamme #aMule palvelimella irc.libera.chat (englanniksi).\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Voit vapaasti raportoida bugeista osoitteessa https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -387,137 +397,137 @@ msgstr ""
 "Online-Signeeraukselle asettamasi kansio ei ole kelvollinen!\n"
 " Online-Signeeraus kytketään pois päältä kunnes korjaat asian asetuksista."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Palvelimen verkkonimi ilmoitettu"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Levytilan esivaraus tiedostolle '%s' epäonnistui: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "VIRHE: Lokitiedostoa ei voida avata"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROITUS: Lokitiedosto on tyhjä. Jotain on pielessä."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Loki nollattiin"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Palvelimen viesti: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Hypättiin yli latauksesta %s, koska pyydetty tiedosto ei ole uudempi."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Yhteyspisteiden listan lataus epäonnistui."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Ladatun versiotarkistustiedoston avaus epäonnistui"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Turmeltunut versiotarkistustiedosto"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Käytät vanhentunutta versiota aMulesta!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Tämän aMulen versio on %i.%i.%i ja uusin versio on %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROITUS: aMulesi versio on vanhentunut: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "aMulesi on uusinta versiota."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Versiotarkistustiedoston lataus epäonnistui"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Käyttäjiä: %s | Tiedostoja: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Käyttäjiä: E: %s K: %s | Tiedostoja: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ei valittuja verkkoja"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID:llä"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID:llä"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Yhdistetty %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Yhdistän %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Käynnistettiin Kad."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Pysäytettiin Kad."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Yhdistetty Kadiin (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Yhdistetty Kadiin (palomuurattu)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Yhteys Kadiin katkaistu"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-verkkoa ei voida käyttää mikäli UDP-portti on estetty asetuksissa, ei käynnistetä."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-verkko estetty asetuksissa, ei yhdistetä."
 
@@ -2588,7 +2598,7 @@ msgstr "Etäyhteys: Pääsy evättiin: "
 msgid "External Connection: Handshake failed."
 msgstr "Etäyhteys: Kättely epäonnistui"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP-lataussäie käynnistetty"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -200,8 +200,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -246,37 +246,42 @@ msgstr "aMule sammutettu."
 msgid "Memory debug results for aMule exit:"
 msgstr "Muistin virheiden etsinnän tulokset aMulen sulkeutuessa:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Maa-asetuksesi vaihdettiin järjestelmän oletuksiksi asetusmuutoksen takia. Pahoittelen."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -284,56 +289,56 @@ msgstr ""
 "\n"
 "Etäyhteyksien asetukset"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "VAROITUS"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Verkot"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i palvelin tiedostossa server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei voitu sitoa portteja annettuun osoitteeseen: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portti %u ei ole saatavilla. Sinulle annetaan LowID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -348,48 +353,48 @@ msgstr ""
 "\n"
 "Tarkista yhteytesi varmistaaksesi että portti on avoinna sekä ulos että sisään."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMulen Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Valittu maa-asetus ei näytä olevan asennettuna järjestelmääsi. (Huom: Yritän asettaa sen kuitenkin)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Tämä on ensimmäinen kerta kun käynnistät aMulen version %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Tämä versio on testiversio jota päivitetään päivittäin,\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "emmekä me anna takuuta ettei se riko mitään, polta taloasi,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "tai tapa koiraasi. Mutta sen *pitäisi* olla silti turvallinen käyttää.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Lisätietoa, tukea ja uudet julkaisut löytyvät kotisivuiltamme osoitteessa\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io tai IRC-kanavaltamme #aMule palvelimella irc.libera.chat (englanniksi).\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Voit vapaasti raportoida bugeista osoitteessa https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -397,137 +402,137 @@ msgstr ""
 "Online-Signeeraukselle asettamasi kansio ei ole kelvollinen!\n"
 " Online-Signeeraus kytketään pois päältä kunnes korjaat asian asetuksista."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Palvelimen verkkonimi ilmoitettu"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Levytilan esivaraus tiedostolle '%s' epäonnistui: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "VIRHE: Lokitiedostoa ei voida avata"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROITUS: Lokitiedosto on tyhjä. Jotain on pielessä."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Loki nollattiin"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Palvelimen viesti: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Hypättiin yli latauksesta %s, koska pyydetty tiedosto ei ole uudempi."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Yhteyspisteiden listan lataus epäonnistui."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Ladatun versiotarkistustiedoston avaus epäonnistui"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Turmeltunut versiotarkistustiedosto"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Käytät vanhentunutta versiota aMulesta!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Tämän aMulen versio on %i.%i.%i ja uusin versio on %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROITUS: aMulesi versio on vanhentunut: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "aMulesi on uusinta versiota."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Versiotarkistustiedoston lataus epäonnistui"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Käyttäjiä: %s | Tiedostoja: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Käyttäjiä: E: %s K: %s | Tiedostoja: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ei valittuja verkkoja"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID:llä"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID:llä"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Yhdistetty %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Yhdistän %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Käynnistettiin Kad."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Pysäytettiin Kad."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Yhdistetty Kadiin (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Yhdistetty Kadiin (palomuurattu)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Yhteys Kadiin katkaistu"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-verkkoa ei voida käyttää mikäli UDP-portti on estetty asetuksissa, ei käynnistetä."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-verkko estetty asetuksissa, ei yhdistetä."
 
@@ -888,7 +893,7 @@ msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2253,49 +2258,49 @@ msgstr "Ei"
 msgid "Yes"
 msgstr "Kyllä"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Ladataan..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP-lataus peruutettu"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "Ladattava URL ei voi olla tyhjä"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Jaettujen tiedostojen listaus käyttäjältä '%s' ei onnistunut"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Ladattu %d tavua"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s palautti: %i - Virhe (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP-lataus peruutettu"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2598,7 +2603,7 @@ msgstr "Etäyhteys: Pääsy evättiin: "
 msgid "External Connection: Handshake failed."
 msgstr "Etäyhteys: Kättely epäonnistui"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP-lataussäie käynnistetty"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -209,8 +209,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossible d'ajouter %u lien depuis le fichier ED2KLinks (cf. le journal pour les détails)."
 msgstr[1] "Impossible d'ajouter %u liens depuis le fichier ED2KLinks (cf. le journal pour les détails)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -255,37 +255,42 @@ msgstr "Fermeture d'aMule terminée."
 msgid "Memory debug results for aMule exit:"
 msgstr "Résultats du débogage de la mémoire pour la sortie d'aMule :"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Votre localisation a été remise à la valeur par défaut à cause d'un changement dans la configuration. Désolé."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Infos"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -293,21 +298,21 @@ msgstr ""
 "\n"
 "Configuration EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Mot de passe renseigné et connexions externes activées."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "Amorçage de réseau"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -315,34 +320,34 @@ msgstr ""
 "aMule a détecté des fichiers d'amorçage de réseau manquants.\n"
 "Sélectionnez ceux à télécharger :"
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "Liste de serveurs eD2k (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nœuds d'amorçage Kad (nodes.dat)"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serveur web s'exécutant avec le pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossible de lier les ports à l'adresse spécifiée : %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Le port %u n'est pas disponible. Vous serez LowID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -357,48 +362,48 @@ msgstr ""
 "\n"
 "Vérifiez votre réseau pour être sûr que le port est ouvert en sortie et en entrée."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Échec de la création du fichier OnlineSig"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Échec de la création du fichier aMule OnlineSig"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La localisation choisie semble ne pas être installée sur votre machine. (Note : Je tente de la forcer quand même)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "C'est la première fois que vous lancez aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Cette version est une version de test, mise à jour quotidiennement, et\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nous ne fournissons aucune garantie que cela n'endommagera rien, brûlera votre maison,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou tuera votre chien. Mais ça *devrait* être à peu près sûr quand-même.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plus d'informations, de l'aide et de nouvelles versions peuvent être trouvées sur notre page web,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, ou sur notre canal IRC : #aMule sur irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Ne vous gênez pas pour reporter tout bogue sur https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -406,137 +411,137 @@ msgstr ""
 "Le répertoire choisi pour les fichiers de signature en ligne est INVALIDE !\n"
 "La signature en ligne sera DÉSACTIVÉE jusqu'à ce que cela soit corrigé dans les préférences."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Nom du serveur signalé"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Erreur lors de la réserve d'espace pour le fichier '%s' : %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ERREUR : impossible d'ouvrir le fichier journal"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVERTISSEMENT : le fichier journal est vide. Quelque chose ne va pas."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Le journal a été effacé"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerMessage : %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saut du téléchargement de %s, car le fichier demandé n'est pas récent."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Échec du téléchargement de la liste des nœuds."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Échec de l'ouverture du fichier de vérification de version téléchargé"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Fichier de vérification de version corrompu"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Vous utilisez une version obsolète d'aMule !"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Votre version d'aMule est %i.%i.%i et la dernière version est %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La dernière version peut toujours être trouvée sur https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVERTISSEMENT : votre version d'aMuled est obsolète : %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Votre version d'aMule est à jour."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Échec du téléchargement du fichier de vérification de version"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilisateurs : %s | Fichiers : %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilisateurs : E : %s K : %s | Fichiers : E : %s K : %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Aucun réseau sélectionné"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "avec un LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "avec un HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connecté à %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connexion à %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Déconnecté de eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad démarré."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad arrêté."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Connecté à Kad (OK)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Connecté à Kad (pare-feu)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Déconnecté de Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Le réseau Kad ne peut être utilisé si le port UDP est désactivé dans les préférences, pas de démarrage."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Le réseau Kad est désactivé dans les préférences, pas de connexion."
 
@@ -897,7 +902,7 @@ msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on gar
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2258,49 +2263,49 @@ msgstr "Non"
 msgid "Yes"
 msgstr "Oui"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Téléchargement…"
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Téléchargement HTTP annulé"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "L'URL de téléchargement ne peut pas être vide"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Échec de la création de la requête HTTP pour %s"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "Téléchargement HTTP : corps de réponse vide pour %s"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Impossible de déplacer le fichier téléchargé vers %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%s téléchargé (%llu octets)"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "L'URL %s a retourné : %i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Échec du téléchargement HTTP pour %s : %s"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 non autorisé pour %s"
@@ -2602,7 +2607,7 @@ msgstr "Connexion externe : accès refusé car : "
 msgid "External Connection: Handshake failed."
 msgstr "Connexion externe : Échange raté."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Processus ASIO %d démarré"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -209,8 +209,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossible d'ajouter %u lien depuis le fichier ED2KLinks (cf. le journal pour les détails)."
 msgstr[1] "Impossible d'ajouter %u liens depuis le fichier ED2KLinks (cf. le journal pour les détails)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -255,27 +255,37 @@ msgstr "Fermeture d'aMule terminée."
 msgid "Memory debug results for aMule exit:"
 msgstr "Résultats du débogage de la mémoire pour la sortie d'aMule :"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Votre localisation a été remise à la valeur par défaut à cause d'un changement dans la configuration. Désolé."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Infos"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -283,21 +293,21 @@ msgstr ""
 "\n"
 "Configuration EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Mot de passe renseigné et connexions externes activées."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "Amorçage de réseau"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -305,34 +315,34 @@ msgstr ""
 "aMule a détecté des fichiers d'amorçage de réseau manquants.\n"
 "Sélectionnez ceux à télécharger :"
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "Liste de serveurs eD2k (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nœuds d'amorçage Kad (nodes.dat)"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serveur web s'exécutant avec le pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossible de lier les ports à l'adresse spécifiée : %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Le port %u n'est pas disponible. Vous serez LowID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -347,48 +357,48 @@ msgstr ""
 "\n"
 "Vérifiez votre réseau pour être sûr que le port est ouvert en sortie et en entrée."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Échec de la création du fichier OnlineSig"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Échec de la création du fichier aMule OnlineSig"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La localisation choisie semble ne pas être installée sur votre machine. (Note : Je tente de la forcer quand même)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "C'est la première fois que vous lancez aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Cette version est une version de test, mise à jour quotidiennement, et\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nous ne fournissons aucune garantie que cela n'endommagera rien, brûlera votre maison,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou tuera votre chien. Mais ça *devrait* être à peu près sûr quand-même.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plus d'informations, de l'aide et de nouvelles versions peuvent être trouvées sur notre page web,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, ou sur notre canal IRC : #aMule sur irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Ne vous gênez pas pour reporter tout bogue sur https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -396,137 +406,137 @@ msgstr ""
 "Le répertoire choisi pour les fichiers de signature en ligne est INVALIDE !\n"
 "La signature en ligne sera DÉSACTIVÉE jusqu'à ce que cela soit corrigé dans les préférences."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Nom du serveur signalé"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Erreur lors de la réserve d'espace pour le fichier '%s' : %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ERREUR : impossible d'ouvrir le fichier journal"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVERTISSEMENT : le fichier journal est vide. Quelque chose ne va pas."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Le journal a été effacé"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerMessage : %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saut du téléchargement de %s, car le fichier demandé n'est pas récent."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Échec du téléchargement de la liste des nœuds."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Échec de l'ouverture du fichier de vérification de version téléchargé"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Fichier de vérification de version corrompu"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Vous utilisez une version obsolète d'aMule !"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Votre version d'aMule est %i.%i.%i et la dernière version est %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La dernière version peut toujours être trouvée sur https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVERTISSEMENT : votre version d'aMuled est obsolète : %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Votre version d'aMule est à jour."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Échec du téléchargement du fichier de vérification de version"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilisateurs : %s | Fichiers : %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilisateurs : E : %s K : %s | Fichiers : E : %s K : %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Aucun réseau sélectionné"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "avec un LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "avec un HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connecté à %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connexion à %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Déconnecté de eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad démarré."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad arrêté."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Connecté à Kad (OK)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Connecté à Kad (pare-feu)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Déconnecté de Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Le réseau Kad ne peut être utilisé si le port UDP est désactivé dans les préférences, pas de démarrage."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Le réseau Kad est désactivé dans les préférences, pas de connexion."
 
@@ -2592,7 +2602,7 @@ msgstr "Connexion externe : accès refusé car : "
 msgid "External Connection: Handshake failed."
 msgstr "Connexion externe : Échange raté."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Processus ASIO %d démarré"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -26,20 +26,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Poedit 3.9\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Afficher aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Contrôle à distance d'aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot :"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -47,7 +47,7 @@ msgstr ""
 "Client P2P multiplateforme basé sur eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -55,59 +55,59 @@ msgstr ""
 "Copyright (c) 2003-2026 L'équipe aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Une partie d'aMule est basée sur \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia : Routage peer-to-peer basé sur la métrique XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Site web :"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forum :"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr "Documentation :"
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr "Bugs :"
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Vérifier les nouvelles versions au démarrage"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Connexion à Kad…"
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Vous utilisez une version obsolète d'aMule !"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Non disponible"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -209,8 +209,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossible d'ajouter %u lien depuis le fichier ED2KLinks (cf. le journal pour les détails)."
 msgstr[1] "Impossible d'ajouter %u liens depuis le fichier ED2KLinks (cf. le journal pour les détails)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -225,47 +225,57 @@ msgstr "Échec de l'ouverture du fichier ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVERTISSEMENT : Vous ne pouvez pas vous ajouter vous-même en tant que source pour un lien eD2k alors que vous avez un LowID."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Et maintenant on quitte l'application principale…"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Interruption de l'instance amuleweb avec le pid '%d' … "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mise à mort de l'instance amuleweb avec le pid '%d' … "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Échec"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit : Arrêt du noyau."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Fermeture d'aMule terminée."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Résultats du débogage de la mémoire pour la sortie d'aMule :"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Votre localisation a été remise à la valeur par défaut à cause d'un changement dans la configuration. Désolé."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Infos"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -273,21 +283,21 @@ msgstr ""
 "\n"
 "Configuration EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Mot de passe renseigné et connexions externes activées."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "Amorçage de réseau"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -295,34 +305,34 @@ msgstr ""
 "aMule a détecté des fichiers d'amorçage de réseau manquants.\n"
 "Sélectionnez ceux à télécharger :"
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "Liste de serveurs eD2k (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nœuds d'amorçage Kad (nodes.dat)"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serveur web s'exécutant avec le pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossible de lier les ports à l'adresse spécifiée : %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Le port %u n'est pas disponible. Vous serez LowID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -337,48 +347,48 @@ msgstr ""
 "\n"
 "Vérifiez votre réseau pour être sûr que le port est ouvert en sortie et en entrée."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Échec de la création du fichier OnlineSig"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Échec de la création du fichier aMule OnlineSig"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La localisation choisie semble ne pas être installée sur votre machine. (Note : Je tente de la forcer quand même)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "C'est la première fois que vous lancez aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Cette version est une version de test, mise à jour quotidiennement, et\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nous ne fournissons aucune garantie que cela n'endommagera rien, brûlera votre maison,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou tuera votre chien. Mais ça *devrait* être à peu près sûr quand-même.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plus d'informations, de l'aide et de nouvelles versions peuvent être trouvées sur notre page web,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, ou sur notre canal IRC : #aMule sur irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Ne vous gênez pas pour reporter tout bogue sur https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -386,137 +396,137 @@ msgstr ""
 "Le répertoire choisi pour les fichiers de signature en ligne est INVALIDE !\n"
 "La signature en ligne sera DÉSACTIVÉE jusqu'à ce que cela soit corrigé dans les préférences."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Nom du serveur signalé"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Erreur lors de la réserve d'espace pour le fichier '%s' : %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ERREUR : impossible d'ouvrir le fichier journal"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVERTISSEMENT : le fichier journal est vide. Quelque chose ne va pas."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Le journal a été effacé"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerMessage : %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saut du téléchargement de %s, car le fichier demandé n'est pas récent."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Échec du téléchargement de la liste des nœuds."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Échec de l'ouverture du fichier de vérification de version téléchargé"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Fichier de vérification de version corrompu"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Vous utilisez une version obsolète d'aMule !"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Votre version d'aMule est %i.%i.%i et la dernière version est %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La dernière version peut toujours être trouvée sur https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVERTISSEMENT : votre version d'aMuled est obsolète : %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Votre version d'aMule est à jour."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Échec du téléchargement du fichier de vérification de version"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilisateurs : %s | Fichiers : %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilisateurs : E : %s K : %s | Fichiers : E : %s K : %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Aucun réseau sélectionné"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "avec un LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "avec un HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connecté à %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connexion à %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Déconnecté de eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad démarré."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad arrêté."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Connecté à Kad (OK)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Connecté à Kad (pare-feu)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Déconnecté de Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Le réseau Kad ne peut être utilisé si le port UDP est désactivé dans les préférences, pas de démarrage."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Le réseau Kad est désactivé dans les préférences, pas de connexion."
 
@@ -555,15 +565,15 @@ msgstr "Ceci est aMule %s basé sur eMule."
 msgid "Running on %s"
 msgstr "Tourne sur %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visitez https://github.com/amule-org/amule/releases/latest pour vérifier si une nouvelle version est disponible."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERREUR FATALE : Échec de la création du minuteur"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -573,222 +583,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "La dernière version peut toujours être trouvée sur https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Non disponible"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "boîte de dialogue aMule détruite"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Connexion en cours"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k : Connexion en cours"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k : Déconnecté"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad : Derrière un pare-feu"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad : Connecté"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad : Connexion en cours"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad : Coupé"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Stopper les essais de connexions en cours"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Se déconnecter des réseaux actuellement connectés"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Se connecter"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Se connecter aux réseaux actuellement activés"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "E : %.1f%s (%.1f) | R : %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " Mo/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " Ko/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "E : %.1f%s | R : %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connecté)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Déconnecté)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Voulez-vous vraiment quitter %s ?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Confirmation de sortie"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Commande de lancement : "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- défaut -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Le répertoire de thèmes '%s' n'existe pas"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVERTISSEMENT : Impossible d'ouvrir le fichier thème '%s' pour la lecture"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Réseaux"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Fenêtre des réseaux"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Recherches"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Fenêtre de Recherche"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Téléchargements"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Fenêtre des Téléchargements"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Fichiers partagés"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Fenêtre des Fichiers Partagés"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Messages"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Fenêtre des Messages"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Fenêtre des Statistiques"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Fenêtre des Préférences"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importer"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "L'outil d'importation de fichier .part"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "À propos"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "À propos/Aide"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Réseau eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Réseau Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Pas de réseau"
 
@@ -878,8 +888,8 @@ msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on gar
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Inconnu"
@@ -1242,19 +1252,19 @@ msgstr "Auto [Haute]"
 msgid "Very low"
 msgstr "Très basse"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Basse"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1286,7 +1296,7 @@ msgid "On Queue"
 msgstr "En attente"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "En téléchargement"
 
@@ -1346,7 +1356,7 @@ msgstr "Serveur Local"
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1417,7 +1427,7 @@ msgstr "Partie"
 msgid "Size"
 msgstr "Taille"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Reçu"
 
@@ -1430,7 +1440,7 @@ msgid "Progress"
 msgstr "Progression"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Sources"
 
@@ -1440,7 +1450,7 @@ msgstr "Sources"
 msgid "Priority"
 msgstr "Priorité"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Statut"
 
@@ -1473,7 +1483,7 @@ msgstr ""
 "Retour de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2124,7 +2134,7 @@ msgstr "Échec de l'ouverture du fichier de la liste d'amis 'emfriends.met' pour
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIQUE - Pas de client dans StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Amis"
 
@@ -2408,8 +2418,8 @@ msgstr "Port invalide pour l'amorçage"
 msgid "Please fill all fields required"
 msgstr "Veuillez remplir tous les champs requis"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Message"
 
@@ -2481,7 +2491,7 @@ msgstr "Ratio de partage"
 msgid "Uploaded"
 msgstr "Émis"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Demandé"
 
@@ -2515,30 +2525,30 @@ msgstr "Erreur inconnue %d"
 msgid "Unable to get error description for error %d"
 msgstr "Impossible d'obtenir la description d'erreur pour l'erreur %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Hachage"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Finalisation"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Terminé"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "En pause"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Erroné"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "En attente"
 
@@ -2582,7 +2592,7 @@ msgstr "Connexion externe : accès refusé car : "
 msgid "External Connection: Handshake failed."
 msgstr "Connexion externe : Échange raté."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Processus ASIO %d démarré"
@@ -2604,7 +2614,7 @@ msgid "WARNING: "
 msgstr "AVERTISSEMENT : "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Fermer"
 
@@ -2713,7 +2723,7 @@ msgstr "Quitter"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "Ko/s"
@@ -2953,7 +2963,7 @@ msgstr "Octets"
 msgid "KB"
 msgstr "Ko"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "Mo"
@@ -3022,7 +3032,7 @@ msgstr "Effacer les téléchargements terminés"
 msgid "File sources:"
 msgstr "Sources du fichier :"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Général"
 
@@ -3043,7 +3053,7 @@ msgstr "Nom complet :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3219,7 +3229,7 @@ msgstr "Nom d'utilisateur :"
 msgid "Userhash :"
 msgstr "Hachage de l'utilisateur :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ajouter"
@@ -3228,15 +3238,15 @@ msgstr "Ajouter"
 msgid "Download-Speed"
 msgstr "Vitesse de réception"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Actuelle"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Moyenne totale"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Moyenne de la session"
 
@@ -3248,7 +3258,7 @@ msgstr "Vitesse d'émission"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Téléchargements actifs"
 
@@ -3256,7 +3266,7 @@ msgstr "Téléchargements actifs"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Envois actifs"
 
@@ -3457,8 +3467,8 @@ msgstr "Sélection du navigateur"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indiquez le nom de votre navigateur ici. Laissez ce champ vide pour utiliser le navigateur par défaut du système."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3532,147 +3542,156 @@ msgstr "Lier l'adresse locale à une IP (vide pour toutes) :"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Utilisateurs avancés uniquement : Si vous avez plusieurs interfaces réseau, entrez l'adresse de l'interface à laquelle aMule doit être lié."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Lier l'adresse locale à une IP (vide pour toutes) :"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Sources maximales par fichier téléchargé :"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Connexions simultanées maximales :"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Se connecter automatiquement au démarrage"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Reconnecter en cas de déconnexion"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Supprimer les serveurs inactifs après"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "essais"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Mise à jour automatique de la liste des serveurs au démarrage"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Mise à jour de la liste des serveurs dès la connexion à un serveur"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Mise à jour de la liste des serveurs dès la connexion d'un client"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Utiliser le système de priorité"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Utiliser la vérification du LowID à la connexion"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Connexion sûre"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Se connecter automatiquement seulement sur les serveurs statiques"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Mettre les serveurs ajoutés manuellement en priorité haute"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestion Intelligente de la Corruption (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Activer"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avancée se fie aux hachages (non recommandé)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Ajouter les fichiers à télécharger en mode Pause"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Ajouter les fichiers à télécharger en priorité automatique"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Essayer de télécharger la première et la dernière partie en premier"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Démarrer le prochain fichier en pause lorsqu'un fichier se termine"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "De la même catégorie"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "Dans l'ordre alphabétique"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Réserver de l'espace disque pour les nouveaux fichiers"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Réserve de l'espace du disque pour les nouveaux fichiers, réduisant ainsi la fragmentation"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe les téléchargements lorsque l'espace disponible est atteint "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Sélectionnez ceci si vous souhaitez qu'aMule vérifie votre espace disque"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Entrez ici l'espace disque minimum désiré."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Sauver 10 sources pour les fichiers rares (< 20 sources)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Émission"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Ajouter les nouveaux fichiers partagés en priorité automatique"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Dossier de destination des téléchargements"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3680,599 +3699,599 @@ msgstr ""
 "Les téléchargements terminés sont stockés ici. Tous les fichiers de ce répertoire sont automatiquement partagés avec les autres pairs.\n"
 "Si ce répertoire contient également des fichiers que vous ne souhaitez pas partager, indiquez un sous-répertoire réservé à aMule."
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Choisissez le répertoire où les téléchargements terminés seront enregistrés. Tous les fichiers de ce répertoire seront partagés avec les autres pairs."
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tous les fichiers de ce répertoire sont partagés avec les autres pairs)"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Dossier des fichiers de téléchargements temporaires"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Dossiers partagés"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clic droit sur l'icône du répertoire pour un partage récursif)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Partager les fichiers cachés"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "Analyser automatiquement à nouveau les répertoires partagés pour rechercher des modifications"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr "Suivre les liens symboliques dans les répertoires partagés"
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Graphiques"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Délais de rafraîchissement : 5 s"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Temps pour la courbe de la moyenne : 100 min"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Échelle du graphique des connexions : 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Échelle des graphiques de réception :"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Échelle des graphiques d'envoi :"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Couleurs : "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fond"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Quadrillage"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Téléchargement actuel"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Téléchargement moyen total"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Téléchargement moyen sur la session"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Envoi actuel"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Envoi moyen total"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Envoi moyen sur la session"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "Barre de vitesse dans l'icône de barre des tâches"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Nœuds Kad actuels"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Nœuds Kad total"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Nœuds Kad pour la session"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Sélectionner"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions client affichées (0=illimité)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! AVERTISSEMENT !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Nombre maximum de nouvelles connexions / 5 secs"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Taille du fichier de tampon : 240000 octets"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Taille de la file d'attente d'envoi : 5000 clients"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Désactiver la mise en veille programmé de l'ordinateur"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Thème à utiliser : "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Afficher le \"Gestionnaire rapide de liens eD2k \" dans chaque fenêtre."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Afficher des infos supplémentaires sur les onglets des catégories"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Afficher la version de l'application dans le titre"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Afficher les taux de transfert dans la barre de titre"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Avant le nom de l'application"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Après le nom de l'application"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Afficher la surcharge de la bande passante"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientation de la barre d'outils verticale"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Fichiers à télécharger en file d'attente"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Afficher le pourcentage de progression"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Afficher la barre de progression"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Relief"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Triage automatique des fichiers (augmente la charge du CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule triera automatiquement les colonnes dans votre liste de téléchargements"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Paramètres de Connexion Externe"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Accepter les connexions externes"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP de l'interface d'écoute :"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Entrer ici une adresse IP valide dans le format a.b.c.d pour l'interface d'écoute EC. Un champ vide ou 0.0.0.0 signifiera toutes les interfaces."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Port TCP :"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activer la redirection de ports en UPnP sur le port EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Mot de passe"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Paramètres du serveur Web"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Démarrer le serveur web au démarrage"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Activer l'accès utilisateur sans privilèges"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Mot de passe sans privilèges"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activer la redirection de port UPnP sur le port du serveur web"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP UPnP du serveur web (Facultatif)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalle de rafraîchissement (en secondes)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Activer la compression Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Cliquer ici pour appliquer tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Annule tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titre :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Commentaire :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Répertoire entrant :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Changer la priorité des nouveaux fichiers assignés :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Ne rien changer"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Choisir la couleur pour cette Catégorie (actuellement sélectionnée) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Cliquer ici pour effacer le journal."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Cliquer ici pour mettre à jour la liste des serveurs à partir de l'URL…"
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Liste des serveurs"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Entrer l'URL d'un fichier server.met et presser le bouton à gauche pour rafraîchir la liste des serveurs connus."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Ajouter un serveur manuellement : Nom"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Entrer ici le nom du nouveau serveur"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP : Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Entrer ici l'adresse IP du serveur, avec le format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Entrer ici le port du serveur."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ajouter manuellement un serveur (remplir les champs à gauche avant)…"
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Journal d'aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Infos Serveur"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Infos ED2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Infos Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Cliquer sur le bouton pour mettre à jour la liste des nœuds depuis l'URL…"
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nœuds (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Entrer l'URL d'un fichier nodes.dat ici et presser le bouton à gauche pour mettre à jour la liste des nœuds connus."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Statistiques des nœuds"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Amorçage"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nouveau nœud"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP :"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Amorçage depuis les clients connus"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Déconnecter Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Utiliser l'Identification Utilisateur Sécurisée (SUI)"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Il est recommandé d'activer cette option. Vous ne recevrez pas de crédits si SUI n'est pas activé."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Supporter le brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Cette option active le brouillage de protocole, cela permet à aMule d'accepter les connexions brouillées des autres clients."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utiliser le brouillage pour les connexions sortantes"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Avec cette option, aMule utilise le brouillage de protocole lors des connexions aux autres clients/serveurs."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Accepter seulement les connexions brouillées"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Avec cette option, aMule n'accepte que les connexions brouillées. Vous aurez moins de sources, mais tout votre trafic sera brouillé"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Tout le monde"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Personne"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Qui peut voir mes fichiers partagés :"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Indique qui peut voir votre liste de fichiers partagés."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtrage des IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtrage des clients"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activer le filtrage des clients selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtrage des serveurs"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Active le filtrage des serveurs selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Recharger la liste"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recharge la liste des IP à filtrer à partir du fichier ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL :"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Mettre à jour maintenant"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Mise à jour d' IPFilter au démarrage"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Niveau de filtrage :"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Toujours filtrer les IPs LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Prise en charge paranoïaque des IPs qui ne se correspondent pas"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Rejette le paquet si l'IP du client est différente de l'ip d'où le paquet est envoyé. À utiliser avec prudence."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utiliser un ipfilter.dat système si disponible"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "S'il n'y a pas de fichier ipfilter.dat local, autoriser l'utilisation d'un fichier ipfilter système."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Activer la Signature En Ligne"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Active l'écriture du fichier de signature en ligne, qui peut-être utilisé par des applications extérieures pour créer des signatures, etc."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Fréquence de mise à jour (Secondes) :"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Change la fréquence des mises à jour de la signature en ligne (en secondes)."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Sauver le fichier de signature en ligne dans : "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Cliquer ici pour sélectionner le répertoire contenant le fichier de signature en ligne."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Voir les drapeaux des pays pour les clients"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Afficher la colonne des drapeaux des pays dans les vues des transferts, des files d'attente et de recherche. Nécessite une base de données MMDB GeoIP valide (cf. ci-dessous)."
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr "Base de données"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr "Source :"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuit, pas de compte)"
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuit, compte nécessaire)"
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr "URL personnalisé"
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Choisissez quel fournisseur procure la base de données GeoIP MMDB. DB-IP est la valeur par défaut - ne nécessite pas de compte. MaxMind nécessite un compte gratuit + une clef de licence. Utilisez un URL personnalisé pour pointer vers tout autre hôte MMDB (par exemple un miroir local)."
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4284,11 +4303,11 @@ msgstr ""
 "Les données IP vers pays par DB-IP.com - https://db-ip.com\n"
 "Licence : Creative Commons Attribution 4.0 - https://creativecommons.org/licenses/by/4.0/deed.fr"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr "Clef de licence :"
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4304,11 +4323,11 @@ msgstr ""
 "Licence : CLUF MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Nécessite une attribution et la création d'un compte ; actualisez au moins tous les 30 jours."
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr "URL de téléchargement :"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4318,211 +4337,211 @@ msgstr ""
 "L'URL peut contenir un identifiant et mot de passe (https://utilisateur:motdepasse@hôte/...) \n"
 "La licence et les conditions d'attribution sont définies par l'URL d'origine - vous en êtes responsable."
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr "Télécharger la base de données GeoIP depuis la source sélectionnée."
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr "Mise à jour automatique au démarrage"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Télécharger à nouveau la base de données GeoIP depuis la source sélectionnée chaque fois qu'aMule démarre."
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrer les messages entrant (sauf la discussion en cours) :"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtrer tous les messages"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrer les messages des gens qui ne sont pas sur votre liste d'amis"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtrer les messages des clients inconnus"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrer les messages contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "ajouter ici les mots qu'aMule doit filtrer : blocage des messages les contenant"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Afficher les messages reçus dans le journal"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Commentaires"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrer les commentaires contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Activer l'authentification"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Active/Désactive l'authentification par nom d'utilisateur/mot de passe"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Nom d'utilisateur : "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Nom d'utilisateur pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Mot de passe pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Activer le Proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Active/Désactive le support proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Type de proxy :"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Hôte du proxy :"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Nom de l'hôte du proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Port du proxy :"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Numéro du port du proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Se connecter à :"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Connexion distante à aMule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nom d'utilisateur"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Se rappeler de ces réglages"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr "Forcer la compression ZLIB"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activer l'historique du mode de débogage bavard."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Seulement vers le fichier journal"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Catégories des messages :"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "En attente…"
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Ajouter des fichiers à importer"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Réessayer avec la sélection"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Supprimer la sélection"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Types d'événements"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiques et clients en attente pour le(s) fichier(s) sélectionné(s) : Session / Tous les temps"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Envois Actifs"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Pourcentage du total de fichiers"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Fichiers sélectionnés"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Envois actifs seulement"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Recharger :"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Recharge vos fichiers partagés"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Envoyer"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Envoie le message spécifié."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Ferme cette session de discussion."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Se connecter à n'importe quel serveur et/ou Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Fichiers partagés"
 
@@ -4599,7 +4618,7 @@ msgstr "tous les autres"
 msgid "Incomplete"
 msgstr "Incomplet"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Arrêté"
 
@@ -4788,34 +4807,34 @@ msgstr "Impossible de lire le fichier seeds pour le fichier partiel %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Erreur lors de la lecture du fichier seeds du fichier .part (%s - %s) : %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Une partie corrompue trouvée (%d) dans %d parties du fichier %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Une partie corrompue trouvée (%d) dans %d partie du .part %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Partie complète (%i) trouvée dans %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Ré-hachage de %s terminé"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Erreur inattendue lors de la finalisation de %s. Fichier mis en pause"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Téléchargement terminé : %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4824,306 +4843,306 @@ msgstr ""
 "Téléchargement suivant terminé :\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Fichier supprimé : %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVERTISSEMENT : Impossible de calculer le hachage de la partie téléchargée. Ensemble de hachage incomplet pour '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERREUR : Impossible de calculer le hachage de la partie téléchargée - Ensemble de hachage incomplet pour (%s). Ceci ne devrait jamais arriver"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "La partie %u de «%s » est marqué comme complétée mais le fichier partiel est plus petit qu'attendu (possède %llu octets, nécessite %llu octets) ; réouverture de la fenêtre de téléchargement."
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF lors du hachage du fichier .part téléchargé %u avec une longueur %u (max %u) du fichier .part '%s' avec une longueur %u : %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVERTISSEMENT : Pas assez d'espace disque disponible ! Mise en pause du fichier : %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "La partie téléchargée %i est corrompue dans le fichier : %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH : Partie corrompue %i récupérée pour %s -> Octets sauvés : %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "En cours d'allocation"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Espace disque insuffisant"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Téléchargé"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERREUR : Impossible d'ouvrir fichier .part : '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Système par défaut"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanais"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturien"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgare"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chinois (Simplifié)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chinois (Traditionnel)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croate"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Tchèque"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danois"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Hollandais"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Anglais (U.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr "Anglais (É-U)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonien"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandais"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Français"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galicien"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Allemand"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hébreux"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italien"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italien (Suisse)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonais"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Coréen"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituanien"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvégien (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polonais"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugais (Brésilien)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Roumain"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Russe"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovène"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Suédois"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Changer de langue"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Il n'y a pas de traductions installées pour aMule"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Pas de langues disponibles"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "pas d'option disponible"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Catégorie invalide trouvée, on passe"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Le port TCP ne peut pas dépasser 65532 car le socket UDP du serveur sera à TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Le port par défaut sera utilisé (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Connexion"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Répertoires"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Serveurs"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Fichiers"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Sécurité"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Contrôles à distance"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Signature en ligne"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avancé"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Événements"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Débogage"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5133,15 +5152,15 @@ msgstr ""
 "    %PARTFILE - chemin complet vers le fichier\n"
 "    %PARTNAME - nom du fichier seulement"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "L'icône de la barre système nécessite libayatana-appindicator3 au moment de la compilation."
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non disponible sous Wayland : le protocole n'informe pas lorsqu'une fenêtre est minimisée, cette option ne peut donc intercepter le bouton de minimisation du système. Solution de contournement : lancez aMule avec `GDK_BACKEND=x11` pour utiliser XWayland à la place."
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5157,26 +5176,26 @@ msgstr ""
 "aMule fonctionnera bien en ne modifiant pas\n"
 "ces réglages."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Échec à la connexion de Cfg au widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis Cfg vers le widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Type de proxy auquel vous êtes connecté"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis le widget vers Cfg avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5184,31 +5203,36 @@ msgstr ""
 "aMule doit être redémarré pour activer ces changements : \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- Port TCP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- Port UDP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Interface de connexion externe changé.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Port de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Consentement de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Support du brouillage de protocole changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5216,7 +5240,7 @@ msgstr ""
 "Votre liste de serveur pour la mise à jour automatique est vide.\n"
 "'Mise à jour automatique au démarrage de la liste des serveurs' va être désactivée."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5224,19 +5248,19 @@ msgstr ""
 "Vous avez activé les connexions externes mais vous n'avez pas spécifié de mot de passe valide.\n"
 "Les connexions externes ne pourront pas être activées tant qu'un mot de passe valide n'est pas spécifié."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Langue changée.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Dossier temporaire changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Réseau ED2K activé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5244,7 +5268,7 @@ msgstr ""
 "Les réseaux eD2k et Kad sont désactivés.\n"
 "Vous ne pourrez pas vous connecter tant que vous n'activerez pas au moins l'un des deux."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5252,7 +5276,7 @@ msgstr ""
 "Kad ne démarrera pas si votre port UDP est désactivé.\n"
 "Activez le port UDP ou désactivez Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5262,19 +5286,19 @@ msgstr ""
 "Vous DEVEZ redémarrer aMule maintenant.\n"
 "Si vous ne le faites pas, ne vous plaignez pas si des bogues surviennent.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule pour un lancement automatique à l'ouverture d'une session. Le dépôt de lancement automatique est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Échec de l'effacement de l'entrée du lancement automatique à l'ouverture d'une session."
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr "Lancement automatique"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5284,41 +5308,41 @@ msgstr ""
 "Entrez s'il vous plaît au moins une URL qui pointe sur un fichier server.met valide.\n"
 "Cliquez sur le bouton \"Liste\" à coté de cette case pour entrer une URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Fichiers temporaires"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Fichiers réceptionnés"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Signatures En Ligne"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Choisir un dossier pour %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Chercher un lecteur vidéo"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Choisir un navigateur"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Exécutable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Éditer la liste des serveurs"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5326,114 +5350,114 @@ msgstr ""
 "Ajoutez ci-dessous des URL pour télécharger des fichiers server.met.\n"
 "Seulement une URL par ligne."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr "Échec de la mise à jour IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr "Données fournies par MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr "Source personnalisée"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr "Données fournies par DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "État : %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "État : %s - %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "État : échec du chargement - cliquez sur « Mettre à jour maintenant » pour actualiser."
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "État : introuvable - cliquez sur « Mettre à jour maintenant » pour télécharger."
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Délais de rafraîchissement : %d seconde"
 msgstr[1] "Délais de rafraîchissement : %d secondes"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps pour le graphe des moyennes : %d minute"
 msgstr[1] "Temps pour le graphe des moyennes : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Échelle du graphique des connexions : %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Taille du tampon de fichiers : %d octet"
 msgstr[1] "Taille du tampon de fichiers : %d octets"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Taille de la fille d'attente d'émission : %d client"
 msgstr[1] "Taille de la fille d'attente d'émission : %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalle de rafraîchissement de la connexion serveur : %d minute"
 msgstr[1] "Intervalle de rafraîchissement de la connexion serveur : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exécuter la commande lors de l'événement '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Activer l'exécution de la commande sur le noyau"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Commande du noyau :"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Activer l'exécution de la commande sur l'interface graphique"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Commande de l'interface graphique :"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Les variables suivantes seront remplacées :"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -5441,32 +5465,32 @@ msgstr ""
 "Les répertoires suivants semblent être des répertoires système ou des emplacements sensibles.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Les partager récursivement publiera chaque fichier contenu dans les sous répertoires sur les réseaux eD2k/Kad. Êtes-vous sûr de vouloir faire cela ?"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr "Confirmer les dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr "Rechargement des fichiers partagés…"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr "Analyse des sous-répertoires…"
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr "Mise à jour des dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr "%u répertoires analysés…"
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Rechargement des fichiers partagés : %u fichiers analysés"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -219,8 +219,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Non se puido engadir a ligazón %u do ficheiro ED2KLinks (consulte o rexistro)."
 msgstr[1] "Non se puideron engadir as ligazóns %u do ficheiro ED2KLinks (consulte o rexistro)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -265,27 +265,37 @@ msgstr "Apagado completado."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuración da memoria ao sair de aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O idioma cambiouse ao predeterminado do sistema debido a un troco na configuración."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -293,20 +303,20 @@ msgstr ""
 "\n"
 "Configuración CE"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "Arranque da rede"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -314,35 +324,35 @@ msgstr ""
 "aMule detectou que faltan ficheiros necesarios para arrancar a rede.\n"
 "Escolla os que queira descargar:"
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de inicio de Kad (nodes.dat)"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se puideron vincular os portos á dirección especificada: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u non está dispoñible . Terá IDBAIXA\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -357,48 +367,48 @@ msgstr ""
 "\n"
 "Comprobe a súa rede para asegurarse de que o porto está aberto para a entrada e saída."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig de aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado semella non estar instalado. (Nota: Intentarase usalo a pesar diso)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que iniciou aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta versión é unha versión en proba, actualizada diariamente, e\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non lle aseguramos que non se rompa algo, lle prenda lume a súa casa,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou mate ao seu can. Pero non debería pasar nada.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Pode atopar máis información, axuda e novas actualizacións na nosa páxina,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, ou na nosa canle IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Pode avisar de calquera problema en https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -406,137 +416,137 @@ msgstr ""
 "O cartafol que especificou para as Sinaturas En Liña non é válido!\n"
 "A Sinatura En Liña permanecerá desactivada ata que se arranxe a configuración."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Nome do servidor avisado"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Fallou a reserva do espazo no disco duro para o ficheiro «%s»: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: non se pode abrir o ficheiro do rexistro"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de rexistro está baleiro. Algo está mal."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "O rexistro foi borrado"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaxe do servidor: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saltouse a descarga de %s, por que o ficheiro pedido é máis antigo."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Non se puido descargar a lista de nodos."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Non se puido abrir o ficheiro de comprobación da versión descargado"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Ficheiro de comprobación da versión corrupto"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Está usando unha versión de aMule desactualizada!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A súa versión de aMule é %i.%i.%i e a última versión é %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A súa versión de aMule está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "A súa copia de aMule está actualizada."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Non se puido descargar o ficheiro de comprobación de versión"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Sen redes seleccionadas"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con IDBaixa"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Desconectouse do eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Iniciado Kad."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Parado Kad."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (devasa)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Non se pode usar a rede Kad se o porto UDP está desactivado nas preferencias. Non se iniciou."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desactivada nas preferencias. Non se iniciou."
 
@@ -2603,7 +2613,7 @@ msgstr "Conexión externa: Acceso denegado debido a: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: Fallou o saúdo."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Fío de E/S asíncrono %d iniciado"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -35,20 +35,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.6\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "control remoto de aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Instantánea:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -56,7 +56,7 @@ msgstr ""
 "Cliente «Multi-Plataforma» p2p baseado no eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -65,59 +65,59 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Parte do aMule está baseado en \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Encamiñamento entre pares baseado na métrica XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Páxina web:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Foro:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprobar se hai unha nova versión ao iniciar"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Conectando a Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Está usando unha versión de aMule desactualizada!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Non dispoñible"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -219,8 +219,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Non se puido engadir a ligazón %u do ficheiro ED2KLinks (consulte o rexistro)."
 msgstr[1] "Non se puideron engadir as ligazóns %u do ficheiro ED2KLinks (consulte o rexistro)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -235,47 +235,57 @@ msgstr "Non se puido abrir o ficheiro con ligazóns eD2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Non podes engadirte a ti mesmo como unha fonte para un enlace eD2k tendo ID baixa."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Saíndo da aplicación principal..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Rematando o proceso de amuleweb co pid «%d» ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Obrigando ao proceso de amuleweb con pid «%d» a pecharse ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Erro"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Ao Sairen(OnExit): Apagando o núcleo."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Apagado completado."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuración da memoria ao sair de aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O idioma cambiouse ao predeterminado do sistema debido a un troco na configuración."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -283,20 +293,20 @@ msgstr ""
 "\n"
 "Configuración CE"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "Arranque da rede"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -304,35 +314,35 @@ msgstr ""
 "aMule detectou que faltan ficheiros necesarios para arrancar a rede.\n"
 "Escolla os que queira descargar:"
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de inicio de Kad (nodes.dat)"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se puideron vincular os portos á dirección especificada: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u non está dispoñible . Terá IDBAIXA\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -347,48 +357,48 @@ msgstr ""
 "\n"
 "Comprobe a súa rede para asegurarse de que o porto está aberto para a entrada e saída."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig de aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado semella non estar instalado. (Nota: Intentarase usalo a pesar diso)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que iniciou aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta versión é unha versión en proba, actualizada diariamente, e\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non lle aseguramos que non se rompa algo, lle prenda lume a súa casa,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou mate ao seu can. Pero non debería pasar nada.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Pode atopar máis información, axuda e novas actualizacións na nosa páxina,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, ou na nosa canle IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Pode avisar de calquera problema en https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -396,137 +406,137 @@ msgstr ""
 "O cartafol que especificou para as Sinaturas En Liña non é válido!\n"
 "A Sinatura En Liña permanecerá desactivada ata que se arranxe a configuración."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Nome do servidor avisado"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Fallou a reserva do espazo no disco duro para o ficheiro «%s»: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: non se pode abrir o ficheiro do rexistro"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de rexistro está baleiro. Algo está mal."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "O rexistro foi borrado"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaxe do servidor: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saltouse a descarga de %s, por que o ficheiro pedido é máis antigo."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Non se puido descargar a lista de nodos."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Non se puido abrir o ficheiro de comprobación da versión descargado"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Ficheiro de comprobación da versión corrupto"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Está usando unha versión de aMule desactualizada!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A súa versión de aMule é %i.%i.%i e a última versión é %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A súa versión de aMule está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "A súa copia de aMule está actualizada."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Non se puido descargar o ficheiro de comprobación de versión"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Sen redes seleccionadas"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con IDBaixa"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Desconectouse do eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Iniciado Kad."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Parado Kad."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (devasa)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Non se pode usar a rede Kad se o porto UDP está desactivado nas preferencias. Non se iniciou."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desactivada nas preferencias. Non se iniciou."
 
@@ -565,15 +575,15 @@ msgstr "Este é aMule %s baseado en eMule."
 msgid "Running on %s"
 msgstr "Executando en %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para obter actualizacións."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO GRAVE: Non se puido crear o temporizador"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -583,222 +593,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Non dispoñible"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Destruído o cadro de diálogo de aMule"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Tras devasa"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Apagado"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Deter a tentativa actual de conexión"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes conectadas"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar ás redes activas"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Enviado: %.1f%s (%.1f) | Descargado: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Enviado: %.1f%s | Descargado: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Desexar saír de %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Confirmación da saída"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Ordes de Arranque: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- por omisión -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Non existe o directorio de temas «%s»"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Non se puido abrir o ficheiro de temas «%s» en modo lectura"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Xanela de Redes"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Buscas"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Xanela de buscas"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Xanela de descargas"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Xanela de ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Xanela de mensaxes"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Xanela de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Xanela de Preferencias"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "A ferramenta para importar ficheiros «part»"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Sobre/Axuda"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Sen rede"
 
@@ -888,8 +898,8 @@ msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantend
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Descoñecido"
@@ -1252,19 +1262,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Moi baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1296,7 +1306,7 @@ msgid "On Queue"
 msgstr "En cola"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Descargando"
 
@@ -1356,7 +1366,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1427,7 +1437,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1440,7 +1450,7 @@ msgid "Progress"
 msgstr "Progreso"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Fontes"
 
@@ -1450,7 +1460,7 @@ msgstr "Fontes"
 msgid "Priority"
 msgstr "Prioridade"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Estado"
 
@@ -1483,7 +1493,7 @@ msgstr ""
 "Comentarios de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automático"
@@ -2134,7 +2144,7 @@ msgstr "Non se puido escribir a lista de amigos ao ficheiro «emfriends.met»!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - non hai cliente en StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2418,8 +2428,8 @@ msgstr "Porto inválido para o arranque"
 msgid "Please fill all fields required"
 msgstr "Enche todos os campos requiridos"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Mensaxe"
 
@@ -2491,7 +2501,7 @@ msgstr "Relación enviado/descargado"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Solicitado"
 
@@ -2525,30 +2535,30 @@ msgstr "Erro descoñecido %d"
 msgid "Unable to get error description for error %d"
 msgstr "Non se puido obter unha descrición do erro %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Creando o hash"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Rematando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Rematado"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pausado"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Erróneo"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Agardando"
 
@@ -2593,7 +2603,7 @@ msgstr "Conexión externa: Acceso denegado debido a: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: Fallou o saúdo."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Fío de E/S asíncrono %d iniciado"
@@ -2615,7 +2625,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Pechar"
 
@@ -2724,7 +2734,7 @@ msgstr "Saír"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2964,7 +2974,7 @@ msgstr "Octetos"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3033,7 +3043,7 @@ msgstr "Limpar descargas completadas"
 msgid "File sources:"
 msgstr "Fontes do ficheiro:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Xeral"
 
@@ -3054,7 +3064,7 @@ msgstr "Nome completo :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3230,7 +3240,7 @@ msgstr "Nome de usuario :"
 msgid "Userhash :"
 msgstr "Hash do usuario :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Engadir"
@@ -3239,15 +3249,15 @@ msgstr "Engadir"
 msgid "Download-Speed"
 msgstr "Velocidade de descarga"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Media de execución"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Media de sesión"
 
@@ -3259,7 +3269,7 @@ msgstr "Velocidade de envío"
 msgid "Connections"
 msgstr "Conexións"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3267,7 +3277,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexións activas (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Envíos activos"
 
@@ -3468,8 +3478,8 @@ msgstr "Selección de navegador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduza o nome do seu navegador aquí. Deixe o campo baleiro para empregar o navegador predeterminado do sistema."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3543,147 +3553,156 @@ msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Só usuarios experimentados: Se ten varias interfaces de rede, introduza a dirección da interface que quere que aMule use."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Límite de fontes por ficheiro descargado:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Conexións simultáneas máximas:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Conectar automaticamente ao iniciarse"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Volver a conectarse ao perder a conexión"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Eliminar servidores caídos tras"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "intentos"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Actualizar automáticamente a lista de servidores no arranque"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar a lista de servidores ao conectarse a un servidor"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Actualizar a lista de servidores cando un cliente se conecte"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Usar sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Control intelixente da IDBaixa ao conectar"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Conexión segura"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Conectar automaticamente só a servidores fixos"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar alta prioridade aos servidores engadidos manualmente"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Xestión Intelixente de Corrupcións (X.I.C, I.C.H en inglés)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Activada"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "O X.I.C. avanzado confía en cada hash (non recomendado)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Poñer en pausa os ficheiros engadidos á lista de descargas"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Engadir os novos ficheiros compartidos con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Tentar descargar antes o primeiro e último anaco do ficheiro"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Comezar co seguinte ficheiro que estea pausado cando remate o ficheiro actual"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Da mesma categoría"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "En orde alfabética"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Reservar espazo no disco para os novos ficheiros"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva o tamaño do ficheiro no disco para reducir a fragmentación"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar descargas canto o espazo libre no disco acade "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción se quere que aMule comprobe o espazo libre no disco"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Introduza o espazo mínimo de disco desexado."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Gardar 10 fontes en ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Enviado"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Engadir novas descargas con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Cartafol de destino para descargas"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3691,601 +3710,601 @@ msgstr ""
 "Aquí gárdanse as descargas completas. Automaticamente compartiranse todos os ficheiros do cartafol co resto de parceiros.\n"
 "Se o cartafol tamén conten ficheiros privados, apunte a ruta a un cartafol só para aMule."
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolla o cartafol onde gardar as descargas completas. Compartiranse todos os ficheiros do cartafol co resto de parceiros."
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Compartiranse todos os ficheiros do cartafol co resto de parceiros)"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Cartafol para ficheiros de descarga temporais"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Preme co botón dereito na icona do cartafol para compartir recursivamente)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Compartir ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "Revisar automaticamente se hai cambios nos cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Gráficas"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 segs"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo de media do gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do gráfico das conexións: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de descargas:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de envíos:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Enreixado"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Media das descargas en execución"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Media de descargas na sesión"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Media de subida en execución"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Media de subida na sesión"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Conexións activas"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade na bandexa do sistema"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuais"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Nodo Kad executándose"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Nodos Kad na sesión"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Árbore"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Cantas versións do cliente a amosar (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "ADVERTENCIA !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Novas conexións máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño do búfer de ficheiro: 240 000 octetos"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de conexión ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Impedir que o ordenador entre en modo espera"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar «Xestor rápido de ligazóns eD2k» en cada xanela."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información engadida nas lapelas das categorías"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Amosar a versión da aplicación no título"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferencia no título"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Antes do nome da aplicación"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Despois do nome da aplicación"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Amosar ancho de banda malgastado"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Barra de ferramentas en orientación vertical"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Cola de Descargas"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Amosar porcentaxe de progreso"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Amosar barra de progreso"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Clasificar ficheiros automaticamente (consume bastantes recursos)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule ordenará as columnas na súa lista de descargas automaticamente"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parámetros da Conexión Externa (CE)"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Aceptar conexións externas"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP da interface na que escoitar:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduza aquí a IP (válida, no formato a.b.c.d) da interface para a CE. Un campo baleiro ou 0.0.0.0 significa calquera interface."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar a configuración de portos por UPnP para o porto de CE"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasinal"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Arrancar o servidor web ao iniciar"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Modelo Web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Contrasinal para o administrador"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Activar invitado"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Contrasinal para o invitado"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Configurar o porto do servidor web mediante UPnP"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP para o UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo de actualización da páxina (en segs)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Activar compresión Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Vale"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Restablecer calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Título :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Comentario :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Cartafol de descargas :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridade para os novos ficheiros asignados :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar cor para esta categoría (a seleccionada) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Restablecer"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Premer este botón para reiniciar o rexistro."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Premer neste botón para actualizar a lista de servidores desde a URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduza a URL dun ficheiro server.met e prema o botón da esquerda para actualizar a lista de servidores coñecidos."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Engadir servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Introduza o nome do novo servidor aquí"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduza a IP do servidor aquí, usando o formato x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Introduza o porto do servidor aquí."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Engadir servidor manualmente (antes enche os campos á esquerda) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Rexistro de aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Info. do servidor"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Prema neste botón para actualizar a lista de nodos dende a URL ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduza aquí a URL ao ficheiro nodes.dat e prema o botón da esquerda, para actualizar a lista de nodos coñecidos."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Estatísticas de nodos"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Arranque autónomo (dende cero)"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Novo nodo"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes coñecidos"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Empregar a Identificación Segura do Usuario"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Aconséllase habilitar esta opción. Non recibirá créditos se a ISU non se habilitou."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Aceptar a ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa a ofuscación do protocolo, e permite que aMule acepte conexións ofuscadas doutros clientes."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación para as conexións saíntes"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use a ofuscación de protocolo cando se conectan outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar só conexións ofuscadas"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción fai que aMule só acepte conexións ofuscadas. Terá menos fontes, pero todo o tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Ninguén"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Quen pode ver os meus ficheiros compartidos:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quen pode solicitar ver a lista de ficheiros compartidos."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtrado de IPs"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos clientes definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos servidores definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Recargar lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar a lista de filtrado de IPs desde o ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre IPs LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Xestión paranoica de IPs non coincidintes"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Rexeitar os paquetes se a IP do cliente é distinta á da IP de onde se recibe o paquete. Usar con coidado."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Empregar un ipfilter.dat global se está dispoñible"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "De non atopar o ipfilter.dat local, permitir o emprego dun ipfilter global."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Activar Sinatura En liña"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar a escritura de ficheiros do SE. Sóese usar para crear sinaturas para aplicacións externas."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segs):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar a frecuencia (en segundos) da actualización da sinatura en liña."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Gardar o ficheiro de sinaturas en liña en: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Prema aquí para seleccionar o directorio que contén os ficheiros de sinaturas en liña."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Amosar as bandeiras do país de orixe dos clientes"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Fluxo de datos :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4293,11 +4312,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4307,225 +4326,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargado: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensaxes entrantes (excepto as da conversación actual):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensaxes"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensaxes de xente que non estea na lista de amigos"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensaxes de clientes descoñecidos"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensaxes que conteñan (use «,» como separador):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "engada aquí palabras para filtrar e bloquear as mensaxes que coincidan"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Amosar as mensaxes recibidas no rexistro"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentarios que conteñan (empregue «,» coma separador):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Activar identificación"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar a identificación mediante nome de usuario e contrasinal"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Nome de usuario: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de usuario a usar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Contrasinal:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "O contrasinal a empregar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Activar proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o tipo de proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Anfitrión do proxy:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "O nome do anfitrión do proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Conectar a amule remoto"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nome de usuario"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Recordar esas opcións"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Rexistro de Depuración Estendido."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Só ao ficheiro do rexistro"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Categorías das mensaxes:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Agardando..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Engadir importados"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Tentar de novo o seleccionado"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Borrar seleccionados"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas e clientes esperando para os ficheiros seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Envíos activos"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Porcentaxe de todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Ficheiros selecionados"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Só subidas activas"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Recargar os seus ficheiros compartidos"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Enviar a mensaxe especificada."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Pechar esta conversa."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a calquera servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Ficheiros compartidos"
 
@@ -4602,7 +4621,7 @@ msgstr "todo o demais"
 msgid "Incomplete"
 msgstr "Incompleto"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Parado"
 
@@ -4791,34 +4810,34 @@ msgstr "Non se puido ler o ficheiro coas sementes para o ficheiro parcial %s (%s
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Non se puido ler o ficheiro coas semente do ficheiro parcial (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Parte corrupta atopada (%d) en %d ficheiro parcial %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Parte corrupta atopada (%d) en %d ficheiros parcial %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Parte (%i) completada atopada en %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Rematouse a recreación do hash %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Ocorreu un erro inesperado mentres se completaba %s. Ficheiro pausado"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Rematouse a descarga: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4827,307 +4846,307 @@ msgstr ""
 "Rematouse a descarga:\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Eliminando ficheiro: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVISO: Non se puido crear o hash da parte descargada, o conxunto de hashes de «%s» está incompleto"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERRO: Non se puido crear o hash da parte descargada, o conxunto de hash de «%s» está incompleto. Isto non debería ocorrer en absoluto"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Parte %u de «%s» aparece como completada, pero o ficheiro parcial é máis pequeno do que debería (temos %llu octetos, precisamos %llu); intentando outra vez a descarga."
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Chegouse ao fin de ficheiro mentres se facía o hash da parte %u descargada con lonxitude %u (máx. %u) do ficheiro partido «%s» con lonxitude %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISO: Non hai suficiente espazo libre no disco! Parando ficheiro: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Part descargado %i é corrupto no ficheiro: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "XIC: Part corrupto recuperado %i para %s -> Octetos gardados: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Reservando"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Espazo no disco insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descargado"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Non se puido abrir o partfile «%s»"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Predeterminado"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chinés (Simplificado)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chinés (Tradicional)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiano (Suizo)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegués (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasileiro)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Castelán"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Cambiar idioma"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Non hai traducións instaladas para aMule"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Ningunha lingua dispoñible"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "non hai opcións disponibles"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida atopada, saltandoa"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP non pode ser máis alto que 65532 debido a que o socket do servidor UDP é TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Empregarase o porto predeterminado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Conexión"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Seguranza"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Sinatura En liña"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Depuración"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5137,15 +5156,15 @@ msgstr ""
 "    %PARTFILE - ruta completa do ficheiro\n"
 "    %PARTNAME - nome do ficheiro"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Para poder engadir unha icona precisa ter libayatana-appindicator3 durante a compilación."
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non dispoñible en Wayland: o protocolo non pode avisar se se minimiza unha xanela, polo que non se pode interceptar o botón de minimizar. Como alternativa, execute aMule con «GDK_BACKEND=x11» para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5161,26 +5180,26 @@ msgstr ""
 "aMule funcionará ben sen que cambie ningún\n"
 "destes parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Non se puido conectar a configuración ao compoñente coa ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Non se puido transferir información dende a configuración ao compoñente con ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao que se está a conectar"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Non se puido transferir información entre o compoñente e a configuración con ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5188,31 +5207,36 @@ msgstr ""
 "aMule debe ser reiniciado para activar estes trocos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Cambiada interface da conexión externa.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Cambiado o porto da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Cambiada a aceptación da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Cambiada interface da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Cambiada opción da ofuscación do protocolo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5220,7 +5244,7 @@ msgstr ""
 "A túa lista de servidores para auto-actualizar está baleira.\n"
 "Desactivarase a actualización no inicio."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5228,19 +5252,19 @@ msgstr ""
 "Permítense conexións externas pero non se especificou un contrasinal.\n"
 "As conexións externas non poden ser activadas ate que se especifique un contrasinal válido."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Cartafol temporal cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede eD2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5248,7 +5272,7 @@ msgstr ""
 "Tanto eD2k e Kad están desactivados.\n"
 "Non poderás conectarte ate activar algún dous."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5256,7 +5280,7 @@ msgstr ""
 "Kad non se iniciará se non está activado o porto UDP.\n"
 "Active o porto UDP ou desactive Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5266,19 +5290,19 @@ msgstr ""
 "Debe reiniciar o aMule agora.\n"
 "Se non o reinicia agora, ature coas consecuencias.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr "Arrancar ao inicio"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5288,41 +5312,41 @@ msgstr ""
 "Introduza polo menos unha URL dun ficheiro server.met.\n"
 "Prema no botón «Listar» para introducir unha URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Ficheiros temporais"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Ficheiros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Sinaturas En Liña"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolla un cartafol para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Atopar o reprodutor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Seleccione o navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Editar a lista dos servidores"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5330,115 +5354,115 @@ msgstr ""
 "Engadir aquí unha URL para descargar unha lista server.met.\n"
 "Só unha url nesta liña."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Período de actualización: %d segundo"
 msgstr[1] "Período de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo medio de gráfico: %d min"
 msgstr[1] "Tempo medio de gráfico: %d min"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica das conexións: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño do búfer dos ficheiros: %d octeto"
 msgstr[1] "Tamaño do búfer dos ficheiros: %d octetos"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño da cola de subida: %d cliente"
 msgstr[1] "Tamaño da cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización da conexión ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualización da conexión ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización da conexión ao servidor. Desactivada"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar unha orde no evento «%s»"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Activar execución de ordes no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Orde do núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Activar execución de ordes na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Orde da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variables serán substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -5446,32 +5470,32 @@ msgstr ""
 "Estas carpetas semellan parte do sistema, ou que poden ser confidenciais:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartir de xeito recursivo publicará calquera ficheiro que teñan debaixo nas redes eD2k e Kad. Comprobe todo ben antes de continuar."
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr "Confirmar e compartir cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr "Recargando os ficheiros compartidos…"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr "Buscando subdirectorios…"
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr "Actualizando os cartafoles compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr "Buscáronse %u directorios…"
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -219,8 +219,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Non se puido engadir a ligazón %u do ficheiro ED2KLinks (consulte o rexistro)."
 msgstr[1] "Non se puideron engadir as ligazóns %u do ficheiro ED2KLinks (consulte o rexistro)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -265,37 +265,42 @@ msgstr "Apagado completado."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuración da memoria ao sair de aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O idioma cambiouse ao predeterminado do sistema debido a un troco na configuración."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -303,20 +308,20 @@ msgstr ""
 "\n"
 "Configuración CE"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "Arranque da rede"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -324,35 +329,35 @@ msgstr ""
 "aMule detectou que faltan ficheiros necesarios para arrancar a rede.\n"
 "Escolla os que queira descargar:"
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de inicio de Kad (nodes.dat)"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se puideron vincular os portos á dirección especificada: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u non está dispoñible . Terá IDBAIXA\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -367,48 +372,48 @@ msgstr ""
 "\n"
 "Comprobe a súa rede para asegurarse de que o porto está aberto para a entrada e saída."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig de aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado semella non estar instalado. (Nota: Intentarase usalo a pesar diso)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que iniciou aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta versión é unha versión en proba, actualizada diariamente, e\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non lle aseguramos que non se rompa algo, lle prenda lume a súa casa,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou mate ao seu can. Pero non debería pasar nada.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Pode atopar máis información, axuda e novas actualizacións na nosa páxina,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, ou na nosa canle IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Pode avisar de calquera problema en https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -416,137 +421,137 @@ msgstr ""
 "O cartafol que especificou para as Sinaturas En Liña non é válido!\n"
 "A Sinatura En Liña permanecerá desactivada ata que se arranxe a configuración."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Nome do servidor avisado"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Fallou a reserva do espazo no disco duro para o ficheiro «%s»: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: non se pode abrir o ficheiro do rexistro"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de rexistro está baleiro. Algo está mal."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "O rexistro foi borrado"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaxe do servidor: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saltouse a descarga de %s, por que o ficheiro pedido é máis antigo."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Non se puido descargar a lista de nodos."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Non se puido abrir o ficheiro de comprobación da versión descargado"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Ficheiro de comprobación da versión corrupto"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Está usando unha versión de aMule desactualizada!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A súa versión de aMule é %i.%i.%i e a última versión é %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A súa versión de aMule está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "A súa copia de aMule está actualizada."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Non se puido descargar o ficheiro de comprobación de versión"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Sen redes seleccionadas"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con IDBaixa"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Desconectouse do eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Iniciado Kad."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Parado Kad."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (devasa)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Non se pode usar a rede Kad se o porto UDP está desactivado nas preferencias. Non se iniciou."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desactivada nas preferencias. Non se iniciou."
 
@@ -907,7 +912,7 @@ msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantend
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2268,49 +2273,49 @@ msgstr "Non"
 msgid "Yes"
 msgstr "Si"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Descarga HTTP cancelada"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "A URL para descargar non pode estar baleira"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Non se puido crear unha petición HTTP para %s"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "Descarga HTTP: corpo da resposta baleiro para %s"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Non se puido mover o ficheiro descargado a %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Descargado %s (%llu octetos)"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "A URL %s devolveu: %i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Non se puido descargar %s mediante HTTP: %s"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "Recibiuse un HTTP 401 (non permitido) para %s"
@@ -2613,7 +2618,7 @@ msgstr "Conexión externa: Acceso denegado debido a: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: Fallou o saúdo."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Fío de E/S asíncrono %d iniciado"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -194,8 +194,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -242,82 +242,92 @@ msgstr "הורדה הסתיימה"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "מידע"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "אישרור יצאיה"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "אזהרה"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "רשתות"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -327,185 +337,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "שם שרת:"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "שגיאה: לא יכול לפתוח קובץ יומן."
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "היומן אופס."
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "עם מ\"ז נמוך (LowID)"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "עם מ\"ז גבוהה (HighID)"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "קאד התחיל."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "קאד נעצר."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "קאד מחובר (בסדר)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "קאד מחובר (מאחורי חומת אש)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "מנותק מקאד."
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "אי אפשר להשתמש ברשת הקאד אם מוואת UDP מבוטלת בהעדפות, לא התחיל."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "קאד מבוטל בהעדפות, לא מתחבר."
 
@@ -2561,7 +2571,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "חיבור חיצוני נסגר."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "רענון אוטמטי התחיל"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -194,8 +194,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -242,92 +242,97 @@ msgstr "הורדה הסתיימה"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "מידע"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "אישרור יצאיה"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "אזהרה"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "רשתות"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -337,185 +342,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "שם שרת:"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "שגיאה: לא יכול לפתוח קובץ יומן."
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "היומן אופס."
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "עם מ\"ז נמוך (LowID)"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "עם מ\"ז גבוהה (HighID)"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "קאד התחיל."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "קאד נעצר."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "קאד מחובר (בסדר)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "קאד מחובר (מאחורי חומת אש)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "מנותק מקאד."
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "אי אפשר להשתמש ברשת הקאד אם מוואת UDP מבוטלת בהעדפות, לא התחיל."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "קאד מבוטל בהעדפות, לא מתחבר."
 
@@ -880,7 +885,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2225,49 +2230,49 @@ msgstr "לא"
 msgid "Yes"
 msgstr "כן"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "מוריד מהרשת..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "הניסיון לקבל את רשימת הקבצים המשותפים מהמשתמש '%s' כשלה."
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "מוריד %s"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "הורדות (%i)"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2571,7 +2576,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "חיבור חיצוני נסגר."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "רענון אוטמטי התחיל"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -21,26 +21,26 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "אודות wxCas"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "אימיול שלט רחוק"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "צילום:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -49,57 +49,57 @@ msgstr ""
 "זכוייות יוצרים (C) 2003-2019 צוות אימיול \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "קאדימליה: תקשורת עמית לעמית מנותבת המבוסס על ה XOR המטרי.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "מתחבר לקאד..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "לא זמין"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -194,8 +194,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -211,103 +211,113 @@ msgstr "פתיחת הקובץ %s·(%s נכשלה"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "נכשל"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "הורדה הסתיימה"
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "מידע"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "אישרור יצאיה"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "אזהרה"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "רשתות"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -317,185 +327,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "שם שרת:"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "שגיאה: לא יכול לפתוח קובץ יומן."
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "היומן אופס."
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "עם מ\"ז נמוך (LowID)"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "עם מ\"ז גבוהה (HighID)"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "קאד התחיל."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "קאד נעצר."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "קאד מחובר (בסדר)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "קאד מחובר (מאחורי חומת אש)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "מנותק מקאד."
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "אי אפשר להשתמש ברשת הקאד אם מוואת UDP מבוטלת בהעדפות, לא התחיל."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "קאד מבוטל בהעדפות, לא מתחבר."
 
@@ -534,15 +544,15 @@ msgstr "זהו אֵימיול %s המבוסס על אִמיול"
 msgid "Running on %s"
 msgstr "פועל על %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "בקר ב https://github.com/amule-org/amule/releases/latest כדי לבדוק האם ישנה גירסה חדישה זמינה."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -552,224 +562,224 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "לא זמין"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "מתחבר"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "קאד: חסום חומתאש"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "קאד: מחובר"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "קאד: מתחבר"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "קאד: מכובה"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "ביטול"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "מנותק"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "התנתק מהרשתות שאליהם אתה מחובר כעת"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "התחבר"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "התחבר לרשתות שמאופשרות כרגע"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "מעלה: %.1f(%.1f) | מוריד: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "מ\"ב/ש"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " ק\"ב/ש"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "מעלה: %.1f | מוריד: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "אימיול (%s | מחובר)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "אימיול (%s | מנותק)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "האם אתה באמת רוצה לצאת מאימיול?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "אישרור יצאיה"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "ספריית הסקינים '%s' לא קיימת"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "רשתות"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "חלון הרשתות"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "חיפושים"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "חלון החיפושים"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "הורדות"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "מוריד מהרשת"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "חלון הקבצים המשותפים"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "הודעות"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "חלון ההודעות"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "סטטיסטיקות"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "חלון גרפי הסטטיסטיקה"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "העדפות"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "חלון הגדרת ההעדפות"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "ייבא"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "כלי הייבא עבור קובץ-החלקים"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "אודות"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "אודות/עזרה"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -861,8 +871,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "לא ידוע"
@@ -1226,19 +1236,19 @@ msgstr "אוטומטי [גבוה]"
 msgid "Very low"
 msgstr "מאוד נמוך"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "נמוך"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1270,7 +1280,7 @@ msgid "On Queue"
 msgstr "על התור"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "מוריד מהרשת"
 
@@ -1330,7 +1340,7 @@ msgstr "שרת מקומי"
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "קאד"
@@ -1402,7 +1412,7 @@ msgstr ""
 msgid "Size"
 msgstr "גודל"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "הועברו"
 
@@ -1415,7 +1425,7 @@ msgid "Progress"
 msgstr "התקדמות"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "מקורות"
 
@@ -1425,7 +1435,7 @@ msgstr "מקורות"
 msgid "Priority"
 msgstr "עדיפות"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "מצב"
 
@@ -1456,7 +1466,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "אוטמטי"
@@ -2087,7 +2097,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "חברים"
 
@@ -2374,8 +2384,8 @@ msgstr "מבואה לא תקפה על מנת לבצע אתחול"
 msgid "Please fill all fields required"
 msgstr "אנא מלא את כל השדות כפי שנדרש"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "הודעה"
 
@@ -2447,7 +2457,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2481,30 +2491,30 @@ msgstr "גירסה לא ידועה"
 msgid "Unable to get error description for error %d"
 msgstr "אזהרה: לא ניתן לפתוח את קובץ הסקין '%s' לקריאה"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "מגבב"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "מסיים"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "סיים"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "הושהה"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "שגוי"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "ממתין"
 
@@ -2551,7 +2561,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "חיבור חיצוני נסגר."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "רענון אוטמטי התחיל"
@@ -2573,7 +2583,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "סגור"
 
@@ -2688,7 +2698,7 @@ msgstr "יציאה"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "ק\"ב/ש"
@@ -2928,7 +2938,7 @@ msgstr "בתים"
 msgid "KB"
 msgstr "ק\"ב"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "מ\"ב"
@@ -2998,7 +3008,7 @@ msgstr "מנקה הורדות שהושלמו"
 msgid "File sources:"
 msgstr "מקורות שנמצאו :"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "כללי"
 
@@ -3019,7 +3029,7 @@ msgstr "שם מלא :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "ל\"ת"
 
@@ -3193,7 +3203,7 @@ msgstr "שם משתמש :"
 msgid "Userhash :"
 msgstr "גיבוב משתשמ :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "הוסף"
@@ -3202,15 +3212,15 @@ msgstr "הוסף"
 msgid "Download-Speed"
 msgstr "מהירות הורדה"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "נוכחיים"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "ממוצע רץ"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "ממוצע ההרצה הנוכחית"
 
@@ -3222,7 +3232,7 @@ msgstr "מהירות-העלאה"
 msgid "Connections"
 msgstr "חיבורים"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "הורדות פעילות"
 
@@ -3230,7 +3240,7 @@ msgstr "הורדות פעילות"
 msgid "Active connections (1:1)"
 msgstr "חיבורים פעילים (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "העלאות פעילים"
 
@@ -3432,8 +3442,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3507,748 +3517,756 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "ההעלאות"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "סיסמא"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "בסדר"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "אתחל מחדש"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "אי.פי.:מבואה"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "קצב מידע :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "מקורות"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4256,11 +4274,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4270,230 +4288,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "מוריד: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "השמתש בדחיסת gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&תפתח את הקובץ"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "ממתין..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "קבצים משותפים"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "בחר מסנן תצוגה"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "העלאות פעילים"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "שלח"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "שולח את ההודעה המצויינת."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "סגור את הצ'אט הנוכחי."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "קבצים משותפים"
 
@@ -4572,7 +4590,7 @@ msgstr "כל האחרים"
 msgid "Incomplete"
 msgstr "חלקי"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "נעצר"
 
@@ -4764,359 +4782,359 @@ msgstr "נשמרו %i מקורות הזרעה עהור קובץ-החלקים: %s
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "שגיאה בקריאת קובץ ההזרעה של קובץ החלקים (%s·-·%s):·%s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "נמצא חלק שהושלם (%i) בתוך %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "הסתיים הגיבוב מחדש של %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "הסתיימה ההורדה של: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "הסתיימה ההורדה של: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "מוחק את הקובץ: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "אזהרה. אין מספיק שטח דיסק פנוי! משהה את הקובץ %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "החלק %i שירד מתוך הקובץ %s פגום"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: תוקן החלק הפגום %i עבור %s -< בתים שנמשרו: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "ערבית"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "בסקית"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "בולגרית"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "קטלונית"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "סינית (מופשטת)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "סינית (מסורתית)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "קרואטית"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "צ'כית"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "דנית"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "הולנדית"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "פינית"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "צרפתית"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "גאלית"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "גרמנית"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "יוונית"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "הונגרית"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "איטלקית"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "איטלקית (שוויצרית)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "יפנית"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "קוראינית"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "ליטאית"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "נורבגית (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "פונלית"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "פורטגזית"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "פורטגזית (ברזילאית)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "רוסית"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "סלובקית"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "ספרדית"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "שוודית"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "טורקית"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "לא זמין"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "מבואת ה TCP אינה יכולה להיות גבוהה יותר מ 65532 מאחר שמבואת ה UDP של השרת היא מבואת ה TCP +3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "נשתמש במבואה שבברירת מחדך (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "חיבור"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "מלונים"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "שרתים"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "קבצים"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "אבטחה"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "פרוקסי"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "שליטה מרחוק"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "חתימה מקוונת"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "ארועים"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "ניפוי שגיאות"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5126,26 +5144,26 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5153,41 +5171,46 @@ msgstr ""
 "אימיול חייב להיות מאותחל מחדש על מנת לאפשר את השינויים הללו:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- מבואת TCP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "חיבור חיצוני נסגר."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5195,26 +5218,26 @@ msgstr ""
 "אתה אפשרת חיבוריים חיצוניים אבל לא הזנת סיסמא תקיפה.\n"
 "חיבורים חיצוניים לא יאופשרו אלא אם כן תוזן סיסמא תקיפה."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- השפה שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- הפסרייה הזמנית שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "כל הרשתות מנוטרלות."
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5222,7 +5245,7 @@ msgstr ""
 "קאד לא יתחיל אם מבואת ה UDB מנוטרלת.\n"
 "תאפשר את מבואת ה UDP או שתנטרל את קאד."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5232,20 +5255,20 @@ msgstr ""
 "אתה חייב לאתחל את אימיול עכשיו!\n"
 "אם לא תאתחל את אימיול עכשיו אל תתלונן אם משהו רע יקרה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "רענון אוטמטי התחיל"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5255,41 +5278,41 @@ msgstr ""
 "בבקשה תכניס לפחות כתובת URL אחת שתצביע לקובץ server.met תקף.\n"
 "לחץ על הכפתור \"רשימה\" שליד הצ'קבוקס הזה כדי להכניס בתובת URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "קבצים זמניים"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "קבצים נכנסים"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "חתימה מקוונת"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "בחר תיקייה עבור %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "חפש נגן סרטים"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "בחר דפדפן"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "קובץ הרצה %s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5297,150 +5320,150 @@ msgstr ""
 "הוסף כאן כתובות URL שמהם ניתן להוריד קבצי server.met.\n"
 "רק כתובת אחת בכל שורה."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "מקורות שלמים"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "השהיית עדון: %d שניות"
 msgstr[1] "השהיית עדון: %d שניות"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "זמן עבור גרף הממוצע: %d דקות"
 msgstr[1] "זמן עבור גרף הממוצע: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "סקאלאת גרף החיבורים: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "גודל זיכרון זמני לקובץ: %d בתים"
 msgstr[1] "גודל זיכרון זמני לקובץ: %d בתים"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "גודל תור ההאלעות: %d לקוחות"
 msgstr[1] "גודל תור ההאלעות: %d לקוחות"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "רענון חיבור לשרת כל: %d דקות"
 msgstr[1] "רענון חיבור לשרת כל: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "רענון חיבור לשרת: מנוטרל"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "נוטרל [%s]"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "בצע פקודה בעת ארוע '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "אפשר הרצת פקודות על הליבה"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "פקודת ליבה:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "אפשר ביצוע פקודות על ממשק גרפי"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "פקודת ממשק גרפי:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "המשתנים הבאים יוחלפו:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "קורא את הספרייה הזמנית"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "טוען מחדש את רשימת הקבצים המשותפים."

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -193,8 +193,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -240,92 +240,97 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Potvrda izlaza"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "UPOZORENJE"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i servera pronadjeno u server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -335,185 +340,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo nikakvu garanciju da nece nista unistiti, tvoju kucu zapaliti, \n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Ime servera :"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -881,7 +886,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2224,50 +2229,50 @@ msgstr "Ne"
 msgid "Yes"
 msgstr "Da"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Downloading..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 #, fuzzy
 msgid "HTTP download cancelled"
 msgstr "Istinska sirina pojasa downloada"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Neuspjesno spasavanje part.met.seeds fajla za %s"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Downloaded:"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Istinska sirina pojasa downloada"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2574,7 +2579,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -20,26 +20,26 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.0beta1\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "O autoru:"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -48,56 +48,56 @@ msgstr ""
 "Autorsko pravo (c) 2003-2019 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr "Autorsko pravo (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Web stranica:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nije dostupno"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -193,8 +193,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -210,102 +210,112 @@ msgstr "Neuspjelo otvaranje %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Neuspjesno"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Potvrda izlaza"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "UPOZORENJE"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i servera pronadjeno u server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -315,185 +325,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo nikakvu garanciju da nece nista unistiti, tvoju kucu zapaliti, \n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Ime servera :"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -532,15 +542,15 @@ msgstr ""
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -550,228 +560,228 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Nije dostupno"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Veza uspostavljena"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Otkaz"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Zaustavlja trenutne pokusaje uspostavljanja veze"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekinuti vezu sa sadasnjim serverom"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Uspostavi vezu"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gore: %.1f(%.1f) | Dole: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gore: %.1f | Dole: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Da li zaista zelite iskljuciti aMule?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Potvrda izlaza"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Pretrage"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Prozor pretraga"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Downloading"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Prozor dijeljenih fajlova"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Poruke"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Prozor poruka"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistike"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Prozor grafova statistike"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Opcije"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Prozor postavke opcija"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Uvezi"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O autoru:"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -862,8 +872,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Nepoznat"
@@ -1232,19 +1242,19 @@ msgstr "Auto [Vi]"
 msgid "Very low"
 msgstr "Vrlo nizak"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Nisko"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normalan"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1276,7 +1286,7 @@ msgid "On Queue"
 msgstr "U redu cekanja"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Downloading"
 
@@ -1336,7 +1346,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1407,7 +1417,7 @@ msgstr ""
 msgid "Size"
 msgstr "Velicina"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Transferirano"
 
@@ -1420,7 +1430,7 @@ msgid "Progress"
 msgstr "Napredak"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Izvori"
 
@@ -1430,7 +1440,7 @@ msgstr "Izvori"
 msgid "Priority"
 msgstr "Prioritet"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Status"
 
@@ -1463,7 +1473,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automatski"
@@ -2091,7 +2101,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2375,8 +2385,8 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Poruka"
 
@@ -2451,7 +2461,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2485,30 +2495,30 @@ msgstr "Nepoznat: %i"
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Hashing"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Zavrsavanje"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Zavrseno"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pausirano"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Sa greskom"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Cekanje"
 
@@ -2554,7 +2564,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2576,7 +2586,7 @@ msgid "WARNING: "
 msgstr "UPOZORENJE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Zatvori"
 
@@ -2692,7 +2702,7 @@ msgstr "Izlaz"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2932,7 +2942,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3002,7 +3012,7 @@ msgstr ""
 msgid "File sources:"
 msgstr "Nadjeni izvori :"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Glavni"
 
@@ -3023,7 +3033,7 @@ msgstr "Puno ime :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3197,7 +3207,7 @@ msgstr "Ime korisnika :"
 msgid "Userhash :"
 msgstr "Hash korisnika :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3206,15 +3216,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Brzina downloada"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Prosjek rada"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Prosjek misije"
 
@@ -3226,7 +3236,7 @@ msgstr "Brzina uploada"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktivni downloadovi"
 
@@ -3234,7 +3244,7 @@ msgstr "Aktivni downloadovi"
 msgid "Active connections (1:1)"
 msgstr "Aktivne veze (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktivni uploadovi"
 
@@ -3436,8 +3446,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3511,751 +3521,759 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Ponovni spoj kod gubitka veze"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Otstrani mrtve servere nakon"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "pokusaja"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Koristi sistem prioriteta"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Koristi pametnu LowID provjeru pri vezanju"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Sigurno povezivanje"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Autopovezivanje samo sa serverima iz staticne liste"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Postavi rucno dodate servere na visoki prioritet"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Omogućiti"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Dodaj nove fajlove u stanju pauze"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Dodaj nove fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Pokusaj prvo downloadovati pocetni i zavrsni chunk "
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Uploadovi"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj nove dijeljene fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafovi"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Obnovi kasnjenje : 5 sekundi"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Vrijeme za prosjecni graf: 100 minuta"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Boje: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Pozadina"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Mreza"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Trenutni download"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Prosjek tekuceg downloada"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Prosjek downloada misije"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Trenutni upload"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Prosjek tekuceg uploada"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Prosjek uploada misije"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktivne veze"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "poluga brzine prikazana u sistemskom koritu"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Izaberi"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! UPOZORENJE !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Maksimalne veze u / 5 sekundi"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fajl Buffer velicina: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Duzina reda cekanja: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Pljosnata"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Obla"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Prihvati spoljasnje veze"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Sifra za puna prava"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Odobri korisnicima sa manje prava"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Sifra za manje prava"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Vrijeme obnove stranice (u sekundama)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Odobri Gzip kompresiju"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Naziv :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Prijemni direktorij :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Promijeni prioritet za nove fajlove :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "Ne mijenjaj"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izaberi boju za ovu kategoriju (trenutno izabrana) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Ponistenje"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikni ovdje da obnovis listu servera sa URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj servera rucno (prije ispuni polja lijevo) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Lista servera"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Svi"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Nitko"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Omoguci online potpis"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Podatak rate :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Izvori"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4263,11 +4281,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4277,233 +4295,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Korisničko ime:"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Lozinka:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Korisničko ime"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Steceno kompresijom :"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otvori fajl"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ceka ..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktivni uploadovi :"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Ukupni fajlovi"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Dijeljeni fajlovi"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Izaberi filter za gledanje"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivni uploadovi"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "Ponovno ucitati"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Posalji"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Dijeljeni fajlovi"
 
@@ -4584,7 +4602,7 @@ msgstr "svi drugi"
 msgid "Incomplete"
 msgstr "Nedovrseno"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Stopirano"
 
@@ -4776,7 +4794,7 @@ msgstr "Spaseni %i seeds izvora za poceti fajl: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, fuzzy, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -4784,349 +4802,349 @@ msgstr[0] "Nadjen koruptan dio (%i) u %i pocetom fajlu %s - FileResultHash |%s| 
 msgstr[1] "Nadjen koruptan dio (%i) u %i pocetom fajlu %s - FileResultHash |%s| FileHash |%s|"
 msgstr[2] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Zavrseno rehashing %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Zavrseno rehashing %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Standard sistema"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanski"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arapski"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturleonski"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bugarski"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalonski"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Kineski"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Kinesko (tradicionalno)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Hrvatski"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Češki"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danski"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Nizozemski"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonski"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finski"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galješki"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Njemački"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grčki"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebrejski"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Mađarski"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Talijanski"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Talijanski (Švicarska)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japanski"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Korejski"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litavski"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveški (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Poljski"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazil)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Rumunjski"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Ruski"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovenski"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Španjolski"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Švedski"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turski"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukrajinski"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Promijeniti jezik"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Nema dostupnih jezika"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Veza"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Direktoriji"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Serveri"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Fajlovi"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Sigurnost"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Sučelje"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Daljinsko upravljanje"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Napredno"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Događaji"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Debugiranje"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5142,157 +5160,162 @@ msgstr ""
 "aMule ce raditi dobro iako ne promijenis\n"
 "nista od ovih opcija."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Parametri za spoljasnju vezu"
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatski"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Privremene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Potrazi videoplejer"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5300,41 +5323,41 @@ msgstr ""
 "Dodaj ovdje URLs da dobijes server.met fajlove. \n"
 "Samo jedna URL po liniji."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -5342,7 +5365,7 @@ msgstr[0] "Obnovi kasnjenje : 5 sekundi"
 msgstr[1] "Obnovi kasnjenje : 5 sekundi"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -5350,12 +5373,12 @@ msgstr[0] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[1] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5363,7 +5386,7 @@ msgstr[0] "Velicina fajl buffera %i bytes"
 msgstr[1] "Velicina fajl buffera %i bytes"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -5371,7 +5394,7 @@ msgstr[0] "Duzina liste cekanja %i klienata"
 msgstr[1] "Duzina liste cekanja %i klienata"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -5379,73 +5402,73 @@ msgstr[0] "Interval obnavljanja veze servera %i minuta"
 msgstr[1] "Interval obnavljanja veze servera %i minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "onemoguci"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -193,8 +193,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -240,82 +240,92 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Potvrda izlaza"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "UPOZORENJE"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i servera pronadjeno u server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -325,185 +335,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo nikakvu garanciju da nece nista unistiti, tvoju kucu zapaliti, \n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Ime servera :"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -2564,7 +2574,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -19,20 +19,20 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "X-Poedit-Basepath: .\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "aMule megjelenítése"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule távoli vezérlő "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Pillanatkép:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -40,7 +40,7 @@ msgstr ""
 "'Minden-platform' p2p ügyfél az eMule alapján \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -48,59 +48,59 @@ msgstr ""
 "Szerzői jog (c) 2003-2026 aMule csapat \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Az aMule részben a következőn alapul: \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Egyenrangú útvonal-megállapítás a XOR metrika alapján.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Honlap:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Fórum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr "Dokumentáció:"
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr "Gondok:"
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Indításkor új verzió keresése"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kapcsolódás a Kad-hoz..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Az aMule egy elavult verzióját használod!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nem elérhető"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -201,8 +201,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -217,47 +217,57 @@ msgstr "ED2KLinks fájl megnyitása sikertelen."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "FIGYELEM: Nem adhatod magad forrásként egy eD2k hivatkozáshoz amíg alacsony azonosítód (lowid) van."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Kilépés a fő alkalmazásból..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - bezárása ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - kivégzése ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Sikertelen"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Mag leállítása."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Az aMule leállítása befejeződött."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Memória debug eredmények az aMule bezárásáról:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Nyelvi beállításaid egy konfigurációs változás miatt az alapértelmezettre lettek átállítva. Bocs."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Infó"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -265,20 +275,20 @@ msgstr ""
 "\n"
 "EC beállítások"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "FIGYELEM"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "Hálózati bootstrap"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -286,34 +296,34 @@ msgstr ""
 "aMule hiányzó hálózati bootstrap fájlokat észlelt.\n"
 "Válassza ki a letölteni kivántakat:"
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "eD2k szerver lista (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad bootstrap csomópontok (nodes.dat)"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nem tudom a portokat a megadott címhez (%s) rendelni."
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "A %u port nem elérhető. Alacsony kliens azonosítót kapsz (LOWID)\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -328,48 +338,48 @@ msgstr ""
 "\n"
 "Ellenőrízd a hálózatodat, hogy megbizonyosodj, hogy a port nyitva van kifelé és befelé egyaránt."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Aláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Az aMule OnlineAláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "A kiválasztott nyelvi beállítások úgy látszik nincsenek telepítve a gépeden. (Megjegyzés: Mindenesetre mepróbálom ezt beállítani)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ez az első alkalom, hogy az aMule %s-t futtatod"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ez egy teszt verzió, naponta frissítve, és\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nem vállalunk garanciát, hogy nem omlik össze, gyújtja fel a házad,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vagy öli meg a kutyád. *Elvileg* nyugodtan használható.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Még több információ, támogatás és új kiadások találhatóak honlapunkon,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "a https://amule-org.github.io, vagy az #aMule IRC csatornánkon az irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nyugodtan jelezz bármilyen hibát a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -377,137 +387,137 @@ msgstr ""
 "Az Online aláírás fájl könyvtárának megadott hely ÉRVÉNYTELEN!\n"
 " Az OnlineAláírás letiltásra kerül, amíg ki nem javítod azt a beállítások menüpontban."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Szerver hostname értesítve"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Lemezterület helyfoglalás a '%s' fájl számára sikertelen: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "HIBA: Nem tudom megnyitni a napló fájlt"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FIGYELEM: a napló üres. Valami nem stimmel."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Napló törölve"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "KiszolgálóÜzenet: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "A %s letöltése kihagyva, mert a kívánt fájl nem újabb."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Csomópont-lista letöltése sikertelen."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Nem sikerült megnyitni a letöltött verzió-ellenőrző fájlt"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Sérült verzió-ellenőrző fájl"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Az aMule egy elavult verzióját használod!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A te aMule verziód %i.%i.%i, a legújabb verzió pedig %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FIGYELEM: A te aMule verziód elavult: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Az aMule verziód naprakész."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Verzió-ellenőrzés fájl letöltése sikertelen."
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Felhasználók: %s | Fájlok: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Felhasználók: E: %s K: %s | Fájlok: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nincs hálózat kiválasztva"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID-val"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID-val"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Kapcsolódva ehhez %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Kapcsolódás %s-hez"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Leválasztva az eD2k-ról"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad elindítva."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad leállítva."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Kapcsolódva a Kad-hoz (rendben)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Kapcsolódva a Kad-hoz (tűzfal mögül)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Leválasztva a Kad-ról"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A Kad hálózat nem használható, ha az UDP port le van tiltva a beállításokban, nem indítom."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A Kad hálózat le van tiltva  a beállításokban, nem kapcsolódom."
 
@@ -546,15 +556,15 @@ msgstr "Ez az aMule %s, az eMule alapján."
 msgid "Running on %s"
 msgstr "%s-en fut"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Új verzióért látogasd meg a https://github.com/amule-org/amule/releases/latest oldalt."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "VÉGZETES HIBA: Időzítő létrehozása sikertelen"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -564,222 +574,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Nem elérhető"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMule dialógus elpusztítva"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Kapcsolódás"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2K: Kapcsolódás"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Szétkapcsolva"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Tűzfal mögött"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Csatlakozva"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Kapcsolódás"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Nincs kapcsolat"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Aktuális kapcsolódási kísérletek leállítása"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Leválaszt az éppen kapcsolódott hálózatokról."
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Kapcsolódás a pillanatnyilag engedélyezett hálózatokhoz."
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Fel: %.1f%s (%.1f) | Le: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Fel: %.1f%s | Le: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Kapcsolódva)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Nincs kapcsolat)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Biztos, hogy ki szeretnél lépni a(z) %s alkalmazásból?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Kilépés megerősítése"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Parancs futtatása: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- alapértelmezett -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "A(z) '%s' felület könyvtár nem létezik"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "FIGYELEM: Nem tudom a(z) '%s' felület fáljt megnyitni olvasásra"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Hálózatok"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Hálózatok ablaka"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Keresések"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Keresés ablaka"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Letöltések ablaka"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Megosztott fájlok"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Megosztott fájlok ablaka"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Üzenetek"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Üzenetek ablaka"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Statisztikai grafikonok ablaka"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Beállítások"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Tulajdonságok beállításának ablaka"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importálás"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "A részfájl importáló eszköz"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Névjegy"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Névjegy/Súgó"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k hálózat"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad hálózat"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Nincs hálózat"
 
@@ -869,8 +879,8 @@ msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Ismeretlen"
@@ -1228,19 +1238,19 @@ msgstr "Auto [Ma]"
 msgid "Very low"
 msgstr "Nagyon alacsony"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Alacsony"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normál"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1272,7 +1282,7 @@ msgid "On Queue"
 msgstr "Várólistások"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Letöltés alatt"
 
@@ -1332,7 +1342,7 @@ msgstr "Helyi kiszolgáló"
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1403,7 +1413,7 @@ msgstr "Rész"
 msgid "Size"
 msgstr "Méret"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Átmásolva"
 
@@ -1416,7 +1426,7 @@ msgid "Progress"
 msgstr "Folyamatjelző"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Források"
 
@@ -1426,7 +1436,7 @@ msgstr "Források"
 msgid "Priority"
 msgstr "Prioritás"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Állapot"
 
@@ -1459,7 +1469,7 @@ msgstr ""
 "Visszajelzés %s-től (%s):\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automatikus"
@@ -2108,7 +2118,7 @@ msgstr "A barátokat tartalmazó emfriends.dat fájl írásra megnyitása sikert
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKUS - nincsen kliens a StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Barátok"
 
@@ -2390,8 +2400,8 @@ msgstr "Érvénytelen port a rendszerindításhoz"
 msgid "Please fill all fields required"
 msgstr "Kérlek töltsd ki az összes kötelező mezőt"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Üzenet"
 
@@ -2460,7 +2470,7 @@ msgstr "Megosztási arány"
 msgid "Uploaded"
 msgstr "Feltöltve"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Kért"
 
@@ -2494,30 +2504,30 @@ msgstr "Ismeretlen hiba %d"
 msgid "Unable to get error description for error %d"
 msgstr "A %d hiba leírásának lekérése sikertelen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Tördelőalgoritmizálás"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Befejezés"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Kész"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Szüneteltetve"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Hibás"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Várakozik"
 
@@ -2561,7 +2571,7 @@ msgstr "Külső kapcsolat: Hozzáférés megtagadva, mert: "
 msgid "External Connection: Handshake failed."
 msgstr "Külső kapcsolat: Kézfogás sikertelen."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio szál %d elindítva"
@@ -2583,7 +2593,7 @@ msgid "WARNING: "
 msgstr "FIGYELEM: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Bezár"
 
@@ -2692,7 +2702,7 @@ msgstr "Kilépés"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2932,7 +2942,7 @@ msgstr "bájt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3001,7 +3011,7 @@ msgstr "Befejeződött letöltések törlése"
 msgid "File sources:"
 msgstr "Fájl források:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Általános"
 
@@ -3022,7 +3032,7 @@ msgstr "Teljes név :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3198,7 +3208,7 @@ msgstr "User név :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hozzáad"
@@ -3207,15 +3217,15 @@ msgstr "Hozzáad"
 msgid "Download-Speed"
 msgstr "Letöltési sebesség"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Aktuális"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Futásátlag"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Munkafolyamatok átlaga"
 
@@ -3227,7 +3237,7 @@ msgstr "Feltöltési sebesség"
 msgid "Connections"
 msgstr "Kapcsolatok"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktív letöltések"
 
@@ -3235,7 +3245,7 @@ msgstr "Aktív letöltések"
 msgid "Active connections (1:1)"
 msgstr "Aktív kapcsolatok (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktív feltöltések"
 
@@ -3436,8 +3446,8 @@ msgstr "Böngésző kiválasztása"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Írd ide a böngésződ nevét. Hagyd üresen, hogy a rendszer alapértelmezett böngészőjéhez."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3511,147 +3521,156 @@ msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Csak haladó felhasználóknak: Ha több hálózati kártyád van, írd ide a címet, amelyhez az aMule kötve legyen."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Max források letöltési fájlonként:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Max egyidejű kapcsolatok:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Automatikus kapcsolódás induláskor"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Kapcsolódás megismétlése megszakadt kapcsolat esetén"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Halott kiszolgálók eltávolítása"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "próbálkozás után"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Kiszolgáló lista automatikus frissítése indításkor"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Kiszolgáló lista frissítése kiszolgálóhoz való kapcsolódáskor"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Kiszolgáló lista frissítése amikor egy ügyfél kapcsolódik"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Prioritási rendszer használata"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Intelligens LowID ellenőrzés használata kapcsolódáskor"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Biztonságos kapcsolódás"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatikus kapcsolódás kizárólag az állandó kiszolgálókhoz"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "A kézileg hozzáadott kiszolgálók Magas Prioritással történő felvétele"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligens Sérülés Kezelő (I.S.K.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Engedélyezés"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Feljett I.S.K. megbízzon minden hash-ben (nem ajánlott)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Fájlok felvétele szüneteltetett módban"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Új letöltések felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Előszőr az első és utolsó adatelemet próbálja meg letölteni"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Következő szüneteltetett fájl indítása amikor egy letöltés befejeződik"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Ugyanabból a kategóriából"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "Betűrendi sorrendben"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Lemezterület helyfogalalás az új fájloknak"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Az új fájlok számára előre lefoglalja a lemezterületet, így csökkentve a töredezettséget"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Letöltések megállítása amikor a szabad hely kevesebb mint "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Jelöld be, ha azt szeretnéd, hogy az aMule ellenőrizze a szabad lemezterületet"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Add meg a kívánt min. szabad lemezterületet."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Mentsen el 10 forrást ritka fájloknál (< 20 forrás)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Feltöltések"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Új megosztott fájl felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Célkönyvtár a letöltéseknek"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3659,599 +3678,599 @@ msgstr ""
 "Elvégzett letöltések tárolási helye. Minden fájl ebben a könytárban automatikusan megosztásra kerül másokkal.\n"
 "Ha a könyvtár fájlokat tartalmaz, amelyek ne kerüljenek megosztásra, állítsa át egy megfelelő alkönyvtárra."
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Válassza ki a könyvtárat az elvégzett letöltéseknek. A könyvtár minden fájlja másokkal megosztásra kerül."
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Minden fájl ebben a könyvtárban másokkal megosztásra kerül)"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Könyvtár az ideiglenes letöltési fájloknak"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Megosztott mappák"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Jobb klikk az mappa ikonra az összes alatta levő mappát is megosztja)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Rejtett fájlok megosztása"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "Megosztott könyvtárak automatikus újraszkennelése"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr "Szimbólikus hivatkozások követése megosztott könyvtárakban"
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafikonok"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Frissítés késleltetés: 5 mp"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Grafikon átlagos ideje: 100 perc"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Kapcsolatok grafikon skálája: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Letöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Feltöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Színek: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Háttér"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Rács"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Aktuális letöltés"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Letöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Letöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Aktuális feltöltés"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Feltöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Feltöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktív kapcsolatok"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "Sebességmérő a rendszertálcán"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Kad-csomópontok aktuális"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kad-csomópontok futó"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kad-csomópontok folyamat"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Kiválaszt"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Fa"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Megjelenített ügyfél verziók száma (0=mind)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! FIGYELEM !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Max új kapcsolat / 5 mp"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fájl buffer méret: 240000 bájt"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Feltöltők várólistájának nagysága: 5000 kliens"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Számítógép időzített készenléti állapotának hatástalanítása"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Használt felület: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "A \"Gyors eD2k hivatkozás kezelő\" mutatása minden ablakban."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Kibővített infók megjelenítése a kategória füleken"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Az alkalmazás verziójának megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Átviteli ráták megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Az alkalmazás neve előtt"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Az alkalmazás neve után"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Többletterhelés sávszélességének mutatása"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Függőleges eszköztár elrendezés"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Letöltendő fájlok várakozási sora"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Százalékos arány mutatása"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Folyamatjelző csík mutatása"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Lapos"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Gömbölyű"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Fájlok automatikus rendezése (erős CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "Az aMule automatikusan rendezni fogja az oszlopokat a letöltési listádban"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Külső kapcsolatok jellemzői"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Külső kapcsolat elfogadása"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "Hallgató interfész IP-je:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Adjon meg itt egy érvényes IP címet a.b.c.d formában az EC hallgató interfésznek. Üres mező vagy 0.0.0.0 jelentése: bármelyik interfész."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP port továbbítás engedélyezése az EC porton"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Jelszó"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Webkiszolgáló indítása induláskor"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Web minta"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Admin jelszó"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Vendég felhasználó engedélyezése"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Vendég jelszó"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "A web kiszolgáló port UPnP továbbításának engedélyezése"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web szerver UPnP TCP port (nem kötelező)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Oldal frissítésének időzítése (mp múlva)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Gzip tömörítés engedélyezése"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kattints ide a beállítási módosítások alkalmazásához."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Beállítási módosítások figyelmen kívül hagyása."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Cím :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Megjegyzés:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Bejövő Mappa :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Újonnan hozzárendelt fájlok prioritásának változtatása :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Ne változzon"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Válassz színt ehhez a kategóriához (jelenleg kiválasztva) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Töröl"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Kattints erre a gombra a logfájl visszaállításához."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kattints erre a gombra a kiszolgálólista frissítéséhez  ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Kiszolgálók listája"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adj meg egy címet a server.met fájlhoz és nyomd meg a baloldali gombot az ismert kiszolgálók listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Kiszolgáló hozzáadása kézzel: Név"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Add meg az új kiszolgáló nevét"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Itt add meg a kiszolgálók IP-jét, használd az x.x.x.x formát."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Add meg a kiszolgáló portját."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Kiszolgáló felvétel kézzel (töltsd ki a baloldali mezőket először) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule Napló"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Kiszolgáló Infó"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K infó"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad infó"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kattints erre a gombra a csomópont-lista frissítéséhez URL-ből ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Csomópontok (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Adj meg egy címet a nodes.dat fájlhoz és nyomd meg a baloldali gombot az ismert csomópontok listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Csomópont statisztikák"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Rendszerbetöltés"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Új csomópont (node)"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Indítás ismert kliensektől"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Leválasztás a Kad-ról"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Biztonságos azonosítás használata"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ajánlott ezt az opciót engedélyezni. Nem fogsz kreditet kapni, ha nincs engedélyezve."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokoll zavarás"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Protokoll zavarás támogatása"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, és az aMule elfogad zavart kapcsolatokat más ügyfelektől."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kimenő kapcsolatok zavarása"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, amikor más ügyfelekhez/kiszolgálókhoz kapcsolódik az aMule."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Csak zavart kapcsolatok elfogadása"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ezen opció hatására az aMule csak zavart kapcsolatokat fog elfogadni. Kevesebb forrásod lesz, de a teljes forgalom zavart lesz"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Mindenki"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Senki"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Ki láthatja a megosztott fájljaimat:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Válaszd ki, hogy kik kérdezhetik le megosztott fájlaid listáját."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP-szűrés"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Kliensek szűrése"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kliensek szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Kiszolgálók szűrése"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kiszolgálók szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Lista újratöltése"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "IP-k listájának újratöltése a ~/.aMule/ipfilter.dat fájlból"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Frissítés most"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "IP szűrő automatikus letöltése indításkor"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Szűrési szint:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Mindig szűrje ki a LAN IP-ket"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "A nem-megegyező IP-k paranoid kezelése"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Eldobja a csomagot, ha a kliens IP különbözik az IP-től, ahonnan a csomag jött. Óvatosan használd."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Rendszer-szintű ipfilter.dat használatának engedélyezése"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ha nem talál helyi ipfilter.dat fájlt, akkor engedje a rendszerszintű ipfilter fájl használatát."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Online-aláírás engedélyezése"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Az online-aláírás fájl írásának engedélyezése, amit külső alkalmazások használhatnak fel aláírások létrehozásához és így tovább."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frissítési gyakoriság (mp):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Online aláírás frissítési gyakoriságának módosítása (mp-ben)."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Online aláírási fájl kimentési helye: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kattints ide az online aláírást tartalmazó könyvtár kiválasztásához."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Kliensek országzászlajainak megjelenítése"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr "Adatbázis"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr "Forrás:"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ingyenes, fiók nélkül)"
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ingyenes, fiók szükséges)"
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr "Egyéni URL"
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Válassza ki a GeoIP MMDB adatbázis szolgáltatóját. DB-IP az alapértelmezett - nincs szükség fiókra. MaxMind egy ingyenes fiókot és licenckulcsot igényel. Használjon egyéni URL-t bármely más MMDB host megadásához (pl. egy helyi tükörhöz)."
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4263,11 +4282,11 @@ msgstr ""
 "IP-to-Country adat DB-IP.com által - https://db-ip.com\n"
 "Licenc: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr "Licenckulcs:"
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4283,11 +4302,11 @@ msgstr ""
 "Licenc: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Hozzárendelést és fiókregisztrációt igényel; legalább 30 naponta frissítse."
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr "Letöltési URL:"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4297,211 +4316,211 @@ msgstr ""
 "Az URL tartalmazhat hitelesítő adatokat (https://user:pass@host/...).\n"
 "A licenc- és megnevezési feltételeket a felmenő URL határozza meg - ön a felelőss."
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr "GeoIP adatbázis letöltése a kiválasztott forrásból."
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr "Automatikus frissítés indításkor"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "GeoIP adatbázis újonnani letöltése a kiválasztott forrásból minden aMule indításkor."
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Bejövő üzenetek kiszűrése (kivéve az aktuális csevegés):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Összes üzenet szűrése"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Barát listában nem szereplőktől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Ismeretlen kliensektől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "A következő(ke)t tartalmazó üzenetek kiszűrése (elválasztónak ','-t használj):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Azon szavak felvétele, amelyeket az amule-nak ki kellene szűrni és blokkolni az ezeket tartalmazó üzeneteket"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "A kapott üzenetek megjelenítése a naplóban"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Megjegyzések"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Megjegyzések kiszűrése, melyek tartalmazzák (',' az elválasztó):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Hitelesítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Felhasználói név/jelszó hitelesítés engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Felhasználói név: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Felhasználói név a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Jelszó:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Jelszó a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Proxy engedélyezése"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Proxy támogatás engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Proxy típusa:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Proxy host:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "A proxy host neve"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Proxy port:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "A proxy port"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Kapcsolódás ehhez:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Bejeletkezés a távoli amule-ra"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Felhasználói név"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Emlékezzen ezekre a beállításokra"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr "ZLIB tömörítés erőltetése"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Bőbeszédű hiba-naplózás engedélyezése."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Csak napló fájlba"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Üzenet kategóriák:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Várakozás..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Importálandók hozzáadása"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Kijelöltek újrapróbálása"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Kijelöltek eltávolítása"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Esemény típusok"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statisztikák és várakozó kliensek a kiválasztott fájl(ok)hoz: Folyamat / Valaha"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Összes fájl százalékaként"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Összes fájl"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Kiválasztott fájlok"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Csak aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Újratöltés:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Megosztott fájlok frissítése"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Küldés"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Megadott üzenet küldése."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Csevegési folyamat bezárása."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Megosztott fájlok"
 
@@ -4576,7 +4595,7 @@ msgstr "összes egyéb"
 msgid "Incomplete"
 msgstr "Befejezetlen"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Megállítva"
 
@@ -4764,33 +4783,33 @@ msgstr " A %s (%s) részfájl forrás fájlja nem olvasható"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Hiba a részfájl forrás-fájljának olvasása közben (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Sérült részt (%d) találtam a %d részű %s fájlban - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "(%i) befejezett fájlrészt találtam a(z) %s fájlban"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "%s újra algoritmizálása befejeződött"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Váratlan hiba a %s fájl befejezése közben. A fájl szüneteltetve."
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Letöltés befejeződött: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4799,307 +4818,307 @@ msgstr ""
 "Letöltés befejeződött:\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Fájl törlése: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "FIGYELEM: Nem tudom a letöltött részt hash-elni - hash-készlet a(z) '%s'-hez hiányos"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "HIBA: Nem tudom a letöltött részt hash-elni - hash-készlet hiányos (%s). Nem volna szabad előfordulnia"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF hiba tördelőalgoritmizáláskor a %u. letöltött résznél, amely %u (max %u) hosszú és a(z) '%s' részfájlhoz tartozik, amely %u hosszú: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "FIGYELEM: Nincs elég szabad hely a lemezen! Fájl szüneteltetése: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "A %i. letöltött fájlrész sérült a %s fájlban"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: %i. sérült rész helyreállítva a '%s'-hez -> megmentett bájtok: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Helyfoglalás"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Elégtelen lemezterület"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Letöltve"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HIBA: A(z) '%s' részfájl megnyitása sikertelen."
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Alapértelmezett"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albán"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arab"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asztúriai"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baszk"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bolgár"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalán"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Kínai (egyszerűsített)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Kínai (hagyományos)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Horvát"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Cseh"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Dán"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holland"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Észt"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finn"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francia"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Gall"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Német"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Görög"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Héber"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Magyar"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Olasz"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Olasz (Svájci)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japán"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Koreai"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litván"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvég (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Lengyel"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugál"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugál (Brazíliai)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Román"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Orosz"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Szlovén"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spanyol"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Svéd"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Török"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukrán"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Nyelv megváltoztatása"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Nincsenek fordítások telepítve az aMule-hez"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Nincs elérhető nyelv"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "nincs elérhető opció"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Érvénytelen kategória találva, mellőzés"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "A TCP port nem lehet magasabb 65532-nél, mert a kiszolgáló UDP port = TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Alapértelmezett port lesz használva (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Csatlakozás"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Mappák"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Kiszolgálók"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Fájlok"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Biztonság"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Felület"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Szűrők"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Távoli elérés"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Online aláírás"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Haladó"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Események"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Hibakeresés"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5109,15 +5128,15 @@ msgstr ""
 "    %PARTFILE - teljes út a fájlhoz\n"
 "    %PARTNAME - csak a fájl neve"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5133,26 +5152,26 @@ msgstr ""
 "Ezen beállítások módosítása nélkül is remekül fog\n"
 "működni az aMule."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg csatolása a widget-hez (ID-je: %d, kulcsa: %s) sikertelen"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Adatátvitel a Cfg-ből a Widget-be (ID-je: %d, kulcsa: %s) sikertelen."
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "A proxy típusa amihez kapcsolódsz"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Adatátvitel a Widget-ből a Cfg-be (ID-je: %d, kulcsa: %s) sikertelen."
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5160,31 +5179,36 @@ msgstr ""
 "Újra kell indítani az aMule-t, hogy az alábbi változás(ok) érvénybe lépjen(ek):\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Külső kapcsolat port megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Külső kapcsolat elfogadása megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokoll zavarás támogatása megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5192,7 +5216,7 @@ msgstr ""
 "Az automatikusan frissített kiszolgálóü lista üres.\n"
 "A 'kiszolgáló lista automatikus frissítése induláskor' letiltva."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5200,19 +5224,19 @@ msgstr ""
 "Engedélyezted a távoli elérést, de nem adtál meg jelszót.\n"
 "A távoli elérés nem használható érvényes jelszó nélkül."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Nyelv megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Ideiglenes mappa megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K hálózat engedélyezve.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5220,7 +5244,7 @@ msgstr ""
 "Az eD2k és a Kad hálózat is le van tiltva.\n"
 "Nem fogsz tudni kapcsolódni, amíg legalább az egyiket nem engedélyezed."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5228,7 +5252,7 @@ msgstr ""
 "A Kad nem fog elindulni, ha az UDP portod le van tiltva.\n"
 "Engedélyezd az UDP portot vagy tiltsd le a Kad-ot."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5238,20 +5262,20 @@ msgstr ""
 "Most újra KELL indítanod az aMule-t.\n"
 "Ha nem indítod újra most, ne panaszkodj, ha bármi rossz történik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatikus frissítés elindítva"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5261,41 +5285,41 @@ msgstr ""
 "Kérlek adj meg legalább egy URL-t, ami érvényes server.met fájlra mutat .\n"
 "Az URL megadásához klikkelj a \"Lista\" gombra ezen checkbox mellett."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "az Ideiglenes fájloknak"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Bejövő fájlok"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "az Online aláírásnak"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Válassz egy mappát a %s-nek"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Böngészés a videolejátszóhoz"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Válaszd ki a böngésződet"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Futtatható%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Kiszolgáló lista szerkesztése"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5303,144 +5327,144 @@ msgstr ""
 "URL-ek felvétele a server.met fájl letöltéséhez.\n"
 "Egy sorba csak egy URL."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Teljes források"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Frissítés késleltetése: %d másodperc"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Grafikon átlagos ideje: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Kapcsolatok grafikon-skálája: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fájl buffer méret: %d bájt"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Feltöltési várólista nagysága: %d kliens"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Kiszolgáló kapcsolat frissítési gyakorisága: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "letiltva"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Parancs végrehajtása a(z) '%s' eseménynél"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Parancs futtatása a magon"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Mag parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Parancs futtatása a grafikus felületen"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "GUI parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "A következő változók lesznek behelyettesítve:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Megosztott fájlok frissítése"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "A megosztott fájlok listájának újratöltése."

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -201,8 +201,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -247,37 +247,42 @@ msgstr "Az aMule leállítása befejeződött."
 msgid "Memory debug results for aMule exit:"
 msgstr "Memória debug eredmények az aMule bezárásáról:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Nyelvi beállításaid egy konfigurációs változás miatt az alapértelmezettre lettek átállítva. Bocs."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Infó"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -285,20 +290,20 @@ msgstr ""
 "\n"
 "EC beállítások"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "FIGYELEM"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "Hálózati bootstrap"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -306,34 +311,34 @@ msgstr ""
 "aMule hiányzó hálózati bootstrap fájlokat észlelt.\n"
 "Válassza ki a letölteni kivántakat:"
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "eD2k szerver lista (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad bootstrap csomópontok (nodes.dat)"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nem tudom a portokat a megadott címhez (%s) rendelni."
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "A %u port nem elérhető. Alacsony kliens azonosítót kapsz (LOWID)\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -348,48 +353,48 @@ msgstr ""
 "\n"
 "Ellenőrízd a hálózatodat, hogy megbizonyosodj, hogy a port nyitva van kifelé és befelé egyaránt."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Aláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Az aMule OnlineAláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "A kiválasztott nyelvi beállítások úgy látszik nincsenek telepítve a gépeden. (Megjegyzés: Mindenesetre mepróbálom ezt beállítani)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ez az első alkalom, hogy az aMule %s-t futtatod"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ez egy teszt verzió, naponta frissítve, és\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nem vállalunk garanciát, hogy nem omlik össze, gyújtja fel a házad,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vagy öli meg a kutyád. *Elvileg* nyugodtan használható.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Még több információ, támogatás és új kiadások találhatóak honlapunkon,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "a https://amule-org.github.io, vagy az #aMule IRC csatornánkon az irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nyugodtan jelezz bármilyen hibát a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -397,137 +402,137 @@ msgstr ""
 "Az Online aláírás fájl könyvtárának megadott hely ÉRVÉNYTELEN!\n"
 " Az OnlineAláírás letiltásra kerül, amíg ki nem javítod azt a beállítások menüpontban."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Szerver hostname értesítve"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Lemezterület helyfoglalás a '%s' fájl számára sikertelen: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "HIBA: Nem tudom megnyitni a napló fájlt"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FIGYELEM: a napló üres. Valami nem stimmel."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Napló törölve"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "KiszolgálóÜzenet: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "A %s letöltése kihagyva, mert a kívánt fájl nem újabb."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Csomópont-lista letöltése sikertelen."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Nem sikerült megnyitni a letöltött verzió-ellenőrző fájlt"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Sérült verzió-ellenőrző fájl"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Az aMule egy elavult verzióját használod!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A te aMule verziód %i.%i.%i, a legújabb verzió pedig %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FIGYELEM: A te aMule verziód elavult: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Az aMule verziód naprakész."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Verzió-ellenőrzés fájl letöltése sikertelen."
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Felhasználók: %s | Fájlok: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Felhasználók: E: %s K: %s | Fájlok: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nincs hálózat kiválasztva"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID-val"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID-val"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Kapcsolódva ehhez %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Kapcsolódás %s-hez"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Leválasztva az eD2k-ról"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad elindítva."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad leállítva."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Kapcsolódva a Kad-hoz (rendben)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Kapcsolódva a Kad-hoz (tűzfal mögül)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Leválasztva a Kad-ról"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A Kad hálózat nem használható, ha az UDP port le van tiltva a beállításokban, nem indítom."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A Kad hálózat le van tiltva  a beállításokban, nem kapcsolódom."
 
@@ -888,7 +893,7 @@ msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2242,49 +2247,49 @@ msgstr "Nem"
 msgid "Yes"
 msgstr "Igen"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Letöltés..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP letöltés megszakítva"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "A letöltendő URL nem lehet üres"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "A %s iránti HTTP kérés létrehozása sikertelen"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP letöltés: a %s válasz tartalma üres"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "A letöltött fájlok eltolása %s helyre sikertelen"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Letöltve %s (%llu bájt)"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "Válasz a %s URL-tól: %i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP letöltés megszakítva"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2581,7 +2586,7 @@ msgstr "Külső kapcsolat: Hozzáférés megtagadva, mert: "
 msgid "External Connection: Handshake failed."
 msgstr "Külső kapcsolat: Kézfogás sikertelen."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio szál %d elindítva"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-29 10:01+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -201,8 +201,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -247,27 +247,37 @@ msgstr "Az aMule leállítása befejeződött."
 msgid "Memory debug results for aMule exit:"
 msgstr "Memória debug eredmények az aMule bezárásáról:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Nyelvi beállításaid egy konfigurációs változás miatt az alapértelmezettre lettek átállítva. Bocs."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Infó"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -275,20 +285,20 @@ msgstr ""
 "\n"
 "EC beállítások"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "FIGYELEM"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "Hálózati bootstrap"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -296,34 +306,34 @@ msgstr ""
 "aMule hiányzó hálózati bootstrap fájlokat észlelt.\n"
 "Válassza ki a letölteni kivántakat:"
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "eD2k szerver lista (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad bootstrap csomópontok (nodes.dat)"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nem tudom a portokat a megadott címhez (%s) rendelni."
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "A %u port nem elérhető. Alacsony kliens azonosítót kapsz (LOWID)\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -338,48 +348,48 @@ msgstr ""
 "\n"
 "Ellenőrízd a hálózatodat, hogy megbizonyosodj, hogy a port nyitva van kifelé és befelé egyaránt."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Aláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Az aMule OnlineAláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "A kiválasztott nyelvi beállítások úgy látszik nincsenek telepítve a gépeden. (Megjegyzés: Mindenesetre mepróbálom ezt beállítani)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ez az első alkalom, hogy az aMule %s-t futtatod"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ez egy teszt verzió, naponta frissítve, és\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nem vállalunk garanciát, hogy nem omlik össze, gyújtja fel a házad,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vagy öli meg a kutyád. *Elvileg* nyugodtan használható.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Még több információ, támogatás és új kiadások találhatóak honlapunkon,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "a https://amule-org.github.io, vagy az #aMule IRC csatornánkon az irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nyugodtan jelezz bármilyen hibát a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -387,137 +397,137 @@ msgstr ""
 "Az Online aláírás fájl könyvtárának megadott hely ÉRVÉNYTELEN!\n"
 " Az OnlineAláírás letiltásra kerül, amíg ki nem javítod azt a beállítások menüpontban."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Szerver hostname értesítve"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Lemezterület helyfoglalás a '%s' fájl számára sikertelen: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "HIBA: Nem tudom megnyitni a napló fájlt"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FIGYELEM: a napló üres. Valami nem stimmel."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Napló törölve"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "KiszolgálóÜzenet: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "A %s letöltése kihagyva, mert a kívánt fájl nem újabb."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Csomópont-lista letöltése sikertelen."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Nem sikerült megnyitni a letöltött verzió-ellenőrző fájlt"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Sérült verzió-ellenőrző fájl"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Az aMule egy elavult verzióját használod!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A te aMule verziód %i.%i.%i, a legújabb verzió pedig %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FIGYELEM: A te aMule verziód elavult: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Az aMule verziód naprakész."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Verzió-ellenőrzés fájl letöltése sikertelen."
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Felhasználók: %s | Fájlok: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Felhasználók: E: %s K: %s | Fájlok: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nincs hálózat kiválasztva"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID-val"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID-val"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Kapcsolódva ehhez %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Kapcsolódás %s-hez"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Leválasztva az eD2k-ról"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad elindítva."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad leállítva."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Kapcsolódva a Kad-hoz (rendben)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Kapcsolódva a Kad-hoz (tűzfal mögül)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Leválasztva a Kad-ról"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A Kad hálózat nem használható, ha az UDP port le van tiltva a beállításokban, nem indítom."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A Kad hálózat le van tiltva  a beállításokban, nem kapcsolódom."
 
@@ -2571,7 +2581,7 @@ msgstr "Külső kapcsolat: Hozzáférés megtagadva, mert: "
 msgid "External Connection: Handshake failed."
 msgstr "Külső kapcsolat: Kézfogás sikertelen."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio szál %d elindítva"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -30,20 +30,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostra aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Controllo remoto di aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -51,7 +51,7 @@ msgstr ""
 "Client p2p multipiattaforma basato su eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -59,59 +59,59 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Parte di aMule è basata su \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: routing peer-to-peer basato su metrica XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Sito:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr "Documentazione:"
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr "Segnalazioni:"
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verifica la disponibilità di nuove versioni all'avvio"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Connessione alla rete Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Non disponibile"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -213,8 +213,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossibile aggiungere %u collegamento dal file ED2KLinks (vedere il log per i dettagli)."
 msgstr[1] "Impossibile aggiungere %u collegamenti dal file ED2KLinks (vedere il log per i dettagli)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -229,47 +229,57 @@ msgstr "Impossibile aprire il link ed2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATTENZIONE: non è possibile aggiungere te stesso come fonte di un link eD2k finché avrai un ID basso."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Chiusura dell'applicazione..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando forzatamente l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Fallito"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule in fase di chiusura: Terminazione del core."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule, arresto completato."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Risultati del debug della memoria per la chiusura di aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza del cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -277,22 +287,22 @@ msgstr ""
 "\n"
 "Configurazione EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -301,35 +311,35 @@ msgstr ""
 "Selezionare quali scaricare:"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "Lista server eD2k (server.met)"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi di bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,48 +354,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Puoi segnalare qualsiasi bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -393,137 +403,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione dello spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Il file di log è stato reimpostato"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file scaricato per il controllo della versione"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Il file per il controllo della versione è corrotto"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni. Connessione non avviata."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni. Connessione interrotta."
 
@@ -562,15 +572,15 @@ msgstr "Questo è aMule %s basato su eMule."
 msgid "Running on %s"
 msgstr "In esecuzione su %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest per controllare se è disponibile una nuova versione."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -580,222 +590,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Non disponibile"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Finestra di aMule chiusa"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Connessione in corso"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Connessione in corso"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Disconnesso"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Connesso"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Connessione in corso"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Spento"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Connetti"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Connetti alle reti attualmente abilitate"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connesso)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Disconnesso)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vuoi veramente uscire da %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- predefinita -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "La directory delle skin '%s' non esiste"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Reti"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Ricerca"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Download"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "File condivisi"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Messaggi"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Finestra Preferenze"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Nessuna rete"
 
@@ -885,8 +895,8 @@ msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mante
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Sconosciuto"
@@ -1249,19 +1259,19 @@ msgstr "Auto [Alta]"
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1293,7 +1303,7 @@ msgid "On Queue"
 msgstr "In coda"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Download in corso"
 
@@ -1353,7 +1363,7 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1424,7 +1434,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensione"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Trasferiti"
 
@@ -1437,7 +1447,7 @@ msgid "Progress"
 msgstr "Avanzamento"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Fonti"
 
@@ -1447,7 +1457,7 @@ msgstr "Fonti"
 msgid "Priority"
 msgstr "Priorità"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Stato"
 
@@ -1480,7 +1490,7 @@ msgstr ""
 "Feedback da: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2131,7 +2141,7 @@ msgstr "Impossibile aprire in scrittura il file della lista degli amici 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICO - nessun client in StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Amici"
 
@@ -2415,8 +2425,8 @@ msgstr "Porta non valida per il bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completa tutti i campi obbligatori"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Messaggio"
 
@@ -2488,7 +2498,7 @@ msgstr "Rapporto di condivisione"
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Richiesto"
 
@@ -2522,30 +2532,30 @@ msgstr "Errore sconosciuto %d"
 msgid "Unable to get error description for error %d"
 msgstr "Impossibile avere una descrizione dell'errore %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Hashing in corso"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "In completamento"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Completo"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "In pausa"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Errato"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "In attesa"
 
@@ -2589,7 +2599,7 @@ msgstr "Connessione esterna: accesso negato a causa di: "
 msgid "External Connection: Handshake failed."
 msgstr "Connessione esterna: errore di negoziazione."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"
@@ -2611,7 +2621,7 @@ msgid "WARNING: "
 msgstr "ATTENZIONE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Chiudi"
 
@@ -2720,7 +2730,7 @@ msgstr "Esci"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2960,7 +2970,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3029,7 +3039,7 @@ msgstr "Rimuovi download completati"
 msgid "File sources:"
 msgstr "Fonti del file:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Generale"
 
@@ -3050,7 +3060,7 @@ msgstr "Nome completo:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/D"
 
@@ -3226,7 +3236,7 @@ msgstr "Nome utente:"
 msgid "Userhash :"
 msgstr "Hash utente:"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Aggiungi"
@@ -3235,15 +3245,15 @@ msgstr "Aggiungi"
 msgid "Download-Speed"
 msgstr "Velocità download"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Corrente"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Media attuale"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Media sessione"
 
@@ -3255,7 +3265,7 @@ msgstr "Velocità upload"
 msgid "Connections"
 msgstr "Connessioni"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Download attivi"
 
@@ -3263,7 +3273,7 @@ msgstr "Download attivi"
 msgid "Active connections (1:1)"
 msgstr "Connessioni attive (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Upload attivi"
 
@@ -3464,8 +3474,8 @@ msgstr "Selezione browser"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Inserisci qui il nome del tuo browser. Lascia vuoto questo campo per utilizzare il browser di sistema predefinito."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3539,147 +3549,156 @@ msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo per utenti esperti: se hai interfacce di rete multiple, inserisci l'indirizzo dell'interfaccia che aMule dovrà utilizzare."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Fonti massime per file in scaricamento:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Connessioni massime simultanee:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Connetti automaticamente all'avvio"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Riconnetti dopo perdita connessione"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Rimuovi server inattivi dopo"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "tentativi"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Aggiorna lista server all'avvio"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Aggiorna la lista server quando ti connetti ad un server"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Aggiorna la lista server quando ti connetti ad un client"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Usa sistema di priorità"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Usa controllo intelligente ID basso in fase di connessione"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Connessione sicura"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Connetti automaticamente solo ai server statici"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Assegna priorità alta ai server aggiunti manualmente"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Trattamento intelligente delle corruzioni (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Abilita"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "L'I.C.H. avanzato si fida di ogni hash (sconsigliato)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Aggiungi i nuovi file da scaricare mettendoli in pausa"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Aggiungi i nuovi file da scaricare con priorità automatica"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Cerca di scaricare prima la parte iniziale e finale del file"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Quando un file viene completato inizia a scaricare il primo file in pausa"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Della stessa categoria"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "In ordine alfabetico"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Prealloca lo spazio su disco per i nuovi file"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per i nuovi file prealloca lo spazio su disco per l'intero file, in questo modo ridurrai la frammentazione"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Interrompi i download quando termina lo spazio su disco "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleziona se vuoi che aMule controlli il tuo spazio su disco"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Inserire lo spazio disco minimo desiderato."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salva 10 fonti per i file rari ( con < 20 fonti)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Assegna priorità automatica ai nuovi file condivisi"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Cartella di destinazione per i file scaricati"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3687,599 +3706,599 @@ msgstr ""
 "Qui vengono salvati i download completati. Tutti i file in questa cartella sono condivisi automaticamente con gli altri peer.\n"
 "Se questa cartella contiene anche file che non vuoi condividere, impostala su una sottocartella riservata ad aMule."
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Scegli la cartella in cui salvare i download completati. Tutti i file in quella cartella saranno condivisi con gli altri peer."
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tutti i file in questa cartella sono condivisi con gli altri peer)"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Cartella per i file temporanei"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Cartelle condivise"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(fai click con il tasto destro sulle icone per condividere ricorsivamente le sottodirectory)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Condividi file nascosti"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ricontrolla automaticamente le modifiche nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr "Segui i collegamenti simbolici nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafici"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Intervallo di aggiornamento: 5 secondi"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Intervallo grafico valori medi: 100 minuti"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Scala grafico connessioni: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Scala grafico di scaricamento:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Scala grafico d'invio:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Colori: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Sfondo"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Griglia"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Download attuale"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Media download in corso"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Media sessione di download"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Upload attuale"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Media upload in corso"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Media sessione di upload"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Connessioni attive"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "Barra della velocità nell'icona sulla barra di sistema"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Nodi Kad attuali"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Nodi Kad attivi"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Nodi Kad nella sessione"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Seleziona"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Albero"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numero di versioni di client visualizzate (0=illimitate)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! ATTENZIONE !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Numero massimo nuove connessioni / 5 secondi"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensione buffer file: 240000 byte"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensione coda upload: 5000 client"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervallo aggiornamento connessione al server: disabilitato"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Disabilita la modalità standby a tempo"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Skin da usare: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra il \"Gestore rapido dei collegamenti eD2k\" in ogni finestra."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informazioni estese sulle schede delle categorie"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Mostra versione dell'applicazione nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Mostra velocità di trasferimento nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Prima del nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Dopo il nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Mostra l'overhead di banda"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientamento verticale della barra degli strumenti"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Scaricamento dei file in coda"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Mostra la percentuale di avanzamento"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Mostra la barra di avanzamento"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Piatta"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Arrotondata"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Ordina automaticamente i file (uso elevato della CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule ordinerà automaticamente le colonne nella lista dei download"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parametri connessioni esterne"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Accetta connessioni esterne"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP dell'interfaccia di ascolto:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Inserisci un IP valido nel formato a.b.c.d per l'interfaccia di ascolto EC. Lasciare il campo vuoto o inserire 0.0.0.0 significa qualsiasi interfaccia."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Abilita il port forwarding tramite UPnP sulla porta EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parametri del server web"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Lancia il webserver all'avvio"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Password per diritti completi"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Abilita utente con diritti limitati"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Password per diritti limitati"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Abilita port forwarding tramite UPnP sulla porta del server web"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP del  server web per UPnP (Facoltativa)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervallo di aggiornamento pagina (in sec)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Abilita compressione gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Fai click qui per applicare le modifiche apportate alle impostazioni."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Annulla ogni modifica alle preferenze."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titolo:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Commento:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Directory file scaricati:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Cambia priorità per i nuovi file assegnati:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Non modificare"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleziona colore per questa categoria (attualmente selezionata):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Pulisci"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Fai clic su questo pulsante per cancellare i log."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Fai clic qui per aggiornare la lista dei server dall'indirizzo..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Lista server"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Inserisci l'url di un file server.met e premi il pulsante a sinistra per aggiornare la lista dei server conosciuti."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Aggiungi un server manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Inserisci qui il nome di un nuovo server"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Inserisci qui l'IP del server, nel formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Inserisci qui la porta del server."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Aggiungi server (riempi campi a sinistra)..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "log di aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Informazioni server"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Informazioni ed2k"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Informazioni Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Fai clic su questo pulsante per aggiornare la lista nodi da un URL..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nodi (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Inserisci l'URL di un file nodes.dat e premi il pulsante a sinistra per aggiornare la lista dei nodi conosciuti."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Statistiche nodi"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nuovo nodo"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap dai client noti"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Disconnetti rete Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Usa identificazione sicura"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "È consigliato attivare questa opzione. Non riceverai crediti se \" \"l'identificazione non sarà abilitata."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Supporta offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Questa opzione abilita l'offuscamento del protocollo, e fa sì che aMule accetti connessioni offuscate dagli altri client."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizza offuscamento per le connessioni in uscita"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Questa opzione fa sì che aMule utilizzi l'offuscamento del protocollo quando si collega ad altri client/server."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Accetta SOLO connessioni offuscate"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Attivando questa opzione aMule accetterà solo connessioni offuscate. Avrai meno fonti, ma tutto il tuo traffico sarà offuscato"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Chiunque"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Nessuno"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Chi può vedere i miei file condivisi:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleziona chi può richiedere di vedere la lista dei tuoi file condivisi."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtraggio IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtra i client"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i client in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtra i server"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i server in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Ricarica lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ricarica lista degli IP da filtrare dal file ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Aggiorna ora"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Aggiorna ipfilter all'avvio"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Livello filtraggio:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre gli IP di una LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestione paranoica degli IP non corrispondenti"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Rifiuta pacchetto se l'IP del Client è diverso dall'IP da cui arriva il pacchetto. Utilizzare con cautela."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat di sistema se disponibile"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se un file ipfilter.dat locale non viene trovato, consenti l'utilizzo del file ipfilter.dat di sistema."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Abilita Online Signature"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Abilita la scrittura del file OS che può essere usato da applicazioni esterne per creare firme e simili."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frequenza di aggiornamento (secondi):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambia la frequenza (in secondi) degli aggiornamenti dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Salva la firma in linea in: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clicca qui per selezionare la directory che contiene i file dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Mostra la nazionalità dei client"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostra la colonna delle bandiere dei paesi nelle viste trasferimenti, coda e ricerca. Richiede un database GeoIP MMDB valido (vedi sotto)."
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr "Database"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr "Sorgente:"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuito, nessun account)"
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, richiede account)"
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr "URL personalizzato"
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Scegli quale provider fornisce il database GeoIP MMDB. DB-IP è il default - nessun account richiesto. MaxMind richiede un account gratuito + license key. Usa URL personalizzato per puntare a qualsiasi altro host MMDB (es. un mirror locale)."
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4291,11 +4310,11 @@ msgstr ""
 "Dati IP-to-Country di DB-IP.com - https://db-ip.com\n"
 "Licenza: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr "License key:"
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4311,11 +4330,11 @@ msgstr ""
 "Licenza: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Richiede attribuzione e registrazione dell'account; aggiornare almeno ogni 30 giorni."
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr "URL di scaricamento:"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4325,211 +4344,211 @@ msgstr ""
 "L'URL può includere credenziali (https://user:pass@host/...).\n"
 "I termini di licenza e attribuzione sono definiti dall'URL upstream - ne sei responsabile."
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr "Scarica il database GeoIP dalla sorgente selezionata."
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr "Aggiornamento automatico all'avvio"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Riscarica il database GeoIP dalla sorgente selezionata ogni volta che aMule si avvia."
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra messaggi in arrivo (tranne per la chat in corso):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtra tutti i messaggi"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra i messaggi da utenti che non sono nella tua lista degli amici"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtra i messaggi da client sconosciuti"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra i messaggi che contengono (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "aggiungi qui le parole che aMule filtrerà rimuovendo i messaggi che le contengono"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Mostra nel log i messaggi ricevuti"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Commenti"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra i commenti contenenti (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Abilita autenticazione"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Abilita o disabilita l'autenticazione con nome utente e password"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Nome utente: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Nome utente utilizzato per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Password:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "La password usata per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Abilita proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Abilita o disabilita il supporto proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Tipo proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Indirizzo proxy:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Il nome host del proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Porta proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "La porta del proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Connetti a:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Login su aMule remoto"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nome utente"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Ricorda impostazioni"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr "Forza la compressione ZLIB"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Abilita il log dettagliato dei messaggi di debug."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Solamente sul file di log"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Categorie messaggi:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "In attesa..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Aggiungi importazioni"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Riprova selezionati"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Rimuovi selezionati"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tipi di evento"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiche e client in coda per i(l) file selezionati(o) : Sessione / Totale"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Upload attivi"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Percentuale di file totali"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Tutti i file"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "File selezionati"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Solo upload attivi"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Ricarica lista:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Ricarica file condivisi"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Invia"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Invia messaggio specificato."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Chiude questa sessione di chat."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Connetti a qualsiasi server e/o a Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "File condivisi"
 
@@ -4606,7 +4625,7 @@ msgstr "tutti gli altri"
 msgid "Incomplete"
 msgstr "Incompleti"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Fermo"
 
@@ -4795,34 +4814,34 @@ msgstr "Impossibile accedere alle fonti del file Part %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Errore nella lettura del file delle fonti del partfile (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Trovata parte danneggiata (%d) in %d parte %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Trovata parte danneggiata (%d) in %d parti %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Trovata parte completata (%i) in %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Nuovo hashing completato %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Errore imprevisto durante il completamento di %s. File messo in pausa"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Download completato: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4831,306 +4850,306 @@ msgstr ""
 "Download completato: \n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Cancellazione file in corso: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ATTENZIONE: Impossibile calcolare l'hash del file parziale - hashset incompleto per '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERRORE: Impossibile calcolare l'hash delle parti scaricate - hashset incompleto (%s). Ciò non dovrebbe mai accadere"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Parte %u di '%s' segnata come completata ma il file parziale è più corto del previsto (presenti %llu byte, richiesti %llu); il gap viene riaperto per riscaricare."
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF durante l'hashing della parte %u scaricata con lunghezza %u (max %u) del file Part '%s' con lunghezza %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ATTENZIONE: non c'è abbastanza spazio libero su disco! Metto in pausa il file: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "La parte di file scaricata %i è danneggiata in: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: recuperata parte danneggiata %i in %s -> risparmiati byte: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Allocazione in corso"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Spazio su disco insufficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Scaricato"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRORE: Apertura del file Part fallita '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Predefinita di sistema"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanese"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabo"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgaro"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalano"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Cinese (semplificato)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Cinese (tradizionale)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croato"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Ceco"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danese"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Olandese"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Inglese (Regno Unito)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr "Inglese (U.S.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estone"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francese"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galiziano"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Tedesco"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Greco"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Ebraico"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiano (Svizzera)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegese (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polacco"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portoghese (Brasile)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Sloveno"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Svedese"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Cambia lingua"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Non ci sono traduzioni di aMule installate"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Nessuna lingua disponibile"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "nessuna opzione disponibile"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Trovata categoria non valida, ignorata"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "La porta TCP non può essere superiore a 65532 perché il socket UDP è fissato a TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Sarà usata la porta predefinita (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Connessione"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Directory"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Server"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "File"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Sicurezza"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interfaccia"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Controlli remoti"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avanzato"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Eventi"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Debug"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5140,15 +5159,15 @@ msgstr ""
 "    %PARTFILE - percorso completo del file\n"
 "    %PARTNAME - solamente il nome del file"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Il supporto per l'icona nella tray richiede libayatana-appindicator3 in fase di compilazione."
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non disponibile su Wayland: il protocollo non segnala quando una finestra viene ridotta a icona, quindi questa opzione non può intercettare il pulsante di riduzione del sistema. Soluzione alternativa: avvia aMule con `GDK_BACKEND=x11` per usare XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5163,26 +5182,26 @@ msgstr ""
 "\n"
 "aMule funzionerà anche senza modificare questi parametri."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Insuccesso nel collegare Cfg al widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati da Cfg al Widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Il tipo di proxy a cui ti stai connettendo"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati dal widget al Cfg con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5190,31 +5209,36 @@ msgstr ""
 "aMule deve essere riavviato per rendere effettive queste modifiche:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- Modifica della porta TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- Modifica della porta UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Interfaccia connessione esterna modificata. \n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Porta della connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Accetta connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Interfaccia connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Modificato il supporto all'offuscamento del protocollo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5222,7 +5246,7 @@ msgstr ""
 "La tua lista dei server per l'aggiornamento automatico è vuota.\n"
 "L'aggiornamento automatico all'avvio sarà disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5230,19 +5254,19 @@ msgstr ""
 "Hai abilitato le connessioni esterne senza però specificare una password.\n"
 "Le connessioni esterne non possono essere abilitate a meno che tu non scelga una password valida."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Modifica della lingua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Modifica della cartella Temp.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Rete ed2k abilitata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5250,7 +5274,7 @@ msgstr ""
 "Le reti eD2k e Kad sono entrambe disabilitate.\n"
 "Non potrai connetterti finché non ne abiliterai almeno una."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5258,7 +5282,7 @@ msgstr ""
 "Kad non può partire se la porta UDP è disabilitata.\n"
 "Abilitala o disabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5268,19 +5292,19 @@ msgstr ""
 "DEVI riavviare aMule ADESSO.\n"
 "Se non lo fai, non lamentarti se succede qualcosa di strano.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Impossibile registrare aMule per l'avvio automatico all'accesso. L'archivio di avvio automatico potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Impossibile rimuovere la voce di avvio automatico all'accesso."
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr "Avvio automatico"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5290,41 +5314,41 @@ msgstr ""
 "Inserisci l'URL di almeno un server valido nel file server.met.\n"
 "Clicca sul pulsante \"Lista\" per inserire l'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "File temporanei"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "File completi"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Scegli una directory per i %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Sfoglia per trovare un riproduttore video"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Scegli browser"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Eseguibile%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Modifica la lista dei server"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5332,114 +5356,114 @@ msgstr ""
 "Inserisci l'URL da cui scaricare il file server.met.\n"
 "Solo un URL per riga."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr "Aggiornamento IP2Country fallito"
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dati di MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr "Sorgente personalizzata"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr "Dati di DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Stato: Caricato%s"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stato: Caricato%s - %s"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Stato: Caricamento fallito - clicca su 'Aggiorna ora' per ricaricare."
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Stato: Non trovato - clicca su 'Aggiorna ora' per scaricare."
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervallo aggiornamento: %d secondo"
 msgstr[1] "Intervallo aggiornamento: %d secondi"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Intervallo grafico della media: %d minuto"
 msgstr[1] "Intervallo grafico della media: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scala grafico delle connessioni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dimensione buffer file: %d byte"
 msgstr[1] "Dimensione buffer file: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Dimensione coda upload: %d client"
 msgstr[1] "Dimensione coda upload: %d client"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervallo aggiornamento connessione ai server: %d minuto"
 msgstr[1] "Intervallo aggiornamento connessione ai server: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervallo aggiornamento connessione ai server: disabilitato"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "disattivato"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Esegui comando se si verifica l'evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Abilita l'esecuzione del comando sul core"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Comando Core:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Abilita l'esecuzione del comando sulla GUI"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Comando GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Le seguenti variabili saranno sostituite:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -5447,32 +5471,32 @@ msgstr ""
 "Le seguenti cartelle sembrano posizioni di sistema o sensibili:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Condividerle ricorsivamente pubblicherà ogni file al loro interno sulle reti eD2k/Kad. Vuoi davvero procedere?"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr "Conferma cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr "Ricarica file condivisi in corso…"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr "Analisi delle sottocartelle in corso…"
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr "Aggiornamento cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr "%u cartelle analizzate…"
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ricarica file condivisi: %u file analizzati"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -213,8 +213,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossibile aggiungere %u collegamento dal file ED2KLinks (vedere il log per i dettagli)."
 msgstr[1] "Impossibile aggiungere %u collegamenti dal file ED2KLinks (vedere il log per i dettagli)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -259,37 +259,42 @@ msgstr "aMule, arresto completato."
 msgid "Memory debug results for aMule exit:"
 msgstr "Risultati del debug della memoria per la chiusura di aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza del cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -297,22 +302,22 @@ msgstr ""
 "\n"
 "Configurazione EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -321,35 +326,35 @@ msgstr ""
 "Selezionare quali scaricare:"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "Lista server eD2k (server.met)"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi di bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -364,48 +369,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Puoi segnalare qualsiasi bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -413,137 +418,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione dello spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Il file di log è stato reimpostato"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file scaricato per il controllo della versione"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Il file per il controllo della versione è corrotto"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni. Connessione non avviata."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni. Connessione interrotta."
 
@@ -904,7 +909,7 @@ msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mante
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2265,49 +2270,49 @@ msgstr "No"
 msgid "Yes"
 msgstr "Sì"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Scaricamento in corso..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Download HTTP cancellato"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "L'URL per scaricare non può essere vuoto"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Impossibile creare la richiesta HTTP per %s"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "Download HTTP: corpo della risposta vuoto per %s"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Impossibile spostare il file scaricato in %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Scaricato %s (%llu byte)"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "L'URL %s ha restituito: %i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Download HTTP fallito per %s: %s"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 Non autorizzato per %s"
@@ -2609,7 +2614,7 @@ msgstr "Connessione esterna: accesso negato a causa di: "
 msgid "External Connection: Handshake failed."
 msgstr "Connessione esterna: errore di negoziazione."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -213,8 +213,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossibile aggiungere %u collegamento dal file ED2KLinks (vedere il log per i dettagli)."
 msgstr[1] "Impossibile aggiungere %u collegamenti dal file ED2KLinks (vedere il log per i dettagli)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -259,27 +259,37 @@ msgstr "aMule, arresto completato."
 msgid "Memory debug results for aMule exit:"
 msgstr "Risultati del debug della memoria per la chiusura di aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza del cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -287,22 +297,22 @@ msgstr ""
 "\n"
 "Configurazione EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -311,35 +321,35 @@ msgstr ""
 "Selezionare quali scaricare:"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "Lista server eD2k (server.met)"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi di bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -354,48 +364,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Puoi segnalare qualsiasi bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -403,137 +413,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione dello spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Il file di log è stato reimpostato"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file scaricato per il controllo della versione"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Il file per il controllo della versione è corrotto"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni. Connessione non avviata."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni. Connessione interrotta."
 
@@ -2599,7 +2609,7 @@ msgstr "Connessione esterna: accesso negato a causa di: "
 msgid "External Connection: Handshake failed."
 msgstr "Connessione esterna: errore di negoziazione."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -209,8 +209,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossibile aggiungere %u collegamento dal file ED2KLinks (vedere il log per i dettagli)."
 msgstr[1] "Impossibile aggiungere %u collegamenti dal file ED2KLinks (vedere il log per i dettagli)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -255,37 +255,42 @@ msgstr "aMule, arresto completato."
 msgid "Memory debug results for aMule exit:"
 msgstr "Risultati del debug della memoria per l'uscita da aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza al cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -293,20 +298,20 @@ msgstr ""
 "\n"
 "Configurazione EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -314,35 +319,35 @@ msgstr ""
 "aMule ha rilevato file di bootstrap di rete mancanti.\n"
 "Seleziona quali scaricare:"
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "Elenco server eD2k (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto aMule web server, o compila aMule con l'opzione --enable-webserver"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -357,48 +362,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Segnalare ogni bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -406,137 +411,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Il file di log è stato cancellato"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file per il controllo della versione scaricato"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "File per il controllo della versione corrotto"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni, connessione interrotta."
 
@@ -897,7 +902,7 @@ msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mante
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2258,49 +2263,49 @@ msgstr "No"
 msgid "Yes"
 msgstr "Sì"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Scaricamento in corso..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Download HTTP cancellato"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "L'URL per scaricare non può essere vuoto"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Impossibile creare la richiesta HTTP per %s"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "Download HTTP: corpo della risposta vuoto per %s"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Impossibile spostare il file scaricato in %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Scaricato %s (%llu byte)"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "L'URL %s ha restituito: %i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Download HTTP non riuscito per %s: %s"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 Non autorizzato per %s"
@@ -2602,7 +2607,7 @@ msgstr "Connessione esterna: accesso negato a causa di: "
 msgid "External Connection: Handshake failed."
 msgstr "Connessione esterna: errore di negoziazione."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -209,8 +209,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossibile aggiungere %u collegamento dal file ED2KLinks (vedere il log per i dettagli)."
 msgstr[1] "Impossibile aggiungere %u collegamenti dal file ED2KLinks (vedere il log per i dettagli)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -255,27 +255,37 @@ msgstr "aMule, arresto completato."
 msgid "Memory debug results for aMule exit:"
 msgstr "Risultati del debug della memoria per l'uscita da aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza al cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -283,20 +293,20 @@ msgstr ""
 "\n"
 "Configurazione EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -304,35 +314,35 @@ msgstr ""
 "aMule ha rilevato file di bootstrap di rete mancanti.\n"
 "Seleziona quali scaricare:"
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "Elenco server eD2k (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto aMule web server, o compila aMule con l'opzione --enable-webserver"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -347,48 +357,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Segnalare ogni bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -396,137 +406,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Il file di log è stato cancellato"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file per il controllo della versione scaricato"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "File per il controllo della versione corrotto"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni, connessione interrotta."
 
@@ -2592,7 +2602,7 @@ msgstr "Connessione esterna: accesso negato a causa di: "
 msgid "External Connection: Handshake failed."
 msgstr "Connessione esterna: errore di negoziazione."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -26,20 +26,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostra aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Controllo remoto di aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -47,7 +47,7 @@ msgstr ""
 "Client p2p multipiattaforma basato su eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -55,59 +55,59 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Parte di aMule è basata su \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: routing peer-to-peer basato su metrica XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Sito:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr "Documentazione:"
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr "Segnalazioni:"
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verifica la disponibilità di nuove versioni all'avvio"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Connessione alla rete Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Non disponibile"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -209,8 +209,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Impossibile aggiungere %u collegamento dal file ED2KLinks (vedere il log per i dettagli)."
 msgstr[1] "Impossibile aggiungere %u collegamenti dal file ED2KLinks (vedere il log per i dettagli)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -225,47 +225,57 @@ msgstr "Impossibile aprire il link ed2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATTENZIONE: non è possibile aggiungere te stesso come fonte di un link eD2k finché avrai un ID basso."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Chiusura dell'applicazione..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Fallito"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule in fase di chiusura: Il core sta venendo terminato."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule, arresto completato."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Risultati del debug della memoria per l'uscita da aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza al cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -273,20 +283,20 @@ msgstr ""
 "\n"
 "Configurazione EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -294,35 +304,35 @@ msgstr ""
 "aMule ha rilevato file di bootstrap di rete mancanti.\n"
 "Seleziona quali scaricare:"
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "Elenco server eD2k (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto aMule web server, o compila aMule con l'opzione --enable-webserver"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -337,48 +347,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Segnalare ogni bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -386,137 +396,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Il file di log è stato cancellato"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file per il controllo della versione scaricato"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "File per il controllo della versione corrotto"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni, connessione interrotta."
 
@@ -555,15 +565,15 @@ msgstr "Questo è aMule %s basato su eMule."
 msgid "Running on %s"
 msgstr "In esecuzione su %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest per sapere se è disponibile una nuova versione."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -573,222 +583,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Non disponibile"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Finestra di aMule chiusa"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Connessione in corso"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Connessione in corso"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Disconnesso"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Connesso"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Connessione in corso"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Spento"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Connetti"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Connetti alle reti attualmente abilitate"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connesso)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Disconnesso)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vuoi veramente uscire da %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- predefinita -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "La directory delle skin '%s' non esiste"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Reti"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Ricerca"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Download"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "File condivisi"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Messaggi"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Finestra Impostazione preferenze"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Nessuna rete"
 
@@ -878,8 +888,8 @@ msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mante
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Sconosciuto"
@@ -1242,19 +1252,19 @@ msgstr "Auto [Alta]"
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1286,7 +1296,7 @@ msgid "On Queue"
 msgstr "In coda"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Download in corso"
 
@@ -1346,7 +1356,7 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1417,7 +1427,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensione"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Trasferiti"
 
@@ -1430,7 +1440,7 @@ msgid "Progress"
 msgstr "Avanzamento"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Fonti"
 
@@ -1440,7 +1450,7 @@ msgstr "Fonti"
 msgid "Priority"
 msgstr "Priorità"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Stato"
 
@@ -1473,7 +1483,7 @@ msgstr ""
 "Feedback da: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2124,7 +2134,7 @@ msgstr "Impossibile aprire in scrittura il file della lista degli amici 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICO - nessun client in StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Amici"
 
@@ -2408,8 +2418,8 @@ msgstr "Porta non valida per il bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completa tutti i campi obbligatori"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Messaggio"
 
@@ -2481,7 +2491,7 @@ msgstr "Rapporto di condivisione"
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Richiesto"
 
@@ -2515,30 +2525,30 @@ msgstr "Errore sconosciuto %d"
 msgid "Unable to get error description for error %d"
 msgstr "Impossibile avere una descrizione dell'errore %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Hashing in corso"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "In completamento"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Completo"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "In pausa"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Errato"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "In attesa"
 
@@ -2582,7 +2592,7 @@ msgstr "Connessione esterna: accesso negato a causa di: "
 msgid "External Connection: Handshake failed."
 msgstr "Connessione esterna: errore di negoziazione."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"
@@ -2604,7 +2614,7 @@ msgid "WARNING: "
 msgstr "ATTENZIONE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Chiudi"
 
@@ -2713,7 +2723,7 @@ msgstr "Esci"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2953,7 +2963,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3022,7 +3032,7 @@ msgstr "Rimuovi download completati"
 msgid "File sources:"
 msgstr "Fonti del file:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Generale"
 
@@ -3043,7 +3053,7 @@ msgstr "Nome completo:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/D"
 
@@ -3219,7 +3229,7 @@ msgstr "Nome utente:"
 msgid "Userhash :"
 msgstr "Hash utente:"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Aggiungi"
@@ -3228,15 +3238,15 @@ msgstr "Aggiungi"
 msgid "Download-Speed"
 msgstr "Velocità download"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Corrente"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Media attuale"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Media sessione"
 
@@ -3248,7 +3258,7 @@ msgstr "Velocità upload"
 msgid "Connections"
 msgstr "Connessioni"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Download attivi"
 
@@ -3256,7 +3266,7 @@ msgstr "Download attivi"
 msgid "Active connections (1:1)"
 msgstr "Connessioni attive (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Upload attivi"
 
@@ -3457,8 +3467,8 @@ msgstr "Selezione browser"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Inserisci qui il nome del tuo browser. Lascia vuoto questo campo per utilizzare il browser di sistema predefinito."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3532,147 +3542,156 @@ msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo per utenti esperti: se hai interfacce di rete multiple, inserisci l'indirizzo dell'interfaccia che aMule dovrà utilizzare."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Fonti massime per file in scaricamento:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Connessioni massime simultanee:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Connetti automaticamente all'avvio"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Riconnetti dopo perdita connessione"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Rimuovi server inattivi dopo"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "tentativi"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Aggiorna lista server all'avvio"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Aggiorna la lista server quando ti connetti ad un server"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Aggiorna la lista server quando ti connetti ad un client"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Usa sistema di priorità"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Usa controllo intelligente ID basso in fase di connessione"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Connessione sicura"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Connetti automaticamente solo ai server statici"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Assegna priorità alta ai server aggiunti manualmente"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Trattamento intelligente delle corruzioni (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Abilita"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "L'I.C.H. avanzato si fida di ogni hash (sconsigliato)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Aggiungi i nuovi file da scaricare mettendoli in pausa"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Aggiungi i nuovi file da scaricare con priorità automatica"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Cerca di scaricare prima la parte iniziale e finale del file"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Quando un file viene completato inizia a scaricare il primo file in pausa"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Della stessa categoria"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "In ordine alfabetico"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Prealloca lo spazio su disco per i nuovi file"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per i nuovi file prealloca lo spazio su disco per l'intero file, in questo modo ridurrai la frammentazione"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Interrompi i download quando termina lo spazio su disco "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleziona se vuoi che aMule controlli il tuo spazio su disco"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Inserire lo spazio disco minimo desiderato."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salva 10 fonti per i file rari ( con < 20 fonti)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Assegna priorità automatica ai nuovi file condivisi"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Cartella di destinazione per i file scaricati"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3680,601 +3699,601 @@ msgstr ""
 "Qui vengono salvati i download completati. Tutti i file in questa cartella sono condivisi automaticamente con gli altri peer.\n"
 "Se questa cartella contiene anche file che non vuoi condividere, impostala su una sottocartella riservata ad aMule."
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Scegli la cartella in cui salvare i download completati. Tutti i file in quella cartella saranno condivisi con gli altri peer."
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tutti i file in questa cartella sono condivisi con gli altri peer)"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Cartella per i file temporanei"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Cartelle condivise"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(fai click con il tasto destro sulle icone per condividere ricorsivamente le sottodirectory)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Condividi file nascosti"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ricontrolla automaticamente le modifiche nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr "Segui i collegamenti simbolici nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafici"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Intervallo di aggiornamento: 5 secondi"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Intervallo grafico valori medi: 100 minuti"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Scala grafico connessioni: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Scala grafico di scaricamento:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Scala grafico d'invio:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Colori: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Sfondo"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Griglia"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Download attuale"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Media download in corso"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Media sessione di download"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Upload attuale"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Media upload in corso"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Media sessione di upload"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Connessioni attive"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "Barra della velocità nell'icona sulla barra di sistema"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Nodi Kad attuali"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Nodi Kad attivi"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Nodi Kad nella sessione"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Seleziona"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Albero"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numero di versioni di client visualizzate (0=illimitate)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! ATTENZIONE !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Numero massimo nuove connessioni / 5 secondi"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensione buffer file: 240000 byte"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensione coda upload: 5000 client"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervallo aggiornamento connessione al server: disabilitato"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Disabilita la modalità standby a tempo"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Skin da usare: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra il \"Gestore rapido dei collegamenti eD2k\" in ogni finestra."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informazioni estese sulle schede delle categorie"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Mostra versione dell'applicazione nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Mostra velocità di trasferimento nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Prima del nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Dopo il nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Mostra l'overhead di banda"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientamento verticale della barra degli strumenti"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Scaricamento dei file in coda"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Mostra la percentuale di avanzamento"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Mostra la barra di avanzamento"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Piatta"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Arrotondata"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Ordina automaticamente i file (uso elevato della CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule ordinerà automaticamente le colonne nella lista dei download"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parametri connessioni esterne"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Accetta connessioni esterne"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP dell'interfaccia di ascolto:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Inserisci un IP valido nel formato a.b.c.d per l'interfaccia di ascolto EC. Lasciare il campo vuoto o inserire 0.0.0.0 significa qualsiasi interfaccia."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Abilita il port forwarding tramite UPnP sulla porta EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parametri del server web"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Lancia il webserver all'avvio"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Password per diritti completi"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Abilita utente con diritti limitati"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Password per diritti limitati"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Abilita port forwarding tramite UPnP sulla porta del server web"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP del  server web per UPnP (Facoltativa)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervallo di aggiornamento pagina (in sec)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Abilita compressione gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Fai click qui per applicare le modifiche apportate alle impostazioni."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Annulla ogni modifica alle preferenze."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titolo:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Commento:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Directory file scaricati:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Cambia priorità per i nuovi file assegnati:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Non modificare"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleziona colore per questa categoria (attualmente selezionata):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Pulisci"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Fai clic su questo pulsante per cancellare i log."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Fai clic qui per aggiornare la lista dei server dall'indirizzo..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Lista server"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Inserisci l'url di un file server.met e premi il pulsante a sinistra per aggiornare la lista dei server conosciuti."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Aggiungi un server manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Inserisci qui il nome di un nuovo server"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Inserisci qui l'IP del server, nel formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Inserisci qui la porta del server."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Aggiungi server (riempi campi a sinistra)..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "log di aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Informazioni server"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Informazioni ed2k"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Informazioni Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Fai clic su questo pulsante per aggiornare la lista nodi da un URL..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nodi (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Inserisci l'URL di un file nodes.dat e premi il pulsante a sinistra per aggiornare la lista dei nodi conosciuti."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Statistiche nodi"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nuovo nodo"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap dai client noti"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Disconnetti rete Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Usa identificazione sicura"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "È consigliato attivare questa opzione. Non riceverai crediti se \" \"l'identificazione non sarà abilitata."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Supporta offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Questa opzione abilita l'offuscamento del protocollo, e fa sì che aMule accetti connessioni offuscate dagli altri client."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizza offuscamento per le connessioni in uscita"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Questa opzione fa sì che aMule utilizzi l'offuscamento del protocollo quando si collega ad altri client/server."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Accetta SOLO connessioni offuscate"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Attivando questa opzione aMule accetterà solo connessioni offuscate. Avrai meno fonti, ma tutto il tuo traffico sarà offuscato"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Chiunque"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Nessuno"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Chi può vedere i miei file condivisi:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleziona chi può richiedere di vedere la lista dei tuoi file condivisi."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtraggio IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtra i client"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i client in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtra i server"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i server in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Ricarica lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ricarica lista degli IP da filtrare dal file ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Aggiorna ora"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Aggiorna ipfilter all'avvio"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Livello filtraggio:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre gli IP di una LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestione paranoica degli IP non corrispondenti"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Rifiuta pacchetto se l'IP del Client è diverso dall'IP da cui arriva il pacchetto. Utilizzare con cautela."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat di sistema se disponibile"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se un file ipfilter.dat locale non viene trovato, consenti l'utilizzo del file ipfilter.dat di sistema."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Abilita Online Signature"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Abilita la scrittura del file OS che può essere usato da applicazioni esterne per creare firme e simili."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frequenza di aggiornamento (secondi):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambia la frequenza (in secondi) degli aggiornamenti dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Salva la firma in linea in: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clicca qui per selezionare la directory che contiene i file dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Mostra la nazionalità dei client"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Velocità:"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Fonti"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4282,11 +4301,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4296,224 +4315,224 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Aggiorna ipfilter all'avvio"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra messaggi in arrivo (tranne per la chat in corso):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtra tutti i messaggi"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra i messaggi da utenti che non sono nella tua lista degli amici"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtra i messaggi da client sconosciuti"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra i messaggi che contengono (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "aggiungi qui le parole che aMule filtrerà rimuovendo i messaggi che le contengono"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Mostra nel log i messaggi ricevuti"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Commenti"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra i commenti contenenti (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Abilita autenticazione"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Abilita o disabilita l'autenticazione con nome utente e password"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Nome utente: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Nome utente utilizzato per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Password:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "La password usata per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Abilita proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Abilita o disabilita il supporto proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Tipo proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Indirizzo proxy:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Il nome host del proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Porta proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "La porta del proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Connetti a:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Login su aMule remoto"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nome utente"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Ricorda impostazioni"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr "Forza la compressione ZLIB"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Abilita il log dettagliato dei messaggi di debug."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Solamente sul file di log"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Categorie messaggi:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "In attesa..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Aggiungi importazioni"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Riprova selezionati"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Rimuovi selezionati"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tipi di evento"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiche e client in coda per i(l) file selezionati(o) : Sessione / Totale"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Upload attivi"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Percentuale di file totali"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Tutti i file"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "File selezionati"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Solo upload attivi"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Ricarica lista:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Ricarica file condivisi"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Invia"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Invia messaggio specificato."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Chiude questa sessione di chat."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Connetti a qualsiasi server e/o a Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "File condivisi"
 
@@ -4590,7 +4609,7 @@ msgstr "tutti gli altri"
 msgid "Incomplete"
 msgstr "Incompleti"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Fermo"
 
@@ -4779,34 +4798,34 @@ msgstr "Impossibile accedere alle fonti del file Part %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Errore nella lettura del file delle fonti del partfile (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Trovata parte corrotta (%d) in %d parte %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Trovata parte corrotta (%d) in %d parti %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Trovata parte completata (%i) in %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Nuovo hashing completato %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Errore imprevisto durante il completamento di %s. File messo in pausa"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Download completato: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4815,307 +4834,307 @@ msgstr ""
 "Download completato: \n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Cancellazione file in corso: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ATTENZIONE: Impossibile calcolare l'hash del file parziale - hashset incompleto per '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERRORE: Impossibile calcolare l'hash delle parti scaricate - hashset incompleto (%s). Ciò non dovrebbe mai accadere"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Parte %u di '%s' segnata come completata ma il file parziale è più corto del previsto (presenti %llu byte, richiesti %llu); il gap viene riaperto per riscaricare."
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF durante l'hashing della parte %u scaricata con lunghezza %u (max %u) del file Part '%s' con lunghezza %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ATTENZIONE: non c'è abbastanza spazio libero su disco! Metto in pausa il file: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "La parte di file scaricata %i è danneggiata in: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: recuperata parte corrotta %i in %s -> risparmiati byte: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Allocazione in corso"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Spazio su disco insufficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Scaricato"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRORE: Apertura del file Part fallita '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Predefinita di sistema"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanese"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabo"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgaro"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalano"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Cinese (semplificato)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Cinese (tradizionale)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croato"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Ceco"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danese"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Olandese"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Inglese (Regno Unito)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglese (Regno Unito)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estone"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francese"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galiziano"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Tedesco"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Greco"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Ebraico"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiano (Svizzera)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegese (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polacco"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portoghese (Brasile)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Sloveno"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Svedese"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Cambia lingua"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Non ci sono traduzioni di aMule installate"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Nessuna lingua disponibile"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "nessuna opzione disponibile"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Trovata categoria non valida, ignorata"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "La porta TCP non può essere superiore a 65532 perché il socket UDP è fissato a TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Sarà usata la porta predefinita (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Connessione"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Directory"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Server"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "File"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Sicurezza"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interfaccia"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Controlli remoti"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avanzato"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Eventi"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Debug"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5125,15 +5144,15 @@ msgstr ""
 "    %PARTFILE - percorso completo del file\n"
 "    %PARTNAME - solamente il nome del file"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Il supporto per l'icona nella tray richiede libayatana-appindicator3 in fase di compilazione."
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non disponibile su Wayland: il protocollo non segnala quando una finestra viene ridotta a icona, quindi questa opzione non può intercettare il pulsante di riduzione del sistema. Soluzione alternativa: avvia aMule con `GDK_BACKEND=x11` per usare XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5148,26 +5167,26 @@ msgstr ""
 "\n"
 "aMule funzionerà anche senza modificare questi parametri."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Insuccesso nel collegare Cfg al widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati da Cfg al Widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Il tipo di proxy a cui ti stai connettendo"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati dal widget al Cfg con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5175,31 +5194,36 @@ msgstr ""
 "aMule deve essere riavviato per rendere effettive queste modifiche:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- Modifica della porta TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- Modifica della porta UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Interfaccia connessione esterna modificata. \n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Porta della connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "Accettata nuova connessione esterna\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Interfaccia connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Modificato il supporto all'offuscamento del protocollo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5207,7 +5231,7 @@ msgstr ""
 "La tua lista dei server per l'aggiornamento automatico è vuota.\n"
 "L'aggiornamento automatico all'avvio sarà disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5215,19 +5239,19 @@ msgstr ""
 "Hai abilitato le connessioni esterne senza però specificare una password.\n"
 "Le connessioni esterne non possono essere abilitate a meno che tu non scelga una password valida."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Modifica della lingua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Modifica della cartella Temp.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Rete ed2k abilitata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5235,7 +5259,7 @@ msgstr ""
 "Le reti eD2k e Kad sono entrambe disabilitate.\n"
 "Non potrai connetterti finché non ne abiliterai almeno una."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5243,7 +5267,7 @@ msgstr ""
 "Kad non può partire se la porta UDP è disabilitata.\n"
 "Abilitala o disabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5253,19 +5277,19 @@ msgstr ""
 "DEVI riavviare aMule ADESSO.\n"
 "Se non lo fai, non lamentarti se succede qualcosa di strano.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Impossibile registrare aMule per l'avvio automatico all'accesso. L'archivio di avvio automatico potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Impossibile rimuovere la voce di avvio automatico all'accesso."
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr "Avvio automatico"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5275,41 +5299,41 @@ msgstr ""
 "Inserisci l'URL di almeno un server valido nel file server.met.\n"
 "Clicca sul pulsante \"Lista\" per inserire l'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "File temporanei"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "File completi"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Scegli una directory per i %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Sfoglia per trovare un riproduttore video"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Scegli browser"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Eseguibile%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Modifica la lista dei server"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5317,115 +5341,115 @@ msgstr ""
 "Inserisci l'URL da cui scaricare il file server.met.\n"
 "Solo un URL per riga."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Fonti complete"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stato:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stato:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervallo aggiornamento: %d secondo"
 msgstr[1] "Intervallo aggiornamento: %d secondi"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Intervallo grafico della media: %d minuto"
 msgstr[1] "Intervallo grafico della media: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scala grafico delle connessioni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dimensione buffer file: %d byte"
 msgstr[1] "Dimensione buffer file: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Dimensione coda upload: %d client"
 msgstr[1] "Dimensione coda upload: %d client"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervallo aggiornamento connessione ai server: %d minuto"
 msgstr[1] "Intervallo aggiornamento connessione ai server: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervallo aggiornamento connessione ai server: disabilitato"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "disattivato"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Esegui comando se si verifica l'evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Abilita l'esecuzione del comando sul core"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Comando Core:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Abilita l'esecuzione del comando sulla GUI"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Comando GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Le seguenti variabili saranno sostituite:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -5433,32 +5457,32 @@ msgstr ""
 "Le seguenti cartelle sembrano posizioni di sistema o sensibili:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Condividerle ricorsivamente pubblicherà ogni file al loro interno sulle reti eD2k/Kad. Vuoi davvero procedere?"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr "Conferma cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr "Ricarica file condivisi in corso…"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr "Analisi delle sottocartelle in corso…"
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr "Aggiornamento cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr "%u cartelle analizzate…"
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ricarica file condivisi: %u file analizzati"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -194,8 +194,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,83 +245,93 @@ msgstr "ダウンロード完了"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "申し訳ありませんが、設定の変更を行ったため、あなたのロケールはシステム標準に変更されました。"
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "情報"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "終了の確認"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "ネットワーク"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.metに%i個のサーバが見つかりました"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "指定したアドレスにポートをバインドできませんでした: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "ポート%uは利用できません。あなたにはLOWIDが与えられます\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -336,48 +346,48 @@ msgstr ""
 "\n"
 "ネットワークを調べ、ポートが入出力に対して開いているか確認してください。"
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "オンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMuleのオンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "選択したロケールはあなたのシステムにインストールされていないようです。（注意：いずれにせよ設定を試みます）"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "初めてaMule %sを起動しています"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "このバージョンはテスト・バージョンで、毎日更新されているものです。\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "あなたに損害を与えないということは保証できません。家を焼いてしまうかも知れないし、\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "犬を殺してしまうかも知れません。しかし、安全に使用できる「はず」です。\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "私たちのホームページamule-org.github.io、またはIRCチャネルirc.libera.chatの#aMuleには、\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "詳細な情報、サポートや新しいリリースがあります。\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -385,138 +395,138 @@ msgstr ""
 "あなたが指定したオンライン証明ファイルのフォルダは不正です！\n"
 "設定で訂正するまでオンライン証明を無効にします。"
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "サーバ名："
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "ファイル '%s' のディスク領域の事前確保が失敗しました: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "エラー：ログファイルを開くことはできません"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "注意：ログファイルは空です。何かがおかしいです。"
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "ログはリセットされました"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "サーバ・メッセージ：%s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "ノード・リストをダウンロードのに失敗しました。"
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "ダウンロードされたバージョン確認ファイルを開くのに失敗しました。"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "破損されたバージョン確認ファイル"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "あなたは古いバージョンのaMuleを使用しています！"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "あなたのaMuleバージョンは%i.%i.%iで、最新バージョンは%li.%li.%liです"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：あなたのaMuledバージョンは古くなっています：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "あなたのaMuleは最新のバージョンです。"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "バージョン確認ファイルのダウンロードに失敗しました"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "ユーザ: %s | ファイル: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "ユーザ: E: %s K: %s | ファイル: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "ネットワークが選択されていません"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowIDを持っています"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighIDを持っています"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "接続しています：%s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "%sに接続中です"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kadを開始しました。"
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kadを中止しました。"
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Kadに接続しています（OK）"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Kadに接続しています（ファイアウォール）"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Kadから切断しています"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDPポートが設定で無効にされていると、Kadネットワークを使用できないため、開始しません。"
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadネットワークは設定で無効にされているため、接続はしません。"
 
@@ -2587,7 +2597,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "外接続用のパスワード。"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "同期化スレドを始めました。"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -194,8 +194,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,93 +245,98 @@ msgstr "ダウンロード完了"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "申し訳ありませんが、設定の変更を行ったため、あなたのロケールはシステム標準に変更されました。"
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "情報"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "終了の確認"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "ネットワーク"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.metに%i個のサーバが見つかりました"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "指定したアドレスにポートをバインドできませんでした: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "ポート%uは利用できません。あなたにはLOWIDが与えられます\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -346,48 +351,48 @@ msgstr ""
 "\n"
 "ネットワークを調べ、ポートが入出力に対して開いているか確認してください。"
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "オンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMuleのオンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "選択したロケールはあなたのシステムにインストールされていないようです。（注意：いずれにせよ設定を試みます）"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "初めてaMule %sを起動しています"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "このバージョンはテスト・バージョンで、毎日更新されているものです。\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "あなたに損害を与えないということは保証できません。家を焼いてしまうかも知れないし、\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "犬を殺してしまうかも知れません。しかし、安全に使用できる「はず」です。\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "私たちのホームページamule-org.github.io、またはIRCチャネルirc.libera.chatの#aMuleには、\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "詳細な情報、サポートや新しいリリースがあります。\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -395,138 +400,138 @@ msgstr ""
 "あなたが指定したオンライン証明ファイルのフォルダは不正です！\n"
 "設定で訂正するまでオンライン証明を無効にします。"
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "サーバ名："
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "ファイル '%s' のディスク領域の事前確保が失敗しました: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "エラー：ログファイルを開くことはできません"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "注意：ログファイルは空です。何かがおかしいです。"
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "ログはリセットされました"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "サーバ・メッセージ：%s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "ノード・リストをダウンロードのに失敗しました。"
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "ダウンロードされたバージョン確認ファイルを開くのに失敗しました。"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "破損されたバージョン確認ファイル"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "あなたは古いバージョンのaMuleを使用しています！"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "あなたのaMuleバージョンは%i.%i.%iで、最新バージョンは%li.%li.%liです"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：あなたのaMuledバージョンは古くなっています：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "あなたのaMuleは最新のバージョンです。"
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "バージョン確認ファイルのダウンロードに失敗しました"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "ユーザ: %s | ファイル: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "ユーザ: E: %s K: %s | ファイル: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "ネットワークが選択されていません"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowIDを持っています"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighIDを持っています"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "接続しています：%s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "%sに接続中です"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kadを開始しました。"
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kadを中止しました。"
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Kadに接続しています（OK）"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Kadに接続しています（ファイアウォール）"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Kadから切断しています"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDPポートが設定で無効にされていると、Kadネットワークを使用できないため、開始しません。"
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadネットワークは設定で無効にされているため、接続はしません。"
 
@@ -893,7 +898,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2254,49 +2259,49 @@ msgstr "いいえ"
 msgid "Yes"
 msgstr "はい"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "ダウンロード中…"
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "ユーザ '%s' から共有ファイルを取得することができませんでした"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "ダウンロード済み"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "ダウンロード数（%i）"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2597,7 +2602,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "外接続用のパスワード。"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "同期化スレドを始めました。"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -20,26 +20,26 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "aMuleを表示する"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMuleリモート制御"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "スナップショット："
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -48,59 +48,59 @@ msgstr ""
 "  著作権2003-2019、aMuleのチーム\n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademliaに基づいています：XORトリックに基づいたP2Pルーティング。\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "起動時に新バージョンを確認する"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kadに接続中です…"
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "あなたは古いバージョンのaMuleを使用しています！"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "利用不可"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -194,8 +194,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -211,107 +211,117 @@ msgstr "%s（%s）を開くことはできませんでした"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "OK、%s を終了中です…\n"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "失敗しました"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "ダウンロード完了"
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "申し訳ありませんが、設定の変更を行ったため、あなたのロケールはシステム標準に変更されました。"
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "情報"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "終了の確認"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "ネットワーク"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.metに%i個のサーバが見つかりました"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "指定したアドレスにポートをバインドできませんでした: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "ポート%uは利用できません。あなたにはLOWIDが与えられます\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -326,48 +336,48 @@ msgstr ""
 "\n"
 "ネットワークを調べ、ポートが入出力に対して開いているか確認してください。"
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "オンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMuleのオンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "選択したロケールはあなたのシステムにインストールされていないようです。（注意：いずれにせよ設定を試みます）"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "初めてaMule %sを起動しています"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "このバージョンはテスト・バージョンで、毎日更新されているものです。\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "あなたに損害を与えないということは保証できません。家を焼いてしまうかも知れないし、\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "犬を殺してしまうかも知れません。しかし、安全に使用できる「はず」です。\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "私たちのホームページamule-org.github.io、またはIRCチャネルirc.libera.chatの#aMuleには、\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "詳細な情報、サポートや新しいリリースがあります。\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -375,138 +385,138 @@ msgstr ""
 "あなたが指定したオンライン証明ファイルのフォルダは不正です！\n"
 "設定で訂正するまでオンライン証明を無効にします。"
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "サーバ名："
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "ファイル '%s' のディスク領域の事前確保が失敗しました: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "エラー：ログファイルを開くことはできません"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "注意：ログファイルは空です。何かがおかしいです。"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "ログはリセットされました"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "サーバ・メッセージ：%s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "ノード・リストをダウンロードのに失敗しました。"
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "ダウンロードされたバージョン確認ファイルを開くのに失敗しました。"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "破損されたバージョン確認ファイル"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "あなたは古いバージョンのaMuleを使用しています！"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "あなたのaMuleバージョンは%i.%i.%iで、最新バージョンは%li.%li.%liです"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：あなたのaMuledバージョンは古くなっています：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "あなたのaMuleは最新のバージョンです。"
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "バージョン確認ファイルのダウンロードに失敗しました"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "ユーザ: %s | ファイル: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "ユーザ: E: %s K: %s | ファイル: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "ネットワークが選択されていません"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowIDを持っています"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighIDを持っています"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "接続しています：%s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "%sに接続中です"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kadを開始しました。"
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kadを中止しました。"
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Kadに接続しています（OK）"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Kadに接続しています（ファイアウォール）"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Kadから切断しています"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDPポートが設定で無効にされていると、Kadネットワークを使用できないため、開始しません。"
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadネットワークは設定で無効にされているため、接続はしません。"
 
@@ -546,15 +556,15 @@ msgstr "これはeMuleに基づいたaMule %s です。"
 msgid "Running on %s"
 msgstr "%s に起動しています"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "新しいバージョンの確認はhttps://github.com/amule-org/amule/releases/latestで。"
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -564,225 +574,225 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "利用不可"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "接続中"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: ファイアウォールされています"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: 接続"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: 接続中"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: オフ"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "現在の接続試行を中止する"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "切断する"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "ネットワークから切断します。"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "接続する"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "ネットワークへ接続します。"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "アップ： %.1f(%.1f) | ダウン： %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "アップ： %.1f | ダウン： %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 接続しています)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 切断しています)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "本当にaMuleを終了しますか？"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "終了の確認"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 #, fuzzy
 msgid "Launch Command: "
 msgstr "コマンド： %s"
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "スキンディレクトリ '%s' は存在しません"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "ネットワーク"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "ネットワークウィンドウ"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "検索"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "検索ウィンドウ"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "ダウンロード数"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "ダウンロード"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "共有ファイルウィンドウ"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "メッセージ"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "メッセージウィンドウ"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "統計グラフウィインドウ"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "設定"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "個人設定ウィンドウ"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "インポート"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "部分ファイルをインポートするためのツール"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "情報"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "ソフトウェア情報／ヘルプ"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kadネットワーク"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "ネットワークなし"
 
@@ -874,8 +884,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "不明"
@@ -1234,19 +1244,19 @@ msgstr "オート [Hi]"
 msgid "Very low"
 msgstr "非常に低い"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "低い"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1278,7 +1288,7 @@ msgid "On Queue"
 msgstr "キューに入っています"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "ダウンロード"
 
@@ -1338,7 +1348,7 @@ msgstr "ローカルサーバ"
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1410,7 +1420,7 @@ msgstr ""
 msgid "Size"
 msgstr "サイズ"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "転送済み"
 
@@ -1423,7 +1433,7 @@ msgid "Progress"
 msgstr "進捗状況"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "ソース数"
 
@@ -1433,7 +1443,7 @@ msgstr "ソース数"
 msgid "Priority"
 msgstr "優先度"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "ステータス"
 
@@ -1466,7 +1476,7 @@ msgstr ""
 "フィードバック:%s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "自動"
@@ -2120,7 +2130,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "友達"
 
@@ -2403,8 +2413,8 @@ msgstr "ブートストラップするためには正しくないポートです
 msgid "Please fill all fields required"
 msgstr "必要なフィールドをすべて入力してください"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "メッセージ"
 
@@ -2473,7 +2483,7 @@ msgstr "共有比"
 msgid "Uploaded"
 msgstr "アップロード済み"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "要求済み"
 
@@ -2507,30 +2517,30 @@ msgstr "不明なバージョン"
 msgid "Unable to get error description for error %d"
 msgstr "注意： スキンファイル '%s' を読むために開けませんでした"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "ハッシュ中"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "完了中"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "完了"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "停止"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "エラーあり"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "待機"
 
@@ -2577,7 +2587,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "外接続用のパスワード。"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "同期化スレドを始めました。"
@@ -2599,7 +2609,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "閉じる"
 
@@ -2714,7 +2724,7 @@ msgstr "終了"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2954,7 +2964,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3024,7 +3034,7 @@ msgstr "完成したダウンロードをクリアします"
 msgid "File sources:"
 msgstr "ソース完了"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "一般"
 
@@ -3045,7 +3055,7 @@ msgstr "完全名："
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "非適用"
 
@@ -3219,7 +3229,7 @@ msgstr "ユーザ名："
 msgid "Userhash :"
 msgstr "ユーザ・ハッシュ："
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "追加"
@@ -3228,15 +3238,15 @@ msgstr "追加"
 msgid "Download-Speed"
 msgstr "ダウンロード速度："
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "現在"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "移動平均"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "セッション平均"
 
@@ -3248,7 +3258,7 @@ msgstr "アップロード速度"
 msgid "Connections"
 msgstr "接続数"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "アクティブなダウンロード数"
 
@@ -3256,7 +3266,7 @@ msgstr "アクティブなダウンロード数"
 msgid "Active connections (1:1)"
 msgstr "アクティブな接続（1:1）"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "アクティブなアップロード数"
 
@@ -3458,8 +3468,8 @@ msgstr "ブラウザ選択"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3533,754 +3543,762 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "スタートアップに自動接続する"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "接続を失う時に再接続する"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "再試行後、応答のないサーバを削除する。再試行回数："
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "回"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "リスト"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "優先度システムを使用する"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "接続の時にLowIDチェックを使用する"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "安全接続"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "スタティック・リストに含まれているサーバのみに自動接続する"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "手動で追加したサーバを高い優先度に設定する"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "ダウンロードファイルを停止モードで追加する"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "ダウンロードファイルを優先度を自動にして追加する"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "最初と最後のチャンクを先にダウンロードしようとする"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "同じカテゴリから"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "新しいファイルのためのディスク領域を事前に確保する"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新しいファイルのためにファイル全体が格納できるディスク領域を事前に確保し、断片化を防ぎます。"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "望ましい最小のディスク領域をここに入力してください。"
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "珍しいファイルには10ソースを保存する（<20ソース）"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "アップロード数"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "新しい共有ファイルを自動優先度として追加する"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "（再帰的に共有するにはフォルダ・アイコンを右クリックしてください）"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "隠れたファイルを共有する"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "グラフ"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "アップデート延期：５秒"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "平均グラフの時間：１００分"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "接続数のグラフスケール：１００"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "グリッド"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "ダウンロード現在"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "ダウンロード移動平均"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "ダウンロードセッション平均"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "アップロード現在"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "アップロード移動平均"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "アップロードセッション平均"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "アクティブ接続数"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "システム・トレイ・アイコン・スピードバー"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "現在のKadノード数"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "動作中のKadノード数"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "セッションのKadノード数"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "選択"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "表示されているクライアントのバージョン数（0＝無制限）"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "！！！注意！！！"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "最大の新しい接続数（5秒ごと）"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "ファイル・バファー・サイズ：240000バイト"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "アップロードキューサイズ：5000クライアント"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "サーバ接続のリフレッシュ空間：無効にする"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "延長情報をカテゴリ・タブで表示する"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "垂直ツールバー"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "フラット"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "ラウンド"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMuleはダウンロードリストの列を自動的にソートする"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "外部接続のパラメタ"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "外部接続を許可にする"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "リスンしているECインターフェイス用の正当なIPアドレスをa.b.c.dのフォーマットで入力してください。空のフィールド、または0.0.0.0は任意のインターフェイスを意味します。"
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "ECポートでUPnPポート転送を有効にする"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "パスワード"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "ウェブテンプレート"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "全権限パスワード"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "低権限ユーザを有効にする"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "低権限パスワード"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "ページのリフレッシュ間隔（秒単位）"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "gzip圧縮を有効にする"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "設定の変更をすべて適用します。"
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "設定の変更を全てリセットする"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "タイトル："
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "コメント："
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "受信ディレクトリ："
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "新しく割り当てられたファイルの優先度を変更する："
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "変更しない"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "このカテゴリの色を選択する（現在選択中）："
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "リセット"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "このボタンをクリックするとログのリセットが行います。"
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "このボタンをクリックするとサーバ・リストはURLから最新化する..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "server.metファイルへのURLをここに入力してから左側のボタンをクリックすると、既知のサーバのリストがアップデートされます。"
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "新しいサーバの名前をここに入力してください"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:ポート"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.xフォーマットでサーバのIPアドレスを入力してください。"
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "サーバのポートをここに入力してください。"
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動でサーバを追加する（先に左側のフィールドを入力してください）..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMuleのログ"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "サーバ情報"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K情報"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad情報"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "このボタンをクリックするとノード・リストをURLからアップデートします..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "ノード数（0）"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "ここにnodes.datファイルへのURLを入力してから左側のボタンをクリックすると、既知のノード・リストをアップデートします。"
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "ノードの統計"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "ブートストラップ"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "新しいノード"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "ポート："
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "既知のクライアントから\n"
 "ブートストラップする"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Kadを切断する"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "セキュア・ユーザ保証（SUI）を使用する"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "このオプションを有効にするのは推奨されます。SUIが有効でないとあなたはクレジットを得られません。"
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "プロトコルを難読化する"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "プロトコルの難読化を有効にする"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "このオプションによってプロトコルの難読化を有効にできます。そうすると、aMuleは他のクライアントからの難読化された接続を受け入れられます。"
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "外方向の接続に難読化を使用する"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "このオプションによって、aMuleは他のサーバまたはクライアントに接続する時にプロトコル難読化を使用します。"
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "難読化された接続のみを受信する"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "このオプションによって、aMuleは難読化された接続のみを受信します。ソース数が減りますが、トラフィックが全て難読化されます。"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "全員"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "あなたの共有ファイル・リストを要求できるユーザを選択してください。"
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IPフィルタリング"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "クライアントをフィルタする"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるクライアントIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "サーバをフィルタする"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるサーバIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "フィルタリングをかける目標のIPリストを~/.aMule/ipfilter.datから再ロードをします。"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL："
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "只今アップデートする"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "フィルタリング段階："
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "いつもLANのIPにフィルタリングをかける"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "適合しないIPを被害妄想的に扱う"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "クライアントIPがパケットがもともと受信されたIPと違いますとパケットを拒否します。使用するに気をつけてください。"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "提供されていれば、全システム応用のipfilter.datファイルを使用する"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "ローカルなipfilter.datファイルが見つからなければ、全システム応用のipfilter.datファイルを使用可能します。"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "オンライン証明を有効にする"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "OSファイルの書き込みを有効にします。このファイルは外のアプリケーションに証明等を作成するためにを使用されます。"
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "アップデート頻度（秒単位）"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "オンライン証明アップデート頻度（秒単位）を変化します。"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "ここをクリックするとオンライン証明ファイルが入っているディレクトリを選択できます。"
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "データ・レート："
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "ソース数"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4288,11 +4306,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4302,232 +4320,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "ダウンロード： "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "受信メッセージをフィルタする（現在のチャットを除く）："
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "全てのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "友達リストの入っていない方々からのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "次のストリングが入っているメッセージをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amuleがメッセージ・フィルタ／ブロックの目標にする言葉をここに追加してください"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "コメント"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "次のストリングが入っていコメントをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "認証を有効にする"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "ユーザ名／パスワード認証を有効／無効にする"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "プロクシーに接続に使うユーザ名"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "パスワード："
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "プロクシーに接続に使うパスワード"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "プロクシを有効にする"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "プロクシ・サポートを有効／無効にする"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "プロクシの種類："
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "プロクシー・ホスト："
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "プロクシー・ホスト名："
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "プロクシーのポート"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "次に接続する："
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "リモートamuleにログインする"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "ユーザ名"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "設定を記憶する"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip圧縮を使用する"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "冗長なデバッグ・ロギングを有効にする"
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "ファイルを開く(&O)"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "メッセージのカテゴリ："
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "待機中…"
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "インポートを追加する"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "選択したものを再試行"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "選択したものを破棄"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "共有ファイルを隠す"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "ビュー・フィルタを選択してください"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "アクティブなアップロード数"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "共有ファイルを再ロードする"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "送信する"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "指示するメッセージを送信します。"
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "チャット・セションを閉じます。"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "すべてのサーバ、もしくはKadに接続する"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "共有ファイル"
 
@@ -4602,7 +4620,7 @@ msgstr "他の全て"
 msgid "Incomplete"
 msgstr "未完成"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "中断しています"
 
@@ -4793,359 +4811,359 @@ msgstr "%i個のソース・シードを次の部分ファイルに保存しま�
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "部分ファイルのシード・ファイルを読む時にエラーが発生しました：（%s - %s）%s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "破損されている部分（%d）が%d部分、ファイル%sに見つかりました：FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "完成した部分（%i）が%sに見つかりました"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "%sの再ハッシュを終了しました"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "ダウンロードが終了しました：%s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "ダウンロードが終了しました：%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "ファイルを削除します：%s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "注意：ディスク容量が足りません！ファイルを停止します：%s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "ダウンロードした部分%i（ファイル：%s）は破損されています"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH：破損された部分%i（%sのため）を回復しました→：%s バイトを保存しました"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "領域確保中"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "ダウンロード済み"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "エラー: 部分ファイル '%s' が開けませんでした"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "システムの標準設定"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "アラブ語"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "バスク語"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "ブルガリア語"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "カタロニア語"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "中国語（簡体字）"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "中国語（繁体字）"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "クロアチア語"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "チェコ語"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "デンマーク語"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "オランダ語"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "フィンランド語"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "フランス語"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "ガリシア語"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "ドイツ語"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "ギリシア語"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "ヘブライ語"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "ハンガリー語"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "イタリア語"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "イタリア語（スイス）"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "日本語"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "韓国語"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "リトアニア語"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "ルウェー語"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "ポーランド語"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "ポルトガル語"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "ポルトガル語（ブラジル）"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "ロシア語"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "スロベニア語"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "スペイン語"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "スウェーデン語"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "言語"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "利用不可"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "サーバのUDPソケトがTCP+3であるためTCPポートを65532以上には設定できません"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "デフォルトポートを使用します (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "接続"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "ディレクトリ"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "サーバ数"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "セキュリティ"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "プロクシ"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "リモート制御"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "オンライン署名"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "イベント"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "デバッグ"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5161,66 +5179,71 @@ msgstr ""
 "この設定を変更しなくてもaMuleはうまく動いて\n"
 "います。"
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "接続するプロクシーの種類"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr "この変更点を有効するにはaMuleを再起動しなければなりません：\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "外部接続は終了しました。"
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "新しい外部接続を認められました"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "プロトコルを難読化する"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5228,26 +5251,26 @@ msgstr ""
 "外部接続を有効にしましたがパスワードを設定していません。\n"
 "有効なパスワードを設定しないと外部接続を可能できません。"
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- 言語を変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- 一時フォルダを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "全てのネットワークが無効になっています。"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5255,7 +5278,7 @@ msgstr ""
 "UDPポートが無効になっているとKadは開始できません。\n"
 "UDPポートを有効にするか、またはKadを無効にしてください。"
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5265,20 +5288,20 @@ msgstr ""
 "必ず早急にaMuleを再起動してください。\n"
 "今すぐに再起動しなければ、挙動がおかしくなる可能性があります。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "オートリフレッシュを開始しました"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5288,41 +5311,41 @@ msgstr ""
 "せめて一つのURLを入力して、有効なserver.metファイルを指定してください。\n"
 "このチェックボクスの近くの\"表\"ボタンをクリックして、URLを入力してください。"
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "一時ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "受信ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "オンライン署名"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr " %s のためのフォルダを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "ビデオプレイヤーを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "ブラウザを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "実行ファイル%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5330,145 +5353,145 @@ msgstr ""
 "server.metファイルをダウンロードするURLをここに追加してください。\n"
 "一行にひとつのURLのみです。"
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "ソース完了"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "アップデート遅延時間： %d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均グラフの時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "接続グラフスケール： %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "ファイルバッファサイズ： %d バイト"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "アップロードキューサイズ： %d クライアント"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "サーバ接続リフレッシュ遅延時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "サーバ接続リフレッシュ遅延時間： 無効"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "無効にする"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr " `%s' イベントにコマンドを実行する"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "コアにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "コアコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "GUIにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "GUIコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "次の変数は置換されます："
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "一時フォルダを読み中です"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "共有ファイル・リストを再ロードします。"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -194,8 +194,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -244,93 +244,98 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "지역정보(로케일)가 설정 변경으로 인해 시스템 기본값으로 변경되었습니다. 죄송합니다."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "정보"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "종료 확인"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "경고"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "통신망"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met에서 %i개의 서버가 발견됨"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "포트 %u는 사용할 수 없습니다. 낮은아이디를 가질것입니다.\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -345,48 +350,48 @@ msgstr ""
 "\n"
 "나가고 들어오는것에 대해 포트가 열려있는지 통신망을 체크하세요. "
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "어뮬 온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "컴퓨터에 선택한 지역정보(로케일)가 설치 않된것 같습니다. (주의: 어쨌든 설정하겠습니다)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "이번에 어뮬 %s를 처음 실행했습니다."
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "이 버전은 테스트 버젼으로, 매일 업데이트되며, \n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "이 프로그램이 어느 것도 부수지 않는다고, 집을 태우지 않는다고, 혹은 \n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "개를 죽이지 않는다고 보장하지 않습니다. 그렇지만 안전하게 사용할 수 있을 것입니다.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "더 많은 정보, 지원, 새 릴리즈는 홈페이지 amule-org.github.io, 또는 IRC 채널\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "(irc.libera.chat의 #aMule)에서 찾을 수 있습니다.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -394,138 +399,138 @@ msgstr ""
 "지정한 온라인 서명 파일을 위한 폴더가 유효하지 않습니다.\n"
 " 온라인 서명은 환경설정에서 수정될 때까지 비활성화 됩니다."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "서버 이름:"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "오류: 로그파일을 열 수 없음"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "경고: 로그파일이 비어있습니다. 뭔가 잘못되어 있습니다."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "로그가 초기화되었습니다."
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "서버메시지: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "노드 목록을 내려받지 못했습니다."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "내려받은 버젼 검사 파일을 열지 못했습니다."
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "손상된 버젼 검사 파일"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "어뮬 버젼은 %i.%i.%i이며 최신 버젼은 %li.%li.%li입니다."
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "경고: 어뮬 버젼은 오래되었습니다: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "어뮬은 최신 버전입니다."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "버젼 검사 파일을 내려받지 못했습니다."
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "낮은아이디로"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "높은아이디로"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s에 연결되었음"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s에 연결중"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad를 시작했습니다."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad를 멈췄습니다."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Kad에 연결됨 (양호)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad에 연결됨 (방화벽)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Kad로부터 연결이 끊김"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 네트워크는 UDP 포트가 비활성될 시 사용할 수 없으며, 따라서 시작하지 않습니다."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 네트워크가 환경설정에서 비활성되어, 연결하지 않습니다."
 
@@ -900,7 +905,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2273,49 +2278,49 @@ msgstr "아니오"
 msgid "Yes"
 msgstr "예"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "내려받기중..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "사용자 %s로부터 공유파일을 찾지 못했습니다."
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "내려받기 %s"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "내려받기 (%i)"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2621,7 +2626,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "외부연결 암호"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "동기화 스레드가 시작되었습니다."

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -22,84 +22,84 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "어뮬 보이기"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "어뮬 원격제어"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "스냅삿"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "시작할때 새 버젼이 있는지 확인"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kad에 연결중..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "유효하지 않음"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -194,8 +194,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -211,106 +211,116 @@ msgstr "%s(%s)을 열지 못했습니다."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "좋아, 나가는중 %s...\n"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "실패"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "지역정보(로케일)가 설정 변경으로 인해 시스템 기본값으로 변경되었습니다. 죄송합니다."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "정보"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "종료 확인"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "경고"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "통신망"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met에서 %i개의 서버가 발견됨"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "포트 %u는 사용할 수 없습니다. 낮은아이디를 가질것입니다.\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -325,48 +335,48 @@ msgstr ""
 "\n"
 "나가고 들어오는것에 대해 포트가 열려있는지 통신망을 체크하세요. "
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "어뮬 온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "컴퓨터에 선택한 지역정보(로케일)가 설치 않된것 같습니다. (주의: 어쨌든 설정하겠습니다)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "이번에 어뮬 %s를 처음 실행했습니다."
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "이 버전은 테스트 버젼으로, 매일 업데이트되며, \n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "이 프로그램이 어느 것도 부수지 않는다고, 집을 태우지 않는다고, 혹은 \n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "개를 죽이지 않는다고 보장하지 않습니다. 그렇지만 안전하게 사용할 수 있을 것입니다.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "더 많은 정보, 지원, 새 릴리즈는 홈페이지 amule-org.github.io, 또는 IRC 채널\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "(irc.libera.chat의 #aMule)에서 찾을 수 있습니다.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -374,138 +384,138 @@ msgstr ""
 "지정한 온라인 서명 파일을 위한 폴더가 유효하지 않습니다.\n"
 " 온라인 서명은 환경설정에서 수정될 때까지 비활성화 됩니다."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "서버 이름:"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "오류: 로그파일을 열 수 없음"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "경고: 로그파일이 비어있습니다. 뭔가 잘못되어 있습니다."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "로그가 초기화되었습니다."
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "서버메시지: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "노드 목록을 내려받지 못했습니다."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "내려받은 버젼 검사 파일을 열지 못했습니다."
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "손상된 버젼 검사 파일"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "어뮬 버젼은 %i.%i.%i이며 최신 버젼은 %li.%li.%li입니다."
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "경고: 어뮬 버젼은 오래되었습니다: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "어뮬은 최신 버전입니다."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "버젼 검사 파일을 내려받지 못했습니다."
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "낮은아이디로"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "높은아이디로"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s에 연결되었음"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s에 연결중"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad를 시작했습니다."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad를 멈췄습니다."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Kad에 연결됨 (양호)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad에 연결됨 (방화벽)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Kad로부터 연결이 끊김"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 네트워크는 UDP 포트가 비활성될 시 사용할 수 없으며, 따라서 시작하지 않습니다."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 네트워크가 환경설정에서 비활성되어, 연결하지 않습니다."
 
@@ -545,15 +555,15 @@ msgstr "이 어뮬 %s는 이뮬 기반으로 되어있습니다."
 msgid "Running on %s"
 msgstr "%s에 동작중"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "https://github.com/amule-org/amule/releases/latest에 방문하셔서 새로운버젼이 있는지 확인하십시오."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -563,233 +573,233 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "유효하지 않음"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "방화벽"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "연결됨"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "취소"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "현재 연결시도를 멈춤"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "연결 끊기"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "통신망으로부터 연결을 끊습니다."
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "연결"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 #, fuzzy
 msgid "Connect to the currently enabled networks"
 msgstr "통신망에 연결합니다."
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "올려주기: %.1f(%.1f) | 내려받기: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 #, fuzzy
 msgid " kB/s"
 msgstr "kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "올려주기: %.1f | 내려받기: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "어뮬 (%s | 연결됨)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "어뮬 (%s | 끊김)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "어뮬을 종료하시겠습니까?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "종료 확인"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 #, fuzzy
 msgid "Launch Command: "
 msgstr "명령: %s"
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "외형 폴더 '%s'가 없습니다."
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "통신망"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "통신망 창"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "검색"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "검색 창"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "내려받기"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "받는중"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "공유 파일 창"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "메시지"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "메시지 창"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "통계"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "통계 그래프 창"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "환경설정"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "환경 설정 창"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "가져오기"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "부분파일 가져오기 도구"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "정보"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "정보/도움"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -881,8 +891,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "알수없는"
@@ -1246,19 +1256,19 @@ msgstr "자동[높음]"
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "낮음"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "보통"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1290,7 +1300,7 @@ msgid "On Queue"
 msgstr "대기열에"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "받는중"
 
@@ -1350,7 +1360,7 @@ msgstr "지역 서버"
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1421,7 +1431,7 @@ msgstr ""
 msgid "Size"
 msgstr "크기"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "전송됨"
 
@@ -1434,7 +1444,7 @@ msgid "Progress"
 msgstr "진척"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "자료"
 
@@ -1444,7 +1454,7 @@ msgstr "자료"
 msgid "Priority"
 msgstr "우선권"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "상태"
 
@@ -1477,7 +1487,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "자동"
@@ -2133,7 +2143,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "친구"
 
@@ -2424,8 +2434,8 @@ msgstr "초기적재에 유효하지 않은 포트"
 msgid "Please fill all fields required"
 msgstr "모든 항목을 채워주세요."
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "메시지"
 
@@ -2497,7 +2507,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2531,30 +2541,30 @@ msgstr "알수없는 버젼"
 msgid "Unable to get error description for error %d"
 msgstr "경고: 외형 파일 '%s'(을)를 읽을 수 없습니다."
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "해시중"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "완료중"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "완료"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "중지됨"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "오류투성이"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "대기중"
 
@@ -2601,7 +2611,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "외부연결 암호"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "동기화 스레드가 시작되었습니다."
@@ -2623,7 +2633,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "닫기"
 
@@ -2738,7 +2748,7 @@ msgstr "종료"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2978,7 +2988,7 @@ msgstr "바이트"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3048,7 +3058,7 @@ msgstr "완료된 내려받기 정리"
 msgid "File sources:"
 msgstr "자료 유지"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "일반"
 
@@ -3069,7 +3079,7 @@ msgstr "전체 이름 :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "없음"
 
@@ -3243,7 +3253,7 @@ msgstr "사용자 이름 :"
 msgid "Userhash :"
 msgstr "사용자 해시 :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "추가"
@@ -3252,15 +3262,15 @@ msgstr "추가"
 msgid "Download-Speed"
 msgstr "내려받기 속도"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "현재"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "동작중 평균"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "세션 평균"
 
@@ -3272,7 +3282,7 @@ msgstr "올려주기 속도"
 msgid "Connections"
 msgstr "연결"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "활성화된 내려받기"
 
@@ -3280,7 +3290,7 @@ msgstr "활성화된 내려받기"
 msgid "Active connections (1:1)"
 msgstr "활성화된 연결 (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "활성화된 올려주기"
 
@@ -3482,8 +3492,8 @@ msgstr "브라우저 선택"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3557,753 +3567,761 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "카뎀리아"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2k"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "시작시 자동연결"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "끊겼을시 재연결"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "죽은서버 제거"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "재시도"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "목록"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "우선순위 시스템을 사용"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "연결할때 현명한 낮은아이디 검사를 사용"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "안전한 연결"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "정적목록내의 서버에만 연결"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "수동으로 추가된 서버에 높은 우선권 부여"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "멈춤 상태로 내려받기에 파일 추가"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "자동 우선권으로 내려받기에 파일 추가"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "처음과 마지막 부분을 먼저 내려받음"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "동일한 분류로부터"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "원하는 최소한의 디스크공간을 입력하세요."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "희귀한 파일인 경우 10개의 자료 저장 (<20 자료)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "올려주기"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "자동 우선권으로 새로운 공유파일을 추가"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(하위폴더 전체를 공유하려면 폴더 아이콘상에서 오른쪽 버튼을 클릭)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "숨은파일 공유"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "그래프"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "갱신 지연 : 5 초"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "평균 그래프 시간 : 100 분"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "연결 그래프 크기 : 100"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "바탕"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "눈금"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "현재 내려받기"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "내려받기 운용 평균"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "내려받기 세션 평균"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "현재 올려주기"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "올려주기 운용 평균"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "올려주기 세션 평균"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "활성화된 연결"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "시스템트레이 아이콘 속도바"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "현재 Kad-노드"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kad-노드 운용"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kad-노드 세션"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "선택"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "표시될 클라이언트 버젼의 수 (0=무제한)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! 경고 !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "최대 새연결 / 5 초"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "파일 버퍼 크기: 240000 바이트"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "올려주기 대기열 크기: 5000 클라이언트"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "서버 연결 갱신 간격: 사용않함"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "분류탭의 확장된 정보를 보여줌"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "수직방향 툴바"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "평평한"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "둥근"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "어뮬은 내려받는 목록의 항목을 자동으로 정렬합니다."
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "외부연결 설정"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "외부연결 받아들임"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "수신대기 외부연결 인터페이스에 a.b.c.d 형식의 유효한 IP를 입력하세요. 항목이 비었거나 0.0.0.0이면 모든 인터페이스를 의미합니다."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "외부연결 포트에 UPnP 포트포워딩 활성화"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "암호"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "웹 템플릿"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "모든 권한 암호"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "낮은권한 사용자 활성화"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "낮은 권한 암호"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "페이지를 갱신 시간 (초)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Gzip압축을 활성화"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "확인"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 적용하려면 이곳을 클릭하세요."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 초기화합니다."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "제목 :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "의견 :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "내려받는 폴더 :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "새롭게 할당된 파일의 우선권를 바꿉니다. :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "변경 않음"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "이 분류의 색을 선택 (일반적으로 선택된) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "초기화"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "로그를 초기화하려면 이 버튼을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "URL로부터 서버 목록을 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "알려진 서버의 목록을 갱신하기 위해서는 이곳에 server.met파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "새로운 서버의 이름을 입력하세요."
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:포트"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.x형식으로 서버의 IP를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "서버의 포트를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "서버 수동 추가 (미리 왼쪽 부분을 채울 것) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "어뮬 로그"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "서버 정보"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2k 정보"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad 정보"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "URL로부터 노드를 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "노드 (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "알려진 노드의 목록을 갱신하기 위해서는 이곳에 nodes.dat파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "노드 상태"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "초기적재"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "새로운 노드"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "포트:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "알려진 클라이언트로부터 \n"
 "초기적재"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Kad 끊김"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "프로토콜 난독화"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "프로토콜 난독화 지원"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "이 선택은 프로토콜 난독화를 활성화하며, 어뮬이 다른 클라이언트로부터 난독화된 연결을 받아들이도록 합니다. "
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "나가는 연결에 난독화 사용"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "이 선택은 어뮬이 다른 서버나 클라이언트에 연결할때 프로토콜 난독화를 사용하게 합니다."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "난독화된 연결만 받음"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "이 선택은 어뮬이 난독화된 연결만 받아들이도록 합니다. 더 작은 자료를 가지지만 자료교환은 난독화됩니다."
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "모두"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "공유 파일 목록 보기를 요청할 수 있는 사람을 선택하세요."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP 차단"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "클라이언트 차단"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 클라이언트 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "서버 차단"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 서버 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat 파일에서 차단할 IP의 목록을 다시 읽음"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "지금 갱신"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "차단 수준:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "랜 IP를 항상 차단"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "클라이언트 IP가 패킷이 수신된 IP와 다르면 패킷을 거부합니다. 조심해서 사용하세요."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "온라인서명을 활성화"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "서명을 생성할 수 있는 외부 응용프로그램에 의해 사용될 수 있는 운영체제 파일의 기록을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "갱신 주기(초)"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "온라인 서명 갱신 주기(초)를 바꿉니다."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "온라인서명 파일을 포함하는 폴더를 선택하려면 클릭하세요."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "데이터율 :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "자료"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4311,11 +4329,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4325,232 +4343,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "내려받기: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "받는 메시지 차단(현재 채팅은 제외)"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "모든 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "친구 목록에 없는 사람으로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "다음 내용이 포함된 메시지를 차단 (쉼표로 분리):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "이곳에 어뮬이 차단하고 막을 메시지에 포함될 단어를 추가하세요."
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "의견들"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "인증 활성화"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "사용자이름/암호 인증을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 사용자이름"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "암호:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 암호"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "프록시 활성화"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "프록시지원을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "프록시 종류:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "프록시 호스트:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "프록시 호스트 이름"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "프록시 포트"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "연결함:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "원격 어뮬에 로그인"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "사용자이름"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "설정을 기억"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip 압축 사용"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "상세한 디버그-로깅 활성화"
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "파일 열기(&O)"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "메시지 분류:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "대기중..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "가져오기 추가"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "선택된 것을 재시도"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "선택된 것을 삭제"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "공유된 파일을 숨김"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "보기 필터 선택"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "활성화된 올려주기"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "보내기"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "지정된 메시지를 보냅니다."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "이 채팅세션을 닫습니다."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "서버 혹은 Kad에 연결"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "공유 파일"
 
@@ -4629,7 +4647,7 @@ msgstr "다른 모두"
 msgid "Incomplete"
 msgstr "내려받음"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "멈춤"
 
@@ -4821,360 +4839,360 @@ msgstr "부분파일을 위해 %i 자료핵심을 저장되었습니다: %s(%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "부분파일의 핵심파일(%s - %s)을 읽는중 오류: %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, fuzzy, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "손상된 부분(%d)이 발견되었습니다. (%d부분 파일 %s에 있는) - 파일해시결과 |%s| 파일해시 |%s|"
 msgstr[1] "손상된 부분(%d)이 발견되었습니다. (%d부분 파일 %s에 있는) - 파일해시결과 |%s| 파일해시 |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "완료된 부분(%i)이 발견되었습니다.  (%s에 있는)"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "%s의 재해시가 완료되었습니다."
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "내려받기 완료: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "내려받기 완료: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "파일 삭제: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "경고: 충분한 디스크공간이 없습니다! 파일 정지: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "%i 부분 내려받기는 파일이 손상되었습니다: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: 손상된 부분 %i를 복구했습니다. (%s의) -> 저장된 바이트: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "기본 설정"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "아랍어"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "바스크어"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "불가리아어"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "카탈로니아어"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "중국어(간체)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "중국어(번체)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "덴마크어"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "네델란드어"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "필란드어"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "프랑스어"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "갈리시아어"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "독일어"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "헝가리어"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "이탈리아어"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "이탈리아어(스위스)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "한국어"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "폴란드어"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "포르투갈어"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "포르투갈어(브라질)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "러시아어"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "슬로베니아어"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "스페인어"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "터키어"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "언어"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "유효하지 않음"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "서버 UDP 소켓이 TCP+3이 되기위해서 TCP 포트가 65532보다 커서는 안됩니다."
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "기본 포트가 사용될 것입니다.(%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "연결"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "폴더"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "서버"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "파일"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "보안"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "프록시"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "원격 조정"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "온라인 서명"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "사건들"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "디버깅"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5190,26 +5208,26 @@ msgstr ""
 "이 설정들을 조정하지 않아도\n"
 "어뮬은 잘 동작할 것입니다."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "연결하고 있는 프록시 타입"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5217,41 +5235,46 @@ msgstr ""
 "변경사항을 활성화 하기위해 어뮬을 재시작해야 합니다:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "외부연결 끊겼습니다."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "프로토콜 난독화"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5259,26 +5282,26 @@ msgstr ""
 "외부연결이 횔성화되어 있지만, 암호를 설정하지 않았습니다.\n"
 "외부연결은 유효한 암호가 설정되기전까지 활성화되지 않습니다."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- 언어가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- 임시 폴더가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "모든 통신망을 사용할수 없습니다."
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5286,7 +5309,7 @@ msgstr ""
 "UDP 포트가 비활성화되어 있으면 Kad는 시작하지 않을 것입니다.\n"
 "UDP 포트를 활성화시키거나 Kad를 비활성화시키십시오."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5296,20 +5319,20 @@ msgstr ""
 "지금 바로 어뮬을 재시작해야 합니다.\n"
 "만일 재시작하지 않는다면, 나쁜 일이 일어나도 불평하지 마십시오.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "자동갱신이 시작됨"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5319,41 +5342,41 @@ msgstr ""
 "적어도 한개의 유효한 server.met파일을 가르키는 URL을 적으세요.\n"
 "URL을 입력하려면 채크박스 옆의 \"목록\"버튼을 클릭하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "임시 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "내려받은 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "온라인 서명"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s하기 위한 폴더를 선택하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "비디오재생을 위한 브라우즈"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "브라우저 선택"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "실행할수 있는 %s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5361,150 +5384,150 @@ msgstr ""
 "server.met파일을 내려받을 URL을 추가하세요.\n"
 "각 행에 오직 하나의 URL을 넣으세요."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "완료된 자료"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "갱신 지연: %d 초"
 msgstr[1] "갱신 지연: %d 초"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "평균 그래프 시간: %d 분"
 msgstr[1] "평균 그래프 시간: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "연결 그래프 크기: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "파일 버퍼 크기: %d 바이트"
 msgstr[1] "파일 버퍼 크기: %d 바이트"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "올려주기 대기열 크기: %d 클라이언트"
 msgstr[1] "올려주기 대기열 크기: %d 클라이언트"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "서버 연결 갱신 주기: %d 분"
 msgstr[1] "서버 연결 갱신 주기: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "서버 연결 갱신 주기: 비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "`%s' 사건에 명령을 실행"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "코어에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "코어 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "GUI에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "GUI 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "다음 변수들은 교체됩니다.:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "임시 폴더를 읽는중"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "공유된 파일 목록을 다시 읽어들입니다."

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -194,8 +194,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -244,83 +244,93 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "지역정보(로케일)가 설정 변경으로 인해 시스템 기본값으로 변경되었습니다. 죄송합니다."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "정보"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "종료 확인"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "경고"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "통신망"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met에서 %i개의 서버가 발견됨"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "포트 %u는 사용할 수 없습니다. 낮은아이디를 가질것입니다.\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -335,48 +345,48 @@ msgstr ""
 "\n"
 "나가고 들어오는것에 대해 포트가 열려있는지 통신망을 체크하세요. "
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "어뮬 온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "컴퓨터에 선택한 지역정보(로케일)가 설치 않된것 같습니다. (주의: 어쨌든 설정하겠습니다)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "이번에 어뮬 %s를 처음 실행했습니다."
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "이 버전은 테스트 버젼으로, 매일 업데이트되며, \n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "이 프로그램이 어느 것도 부수지 않는다고, 집을 태우지 않는다고, 혹은 \n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "개를 죽이지 않는다고 보장하지 않습니다. 그렇지만 안전하게 사용할 수 있을 것입니다.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "더 많은 정보, 지원, 새 릴리즈는 홈페이지 amule-org.github.io, 또는 IRC 채널\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "(irc.libera.chat의 #aMule)에서 찾을 수 있습니다.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -384,138 +394,138 @@ msgstr ""
 "지정한 온라인 서명 파일을 위한 폴더가 유효하지 않습니다.\n"
 " 온라인 서명은 환경설정에서 수정될 때까지 비활성화 됩니다."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "서버 이름:"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "오류: 로그파일을 열 수 없음"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "경고: 로그파일이 비어있습니다. 뭔가 잘못되어 있습니다."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "로그가 초기화되었습니다."
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "서버메시지: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "노드 목록을 내려받지 못했습니다."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "내려받은 버젼 검사 파일을 열지 못했습니다."
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "손상된 버젼 검사 파일"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "어뮬 버젼은 %i.%i.%i이며 최신 버젼은 %li.%li.%li입니다."
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "경고: 어뮬 버젼은 오래되었습니다: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "어뮬은 최신 버전입니다."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "버젼 검사 파일을 내려받지 못했습니다."
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "낮은아이디로"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "높은아이디로"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s에 연결되었음"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s에 연결중"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad를 시작했습니다."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad를 멈췄습니다."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Kad에 연결됨 (양호)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad에 연결됨 (방화벽)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Kad로부터 연결이 끊김"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 네트워크는 UDP 포트가 비활성될 시 사용할 수 없으며, 따라서 시작하지 않습니다."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 네트워크가 환경설정에서 비활성되어, 연결하지 않습니다."
 
@@ -2611,7 +2621,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "외부연결 암호"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "동기화 스레드가 시작되었습니다."

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -197,8 +197,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -248,84 +248,94 @@ msgstr "Atsiuntimas baigtas"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Pasikeitus parinktims aplinkos kalba buvo pakeista į sistemoje numatytą kalbą."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informacija"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "DĖMESIO"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Tinklas"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met faile rastas %i serveris"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nepavyko susieti prievadų su nurodytu adresu: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Prievadas %u neprieinamas. Gavote žemą ID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -341,48 +351,48 @@ msgstr ""
 "\n"
 "Patikrinkite sistemines tinklo parinktis ir įsitikinkite, kad nurodytas prievadas atviras tiek išsiuntimui, tiek priėmimui."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo parašo failo"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo aMule parašo failo"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Nurodyta lokalė jūsų kompiuteryje neįdiegta. (Dėmesio: šiaip ar taip vis tiek pabandysime naudoti nurodytą lokalę)."
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule paleista pirmą kartą %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ši versija yra darbinė versija, atnaujinama kasdien, ir\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "todėl negalime garantuoti, kad ji nenulūš, nepadegs namų ar\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nenumarins šuns. Bet šiaip ar taip ją naudoti turėtų būti saugu.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daugiau informacijos, pagalbos ir naujausias galutines versijas rasite mūsų\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "svetainėje https://amule-org.github.io arba IRC kanale #aMule serveryje irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -390,138 +400,138 @@ msgstr ""
 "Neteisingai nurodėte keičiamo parašo aplanką!\n"
 "Keičiamas parašas bus išjungtas tol, kol pakeisite parinktis."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Serverio pavadinimas:"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Nepavyko paskirti disko vietos failui „%s“: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "KLAIDA: nepavyko atverti žurnalo failo"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "DĖMESIO: žurnalas tuščias. Kažkas čia ne taip."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Žurnalas išvalytas"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serverio pranešimas: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Nepavyko atsiųsti mazgų sąrašo."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Nepavyko atverti atsiųstos versijos tikrinimo failo"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Sugadintas versijos tikrinimo failas"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Naudojate pasenusią aMule versiją!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ši aMule versija yra %i.%i.%i, o naujausia versija yra %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "DĖMESIO: ši aMule versija yra pasenusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Naudojate naują aMule versiją."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Nepavyko atsiųsti versijos tikrinimo failo"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Naudotojai: %s | Failai: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Naudotojai: eD2k: %s Kad: %s | Failai: eD2k: %s Kad: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Neparinktas joks tinklas"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "žemas ID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "aukštas ID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Prisijungta prie %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Jungiamasi prie %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Atsijungta nuo eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kademlia paleista."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kademlia sustabdyta."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Prisijungta prie Kademlia"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Prisijungta prie Kademlia (už ugniasienės)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Atsijungta nuo Kademlia"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nepavyks prisijungti prie Kademlia tinklo, jei parinktyse yra išjungtas UDP prievadas."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kademlia tinklas išjungtas parinktyse, ryšys nebus užmezgamas."
 
@@ -2621,7 +2631,7 @@ msgstr "Išorinis ryšys: prieiga nesuteikta"
 msgid "External Connection: Handshake failed."
 msgstr "Išorinis ryšys: prieiga nesuteikta"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automatinis atnaujinimas paleistas"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -197,8 +197,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -248,94 +248,99 @@ msgstr "Atsiuntimas baigtas"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Pasikeitus parinktims aplinkos kalba buvo pakeista į sistemoje numatytą kalbą."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informacija"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "DĖMESIO"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Tinklas"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met faile rastas %i serveris"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nepavyko susieti prievadų su nurodytu adresu: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Prievadas %u neprieinamas. Gavote žemą ID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -351,48 +356,48 @@ msgstr ""
 "\n"
 "Patikrinkite sistemines tinklo parinktis ir įsitikinkite, kad nurodytas prievadas atviras tiek išsiuntimui, tiek priėmimui."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo parašo failo"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo aMule parašo failo"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Nurodyta lokalė jūsų kompiuteryje neįdiegta. (Dėmesio: šiaip ar taip vis tiek pabandysime naudoti nurodytą lokalę)."
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule paleista pirmą kartą %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ši versija yra darbinė versija, atnaujinama kasdien, ir\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "todėl negalime garantuoti, kad ji nenulūš, nepadegs namų ar\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nenumarins šuns. Bet šiaip ar taip ją naudoti turėtų būti saugu.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daugiau informacijos, pagalbos ir naujausias galutines versijas rasite mūsų\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "svetainėje https://amule-org.github.io arba IRC kanale #aMule serveryje irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -400,138 +405,138 @@ msgstr ""
 "Neteisingai nurodėte keičiamo parašo aplanką!\n"
 "Keičiamas parašas bus išjungtas tol, kol pakeisite parinktis."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Serverio pavadinimas:"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Nepavyko paskirti disko vietos failui „%s“: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "KLAIDA: nepavyko atverti žurnalo failo"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "DĖMESIO: žurnalas tuščias. Kažkas čia ne taip."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Žurnalas išvalytas"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serverio pranešimas: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Nepavyko atsiųsti mazgų sąrašo."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Nepavyko atverti atsiųstos versijos tikrinimo failo"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Sugadintas versijos tikrinimo failas"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Naudojate pasenusią aMule versiją!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ši aMule versija yra %i.%i.%i, o naujausia versija yra %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "DĖMESIO: ši aMule versija yra pasenusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Naudojate naują aMule versiją."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Nepavyko atsiųsti versijos tikrinimo failo"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Naudotojai: %s | Failai: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Naudotojai: eD2k: %s Kad: %s | Failai: eD2k: %s Kad: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Neparinktas joks tinklas"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "žemas ID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "aukštas ID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Prisijungta prie %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Jungiamasi prie %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Atsijungta nuo eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kademlia paleista."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kademlia sustabdyta."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Prisijungta prie Kademlia"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Prisijungta prie Kademlia (už ugniasienės)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Atsijungta nuo Kademlia"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nepavyks prisijungti prie Kademlia tinklo, jei parinktyse yra išjungtas UDP prievadas."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kademlia tinklas išjungtas parinktyse, ryšys nebus užmezgamas."
 
@@ -897,7 +902,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2278,49 +2283,49 @@ msgstr "Ne"
 msgid "Yes"
 msgstr "Taip"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Atsiunčiama..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Nepavyko gauti dalinamų failų iš vartotojo „%s“"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Atsiųsta"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Atsiuntimai (%i)"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2631,7 +2636,7 @@ msgstr "Išorinis ryšys: prieiga nesuteikta"
 msgid "External Connection: Handshake failed."
 msgstr "Išorinis ryšys: prieiga nesuteikta"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automatinis atnaujinimas paleistas"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -21,26 +21,26 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Rodyti aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule nuotolinio valdymo pultelis "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Ekrano kopija:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -49,59 +49,59 @@ msgstr ""
 "Autorinės teisės (C) 2003-2019 aMule komanda \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: p2p maršrutizavimas, paremtas XOR metrika.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Paleidus programą ieškoti naujesnės versijos"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Jungiamsi prie Kademlia..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Naudojate pasenusią aMule versiją!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nėra"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -197,8 +197,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -214,108 +214,118 @@ msgstr "Nepavyko atverti %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "DĖMESIO: jei jūsų ID yra žemas, negalite įdėti savęs prie eD2k nuorodos šaltinių."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Darbas baigiamas %s...\n"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Nepavyko"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Atsiuntimas baigtas"
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Pasikeitus parinktims aplinkos kalba buvo pakeista į sistemoje numatytą kalbą."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informacija"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "DĖMESIO"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Tinklas"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met faile rastas %i serveris"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nepavyko susieti prievadų su nurodytu adresu: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Prievadas %u neprieinamas. Gavote žemą ID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -331,48 +341,48 @@ msgstr ""
 "\n"
 "Patikrinkite sistemines tinklo parinktis ir įsitikinkite, kad nurodytas prievadas atviras tiek išsiuntimui, tiek priėmimui."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo parašo failo"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo aMule parašo failo"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Nurodyta lokalė jūsų kompiuteryje neįdiegta. (Dėmesio: šiaip ar taip vis tiek pabandysime naudoti nurodytą lokalę)."
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule paleista pirmą kartą %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ši versija yra darbinė versija, atnaujinama kasdien, ir\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "todėl negalime garantuoti, kad ji nenulūš, nepadegs namų ar\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nenumarins šuns. Bet šiaip ar taip ją naudoti turėtų būti saugu.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daugiau informacijos, pagalbos ir naujausias galutines versijas rasite mūsų\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "svetainėje https://amule-org.github.io arba IRC kanale #aMule serveryje irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -380,138 +390,138 @@ msgstr ""
 "Neteisingai nurodėte keičiamo parašo aplanką!\n"
 "Keičiamas parašas bus išjungtas tol, kol pakeisite parinktis."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Serverio pavadinimas:"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Nepavyko paskirti disko vietos failui „%s“: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "KLAIDA: nepavyko atverti žurnalo failo"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "DĖMESIO: žurnalas tuščias. Kažkas čia ne taip."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Žurnalas išvalytas"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serverio pranešimas: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Nepavyko atsiųsti mazgų sąrašo."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Nepavyko atverti atsiųstos versijos tikrinimo failo"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Sugadintas versijos tikrinimo failas"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Naudojate pasenusią aMule versiją!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ši aMule versija yra %i.%i.%i, o naujausia versija yra %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "DĖMESIO: ši aMule versija yra pasenusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Naudojate naują aMule versiją."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Nepavyko atsiųsti versijos tikrinimo failo"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Naudotojai: %s | Failai: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Naudotojai: eD2k: %s Kad: %s | Failai: eD2k: %s Kad: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Neparinktas joks tinklas"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "žemas ID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "aukštas ID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Prisijungta prie %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Jungiamasi prie %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Atsijungta nuo eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kademlia paleista."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kademlia sustabdyta."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Prisijungta prie Kademlia"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Prisijungta prie Kademlia (už ugniasienės)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Atsijungta nuo Kademlia"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nepavyks prisijungti prie Kademlia tinklo, jei parinktyse yra išjungtas UDP prievadas."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kademlia tinklas išjungtas parinktyse, ryšys nebus užmezgamas."
 
@@ -551,15 +561,15 @@ msgstr "aMule %s, sukurta eMule pagrindu."
 msgid "Running on %s"
 msgstr "Vykdoma %s sistemoje"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Aplankykite https://github.com/amule-org/amule/releases/latest ir pasitikrinkite ar nėra naujesnės versijos."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -569,224 +579,224 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Nėra"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Jungiamasi"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: jungiamasi"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: atsijungta"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: už ugniasienės"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: prisijungta"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: jungiamasi"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: išjungta"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Nutraukti bandymus prisijungti"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Atsijungti"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Atsijungti nuo pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Prisijungti"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Prisijungti prie pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Išs.: %.1f(%.1f) | Ats.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Išs.: %.1f | Ats.: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | prisijungta)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | neprisijungta)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ar tikrai norite baigti darbą su aMule?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Išvaizdos failų aplankas %s neegzistuoja"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Tinklas"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Tinklo langas"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Paieška"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Paieškos langas"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Siuntimai"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Atsiunčiama"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Dalinami failai"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Dalinamų failų langas"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Žinutės"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Žinučių langas"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Statistikos grafikų langas"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Parinktys"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Parinkčių langas"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Įkelti"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Dalinai atsiųstų failų įkėlimo įrankis"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Apie"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Apie/pagalba"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k tinklas"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad tinklas"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Jokio tinklo"
 
@@ -878,8 +888,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Nežinoma"
@@ -1248,19 +1258,19 @@ msgstr "Automatiškai (aukštas)"
 msgid "Very low"
 msgstr "Labai žemas"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Žemas"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normalus"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1292,7 +1302,7 @@ msgid "On Queue"
 msgstr "Eilėje"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Atsiunčiama"
 
@@ -1352,7 +1362,7 @@ msgstr "Vietinis serveris"
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kademlia"
@@ -1424,7 +1434,7 @@ msgstr ""
 msgid "Size"
 msgstr "Dydis"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Persiųsta"
 
@@ -1437,7 +1447,7 @@ msgid "Progress"
 msgstr "Eiga"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Šaltiniai"
 
@@ -1447,7 +1457,7 @@ msgstr "Šaltiniai"
 msgid "Priority"
 msgstr "Prioritetas"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Būsena"
 
@@ -1480,7 +1490,7 @@ msgstr ""
 "Atsakymas iš: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automatiškas"
@@ -2140,7 +2150,7 @@ msgstr "Nepavyko atverti draugų sąrašo failo „emfriends.met“ rašymui!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Draugai"
 
@@ -2431,8 +2441,8 @@ msgstr "Klaidingas inicializavimo prievadas"
 msgid "Please fill all fields required"
 msgstr "Prašome užpildyti visus privalomus laukus"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Žinutė"
 
@@ -2507,7 +2517,7 @@ msgstr "Platinimo santykis"
 msgid "Uploaded"
 msgstr "Išsiųsta"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Paprašyta"
 
@@ -2541,30 +2551,30 @@ msgstr "Nežinoma versija"
 msgid "Unable to get error description for error %d"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Vykdoma maiša"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Patvirtinama"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Baigta"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pristabdyta"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Klaidinga"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Laukiama"
 
@@ -2611,7 +2621,7 @@ msgstr "Išorinis ryšys: prieiga nesuteikta"
 msgid "External Connection: Handshake failed."
 msgstr "Išorinis ryšys: prieiga nesuteikta"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automatinis atnaujinimas paleistas"
@@ -2633,7 +2643,7 @@ msgid "WARNING: "
 msgstr "DĖMESIO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Užverti"
 
@@ -2749,7 +2759,7 @@ msgstr "Baigti"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2989,7 +2999,7 @@ msgstr "Baitai"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3059,7 +3069,7 @@ msgstr "Pašalinti iš sąrašo jau atsiųstus failus"
 msgid "File sources:"
 msgstr "Pilni šaltiniai"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Bendra"
 
@@ -3080,7 +3090,7 @@ msgstr "Pilnas pavadinimas:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "Nežinoma"
 
@@ -3254,7 +3264,7 @@ msgstr "Naudotojo vardas:"
 msgid "Userhash :"
 msgstr "Naudotojo maišos f-ja:"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Įdėti"
@@ -3263,15 +3273,15 @@ msgstr "Įdėti"
 msgid "Download-Speed"
 msgstr "Atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Dabartinė sparta"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Seanso vidurkis"
 
@@ -3283,7 +3293,7 @@ msgstr "Išsiuntimo sparta"
 msgid "Connections"
 msgstr "Ryšiai"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktyvūs atsiuntimai"
 
@@ -3291,7 +3301,7 @@ msgstr "Aktyvūs atsiuntimai"
 msgid "Active connections (1:1)"
 msgstr "Aktyvūs ryšiai (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktyvūs išsiuntimai"
 
@@ -3493,8 +3503,8 @@ msgstr "Naršyklės parintys"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3568,754 +3578,762 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Pradėjus darbą prisijungti automatiškai"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Nutrūkus ryšiui prisijungti vėl"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Pašalinti neatsiliepiantį serverį po"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "bandymų"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Automatiškai atnaujinti serverių sąrašą paleidus programą"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Sąrašas"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Atnaujinti serverių sąrašą prisijungus prie serverio"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Atnaujinti serverių sąrašą prisijungus klientui"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Naudoti prioritetų sistemą"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Jungiantis naudoti išmoningą žemo ID tikrinimą"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Saugus jungimasis"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatiškai jungtis tik prie serverių iš pastovaus sąrašo"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Naudotojo įdėtiems serveriams nurodyti aukštą prioritetą"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Failus į atsiuntimo eilę įdėti pristabdytos būsenos"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Į atsiuntimo eilę įdedamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Visų pirma bandyti atsiųsti pirmą ir paskutinę failo dalį"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Siųsti tos pačios kategorijos failą"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Naujiems failams paskirti vietą diske"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Naujiems failams iš anksto paskirti vietą diske visam failui. Taip bus sumažinta fragmentacija"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Įjunkite, jei norite, kad aMule tikrintų laisvą vietą diske"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Įrašykite kiek diske palikti laisvos vietos."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Įrašyti 10 šaltinių retiems failams (mažiau nei 20 šaltinių)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Išsiuntimai"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Naujiems dalinamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(spragtelėję dešiniu klavišu dalinsitės ir gilesniais paaplankiais)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Dalintis slepiamais failais"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafikai"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Atnaujinimo dažnis: 5 s"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Vidurkių grafiko dydis: 100 min"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Ryšių grafiko skalė: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fonas"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Rėmeliai"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Dabartinė atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Dabartinis atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Seanso atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Dabartinė išsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Dabartinis išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Seanso išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktyvūs ryšiai"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistemos dėklo spartos indikatorius"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Dabartiniai Kademlia mazgai"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kademlia mazgų dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kademlia mazgų seanso vidurkis"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Nurodykite spalvą"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Rodomų klientų versijų skaičius (0 – neribojama)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "DĖMESIO!!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Per 5 s užmegzti ne daugiau ryšių, nei nurodyta"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Failo buferio dydis: 240000 baitai"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Išsiuntimo eilė: 5000 klientų"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Rodyti papildomą informaciją kategorijų kortelėse"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Mygtukus išdėstyti vertikaliai"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plokščia"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Erdvinė"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "Įjungus šią parinktį atsiuntimo eilėje esantys failai bus rūšiuojami automatiškai"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Išorinio ryšio parinktys"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Priimti išorinius ryšius"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Įrašykite išorinių ryšių besiklausančio įrenginio IP adresą a.b.c.d forma. Tuščias laukelis arba adresas 0.0.0.0 reiškia bet kokį įrenginį."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC prievade įjungti UPnP prievadų perdavimą"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "www šablonas"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Pilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Įjungti nepilnos prieigos naudotoją"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Nepilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Puslapio atnaujinimo periodas (sekundėmis)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Įjungti Gzip suspaudimą"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Gerai"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Patvirtinti naujai nurodytas parinktis."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Atšaukti bet kokius pakeitimus."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Pavadinimas:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Komentaras:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Atsiųstų failų aplankas:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Keisti naujai priskirtų failų prioritetą:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "Nekeisti"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Nurodykite dabartinės kategorijos spalvą:"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Perkrauti"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Išvalyti įvykių žurnalą."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Paspaudę šį mygtuką atnaujinsite serverių sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Serverių sąrašas"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Įrašykite server.met failo URL ir paspaudę mygtuką kairėje atnaujinsite serverių sąrašą."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Įdėti serverį rankiniu būdu: pavadinimas"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Įrašykite serverio pavadinimą"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:prievadas"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Įrašykite serverio IP adresą naudodami a.b.c.d formą."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Įrašykite serverio prievadą."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Įdėti serverį (prieš tai užpildykite laukelius kairėje)..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule žurnalas"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Serverio informacija"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K informacija"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kademlia informacija"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Spragtelėję šį mygtuką atnaujinsite mazgų sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Mazgai (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Įrašykite nodes.dat failo URL ir paspaudę mygtuką kairėje atnaujinsite mazgų sąrašą."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Mazgų statistika"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Inicializavimas"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Naujas mazgas"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Prievadas:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Inicializuoti iš \n"
 "žinomų klientų"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Atjungti Kademlia"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Naudoti saugų kliento atpažinimą"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Rekomenduojama įjungti šią parinktį. Jei išjungsite, negausite kreditų."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokolo slėpimas"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Įjungti protokolo slėpimą"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ši parinktis įjungia protokolo slėpimą. Tuomet aMule priiminės slepiamus ryšius iš kitų klientų."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Slėpti išeinančius ryšius"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Įjungus šią parinktį aMule, jungdamasi prie kitų klientų ar serverių, slėps išeinančius ryšius."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Priimti tik slepiamus ryšius"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Įjungus šią parinktį aMule priims tik slepiamus ryšius. Šaltinių bus rasta mažiau, bet visas srautas bus slepiamas"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Visi"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Niekas"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Nurodykite kas gali pamatyti dalinamų failų sąrašą."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP filtravimas"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtruoti klientus"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti klientų IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtruoti serverius"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti serverių IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Atnaujinti IP adresų sąrašą iš ~/.aMule/ipfilter.dat failo"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Atnaujinti dabar"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Filtravimo lygmuo:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Visuomet filtruoti LAN IP adresus"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranojiškai elgtis su neatitikusiais IP adresais"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Atmesti paketą, jei kliento IP adresas skiriasi nuo paketo šaltinio IP adreso. Naudoti atsargiai."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Jei įjungtas, naudoti ipfilter.dat failą visoje sistemoje"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jei nėra vietinio ipilter.dat failo, naudoti ipfilter.dat visoje sistemoje."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Įjungti keičiamą parašą"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Įjungus šią parinktį bus įrašomas keičiamo parašo failas, kurį galite naudoti kitoje programoje parašų kūrimui ir pan."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Atnaujinimo dažnis (sekundėmis):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Keičiamo parašo atnaujinimo dažnis sekundėmis."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Nurodykite aplanką, kuriame yra keičiamo parašo failas."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Siuntimo sparta:"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Šaltiniai"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4323,11 +4341,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4337,232 +4355,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Atsiųsta: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruoti gaunamas žinutes (išskyrus dabartinį pokalbį):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtruoti visas žinutes"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruoti žinutes nuo naudotojų, nesančių draugų sąraše"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruoti žinutes turinčias tekstą („,“ naudokite kaip skirtuką):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Įrašykite žodžius, kurių aMule ieškos žinutės tekste ir filtruos žinutę"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Komentarai"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruoti komentarus, turinčius (atskirkite kableliu):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Įjungti autentifikavimą"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Įjungti ar išjungti naudotojo vardo ir slaptažodžio autentifikavimą"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Naudotojo vardas prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Slaptažodis:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Slaptažodis prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Įjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Įjungti ar išjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Serverio tipas:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Serverio mazgas:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Atstovaujančio serverio mazgo pavadinimas"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Serverio prievadas:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Atstovaujančio serverio prievadas"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Prijungti prie:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Prisijungti prie nutolusios aMule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Naudotojo vardas"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Įsiminti parinktis"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Naudoti gzip pakavimą"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Įjungti išsamų klaidų taisymo žurnalą."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Atverti failą"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Žinučių kategorijos:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Laukiama..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Įdėti failus"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Pažymėtas bandyti iš naujo"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Pašalinti pažymėtas"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Slėpti dalinamus failus"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Parinkite filtrą"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktyvūs išsiuntimai"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Siųsti"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Išsiųsti įrašytą žinutę."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Dalinami failai"
 
@@ -4641,7 +4659,7 @@ msgstr "Visa kita"
 msgid "Incomplete"
 msgstr "Neužbaigtos"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Sustabdyta"
 
@@ -4834,7 +4852,7 @@ msgstr "Įrašytas %i platinantis šaltinis dalių failui %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Nuskaitant dalių failo platinančių šaltinių failą įvyko klaida (%s – %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -4842,353 +4860,353 @@ msgstr[0] "Aptikta klaidinga dalis (%d) %d dalies faile %s – failo rezultatų 
 msgstr[1] "Aptikta klaidinga dalis (%d) %d dalių faile %s – failo rezultatų maišos f-ja |%s| failo maišos f-ja |%s|"
 msgstr[2] "Aptikta klaidinga dalis (%d) %d dalių faile %s – failo rezultatų maišos f-ja |%s| failo maišos f-ja |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Aptikta baigta dalis (%i) %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Baigtas maišos f-jos reikšmės perskaičiavimas %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Baigiant siųsti %s įvyko netikėta klaida. Failas pristabdytas"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Atsiųsta: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Atsiųsta: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Šalinamas failas: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "DĖMESIO: atsiųstai daliai nepavyko apskaičiuoti maišos funkcijos – %s maišos reikšmės nebaigtos"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "DĖMESIO: atsiųstai daliai nepavyko apskaičiuoti maišos funkcijos – %s maišos reikšmės nebaigtos. Tokių dalykų neturi būti"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "Dėmesio: diske nepakanka laisvos vietos! Failas pristabdomas: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Atsiųsta sugadinta %i dalis: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "Klaidų taisymo įrankis: atstatyta sugadinta dalis %i %s –> išgelbėta %s baitų"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Paskiriama vieta"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Nepakanka laisvos vietos"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Atsiųsta"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "KLAIDA: nepavyko atverti dalių failo „%s“"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Numatyta"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabų"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskų"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgarų"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalonų"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Kinų (supaprastinta)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Kinų (tradicinė)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Kroatų"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Čekų"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danų"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Olandų"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Suomių"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Prancūzų"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galisijos"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Vokiečių"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Graikų"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Žydų"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Vengrų"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italų"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italų (Šveicarijos)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonų"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Korėjiečių"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lietuvių"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegų (naujoji norvegų)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Lenkų"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugalų"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalų (Brazilijos)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Rusų"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovėnų"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Ispanų"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Švedų"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turkų"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "Kalba"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Nėra"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP prievadas negali būti didesnis nei 65532, nes serverio UDP prievadas yra TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bus naudojamas numatytas prievadas (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Kanalas"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Aplankai"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Serveriai"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Failai"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Saugumas"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Atstovaujantis serveris"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Nutolęs valdymas"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Keičiamas parašas"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Įvykiai"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Taisymas"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5203,26 +5221,26 @@ msgstr ""
 "\n"
 "aMule puikiai veikia nieko nepakeitus šiame lange."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Atstovaujančio serverio, prie kurio jungsitės, tipas"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5230,41 +5248,46 @@ msgstr ""
 "Kad įsigaliotų šie pakeitimai, aMule reikia paleisti iš naujo:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "– pakeistas TCP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "– pakeistas UDP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Išorinis ryšys nutrauktas."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo slėpimas"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5272,20 +5295,20 @@ msgstr ""
 "Įjungėte išorinius ryšius, bet parinktyse nenurodėte slaptažodžio.\n"
 "Kol nenurodysite slaptažodžio, išoriniai ryšiai nebus įjungti."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "– kalba pakeista.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "– laikinų failų aplankas pakeistas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Visi tinklai išjungti."
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5293,7 +5316,7 @@ msgstr ""
 "Tiek eD2k, tiek Kademlia tinklai yra išjungti.\n"
 "Norėdami prisijungti įjunkite bent vieną iš šių tinklų."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5301,7 +5324,7 @@ msgstr ""
 "Nepavyks prisijungti prie Kademlia tinklo, nes išjungtas UDP prievadas.\n"
 "Arba įjunkite UDP prievadą, arba išjunkite Kademlia tinklą."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5311,20 +5334,20 @@ msgstr ""
 "Būtina paleisti aMule iš naujo.\n"
 "Jei dabar pat neperleisite aMule, nesiskųskite jei kas nors bus ne taip.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatinis atnaujinimas paleistas"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5334,41 +5357,41 @@ msgstr ""
 "Įrašykite bent vieną server.met failo URL.\n"
 "Norėdami įrašyti URL, paspauskite mygtuką „Sąrašas“."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Laikini failai"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Atsiųsti failai"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Keičiami parašai"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Parinkite aplanką %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Parinkite video grotuvą"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Parinkite naršyklę"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Vykdomas failas %s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Keisti serverių sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5376,42 +5399,42 @@ msgstr ""
 "Įrašykite server.met failų URL.\n"
 "Vieną URL vienoje eilutėje."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Pilni šaltiniai"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -5419,7 +5442,7 @@ msgstr[0] "Atnaujinimo intervalas: %d s"
 msgstr[1] "Atnaujinimo intervalas: %d s"
 msgstr[2] "Atnaujinimo intervalas: %d s"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -5427,12 +5450,12 @@ msgstr[0] "Vidurkių grafiko trukmė: %d min."
 msgstr[1] "Vidurkių grafiko trukmė: %d min."
 msgstr[2] "Vidurkių grafiko trukmė: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ryšių grafiko mastelis: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5440,7 +5463,7 @@ msgstr[0] "Failų buferio dydis: %d baitas"
 msgstr[1] "Failų buferio dydis: %d baitai"
 msgstr[2] "Failų buferio dydis: %d baitų"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -5448,7 +5471,7 @@ msgstr[0] "Išsiuntimo eilės dydis: %d klientas"
 msgstr[1] "Išsiuntimo eilės dydis: %d klientai"
 msgstr[2] "Išsiuntimo eilės dydis: %d klientų"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -5456,75 +5479,75 @@ msgstr[0] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[1] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[2] "Serverio ryšio atnaujinimo intervalas: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "Išjungti"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Įvykus „%s“ įvykiui įvykdyti komandą"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Įjungti komandos vykdymą branduolyje"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Branduolio komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Įjungti komandos vykdymą grafinėje aplinkoje"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Grafinės aplinkos komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Šie kintamieji bus pakeisti:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Skaitomas laikinų failų aplankas"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Atnaujinti dalinamų failų sąrašą."

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-07-01 15:01+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -190,8 +190,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -236,27 +236,37 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informācija"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -264,53 +274,53 @@ msgstr ""
 "\n"
 "EC iestatījumi"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "BRĪDINĀJUMS"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "eD2k serveru saraksts (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -320,184 +330,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plašāka informācija, atbalsts un jaunās versijas ir pieejamas mūsu vietnē\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io vai mūsu IRC kanālā #aMule vietnē irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "KĻŪDA: nevar atvērt žurnāldatni"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "BRĪDINĀJUMS: žurnāldatne ir tukša. Te kaut kas nav kā vajag :-(."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Jūs izmantojiet novecojušu aMule versiju!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Jaunāko aMule versiju vienmēr var iegūt https://github.com/amule-org/amule/releases/latest vietnē"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "BRĪDINĀJUMS: Jūsu aMule versija ir novecojusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Šī ir jaunākā aMule versija."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Neizdevās lejupielādēt versijas pārbaudes datni"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Lietotāji: %s | Datnes: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Lietotāji: E: %s K: %s | Datnes: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "ar zemu ID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "ar augstu ID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Pieslēgts %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Pieslēdzas %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Atslēgts no eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Pieslēgts Kad (veiksmīgi)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Pieslēgts Kad (aiz ugunsmūra)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Atslēgts no Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad tīkls ir atspējots iestatījumos, nepieslēdzas tīklam."
 
@@ -2527,7 +2537,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-07-01 15:01+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,26 +17,26 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= 19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Par programmu"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -44,59 +44,59 @@ msgstr ""
 "Autortiesības (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Vienādranga (P2P) maršrutēšana, pamatojoties uz XOR (izslēdzošā VAI) metriku.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Autortiesības (c) 2002-2011 Petars Majmunkovs ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Vietne:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forums:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr "Dokumentācija:"
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr "Problēmas:"
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kad palaiž, pārbaudīt, vai nav pieejama jauna versija"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Pieslēdzas Kad…"
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Jūs izmantojiet novecojušu aMule versiju!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nav pieejama neviena valoda"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -190,8 +190,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -206,47 +206,57 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Pašlaik aizver galveno programmu…"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Pārtrauc amuleweb procesu ar pid '%d' … "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Iznīcina amuleweb procesu ar pid '%d' … "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Neizdevās"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informācija"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -254,53 +264,53 @@ msgstr ""
 "\n"
 "EC iestatījumi"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "BRĪDINĀJUMS"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "eD2k serveru saraksts (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -310,184 +320,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plašāka informācija, atbalsts un jaunās versijas ir pieejamas mūsu vietnē\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io vai mūsu IRC kanālā #aMule vietnē irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "KĻŪDA: nevar atvērt žurnāldatni"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "BRĪDINĀJUMS: žurnāldatne ir tukša. Te kaut kas nav kā vajag :-(."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Jūs izmantojiet novecojušu aMule versiju!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Jaunāko aMule versiju vienmēr var iegūt https://github.com/amule-org/amule/releases/latest vietnē"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "BRĪDINĀJUMS: Jūsu aMule versija ir novecojusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Šī ir jaunākā aMule versija."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Neizdevās lejupielādēt versijas pārbaudes datni"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Lietotāji: %s | Datnes: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Lietotāji: E: %s K: %s | Datnes: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "ar zemu ID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "ar augstu ID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Pieslēgts %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Pieslēdzas %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Atslēgts no eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Pieslēgts Kad (veiksmīgi)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Pieslēgts Kad (aiz ugunsmūra)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Atslēgts no Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad tīkls ir atspējots iestatījumos, nepieslēdzas tīklam."
 
@@ -526,15 +536,15 @@ msgstr ""
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Apmeklējiet https://github.com/amule-org/amule/releases/latest vietni, lai pārbaudītu, vai nav pieejama jauna versija."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -544,222 +554,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Jaunāko aMule versiju vienmēr var iegūt https://github.com/amule-org/amule/releases/latest vietnē"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Nav pieejama neviena valoda"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Pieslēdzas"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Pieslēdzas"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Atslēgts"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Aiz ugunsmūra"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Pieslēgts"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Pieslēdzas"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Izslēgts"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Atslēgties"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Atslēgties no tīkliem, kuriem pašlaik esiet pieslēdzies"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Pieslēgties"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Pieslēgties pašlaik iespējotajiem tīkliem"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "↑Augšup.: %.1f%s (%.1f) | ↓Lejup.: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "↑Augšup.: %.1f%s | ↓Lejup.: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Pieslēgts)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Atslēgts)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Tīkli"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Lejupielādes"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Lejupielādes logs"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Kopīgotās datnes"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Ziņojumi"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Iestatījumi"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Par programmu"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Par programmu/Palīdzība"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k tīkls"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad tīkls"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -847,8 +857,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Nezināms"
@@ -1212,19 +1222,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1256,7 +1266,7 @@ msgid "On Queue"
 msgstr "Rindā"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Lejupielādē"
 
@@ -1316,7 +1326,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1387,7 +1397,7 @@ msgstr "Daļa"
 msgid "Size"
 msgstr "Izmērs"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Pārsūtīti"
 
@@ -1400,7 +1410,7 @@ msgid "Progress"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Avoti"
 
@@ -1410,7 +1420,7 @@ msgstr "Avoti"
 msgid "Priority"
 msgstr "Prioritāte"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Statuss"
 
@@ -1441,7 +1451,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr ""
@@ -2065,7 +2075,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Draugi"
 
@@ -2343,8 +2353,8 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Ziņojums"
 
@@ -2416,7 +2426,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr "Augšupielādēts"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2450,30 +2460,30 @@ msgstr ""
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Skaitļo kontrolsummu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Pabeidz"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Gaida"
 
@@ -2517,7 +2527,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2539,7 +2549,7 @@ msgid "WARNING: "
 msgstr "BRĪDINĀJUMS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Aizvērt"
 
@@ -2648,7 +2658,7 @@ msgstr "Iziet"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2888,7 +2898,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr ""
@@ -2957,7 +2967,7 @@ msgstr ""
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr ""
 
@@ -2978,7 +2988,7 @@ msgstr ""
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr ""
 
@@ -3152,7 +3162,7 @@ msgstr "Lietotājvārds :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Pievienot"
@@ -3161,15 +3171,15 @@ msgstr "Pievienot"
 msgid "Download-Speed"
 msgstr "Lejupielādes ātrums"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Pašreizējais"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Visu laiku vidējais"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Sesijas vidējais"
 
@@ -3181,7 +3191,7 @@ msgstr "Augšupielādes ātrums"
 msgid "Connections"
 msgstr "Savienojumi"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktīvas lejupielādes"
 
@@ -3189,7 +3199,7 @@ msgstr "Aktīvas lejupielādes"
 msgid "Active connections (1:1)"
 msgstr "Aktīvi savienojumi (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktīvas augšupielādes"
 
@@ -3390,8 +3400,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ievadiet šeit sava pārlūka nosaukumu. Atstājiet šo lauku tukšu, ja vēlaties izmantot sistēmas noklusējuma pārlūku."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3465,745 +3475,753 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Kad palaiž, automātiski pieslēgties"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "mēģinājumiem"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Kad palaiž, automātiski atjaunināt serveru sarakstu"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Saraksts"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Atjaunināt serveru sarakstu, kad pieslēdzas serverim"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Iespējot"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Augšupielādes"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafiki"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Krāsas: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Režģis"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktīvi savienojumi"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Atlasīt"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plakana"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Apaļa"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Kad palaiž, palaist arī tīmekļa serveri"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Iespējot Gzip saspiešanu"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Labi"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Komentārs :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Atiestatīt"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Ports"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Ports:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Atslēgt Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Jebkurš"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Neviens"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Kas var skatīt manas kopīgotās datnes:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr "Datubāze"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4211,11 +4229,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4225,222 +4243,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr "Kad palaiž, automātiski atjaunināt"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Komentāri"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Lietotājvārds: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Lietotājvārds, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Parole:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Parole, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Izmantot starpniekserveri"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Starpniekservera tips:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Starpniekserveris:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Starpniekservera resursdatora nosaukums"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Starpniekservera ports:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Starpniekservera ports"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Lietotājvārds"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Gaida…"
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Sūtīt"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Kopīgotās datnes"
 
@@ -4518,7 +4536,7 @@ msgstr ""
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr ""
 
@@ -4707,355 +4725,355 @@ msgstr ""
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Lejupielādēta"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Sistēmas"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albāņu"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arābu"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Astūriešu"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Basku"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgāru"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalāņu"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Ķīniešu (vienkāršotā)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Ķīniešu (tradicionālā)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Horvātu"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Čehu"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Dāņu"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Nīderlandiešu"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Angļu (Apvienotās Karalistes)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr "Angļu (ASV)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Igauņu"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Somu"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Franču"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galisiešu"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Vācu"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grieķu"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Ivrits"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Ungāru"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Itāļu"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Itāļu (Šveices)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japāņu"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Korejiešu"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lietuviešu"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvēģu (Jaunnorvēģu)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Poļu"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugāļu"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugāļu (Brazīlijas)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Rumāņu"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Krievu"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovēņu"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spāņu"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Zviedru"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turku"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukraiņu"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Mainīt valodu"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "aMule nav uzstādīta neviena valodas datne"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Nav pieejama neviena valoda"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Savienojums"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Serveri"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Datnes"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Drošība"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Saskarne"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Starpniekserveris"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Notikumi"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5065,56 +5083,60 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+msgid "- Network interface binding changed.\n"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5122,241 +5144,241 @@ msgstr ""
 "Jūsu automātiskās atjaunināšanas serveru saraksts ir tukšs.\n"
 "'Kad palaiž, automātiski atjaunināt serveru sarakstu' iestatījums tiks atspējots."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Rediģēt serveru sarakstu"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-07-01 15:01+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -190,8 +190,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -236,37 +236,42 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informācija"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -274,53 +279,53 @@ msgstr ""
 "\n"
 "EC iestatījumi"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "BRĪDINĀJUMS"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "eD2k serveru saraksts (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -330,184 +335,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plašāka informācija, atbalsts un jaunās versijas ir pieejamas mūsu vietnē\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io vai mūsu IRC kanālā #aMule vietnē irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "KĻŪDA: nevar atvērt žurnāldatni"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "BRĪDINĀJUMS: žurnāldatne ir tukša. Te kaut kas nav kā vajag :-(."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Jūs izmantojiet novecojušu aMule versiju!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Jaunāko aMule versiju vienmēr var iegūt https://github.com/amule-org/amule/releases/latest vietnē"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "BRĪDINĀJUMS: Jūsu aMule versija ir novecojusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Šī ir jaunākā aMule versija."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Neizdevās lejupielādēt versijas pārbaudes datni"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Lietotāji: %s | Datnes: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Lietotāji: E: %s K: %s | Datnes: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "ar zemu ID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "ar augstu ID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Pieslēgts %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Pieslēdzas %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Atslēgts no eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Pieslēgts Kad (veiksmīgi)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Pieslēgts Kad (aiz ugunsmūra)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Atslēgts no Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad tīkls ir atspējots iestatījumos, nepieslēdzas tīklam."
 
@@ -866,7 +871,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2195,49 +2200,49 @@ msgstr "Nē"
 msgid "Yes"
 msgstr "Jā"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Lejupielādē…"
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2537,7 +2542,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -201,8 +201,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -247,37 +247,42 @@ msgstr "aMule is afgesloten."
 msgid "Memory debug results for aMule exit:"
 msgstr "Geheugen debug resultaten voor het afsluiten van aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "De taalinstelling is veranderd naar de systeemstandaard vanwege een configuratiewijziging. Sorry."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -285,56 +290,56 @@ msgstr ""
 "\n"
 "EV-configuratie"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "WAARSCHUWING"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Netwerken"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server in server.met gevonden"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kon geen poorten koppelen aan het opgegeven adres: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Poort %u is niet beschikbaar. U krijgt een LAAG ID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -349,48 +354,48 @@ msgstr ""
 "\n"
 "Controleer uw netwerk en zorg ervoor dat de poort open is voor in- en uitgaand verkeer."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Kon bestand met online handtekening niet maken"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Kon aMule OnlineHandtekening Bestand niet maken"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "De gekozen taalinstelling lijkt niet geïnstalleerd te zijn op uw pc. (Let op: Ik probeer het toch in te stellen)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dit is de eerste keer dat u aMule %s draait"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dit is een testversie, dagelijks geupdatet, en\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "we geven geen garantie dat het niks kapot maakt of uw huis in brand steekt,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "of uw hond doodt. Maar het *zou* veilig moeten zijn om het te gebruiken.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meer informatie, ondersteuning en niuwe versies kunnen gevonden worden op onze homepage,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "op https://amule-org.github.io, of op ons IRC-kanaal #amule op irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bugs kunt u altijd melden op https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -398,137 +403,137 @@ msgstr ""
 "De map voor online-handtekeningbestanden die u heeft opgegeven is ONGELDIG!\n"
 " OnlineSignature is UITGESCHAKELD totdat u dit verbetert in voorkeuren."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Server-hostnaam geïnformeerd"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Toewijzen schijfruimte voor bestand '%s' mislukt: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "FOUT: kan logbestand niet openen"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WAARSCHUWING: logboekbestand is leeg. Er is iets mis."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Logboek is gewist"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Server-bericht: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download van %s overgeslagen, omdat gevraagd bestand niet nieuwer is."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Kon nodelijst niet downloaden."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Kon gedownload versie controle bestand niet openen"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Beschadigd bestand voor versiecontrole"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "U gebruikt een verouderde versie van aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Uw aMule-versie is %i.%i.%i en de nieuwste versie is %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WAARSCHUWING: Uw aMuled-versie is verouderd: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "U heeft de nieuwste aMule-versie."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Kon bestand voor versiecontrole niet downloaden"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Gebruikers: %s | Bestanden: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Gebruikers: E: %s K: %s | Bestanden: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Geen netwerken geselecteerd"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "met Laag ID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "met Hoog ID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbonden met %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinden met %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Verbinding verbroken met eD2K"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad gestart."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad gestopt."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Verbonden met Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Verbonden met Kad (firewalled)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Verbinding met Kad verbroken"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-netwerk kan niet gebruikt worden als de UDP-poort is uitgeschakeld in voorkeuren, wordt niet gestart."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-netwerk is uitgeschakeld in voorkeuren, wordt niet mee verbonden."
 
@@ -888,7 +893,7 @@ msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden.
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2255,49 +2260,49 @@ msgstr "Nee"
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Downloaden..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP-download geannuleerd"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "De URL om te downloaden mag niet leeg zijn"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Kon gedeelde bestanden niet ontvangen van gebruiker '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Map voor tijdelijke downloadbestanden"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%d bytes gedownload"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "De URL %s leverde op: %i - Fout (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP-download geannuleerd"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2600,7 +2605,7 @@ msgstr "Externe verbinding: toegang geweigerd omdat: "
 msgid "External Connection: Handshake failed."
 msgstr "Externe verbinding: handshake mislukt."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-download thread %d gestart"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -201,8 +201,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -247,27 +247,37 @@ msgstr "aMule is afgesloten."
 msgid "Memory debug results for aMule exit:"
 msgstr "Geheugen debug resultaten voor het afsluiten van aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "De taalinstelling is veranderd naar de systeemstandaard vanwege een configuratiewijziging. Sorry."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -275,56 +285,56 @@ msgstr ""
 "\n"
 "EV-configuratie"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "WAARSCHUWING"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Netwerken"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server in server.met gevonden"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kon geen poorten koppelen aan het opgegeven adres: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Poort %u is niet beschikbaar. U krijgt een LAAG ID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -339,48 +349,48 @@ msgstr ""
 "\n"
 "Controleer uw netwerk en zorg ervoor dat de poort open is voor in- en uitgaand verkeer."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Kon bestand met online handtekening niet maken"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Kon aMule OnlineHandtekening Bestand niet maken"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "De gekozen taalinstelling lijkt niet geïnstalleerd te zijn op uw pc. (Let op: Ik probeer het toch in te stellen)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dit is de eerste keer dat u aMule %s draait"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dit is een testversie, dagelijks geupdatet, en\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "we geven geen garantie dat het niks kapot maakt of uw huis in brand steekt,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "of uw hond doodt. Maar het *zou* veilig moeten zijn om het te gebruiken.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meer informatie, ondersteuning en niuwe versies kunnen gevonden worden op onze homepage,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "op https://amule-org.github.io, of op ons IRC-kanaal #amule op irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bugs kunt u altijd melden op https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -388,137 +398,137 @@ msgstr ""
 "De map voor online-handtekeningbestanden die u heeft opgegeven is ONGELDIG!\n"
 " OnlineSignature is UITGESCHAKELD totdat u dit verbetert in voorkeuren."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Server-hostnaam geïnformeerd"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Toewijzen schijfruimte voor bestand '%s' mislukt: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "FOUT: kan logbestand niet openen"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WAARSCHUWING: logboekbestand is leeg. Er is iets mis."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Logboek is gewist"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Server-bericht: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download van %s overgeslagen, omdat gevraagd bestand niet nieuwer is."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Kon nodelijst niet downloaden."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Kon gedownload versie controle bestand niet openen"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Beschadigd bestand voor versiecontrole"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "U gebruikt een verouderde versie van aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Uw aMule-versie is %i.%i.%i en de nieuwste versie is %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WAARSCHUWING: Uw aMuled-versie is verouderd: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "U heeft de nieuwste aMule-versie."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Kon bestand voor versiecontrole niet downloaden"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Gebruikers: %s | Bestanden: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Gebruikers: E: %s K: %s | Bestanden: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Geen netwerken geselecteerd"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "met Laag ID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "met Hoog ID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbonden met %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinden met %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Verbinding verbroken met eD2K"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad gestart."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad gestopt."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Verbonden met Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Verbonden met Kad (firewalled)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Verbinding met Kad verbroken"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-netwerk kan niet gebruikt worden als de UDP-poort is uitgeschakeld in voorkeuren, wordt niet gestart."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-netwerk is uitgeschakeld in voorkeuren, wordt niet mee verbonden."
 
@@ -2590,7 +2600,7 @@ msgstr "Externe verbinding: toegang geweigerd omdat: "
 msgid "External Connection: Handshake failed."
 msgstr "Externe verbinding: handshake mislukt."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-download thread %d gestart"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:11+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -23,20 +23,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.4.2\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Toon aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule controle op afstand "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -44,7 +44,7 @@ msgstr ""
 "'Alle-Platformen' p2p client gebaseerd op eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -53,59 +53,59 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Een deel van aMule is gebaseerd op \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing gebaseerd op de XOR-metric.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Website:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Controleer op nieuwe versie bij het starten"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Verbinding met Kad wordt gemaakt..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "U gebruikt een verouderde versie van aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Niet beschikbaar"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -201,8 +201,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -217,47 +217,57 @@ msgstr "Kon bestand ED2KLinks niet openen."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WAARSCHUWING: U kunt uzelf niet toevoegen als bron voor een eD2k-link terwijl u een laag id hebt."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Hoofdapp wordt nu afgesloten..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt afgesloten ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt gedood ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Mislukt"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Kern wordt afgesloten."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule is afgesloten."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Geheugen debug resultaten voor het afsluiten van aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "De taalinstelling is veranderd naar de systeemstandaard vanwege een configuratiewijziging. Sorry."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -265,56 +275,56 @@ msgstr ""
 "\n"
 "EV-configuratie"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "WAARSCHUWING"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Netwerken"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server in server.met gevonden"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kon geen poorten koppelen aan het opgegeven adres: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Poort %u is niet beschikbaar. U krijgt een LAAG ID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -329,48 +339,48 @@ msgstr ""
 "\n"
 "Controleer uw netwerk en zorg ervoor dat de poort open is voor in- en uitgaand verkeer."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Kon bestand met online handtekening niet maken"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Kon aMule OnlineHandtekening Bestand niet maken"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "De gekozen taalinstelling lijkt niet geïnstalleerd te zijn op uw pc. (Let op: Ik probeer het toch in te stellen)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dit is de eerste keer dat u aMule %s draait"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dit is een testversie, dagelijks geupdatet, en\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "we geven geen garantie dat het niks kapot maakt of uw huis in brand steekt,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "of uw hond doodt. Maar het *zou* veilig moeten zijn om het te gebruiken.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meer informatie, ondersteuning en niuwe versies kunnen gevonden worden op onze homepage,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "op https://amule-org.github.io, of op ons IRC-kanaal #amule op irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bugs kunt u altijd melden op https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -378,137 +388,137 @@ msgstr ""
 "De map voor online-handtekeningbestanden die u heeft opgegeven is ONGELDIG!\n"
 " OnlineSignature is UITGESCHAKELD totdat u dit verbetert in voorkeuren."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Server-hostnaam geïnformeerd"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Toewijzen schijfruimte voor bestand '%s' mislukt: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "FOUT: kan logbestand niet openen"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WAARSCHUWING: logboekbestand is leeg. Er is iets mis."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Logboek is gewist"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Server-bericht: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download van %s overgeslagen, omdat gevraagd bestand niet nieuwer is."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Kon nodelijst niet downloaden."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Kon gedownload versie controle bestand niet openen"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Beschadigd bestand voor versiecontrole"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "U gebruikt een verouderde versie van aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Uw aMule-versie is %i.%i.%i en de nieuwste versie is %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WAARSCHUWING: Uw aMuled-versie is verouderd: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "U heeft de nieuwste aMule-versie."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Kon bestand voor versiecontrole niet downloaden"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Gebruikers: %s | Bestanden: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Gebruikers: E: %s K: %s | Bestanden: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Geen netwerken geselecteerd"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "met Laag ID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "met Hoog ID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbonden met %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinden met %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Verbinding verbroken met eD2K"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad gestart."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad gestopt."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Verbonden met Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Verbonden met Kad (firewalled)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Verbinding met Kad verbroken"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-netwerk kan niet gebruikt worden als de UDP-poort is uitgeschakeld in voorkeuren, wordt niet gestart."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-netwerk is uitgeschakeld in voorkeuren, wordt niet mee verbonden."
 
@@ -548,15 +558,15 @@ msgstr "Dit is aMule %s gebaseerd op eMule."
 msgid "Running on %s"
 msgstr "Draaiend op %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bezoek https://github.com/amule-org/amule/releases/latest om te zien of een nieuwe versie beschikbaar is."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATALE FOUT: Kon Timer niet aanmaken"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -566,222 +576,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Niet beschikbaar"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoogvenster afgesloten"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Aan het verbinden"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2K: Verbinden"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2K: Verbinding verbroken"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Verbonden"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Verbinden"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Uitgeschakeld"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Beëindig de huidige verbindingspogingen"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Verbreek"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Verbreek de huidige verbonden netwerken"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Verbind met de momenteel ingeschakelde netwerken"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upload: %.1f%s (%.1f) | Download: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upload: %.1f%s | Download: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbonden)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Niet verbonden)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Wilt u %s echt afsluiten?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Bevestig afsluiten"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Voer commando uit: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- standaard -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinmap '%s' bestaat niet"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WAARSCHUWING: Kon skin-bestand '%s' niet openen om te lezen"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Netwerken"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Netwerkvenster"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Zoeken"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Zoekvenster"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Downloadsvenster"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Gedeelde bestanden"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Gedeelde bestanden-venster"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Berichten"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Berichtenvenster"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistieken"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Statistiekenvenster (Grafieken)"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Voorkeureninstellingen-venster"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importeer"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Het deelbestand importeerprogramma"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Over"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Over/Help"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k-netwerk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad netwerk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Geen netwerk"
 
@@ -869,8 +879,8 @@ msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden.
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Onbekend"
@@ -1233,19 +1243,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Heel laag"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Laag"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1277,7 +1287,7 @@ msgid "On Queue"
 msgstr "In wachtrij"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Downloaden"
 
@@ -1337,7 +1347,7 @@ msgstr "Lokale server"
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1409,7 +1419,7 @@ msgstr "Deel"
 msgid "Size"
 msgstr "Grootte"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Overgebracht"
 
@@ -1422,7 +1432,7 @@ msgid "Progress"
 msgstr "Voortgang"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Bronnen"
 
@@ -1432,7 +1442,7 @@ msgstr "Bronnen"
 msgid "Priority"
 msgstr "Prioriteit"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Status"
 
@@ -1465,7 +1475,7 @@ msgstr ""
 "Feedback van: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2120,7 +2130,7 @@ msgstr "Kon niet schrijven naar vriendenlijst-bestand 'emfriends.met'!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIEK - geen client bij StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Vrienden"
 
@@ -2405,8 +2415,8 @@ msgstr "Ongeldige poort om van te bootstrappen"
 msgid "Please fill all fields required"
 msgstr "Vul alle benodigde velden in"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Bericht"
 
@@ -2478,7 +2488,7 @@ msgstr "Deelverhouding"
 msgid "Uploaded"
 msgstr "Geüpload"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Aangevraagd"
 
@@ -2512,30 +2522,30 @@ msgstr "Onbekende fout %d"
 msgid "Unable to get error description for error %d"
 msgstr "Kon foutbeschrijving niet verkrijgen voor fout %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Aan het hashen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Voltooien"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Compleet"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Gepauzeerd"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Foutief"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Wachten"
 
@@ -2580,7 +2590,7 @@ msgstr "Externe verbinding: toegang geweigerd omdat: "
 msgid "External Connection: Handshake failed."
 msgstr "Externe verbinding: handshake mislukt."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-download thread %d gestart"
@@ -2602,7 +2612,7 @@ msgid "WARNING: "
 msgstr "WAARSCHUWING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Sluiten"
 
@@ -2718,7 +2728,7 @@ msgstr "Afsluiten"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2959,7 +2969,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3028,7 +3038,7 @@ msgstr "Verwijdert complete downloads"
 msgid "File sources:"
 msgstr "Bestandsbronnen:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Algemeen"
 
@@ -3049,7 +3059,7 @@ msgstr "Volledige naam :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/B"
 
@@ -3225,7 +3235,7 @@ msgstr "Gebruikersnaam :"
 msgid "Userhash :"
 msgstr "Gebruikershash :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Toevoegen"
@@ -3234,15 +3244,15 @@ msgstr "Toevoegen"
 msgid "Download-Speed"
 msgstr "Downloadsnelheid"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Huidige"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Lopende gemiddelde"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Sessie gemiddelde"
 
@@ -3254,7 +3264,7 @@ msgstr "Uploadsnelheid"
 msgid "Connections"
 msgstr "Verbindingen"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Actieve downloads"
 
@@ -3262,7 +3272,7 @@ msgstr "Actieve downloads"
 msgid "Active connections (1:1)"
 msgstr "Actieve verbinding (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Actieve uploads"
 
@@ -3463,8 +3473,8 @@ msgstr "Browserselectie"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Voer hier uw browsernaam in. Laat dit veld leeg om de standaardbrowser van uw systeem te gebruiken."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3538,750 +3548,759 @@ msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Enkel voor gevorderde gebruikers: Als u meerdere netwerk-interfaces hebt, voer hier het adres in van de interface waar aMule mee verbonden moet worden."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Max bronnen per bestand aan het downloaden:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Max gelijktijdige verbindingen:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Autoverbind bij het opstarten"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Verbind opnieuw bij verbroken verbinding"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Verwijder dode server na"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "pogingen"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Auto-update serverlijst bij het opstarten"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lijst"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Update serverlijst bij het verbinden met een server"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Update serverlijst wanneer een client verbindt"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Gebruik prioriteitssysteem"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Gebruik slimme laag-ID controle bij verbinden"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Veilig verbinden"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoverbind alleen met servers in statische lijst"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Zet handmatig toegevoegde servers op hoge prioriteit"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente corruptieafhandling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Geavanceerde I.C.H. vertrouwt elke hash (niet aanbevolen)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Voeg bestanden aan downloads toe in pauze-modus"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Voeg bestanden aan downloads toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Probeer eerste en laatste delen eerst te downloaden"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Start volgend gepauzeerd bestand als een bestand compleet is"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Uit dezelfde categorie"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "In alfabetische volgorde"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden, beperkt hierdoor fragmentatie"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stop downloads als de vrije schijfruimte bedraagt "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecteer dit als u wilt dat aMule uw schijfruimte controleert"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Voer hier de gewenste min schijfruimte in."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bewaar 10 bronnen van zeldzame bestanden (<20 bronnen)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Voeg nieuwe gedeelde bestanden toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Doelmap voor downloads"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Map voor tijdelijke downloadbestanden"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtermuisklik op mappictogram om recursief te delen)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Deel verborgen bestanden"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafieken"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Update-vertraging : 5 seconden"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Tijd voor gemiddeldengrafiek: 100 minuten"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Schaal verbindingengrafiek: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Schaal downloadgrafiek:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Schaal uploadgrafiek:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Kleuren: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Achtergrond"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Raster"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Huidige download"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Lopend gemiddelde download"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Sessie gemiddelde download"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Huidige upload"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Lopend gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Sessie gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Actieve verbindingen"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systeemvak-pictogram met snelheidsbalk"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Kad-nodes huidig"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kad-nodes draaiende"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kad-nodes sessie"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Selecteer"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Boom"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Aantal getoonde client-versies (0=onbegrensd)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! WAARSCHUWING !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Max nieuwe verbindingen / 5 seconden"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Grootte van bestandsbuffer : 240000 bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Grootte van uploadwachtrij: 5000 clients"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-verbinding verversingsinterval: Uitschakelen"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Schakel standby-modus van computer uit"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Gebruik skin: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Toon \"Snelle eD2k-links afhandelaar\" in elk venster."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Geef uitgebreide informatie weer op categorie-tabs"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Toon applicatieversie op titel"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Toon overdrachtsnelheden op titel"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Voor applicatienaam"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Na applicatienaam"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Toon overhead bandbreedte"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Verticale knoppenbalk"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Downloadwachtrij bestanden"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Toon voortgangspercentage"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Toon voortgangsindicator"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Rond"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Auto-sorteer bestanden (hoog CPU-gebruik)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule zal de kolommen in uw downloadlijst automatisch sorteren"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Externe verbinding parameters"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Accepteer externe verbindingen"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP van de luisterende interface:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Voer hier een geldig IP in het formaat a.b.c.d in van de luisterende EV-interface. Een leeg veld of 0.0.0.0 betekent elke interface."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Schakel UPnP portforwarding van de EV-poort in"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Start webserver bij het opstarten"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Web-template"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Alle rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Schakel gebruiker met beperkte rechten in"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Beperkte rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Schakel UPnP portforwarding van de webserver-poort in"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web server UPnP TCP-poort (optioneel)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Pagina verversingstijd (in seconden)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Schakel Gzip-compressie in"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klik hier om de veranderingen gemaakt in de voorkeuren toe te passen."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Maak veranderingen aan de voorkeuren ongedaan."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titel :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Commentaar :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Binnenkomende map :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Verander prioriteit voor nieuw toegevoegde bestanden :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Niet veranderen"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecteer kleur voor deze categorie (nu geselecteerd) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Leegmaken"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Klik op deze knop om het logboek te wissen."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik op deze knop om de lijst van servers te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Server-lijst"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Voer de url naar een server.met bestand hier in en druk op de knop links om de lijst met bekende servers te vernieuwen."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Voeg server handmatig toe: Naam"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Voer hier de naam van de nieuwe server in"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Poort"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Voer hier het IP van de server in, gebuik het x.x.x.x formaat."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Voer hier de poort van de server in."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Voeg een server handmatig toe (vul velden links in voor) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule log"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Server-info"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad info"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klik op deze knop om de nodes-lijst te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Voer hier de url in naar een nodes.dat bestand en druk op de knop links om de lijst van bekende nodes te updaten."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Nodes stats"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nieuwe node"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Poort:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap van bekende clients"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Verbreek verbinding met Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Gebruik beveiligde gebruikersidentificatie"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Het is aan te raden om deze optie in te schakelen. U ontvangt geen credits indien SUI niet ingeschakeld is."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Ondersteun protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Deze optie schakelt Protocol Obfuscatie in, en zorgt er voor dat aMule geobfusceerde verbindingen van andere clients accepteert."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Gebruik obfuscatie voor uitgaande verbindingen"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Deze optie zorgt er voor dat aMule protocol-obfuscatie gebruikt bij het verbinden met andere clients/servers."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Accepteer alleen geobfusceerde verbindingen"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Deze optie zorgt er voor dat aMule alleen geobfusceerde verbindingen accepteert. U heeft minder bronnen, maar al uw verkeer is geobfusceerd"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Iedereen"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Wie kan mijn gedeelde bestanden zien:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecteer wie een lijst van uw gedeelde bestanden kan opvragen."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP-filteren"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filter clients"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de client-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filter servers"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de server-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Lijst opnieuw laden"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Laadt de lijst met IPs om te filteren opnieuw uit het bestand ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Update nu"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Niveau van filteren:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filter LAN IPs altijd"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoïde behandeling van niet-kloppende IPs"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Weigert een pakket als het client-IP anders is dan het IP waar het pakket van is ontvangen. Wees voorzichtig hiermee."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Gebruik systeemwijd ipfilter.dat indien beschikbaar"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Indien er geen lokaal ipfilter.dat gevonden wordt, sta gebruik van een systeemwijd ipfilter toe."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Schakel online handtekening in"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Schakelt het schrijven van het OH-bestand in, die kan gebruikt worden door externe applicaties om handtekeningen en dergelijke te maken."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Update-frequentie (seconden):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Verander de frequentie (in seconden) van de Online Handtekening updates."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Bewaar online-handtekeningbestand in: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klik hier om de map te selecteren die de online-handtekening-bestanden bevat."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Toon landenvlaggen voor clients"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Datasnelheid :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Bronnen"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4289,11 +4308,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4303,225 +4322,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filter binnenkomende berichten (behalve huidige chat):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filter alle berichten"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filter berichten van mensen niet op uw vriendenlijst"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filter berichten van onbekende clients"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filter berichten met (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "voeg hier de woorden toe die amule moet filteren en berichten daarmee blokkeren"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Toon ontvangen berichten in het logboek"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Commentaren"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filter commentaren die de volgende tekens bevatten (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Schakel aanmelding in"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Schakel gebruikersnaam/wachtwoord aanmelding in/uit"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Gebruikersnaam: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "De gebruikersnaam is nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Wachtwoord:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Het wachtwoord nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Schakel proxy in"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Schakel proxy ondersteuning in/uit"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Proxy-type:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Proxy-host:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "De proxy hostnaam"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Proxy-poort:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "De proxy poort"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Verbind met:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Inloggen op amule op afstand"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Gebruikersnaam"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Onthoud deze instellingen"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Gebruik Gzip-compressie"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Schakel uitgebreide foutopsporing en logboek in."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Alleen naar logbestand"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Berichtcategorieën:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wachtend..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Voeg geïmporteerden toe"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Probeer geselecteerde opnieuw"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Verwijder geselecteerde"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Gebeurtenistypes"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistieken en clients in wachtrij voor geselecteerd(e) bestand(en) : Sessie / Alle"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Actieve uploads"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Procent van alle bestanden"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Geselecteerde bestanden"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Alleen actieve uploads"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Opnieuw laden:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Verstuur"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Verstuurt het opgegeven bericht."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Sluit deze chat-sessie."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Verbind met een server en/of Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Gedeelde bestanden"
 
@@ -4598,7 +4617,7 @@ msgstr "alle anderen"
 msgid "Incomplete"
 msgstr "Incompleet"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Gestopt"
 
@@ -4788,34 +4807,34 @@ msgstr "Kan seed-bestand voor deelbestand niet lezen: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Fout bij het lezen van deelbestands seeds-bestand (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Beschadigd deel (%d) gevonden in %d deelbestand %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Beschadigd deel (%d) gevonden in %d delen bestand %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Compleet deel (%i) gevonden in %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Klaar met opnieuw hashen %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Onverwachte fout tijdens het voltooien van %s. Bestand gepauzeerd"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Klaar met downloaden: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4824,307 +4843,307 @@ msgstr ""
 "Klaar met downloaden:\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Verwijderen van bestand: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "WAARSCHUWING: Kan gedownload deel niet hashen - incomplete hashset voor '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "FOUT: Kan gedownload deel niet hashen - hashset incompleet (%s). Dit zou nooit mogen gebeuren"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOB bij het hashen van gedownload deel %u met lengte %u (max %u) van deelbestand '%s' met lengte %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "WAARSCHUWING: Niet voldoende vrije schijfruimte! Pauzeren van bestand: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Gedownload deel %i is beschadigd in bestand: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: beschadigd deel %i van %s hersteld -> Bespaarde bytes: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Toewijzen"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Onvoldoende schijfruimte"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Gedownload"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FOUT: Kon deelbestand '%s' niet openen"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Systeemstandaard"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanees"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgaars"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalaans"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chinees (Vereenvoudigd)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chinees (Traditioneel)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Tsjechisch"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Deens"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonisch"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Fins"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Frans"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Gallisch"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Duits"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grieks"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebreeuws"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Hongaars"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiaans"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiaans (Zwitsers)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japans"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Koreaans"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litouws"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Noors"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Pools"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugees"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugees (Braziliaans)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Roemeens"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Sloveens"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spaans"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Zweeds"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turks"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Oekraïens"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Verander taal"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Er zijn geen vertalingen voor aMule geïnstalleerd"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Geen talen beschikbaar"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "geen opties beschikbaar"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Ongeldige categorie gevonden, wordt overgeslagen"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-poort kan niet hoger zijn dan 65532 omdat de server UDP-poort de TCP-poort + 3 is"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standaard poort zal worden gebruikt (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Verbinding"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Mappen"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servers"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Beveiliging"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filters"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Besturing op afstand"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Online handtekening"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Gebeurtenissen"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Foutopsporing"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5134,15 +5153,15 @@ msgstr ""
 "    %PARTFILE - volledig pad naar het bestand\n"
 "    %PARTNAME - alleen bestandsnaam"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5158,26 +5177,26 @@ msgstr ""
 "aMule zal goed draaien zonder deze instellingen\n"
 "te wijzigen."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Kon Cfg niet verbinden met widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Cfg naar widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Het type proxy waarmee u verbinding maakt"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Widget naar Cfg met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5185,31 +5204,36 @@ msgstr ""
 "aMule moet opnieuw gestart worden om deze veranderingen toe te passen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Interface voor externe verbinding veranderd.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Poort voor externe verbinding is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Acceptatie voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Interface voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Ondersteuning voor Protocol-obfuscatie is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5217,7 +5241,7 @@ msgstr ""
 "Uw Auto-update serverlijst is leeg.\n"
 "'Auto-update serverlijst bij het opstarten' wordt uitgeschakeld."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5225,19 +5249,19 @@ msgstr ""
 "U hebt externe verbindingen ingeschakeld maar geen wachtwoord ingesteld.\n"
 "Externe verbindingen kunnen niet ingeschakeld worden tenzij een geldig wachtwoord is ingesteld."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Taal veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Tijdelijke map veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-netwerk ingeschakeld.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5245,7 +5269,7 @@ msgstr ""
 "Zowel het eD2K als het Kad-netwerk zijn uitgeschakeld.\n"
 "U kun niet verbinden tot u minimaal een netwerk inschakelt."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5253,7 +5277,7 @@ msgstr ""
 "Kad zal niet starten als uw UDP-poort is uitgeschakeld.\n"
 "Schakel de UDP-poort in of schakel Kad uit."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5263,20 +5287,20 @@ msgstr ""
 "U MOET aMule nu opnieuw starten.\n"
 "Als u dat niet doet moet u niet klagen als er iets misgaat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatisch verversen gestart"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5286,41 +5310,41 @@ msgstr ""
 "Vul minimaal een URL naar een geldig server.met bestand in.\n"
 "Klik op de knop \"Lijst\" hiernaast om een URL in te voeren."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Tijdelijke bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Binnenkomende bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Online handtekeningen"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Kies een map voor %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Blader naar videospeler"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Selecteer browser"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Uitvoerbare%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Bewerk serverlijst"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5328,149 +5352,149 @@ msgstr ""
 "Voeg hier URL's toe om server.met bestanden te downloaden.\n"
 "Slechts één url per regel."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Complete bronnen"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Update-vertraging: %d seconde"
 msgstr[1] "Update-vertraging: %d seconden"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tijd voor gemiddeldengrafiek: %d minuut"
 msgstr[1] "Tijd voor gemiddeldengrafiek: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Schaal verbindingengrafiek: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Grootte van bestandsbuffer: %d byte"
 msgstr[1] "Grootte van bestandsbuffer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Grootte van uploadwachtrij: %d client"
 msgstr[1] "Grootte van uploadwachtrij: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-verbinding verversingsinterval: %d minuut"
 msgstr[1] "Server-verbinding verversingsinterval: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server verbinding verversingstijd: Uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Voer commando uit bij gebeurtenis '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Schakel uitvoeren van commando's in kern in"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Kerncommando:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Schakel uitvoeren van commando's in GUI in"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "GUI commando:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "De volgende variabelen worden vervangen:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Laad gedeelde-bestandenlijst opnieuw."

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -196,8 +196,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -247,84 +247,94 @@ msgstr "Nedlasting fullført"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Dine lokale innstilingar har vorte endra til opprinnelege systeminnstillingar på grunn av konfigurasjonsending. Beklager."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Stadfesting av avslutting"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ÅTVARING"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nettverk"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i tenar funne i server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Greidde ikkje å knyte portar til adressa: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port·%u er ikkje tilgjengeleg. Du vil få LågID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -339,48 +349,48 @@ msgstr ""
 "\n"
 "Sjekk nettverket ditt for å vere viss på at porten er open for inn- og utgåande trafikk."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Greidde ikkje å lage OnlineSigfil"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Greidde ikkje å lage aMule si OnlineSigfil."
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Dei valte lokale innstillingane ser ikkje ut til å vere installerte på maskina di. (Merk: Eg freistar å setje dei likevel)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dette er første gongen du køyrer aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Denne utgåva er ei testutgåve, oppdatert dagleg, og\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi gir ingen garanti for skade eller nedbrenning av huset ditt,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller drep hunden din. Men det *burde* vere trygt å nytte uansett.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meir informasjon, brukarstøtte og nye utgåver kan verte funne på heimesida vår.\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "på https://amule-org.github.io, eller på IRC-kanalen vår #aMule·på·irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -388,138 +398,138 @@ msgstr ""
 "Mappa spesifisert for nettsignaturar er UGANGBAR!\n"
 " Nettsignaturar vert DEAKTIVERT fram til du ordnar det i innstillingar."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Tenarnamn:"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Henting av diskplass for fila '%s' mislukka: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "FEIL: Greier ikkje å opne loggfila"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ÅTVARING: loggfila er tom. Noko er gale."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Loggen har vorte nullstilt"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Tenarmelding: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Klarte ikkje å laste ned nodelista."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Klarte ikkje å opne den nedlaste utgåvesjekkfila"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Korrupt utgåvesjekkfil"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Du nyttar ei utdatert utgåve av aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Di utgåve av aMule er %i.%i.%i og den siste utgåva er %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ÅTVARING: Utgåva di av aMule er utdatert: %i.%i.%i·<·%li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Utgåva di av aMule er oppdatert."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Klarte ikkje å laste ned utgåvesjekkfila"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Brukarar: %s | Filer: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Brukarar: E %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ingen valde nettverk"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "med LågID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "med HøgID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Tilkopla %s·%s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Koplar til %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Fråkopla eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad starta."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad stogga."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Tilkopla Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Tilkopla Kad (brannmura)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Fråkopla Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad kan ikkje nyttast dersom UDP-porten er deaktivert i innstillingar. Startar ikkje."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-nettverket er deaktivert i innstillingar. Koplar ikkje til."
 
@@ -2605,7 +2615,7 @@ msgstr "Ekstern kopling: Tilgang nekta fordi:"
 msgid "External Connection: Handshake failed."
 msgstr "Ekstern kopling: Tilgang nekta"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Autooppfrisking starta"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -196,8 +196,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -247,94 +247,99 @@ msgstr "Nedlasting fullført"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Dine lokale innstilingar har vorte endra til opprinnelege systeminnstillingar på grunn av konfigurasjonsending. Beklager."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Stadfesting av avslutting"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ÅTVARING"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nettverk"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i tenar funne i server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Greidde ikkje å knyte portar til adressa: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port·%u er ikkje tilgjengeleg. Du vil få LågID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -349,48 +354,48 @@ msgstr ""
 "\n"
 "Sjekk nettverket ditt for å vere viss på at porten er open for inn- og utgåande trafikk."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Greidde ikkje å lage OnlineSigfil"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Greidde ikkje å lage aMule si OnlineSigfil."
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Dei valte lokale innstillingane ser ikkje ut til å vere installerte på maskina di. (Merk: Eg freistar å setje dei likevel)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dette er første gongen du køyrer aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Denne utgåva er ei testutgåve, oppdatert dagleg, og\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi gir ingen garanti for skade eller nedbrenning av huset ditt,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller drep hunden din. Men det *burde* vere trygt å nytte uansett.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meir informasjon, brukarstøtte og nye utgåver kan verte funne på heimesida vår.\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "på https://amule-org.github.io, eller på IRC-kanalen vår #aMule·på·irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -398,138 +403,138 @@ msgstr ""
 "Mappa spesifisert for nettsignaturar er UGANGBAR!\n"
 " Nettsignaturar vert DEAKTIVERT fram til du ordnar det i innstillingar."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Tenarnamn:"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Henting av diskplass for fila '%s' mislukka: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "FEIL: Greier ikkje å opne loggfila"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ÅTVARING: loggfila er tom. Noko er gale."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Loggen har vorte nullstilt"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Tenarmelding: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Klarte ikkje å laste ned nodelista."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Klarte ikkje å opne den nedlaste utgåvesjekkfila"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Korrupt utgåvesjekkfil"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Du nyttar ei utdatert utgåve av aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Di utgåve av aMule er %i.%i.%i og den siste utgåva er %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ÅTVARING: Utgåva di av aMule er utdatert: %i.%i.%i·<·%li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Utgåva di av aMule er oppdatert."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Klarte ikkje å laste ned utgåvesjekkfila"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Brukarar: %s | Filer: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Brukarar: E %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ingen valde nettverk"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "med LågID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "med HøgID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Tilkopla %s·%s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Koplar til %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Fråkopla eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad starta."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad stogga."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Tilkopla Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Tilkopla Kad (brannmura)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Fråkopla Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad kan ikkje nyttast dersom UDP-porten er deaktivert i innstillingar. Startar ikkje."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-nettverket er deaktivert i innstillingar. Koplar ikkje til."
 
@@ -895,7 +900,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2267,49 +2272,49 @@ msgstr "Nei"
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Lastar ned..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Greidde ikkje å hente delte filer frå brukar '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Lasta ned"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Nedlastingar (%i)"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2615,7 +2620,7 @@ msgstr "Ekstern kopling: Tilgang nekta fordi:"
 msgid "External Connection: Handshake failed."
 msgstr "Ekstern kopling: Tilgang nekta"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Autooppfrisking starta"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -21,26 +21,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Syne aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule fjernkontroll"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Bilete:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -49,59 +49,59 @@ msgstr ""
 "Opphavsrett (c) 2003-2019 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: P2P brukarruting bygd på XOR metric.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Sjå etter ny utgåve ved oppstart"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Koplar til Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Du nyttar ei utdatert utgåve av aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -196,8 +196,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -213,108 +213,118 @@ msgstr "Greidde ikkje å opne %s·(%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ÅTVARING: Du kan ikkje leggje deg sjølv til som kjelde for ei eD2k lenkje medan du har ein lågid."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Ok,·avsluttar·%s...\n"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Mislukka"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Nedlasting fullført"
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Dine lokale innstilingar har vorte endra til opprinnelege systeminnstillingar på grunn av konfigurasjonsending. Beklager."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Stadfesting av avslutting"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ÅTVARING"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nettverk"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i tenar funne i server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Greidde ikkje å knyte portar til adressa: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port·%u er ikkje tilgjengeleg. Du vil få LågID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -329,48 +339,48 @@ msgstr ""
 "\n"
 "Sjekk nettverket ditt for å vere viss på at porten er open for inn- og utgåande trafikk."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Greidde ikkje å lage OnlineSigfil"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Greidde ikkje å lage aMule si OnlineSigfil."
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Dei valte lokale innstillingane ser ikkje ut til å vere installerte på maskina di. (Merk: Eg freistar å setje dei likevel)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dette er første gongen du køyrer aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Denne utgåva er ei testutgåve, oppdatert dagleg, og\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi gir ingen garanti for skade eller nedbrenning av huset ditt,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller drep hunden din. Men det *burde* vere trygt å nytte uansett.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meir informasjon, brukarstøtte og nye utgåver kan verte funne på heimesida vår.\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "på https://amule-org.github.io, eller på IRC-kanalen vår #aMule·på·irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -378,138 +388,138 @@ msgstr ""
 "Mappa spesifisert for nettsignaturar er UGANGBAR!\n"
 " Nettsignaturar vert DEAKTIVERT fram til du ordnar det i innstillingar."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Tenarnamn:"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Henting av diskplass for fila '%s' mislukka: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "FEIL: Greier ikkje å opne loggfila"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ÅTVARING: loggfila er tom. Noko er gale."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Loggen har vorte nullstilt"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Tenarmelding: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Klarte ikkje å laste ned nodelista."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Klarte ikkje å opne den nedlaste utgåvesjekkfila"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Korrupt utgåvesjekkfil"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Du nyttar ei utdatert utgåve av aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Di utgåve av aMule er %i.%i.%i og den siste utgåva er %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ÅTVARING: Utgåva di av aMule er utdatert: %i.%i.%i·<·%li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Utgåva di av aMule er oppdatert."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Klarte ikkje å laste ned utgåvesjekkfila"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Brukarar: %s | Filer: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Brukarar: E %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Ingen valde nettverk"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "med LågID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "med HøgID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Tilkopla %s·%s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Koplar til %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Fråkopla eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad starta."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad stogga."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Tilkopla Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Tilkopla Kad (brannmura)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Fråkopla Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad kan ikkje nyttast dersom UDP-porten er deaktivert i innstillingar. Startar ikkje."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-nettverket er deaktivert i innstillingar. Koplar ikkje til."
 
@@ -549,15 +559,15 @@ msgstr "Dette er aMule %s basert på eMule."
 msgid "Running on %s"
 msgstr "Køyrer på %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vitje https://github.com/amule-org/amule/releases/latest for å sjekke om ei ny utgåve er tilgjengeleg."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -567,224 +577,224 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Koplar til"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Koplar til"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Fråkopla"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Brannmura"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Tilkopla"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Koplar til"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Stopp inneverande oppkoplingsfreistingar"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Kople frå"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Kople frå dei aktive nettverka"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Kople til"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Kople til dei valde nettverka"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Opp:·%.1f(%.1f)·|·Ned:·%.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Opp:·%.1f·|·Ned:·%.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule·(%s·|·Tilkopla)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule·(%s·|·Fråkopla)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du verkeleg avslutte aMule?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Stadfesting av avslutting"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinnkatalogen '%s' finst ikkje"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Nettverk"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Nettverksavindauge"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Søk"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Søkjevindauge"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Nedlastingar"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Lastar ned"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Delte filer"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Vindauge for delte filer"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Meldingar"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Meldingsvindauge"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistikk"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Statistikkgrafvindauge"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Innstillingar"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Innstillingsvalsvindauge"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importér"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Verkty for delfilimport"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Om/hjelp"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "ed2k nettverk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad nettverk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Ikkje noko nettverk"
 
@@ -876,8 +886,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Ukjend"
@@ -1241,19 +1251,19 @@ msgstr "Auto·[Hø]"
 msgid "Very low"
 msgstr "Svært låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Vanleg"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1285,7 +1295,7 @@ msgid "On Queue"
 msgstr "I kø"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Lastar ned"
 
@@ -1345,7 +1355,7 @@ msgstr "Lokal tenar"
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1417,7 +1427,7 @@ msgstr ""
 msgid "Size"
 msgstr "Storleik"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1430,7 +1440,7 @@ msgid "Progress"
 msgstr "Framdrift"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Kjelder"
 
@@ -1440,7 +1450,7 @@ msgstr "Kjelder"
 msgid "Priority"
 msgstr "Prioritet"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Status"
 
@@ -1473,7 +1483,7 @@ msgstr ""
 "Tilbakemelding frå: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automatisk"
@@ -2129,7 +2139,7 @@ msgstr "Greidde ikkje å opne venelista 'enfriends.met' for skriving!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Vener"
 
@@ -2418,8 +2428,8 @@ msgstr "Ikkje gangbar port for eigenoppstart"
 msgid "Please fill all fields required"
 msgstr "Vér god å fylle ut alle naudsynte felt"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Melding"
 
@@ -2491,7 +2501,7 @@ msgstr "Delingsrate"
 msgid "Uploaded"
 msgstr "Lasta opp"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Etterspurt"
 
@@ -2525,30 +2535,30 @@ msgstr "Ukjend utgåve"
 msgid "Unable to get error description for error %d"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Hashar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Ferdigstiller"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Ferdig"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pausa"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Feilaktig"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Ventar"
 
@@ -2595,7 +2605,7 @@ msgstr "Ekstern kopling: Tilgang nekta fordi:"
 msgid "External Connection: Handshake failed."
 msgstr "Ekstern kopling: Tilgang nekta"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Autooppfrisking starta"
@@ -2617,7 +2627,7 @@ msgid "WARNING: "
 msgstr "ÅTVARING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Stengje"
 
@@ -2733,7 +2743,7 @@ msgstr "Avslutt"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2973,7 +2983,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3043,7 +3053,7 @@ msgstr "Ryddar bort ferdige nedlastingar"
 msgid "File sources:"
 msgstr "Komplette kjelder"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Generelt"
 
@@ -3064,7 +3074,7 @@ msgstr "Fullt namn :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "I/T"
 
@@ -3238,7 +3248,7 @@ msgstr "Brukarnamn :"
 msgid "Userhash :"
 msgstr "Brukarhash :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Legg til"
@@ -3247,15 +3257,15 @@ msgstr "Legg til"
 msgid "Download-Speed"
 msgstr "Nedlastingsfart"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Novérande"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Gjennomsnitt økt"
 
@@ -3267,7 +3277,7 @@ msgstr "Opplastingsfart"
 msgid "Connections"
 msgstr "Koplingar"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktive nedlastingar"
 
@@ -3275,7 +3285,7 @@ msgstr "Aktive nedlastingar"
 msgid "Active connections (1:1)"
 msgstr "Aktive koplingar (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktive opplastingar"
 
@@ -3477,8 +3487,8 @@ msgstr "Nettlesarval"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3552,754 +3562,762 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2k"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Automatisk tilkopling ved oppstart"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Kople til dersom fråkopla"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Ta bort daude tenarar etter"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "freistnader"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Automatisk oppdatering av tenarlista ved oppstart"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Oppdater tenarlista ved oppkopling til ein tenar"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Oppdater tenarlista når ein klient koplar til"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Bruk prioritetssystem"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Bruk smart LågID sjekk ved tilkopling"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Trygg tilkopling"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatisk tilkopling berre til tenarar i statisk liste"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Gje høg prioritet til manuelt tillagde tenarar"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Legg filer til nedlasting i pausemodus"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Legg filer til nedlasting med autoprioritet"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Prøv å laste ned første og siste del først"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Frå same kategori"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Hent diskplass for nye filer"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Hentar diskplass for heile nye filer, og reduserer fragmentering"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vel denne dersom du vil at aMule skal sjekke om du har nok diskplass"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Skriv inn mimimum ønska diskplass."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Lagre 10 kjelder til sjeldne filer (< 20 kjelder)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Opplastingar"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Legg til nye delte filer med autoprioritet"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Høgreklikk på mappeikonet for å dele underkatalogar)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Dele gøymde filer"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafar"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Oppdateringsforseinking: 5 sek"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gjennomsnittleg graf: 100 min"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Koplingsgrafskala: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Rutenett"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Last ned novérande"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Last ned køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Last ned øktgjennomsnitt"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Opplasting no"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Gjennomsnittleg køyrande opplasting"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Gjennomsnittleg økt opplasting"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktive koplingar"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Fartslinje i ikontrauet"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Kadnodar no"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Køyrande kadnodar"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kadnodar (økt)"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Velje"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Tal på klienutgåver synt (0=uinnskrenka)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! ÅTVARING !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Maks nye koplingar / 5 sek"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbufferstorleik: 240000·bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Storleik på opplastingskø: 5000 klientar"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktiver"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Syne utvida informasjon i kategorifaneblad"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktylinjeorientering"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Flat"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule sorterer kolonnene i nedlastingslista di automatisk"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parameter for ekstern kopling"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Akseptér eksterne koplingar"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Skriv in ei gyldig IP i a.b.c.d format for det lyttande EC-grensesnittet. Eit tomt felt eller 0.0.0.0 betyr samtlege grensesnitt."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivér UPnP-portvidaresending på EC-porten"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passord"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Vevmønster"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Passord for fulle rettar"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Aktivér brukar med få rettar"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Passord for låge rettar"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Sideoppfriskingstid (i sekund)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Aktivér Gzipkompresjon"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikk her for å utføre samtlege endringar gjorde i innstillingar."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Nullstill alle endringar i innstillingar."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Tittel :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Innkomande kat:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Endre prioritet for nytileigna filer :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "Ikkje endre"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vel farge for denne kategprien (no valt)"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Still attende"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Klikk denne knappen for å nullstille loggen."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere tenarlista frå nettadresse ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Tenarliste"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Skriv inn nettadressa til ei server.met fil her og klikk på knappen til venstre for å oppdatere tenarlista."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Legg til tenar manuelt: Namn"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Skriv inn namnet på den nye tenaren her"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Skriv inn IP`en til tenaren her, i x.x.x.x format."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Skriv inn porten til tenaren her."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Legg til ein tenar manuelt (fyll først ut felta til venstre) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMulelogg"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Tenarinfo"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2k-info"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere nodelista frå internettadresse ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nodar (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Skriv inn internettadressa til ei nodes-dat fil her og klikk på knappen til venstre for å oppdatere lista over kjende nodar."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Nodestatistikk"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Eigenoppstart"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Ny node"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Eigenoppstart frå \n"
 "kjende klientar"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Kople frå Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Sikker brukaridentifikasjon (SUI)"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det er tilrådd å aktivere denne funksjonen. Du vil ikkje få kredittar dersom SUI ikkje er aktivert."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Støtte protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Dette valet aktiverer protokolltåkeleggjing og gjer at aMule tek imot tåkelagde koplingar frå andre klientar."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Bruk tåkeleggjing for utgåande koplingar"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Dette valet får aMule til å nytte protokolltåkeleggjing ved tilkopling til andreklientar/tenarar."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Berre godta tåkelagde koplingar"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Dette valet får aMule til å berre godta tåkelagde koplingar. Du vil få færre kjelder, men all trafikken din vert tåkelagd"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Ingen"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vel kven som kan be om å sjå ei liste over dei delte filene dine."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtrér klientar"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér IP-filterring av klientar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtrér tenarar"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér filtrering av tenarar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Last om att lista av IP`ar å filtre frå fila ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "Nettadresse:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Oppdatér no"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Filternivå:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Alltid filtrér LAN IP`ar"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid handsaming av ujamne IP`ar"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Avviser pakkar dersom klientadressa er ulik adressa pakken vert motteken frå. Vér varsam med dette."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Bruk systemomspennande ipfilter.dat dersom tilgjengeleg"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Tillat bruk av ipfilter for heile systemet dersom inga lokal ipfilter-dat vert funnen"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Aktivér nettsignatur"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiverer skriving av OS-fila, som kan verte nytta av eksterne program forå lage signaturar og liknande."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Oppdateringsfrekvens (sekund):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Endre frekvensen (i sekund) for oppdatering av nettsignaturar."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikk her for å velje katalogen med nettsignaturfilene."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Datasnøggleik :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Kjelder"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4307,11 +4325,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4321,232 +4339,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Nedlasting: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrér innkomande meldingar (utanom novérande samtale):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtrér alle meldingar"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrér meldingar frå alle som ikkje er på kameratlista"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrér meldingar som inneheld (bruk ','som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "legg til ord aMule skal filtrére og blokkere"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Kommentarar"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrér kommentarar som inneheld (bruk ',' som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Aktivér godkjenning"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivér/deaktivér godkjenning av brukarnamn/passord"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Brukarnamn å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Passord:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Passord å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Aktivér vikar"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Aktivere/deaktivere vikarstøtte"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Vikartype:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Vikarvert:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Vikaren sitt vertsnamn"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Vikarport:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Vikarport"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Kople til:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Logge inn på fjern aMule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Brukarnamn"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Hugs desse innstillingane"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Nytt gzipkomprimering"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivér utførleg avfeilingslogg."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Opne fila"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Meldingskategoriar:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ventar..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Importér"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Prøv om att valde"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Fjern valde"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Gøyme delte filer"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Vel synsfilter"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive opplastingar"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Lastar inn att delte filer"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Sender meldinga."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Stengje denne lynmeldingsøkta."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Kople til vilkårleg tenar og/eller Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Delte filer"
 
@@ -4623,7 +4641,7 @@ msgstr "alle andre"
 msgid "Incomplete"
 msgstr "Uferdig"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Stogga"
 
@@ -4815,360 +4833,360 @@ msgstr "Lagra %i kjeldefrø for delfila: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Feil i lesing av delfila si kjeldefil (%s·-·%s):·%s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Fann korrupt del (%d) i %d delfil %s - Filresultathash |%s| Filhash | %s"
 msgstr[1] "Fann korrupt del (%d) i %d deler i fila %s - Filresultathash |%s| Filhash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Fann ferdig del (%i)·i·%s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Ferdig med omhashing av %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Uventa feil ved fullføring av %s. Sette fila på pause"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Ferdig med å laste ned: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Ferdig med å laste ned: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Slettar fila: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ÅTVARING: Greier ikkje å hashe nedlasta del - hashsett ikkje komplett for '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "FEIL: Greier ikkje å hashe nedlasta del - hashsett ikkje komplett (%s). Dette burde aldri skje"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ÅTVARING: Ikkje nok ledig diskplass! Set fila %s på pause"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Nedlasta del %i er korrupt i fila: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Attskapte korrupt del %i·for·%s·->·Lagra bytes:·%s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Hentar plass"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Ikkje nok diskplass"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Lasta ned"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "Feil: Greidde ikkje opne delfila '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Standardinnstillingar"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabisk"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskisk"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgarsk"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalansk"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Kinesisk (forenkla)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Kinesisk (tradisjonell)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Kroatisk"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Tsjekkisk"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Dansk"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Nederlansk"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finsk"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Fransk"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galisisk"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Tysk"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Gresk"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebraisk"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiensk"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiensk (sveitsisk)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japansk"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Koreansk"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norsk (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polsk"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugisisk"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisisk (Brasil)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Russisk"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovensk"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spansk"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Svensk"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "Språk"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port kan ikkje vere høgare enn 65532 fordi tenaren si UDPkopling er TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardport vert nytta (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Kopling"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Katalogar"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Tenarar"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Tryggleik"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Fjernkontrollar"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Nettsignatur"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Hendingar"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Melde om feil"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5184,26 +5202,26 @@ msgstr ""
 "aMule køyrer fint utan justering av nokon av\n"
 "desse innstillingane."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Typen vikar du koplar til"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5211,41 +5229,46 @@ msgstr ""
 "aMule·treng omstart for å gjere endringane moglege:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "-·TCP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "-·UDP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Ekstern kopling lukka."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolltåkeleggjing"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5253,20 +5276,20 @@ msgstr ""
 "Du har aktivert eksterne koplingar, men har ikkje skrive inn eit passord.\n"
 "Eksterne koplingar kan ikkje aktiverast utan eit gyldig passord."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Språk endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Mellombels mappe endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Alle nettverk er deaktiverte."
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5274,7 +5297,7 @@ msgstr ""
 "Både eD2k og kadnettverket er dekativert.\n"
 "Du vil ikkje klare å kople til før du aktiverer minst eitt av dei."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5282,7 +5305,7 @@ msgstr ""
 "Kad kan ikkje starte dersom UDP-porten er deaktivert.\n"
 "Aktivér UDP-porten eller deaktivér Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5292,20 +5315,20 @@ msgstr ""
 "Du MÅ starte om att aMule no.\n"
 "Ikkje klag dersom du ikkje gjer dette og du får problem.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Autooppfrisking starta"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5315,41 +5338,41 @@ msgstr ""
 "Vér god og fylle ut ein URL som peikar til ei gyldig server.met fil.\n"
 "Klikk på knappen \"Liste\" ved denne boksen for å skrive inn ein URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Mellombelse filer"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Innkomande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Nettsignaturar"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vel ei mappe for %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Bla etter videospelar"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Vél nettlesar"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Køyrbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Handsame tenarlista"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5357,150 +5380,150 @@ msgstr ""
 "Skriv inn URL`en for å laste ned server.met filer.\n"
 "Berre ein URL på kvar linje."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Komplette kjelder"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Oppdateringspause: %d sekund"
 msgstr[1] "Oppdateringspause: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gjennomsnittleg graf: %d minutt"
 msgstr[1] "Tid for gjennomsnittleg graf; %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Koplingsgrafskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbufferstorleik: %d byte"
 msgstr[1] "Filbufferstorleik: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Opplastingskøstorleik: %d klient"
 msgstr[1] "Opplastingskøstorleik: %d klientar"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 msgstr[1] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktivert"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "deaktivere"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Køyr kommando på `%s' hending"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Aktivér kommandokøyring i kjernen"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Kjernekommando:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Aktivér kommandokøyring på drakt"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Draktkommando:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Følgjande variablar vert erstatta:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Les mellombels mappe"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lastar inn att lista over delte filer."

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -23,20 +23,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Pokaż aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "zdalna kontrola aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Zrzut ekranu:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -44,7 +44,7 @@ msgstr ""
 "\"Ogólnie-Platformy\" klient P2P oparty na eMule\n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -53,59 +53,59 @@ msgstr ""
 "Copyright (c) 2003-2019 Zespół aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Część aMule oparta jest na \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: routing peer-to-peer oparty na metryce XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Strona internetowa:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Sprawdź podczas startu czy jest nowa wersja"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Łączę z Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Używasz przestarzałej wersji aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Niedostępny"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -202,8 +202,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -218,47 +218,57 @@ msgstr "Nie udało się otworzyć pliku ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UWAGA: Nie możesz dodać samego siebie jako źródło linku ed2k, gdy masz lowid."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Teraz, zakańczam główną aplikację..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Zakańczam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabiłam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Nieudane"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Zakończenie jądra."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Zamykanie aMule zakończone."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Wyniki debugu pamięci dla wyjścia aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Twoje ustawienia lokalne zostały zmienione na domyślne systemowe w związku ze zmianą konfiguracji. Przepraszamy."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informacje"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -266,56 +276,56 @@ msgstr ""
 "\n"
 "Konfiguracja EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "UWAGA"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sieci"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i serwer znaleziono w server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nie można było powiązać portów z określonym adresem: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u jest niedostępny. Będziesz mieć LowID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -330,48 +340,48 @@ msgstr ""
 "\n"
 "Sprawdź swoją sieć aby mieć pewność, że port jest otwarty dla wejścia i wyjścia."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Wybrane lokale wydają się być niezainstalowane. (Uwaga: I tak spróbuję je ustawić)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Po raz pierwszy uruchomiłeś aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ta wersja jest aktualizowaną codziennie wersją testową i\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nie dajemy żadnej gwarancji, że nie zniszczy ona niczego, nie spali twojego domu\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "lub zabije twojego psa. *Powinna* ona jednak mimo wszystko działać poprawnie.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Więcej informacji, pomoc i nowe wydania znajdziesz na naszej stronie \n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io lub na naszym kanale IRC: #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nie wahaj się zgłaszać jakichkolwiek błędów na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -379,137 +389,137 @@ msgstr ""
 "Katalog wybrany na pliki sygnatury online jest nieprawidłowy!\n"
 " Sygnatura online zostanie wyłączona dopóki nie poprawisz tego w preferencjach."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Zawiadomiono nazwę hostu serwera"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Wstępna alokacja dysku dla pliku '%s' nie powiodła się: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "BŁĄD: nie mogę otworzyć pliku logów"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UWAGA: plik logów jest pusty. Coś jest nie tak."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Logi zostały zresetowane"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Wiadomość z serwera: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pominięto pobranie %s, ponieważ żądany plik nie jest nowszy."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Pobieranie listy węzłów nie powiodło się."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Nie można otworzyć pobranego pliku kontroli wersji"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Uszkodzony plik kontorli wersji"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Używasz przestarzałej wersji aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Twoje wersja eMule to %i.%i.%i, najnowszą wersją jest %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UWAGA: Twoja wersja aMule jest przestarzała: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Twoja kopia aMule jest przestarzała."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Nie udało się pobrać pliku kontroli wersji"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Użytkowników: %s | Plików: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Użytkowników: E: %s K: %s | Plików: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nie wybrano sieci"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "z LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "z HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Połączony z %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Łączenie z %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Rozłączono z eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Włączono Kad."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Zatrzymano Kad."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Połączono z Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Połączono z Kad (za firewallem)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Rozłączono z Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nie można użyć sieci Kad, jeśli port UDP jest wyłączony w preferencjach, nie włączam."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Zablokowano sieć Kad w preferencjach, nie łączę."
 
@@ -549,15 +559,15 @@ msgstr "To jest aMule %s oparty na eMule."
 msgid "Running on %s"
 msgstr "Uruchomiony na %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Odwiedź https://github.com/amule-org/amule/releases/latest aby sprawdzić czy jest dostępna nowa wersja."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRYTYCZNY BŁĄD: Nie udało się utworzyć Timera"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -567,223 +577,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Niedostępny"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "dialog aMule zniszczony"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Łączenie"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Łączenie"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Rozłączony"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Połączony"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Łączenie"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Wyłączony"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Zatrzymaj aktualne próby połączenia"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Rozłącz"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Rozłącz z aktualnie połączonymi sieciami"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Podłącz"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Połącz z aktualnie włączonymi sieciami"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Wysł: %.1f(%.1f) | Pobr: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Wysł: %.1f | Pobr: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Połączony)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Rozłączony)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Czy na pewno chcesz opuścić %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Potwierdzenie wyjścia"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Uruchomienie polecenia: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- domyślnie -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Katalog skórek '%s' nie istnieje"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OSTRZEŻENIE: Nie udało się otworzyć pliku skórki '%s' do odczytu"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Sieci"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Okno sieci"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Szukaj"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Okno wyszukiwania"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Pobieranie"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Okno pobierań"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Udostępnione pliki"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Okno udostępnionych plików"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Wiadomości"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Okno wiadomości"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statystyki"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Okno wykresów statystyk"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencje"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Okno preferencji"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Narzędzie importowania plików części"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informacje o"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Informacje/Pomoc"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Sieć eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Sieć Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Brak sieci"
 
@@ -871,8 +881,8 @@ msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nad
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Nieznany"
@@ -1240,19 +1250,19 @@ msgstr "Auto [Wy]"
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Niski"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1284,7 +1294,7 @@ msgid "On Queue"
 msgstr "W kolejce"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Pobieranie"
 
@@ -1344,7 +1354,7 @@ msgstr "Serwer lokalny"
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1416,7 +1426,7 @@ msgstr "Część"
 msgid "Size"
 msgstr "Rozmiar"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Przesłano"
 
@@ -1429,7 +1439,7 @@ msgid "Progress"
 msgstr "Postęp"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Źródła"
 
@@ -1439,7 +1449,7 @@ msgstr "Źródła"
 msgid "Priority"
 msgstr "Priorytet"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Status"
 
@@ -1472,7 +1482,7 @@ msgstr ""
 "Informacja zwrotna od:  %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automatyczny"
@@ -2127,7 +2137,7 @@ msgstr "Nie udało się otworzyć pliku listy przyjaciół 'emfriends.met' do za
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRYTYCZNE - brak klienta przy StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Znajomi"
 
@@ -2414,8 +2424,8 @@ msgstr "Nieprawidłowy port do rozruchu"
 msgid "Please fill all fields required"
 msgstr "Proszę wypełnij wszystkie wymagane pola"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Wiadomość"
 
@@ -2490,7 +2500,7 @@ msgstr "Ratio wymiany"
 msgid "Uploaded"
 msgstr "Wysłano"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Zażądano"
 
@@ -2524,30 +2534,30 @@ msgstr "Nieznana wersja"
 msgid "Unable to get error description for error %d"
 msgstr "Nie można utworzyć docelowego pliku %s do pobrania!"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Tworzenie skrótu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Zakańczanie"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Ukończono"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Wstrzymano"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Błędne"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Czeka"
 
@@ -2592,7 +2602,7 @@ msgstr "External Connection: Brak dostępu z powodu: "
 msgid "External Connection: Handshake failed."
 msgstr "External Connection: Brak nawiązania"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rozpoczęte pobranie wątku HTTP"
@@ -2614,7 +2624,7 @@ msgid "WARNING: "
 msgstr "OSTRZEŻENIE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Zamknij"
 
@@ -2730,7 +2740,7 @@ msgstr "Wyjdź"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2970,7 +2980,7 @@ msgstr "Bajtów"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3039,7 +3049,7 @@ msgstr "Wyczyść skończone pobierania"
 msgid "File sources:"
 msgstr "Źródła pliku:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Ogólne"
 
@@ -3060,7 +3070,7 @@ msgstr "Pełna nazwa :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "Brak"
 
@@ -3236,7 +3246,7 @@ msgstr "Nazwa użytkownika :"
 msgid "Userhash :"
 msgstr "Skrót użytkownika :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3245,15 +3255,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Prędkość pobierania"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Aktualna"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Bieżąca średnia"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Średnia sesji"
 
@@ -3265,7 +3275,7 @@ msgstr "Prędkość wysyłania"
 msgid "Connections"
 msgstr "Połączenie"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktywne pobierania"
 
@@ -3273,7 +3283,7 @@ msgstr "Aktywne pobierania"
 msgid "Active connections (1:1)"
 msgstr "Aktywnych połączeń (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktywne wysyłania"
 
@@ -3474,8 +3484,8 @@ msgstr "Wybór przeglądarki"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Podaj tutaj nazwę swojej przeglądarki. Pozostaw to pole puste, aby korzystać z domyślnej przeglądarki systemu."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3549,752 +3559,761 @@ msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Tylko zaawansowani użytkownicy: Jeśli masz kilka interfejsów sieciowych, wpisz adres interfejsu do którego powiązany powinien być aMule."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Maks. ilość źródeł dla pobieranego pliku:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Maksymalne połączenia jednoczesne:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Automatycznie połącz przy uruchomieniu"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Połącz ponownie po rozłączeniu"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Usuń martwe serwery po"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "próbach"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Autoaktualizacja listy serwerów przy starcie"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Uaktualnij listę serwerów przy połączeniu do serwera"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Uaktualnij listę serwerów przy połączeniu klienta"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Używaj systemu priorytetów"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Używaj inteligentnego sprawdzania LowID przy połączeniu"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Bezpieczne połączenie"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatyczne łączenie tylko do serwerów statycznych"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Ustaw priorytet ręcznie dodanych serwerów na Wysoki"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentna obsługa uszkodzeń (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Włączone"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Zaawansowane I.C.H. ufa każdemu skrótu (nie zalecane)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Dodaj pliki do pobrania w trybie wstrzymania"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Dodaj pliki do pobrania z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Próbuj najpierw pobrać pierwszy i ostatni kawałek"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Zacznij następny wstrzymany plik, gdy plik gotowy"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Z tej samej kategorii"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Alokuj wstępnie przestrzeń dyskową dla nowych plików"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Dla nowych plików alokuje wstępnie przestrzeń dyskową dla całego pliku redukując w ten sposób fragmentację"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Zatrzymaj pobieranie gdy zabraknie wolnego miejsca na dysku"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Zaznacz jeśli chcesz, aby aMule sprawdzał Twoją przestrzeń dyskową"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Wpisz tu minimalną ilość miejsca na dysku."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Zapisz 10 źródeł dla rzadkich plików (< 20 źródeł)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Wysyłanie"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj udostępnione pliki z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Folder docelowy dla pobrań"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Folder dla pobranych plików tymczasowych"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Kliknij prawym przyciskiem na katalog, aby udostępnić go razem z podkatalogami)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Udostępnij pliki ukryte"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Wykresy"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Odśwież co : 5 sekund"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Czas dla wykresów średnich: 100 minut"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Skala wykresu połączeń: 100"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Skala wykresu pobierania:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Skala wykresu przesyłania:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Kolory: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Tło"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Siatka"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Aktualnie pobierane"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Bieżąca średnia pobierania"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Średnia pobierania sesji"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Aktualnie wysyłane"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Bieżąca średnia wysyłania"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Średnia wysyłania sesji"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktywnych połączeń"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona prędkości w zasobniku systemowym"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Obecne Kad-węzły "
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Działające Kad-węzły"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Sesyjne Kad-węzły"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Wybierz"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Drzewo"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Liczba wyświetlanych wersji klienta (0=nieograniczona)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! UWAGA !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Maks. nowych połączeń"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Rozmiar bufora plików: 240000 bajtów"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Rozmiar kolejki wysyłania: 5000 klientów"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Skóra do użycia:"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Pokazuj \"Szybkie wyłapywanie linków eD2K\" w każdym oknie."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Pokaż rozszerzone info w kartach kategorii"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Przed nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Za nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Pokaż narzut przepustowości"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Pionowa orientacja paska narzędzi"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Pobierane pliki w kolejce"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Pokaż procent postępu"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Pokaż pasek postępu"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Płaski"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Okrągły"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Auto-sortowanie plików (wysokie obciążenie procesora)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule będzie sortował kolumny w liście pobierania automatycznie"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parametry zewnętrznych połączeń"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Akceptuj zewnętrzne połączenia"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP z interfejsem słuchania:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Wprowadź tutaj w formacie a.b.c.d prawidłowy adres ip nasłuchującego interfejsu EC. Puste pole lub 0.0.0.0 oznacza dowolny interfejs."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Włącz forwarding portu UPnP na porcie EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Hasło"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Uruchom serwera internetowego przy starcie"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Szablon WWW"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Hasło pełnych uprawnień"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Włącz użytkowników z niskimi uprawnieniami"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Hasło niskich uprawnień"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Włącz przekierowanie portu UPnP na port serwera internetowego"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port web serwera UPnP TCP (opcjonalnie)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Odświeżanie strony co:  (w sekundach)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Włącz kompresję Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknij tu aby zastosować wszystkie zmiany dokonane w preferencjach."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Reset wszystkich zmian dokonanych w preferencjach."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Tytuł :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Komentarz :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Katalog przychodzących :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Zmień priorytet nowo przydzielonych plików :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "Nie zmieniaj"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Wybierz kolor dla tej kategorii (aktualnie wybrany) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Resetuj"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Kliknij tu aby wyczyścić logi."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknij na tym przycisku aby uaktualnić listę serwerów z URL-a ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Lista serwerów"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Wpisz tu url do pliku server.met  i przyciśnij przycisk po lewej aby zaktualizować listę znanych serwerów."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Dodaj serwer ręcznie: Nazwa"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Wpisz tu nazwę nowego serwera"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Wpisz tu IP serwera, używając formatu x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Wpisz tu port serwera."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj ręcznie serwer (wypełnij pola od lewej) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Logi aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Serwer Info"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Info eD2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknij ten przycisk, aby uaktualnić listę węzłów z adresu URL ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Węzły (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Wprowadź tutaj url pliku nodes.dat i naciśnij przycisk z lewej, aby zaktualizować listę znanych węzłów."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Statystyki węzłów"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nowy węzeł"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Rozruch od znanych klientów"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Rozłącz z Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Użyj bezpiecznej identyfikacji użytkownika"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Zalecane jest włączenie tej opcji. Nic nie zyskasz wyłączając bezpieczną identyfikację użytkownika."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Maskowanie protokołu"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Obsługa maskowania protokołu"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Opcja ta włącza maskowanie protokołu i powoduje, że aMule będzie akceptował zamaskowane połączenia od innych klientów."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Użyj maskowania dla połączeń wychodzących"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Opcja ta powoduje, że aMule będzie używał maskowania protokołu podczas łączenia z innymi klientami/serwerami."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Akceptuj tylko zamaskowane połączenia"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Opcja ta powoduje, że aMule akceptuje tylko zamaskowane połączenia. Uzyskasz mniej źródeł, ale cały twój ruch będzie zamaskowany"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Wszyscy"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Nikt"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Kto może widzieć moje udostępnione pliki:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wybierz kto może zażądać pokazania listy twoich udostępnionych plików."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtrowanie IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtruj klientów"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP klientów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtruj serwery"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP serwerów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Przeładuj listę"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Przeładuj listę filtrowanych IP z pliku ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Uaktualnij teraz"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Poziom filtrowania:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Zawsze filtruj IP z LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidalna obsługa niepasujących IP"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Odrzuca pakiety, gdy ip klienta jest różne od ip, z którego pakiet jest otrzymywany. Używaj z ostrożnością."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Użyj ogólno-systemowego ipfilter.dat jeśli dostępny"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jeśli ipfilter.dat nie istnieje lokalnie, zezwól na użycie ogólno-systemowego pliku ipfilter."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Włącz podpis online"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Włącza zapisywanie pliku OS, który może być użyty przez zewnętrzne aplikacje do stworzenia sygnatury itp."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Częstotliwość odświeżania (sek):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Zmień częstotliwość (w sekundach) aktualizacji Sygnatury Online."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Zapisz podpis internetowy w pliku: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknij tu aby wskazać katalog zawierający pliki Sygnatur Online."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Prędkość transmisji danych :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Źródła"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4302,11 +4321,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4316,231 +4335,231 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Pobranych: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruj wiadomości przychodzące (za wyjątkiem aktualnej rozmowy):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtruj wszystkie wiadomości"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruj wiadomości od ludzi, którzy nie są na twojej liście znajomych"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtruj wiadomości od nieznanych klientów"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruj wiadomości zawierające (jako separatora użyj ','):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "dodaj frazy które według których amule powinien filtrować i blokować wiadomości"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Pokaż otrzymane wiadomości w dzienniku"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Komentarze"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruj komentarze zawierające (użyj ',' jako separatora):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Włącz uwierzytelnianie"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Włącza/Wyłącza uwierzytelnianie login/hasło"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Nazwa uzytkownika: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Login używany do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Hasło:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Hasło używane do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Włącz proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Włącza/Wyłącza obsługę proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Adres proxy:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Nazwa hosta proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Port serwera proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Połącz z:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Login do zdalnego amule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nazwa użytkownika"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Zapamiętaj te ustawienia"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Używaj kompresji gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Włącz gadatliwe logowanie debugowe."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otwórz plik"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Kategorie wiadomości:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Czekam..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Dodaj importy"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Przywróć wybrane"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Usuń wybrane"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Typy zdarzeń"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statystyki i klienty w kolejce dla wybranego plik(u-ów) : Sesja / Cały czas"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 #, fuzzy
 msgid "Percent of total files"
 msgstr "procent wszystkich plików"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Wszystkie udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Wybierz filtr przeglądania"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Przeładuj:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Wyślij"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Wysyła wybraną wiadomość."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Zamknij tę sesję czata."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Podłącz do dowolnego serwera i/lub Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Udostępnione pliki"
 
@@ -4619,7 +4638,7 @@ msgstr "wszystkie inne"
 msgid "Incomplete"
 msgstr "Niekompletne"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Zatrzymany"
 
@@ -4811,7 +4830,7 @@ msgstr "Zapisano %i zarodek źródeł dla pliku części: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Błąd podczas odczytu pliku źródeł plików części  (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -4819,335 +4838,335 @@ msgstr[0] "Znaleziono uszkodzoną część (%d) w %d pliku części %s - FileRes
 msgstr[1] "Znaleziono uszkodzoną część (%d) w %d plikach części %s - FileResultHash |%s| FileHash |%s|"
 msgstr[2] "Znaleziono uszkodzoną część (%d) w %d plikach części %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Znaleziono kompletnych części (%i) w %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Skończono ponowne tworzenie skrótu %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Nieoczekiwany błąd podczas zakańczania %s. Plik wstrzymany"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Skończono pobieranie: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Skończono pobieranie: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Usuwanie pliku: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "OSTRZEŻENIE: Nie można utworzyć skrótu pobranej części - zestaw skrótów jest niekompletny dla '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "BŁĄD: Nie można utworzyć skrótu pobranej części - zestaw skrótów niekompletny (%s). Nie powinno do tego dojść"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "UWAGA: Niewystarczająca ilość wolnego miejsca! Wstrzymywanie pliku: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Pobrana część %i jest uszkodzona w pliku: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Odzyskano uszkodzoną część %i dla %s -> Zapisanych bajtów: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Alokuję"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Niewystarczająca ilość przestrzeni dyskowej"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Pobrano"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "BŁĄD: Nie udało się otworzyć pliku części '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Domyślny systemowy"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albański"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabski"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturyjski"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bułgarski"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Kataloński"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chiński (Uproszczony)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chiński (Tradycyjny)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Chorwacki"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Czeski"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Duński"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holenderski"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estoński"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Fiński"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galicyjski"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Niemiecki"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grecki"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebrajski"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Włoski"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Włoski (Szwajcarski)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japoński"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Koreański"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litewski"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norweski (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polski"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazylijski)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Rumuński"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Rosyjski"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Słoweński"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Hiszpański"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Szwedzki"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turecki"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukraiński"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Zmień język"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Niedostępny"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "nie ma dostępnych opcji"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Znaleziono nieprawidłową kategorie, pomijam"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Port TCP nie może być większy niż 65532, gdyż gniazdo UDP serwera będzie TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Zostanie użyty domyślny port (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Połączenie"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Katalogi"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Serwery"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Pliki"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Bezpieczeństwo"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interfejs"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Zdalna kontrola"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Sygnatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Zawansowane"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Zdarzenia"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Debugowanie"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5157,15 +5176,15 @@ msgstr ""
 "    %PARTFILE - pełna ścieżka do pliku\n"
 "    %PARTNAME - tylko nazwa pliku"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5179,26 +5198,26 @@ msgstr ""
 "\n"
 "aMule będzie działał prawidłowo bez zmiany tych ustawień."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Błąd połączenia Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Typ serwera proxy do którego się łączysz"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z widżetu do Cfg z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5206,35 +5225,40 @@ msgstr ""
 "aMule musi zostać zrestartowany przed wprowadzeniem tych zmian:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- Zmieniono port TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- Zmieniono port UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Zewnętrzne połączenie zamknięte."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nowe zewnętrzne połączenie zaakceptowane"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Maskowanie protokołu"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5242,7 +5266,7 @@ msgstr ""
 "Twoja lista auto-aktualizacji serwerów jest pusta.\n"
 "'Autoaktualizacja listy serwerów przy starcie' zostanie wyłączona."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5250,19 +5274,19 @@ msgstr ""
 "Połączenia zewnętrzne zostały włączone, ale nie zostało podane hasło.\n"
 "Połączenia zewnętrzne nie mogą być włączone dopóki nie zostanie podane poprawne hasło."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Zmieniono język.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Zmieniono folder tymczasowy.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- sieć ED2K włączona.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5270,7 +5294,7 @@ msgstr ""
 "Zarówno sieć eD2K jak i Kad zostały wyłączone.\n"
 "Nie będzie możliwe połączenie, dopóki nie włączysz przynajmniej jednej z nich."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5278,7 +5302,7 @@ msgstr ""
 "Kad nie uruchomi się, jeśli twój port UDP jest wyłączony.\n"
 "Włącz port UDP lub wyłącz Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5288,20 +5312,20 @@ msgstr ""
 "Musisz zrestartować teraz aMule.\n"
 "Jeśli nie zrestartujesz go teraz, nie narzekaj, jeśli stanie się coś złego.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "automatyczne odświeżanie rozpoczęte"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5311,41 +5335,41 @@ msgstr ""
 "Proszę wpisać co najmniej jeden URL wskazujący poprawny plik server.met.\n"
 " Kliknij na przycisku \"Lista\", aby wpisać URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Pliki tymczasowe"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Pliki przychodzące"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Sygnatury Online"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wybierz folder na %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Szukaj odtwarzacza filmów"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Wybierz przeglądarkę"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Program%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Edytuj listę serwerów"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5353,42 +5377,42 @@ msgstr ""
 "Dodaj jeden URL w każdej linii.\n"
 "Tylko jeden URL w każdej linii."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Pełne źródła"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -5396,7 +5420,7 @@ msgstr[0] "Opóźnienie odświeżania: %d sekunda"
 msgstr[1] "Opóźnienie odświeżania: %d sekundy"
 msgstr[2] "Opóźnienie odświeżania: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -5404,12 +5428,12 @@ msgstr[0] "Czas dla przeciętnego wykresu: %d minuta"
 msgstr[1] "Czas dla przeciętnego wykresu: %d minuty"
 msgstr[2] "Czas dla przeciętnego wykresu: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Skala wykresu połączeń: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5417,7 +5441,7 @@ msgstr[0] "Rozmiar bufora pliku: %d bajt"
 msgstr[1] "Rozmiar bufora pliku: %d bajty"
 msgstr[2] "Rozmiar bufora pliku: %d bajtów"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -5425,7 +5449,7 @@ msgstr[0] "Rozmiar kolejki wysyłania: %d klient"
 msgstr[1] "Rozmiar kolejki wysyłania: %d klientów"
 msgstr[2] "Rozmiar kolejki wysyłania: %d klientów"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -5433,74 +5457,74 @@ msgstr[0] "Odświeżanie połączeń do serwera co: %d minutę"
 msgstr[1] "Odświeżanie połączeń do serwera co: %d minuty"
 msgstr[2] "Odświeżanie połączeń do serwera co: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Wykonaj komendę przy wydarzeniu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Włącz wykonanie komendy w rdzeniu"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Komenda rdzenia:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Włącz wykonanie komendy w GUI"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Komenda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Następujące zmienne zostaną zastąpione:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Przeładowuje listę udostępnionych plików."

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -202,8 +202,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -248,27 +248,37 @@ msgstr "Zamykanie aMule zakończone."
 msgid "Memory debug results for aMule exit:"
 msgstr "Wyniki debugu pamięci dla wyjścia aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Twoje ustawienia lokalne zostały zmienione na domyślne systemowe w związku ze zmianą konfiguracji. Przepraszamy."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informacje"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -276,56 +286,56 @@ msgstr ""
 "\n"
 "Konfiguracja EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "UWAGA"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sieci"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i serwer znaleziono w server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nie można było powiązać portów z określonym adresem: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u jest niedostępny. Będziesz mieć LowID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -340,48 +350,48 @@ msgstr ""
 "\n"
 "Sprawdź swoją sieć aby mieć pewność, że port jest otwarty dla wejścia i wyjścia."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Wybrane lokale wydają się być niezainstalowane. (Uwaga: I tak spróbuję je ustawić)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Po raz pierwszy uruchomiłeś aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ta wersja jest aktualizowaną codziennie wersją testową i\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nie dajemy żadnej gwarancji, że nie zniszczy ona niczego, nie spali twojego domu\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "lub zabije twojego psa. *Powinna* ona jednak mimo wszystko działać poprawnie.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Więcej informacji, pomoc i nowe wydania znajdziesz na naszej stronie \n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io lub na naszym kanale IRC: #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nie wahaj się zgłaszać jakichkolwiek błędów na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -389,137 +399,137 @@ msgstr ""
 "Katalog wybrany na pliki sygnatury online jest nieprawidłowy!\n"
 " Sygnatura online zostanie wyłączona dopóki nie poprawisz tego w preferencjach."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Zawiadomiono nazwę hostu serwera"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Wstępna alokacja dysku dla pliku '%s' nie powiodła się: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "BŁĄD: nie mogę otworzyć pliku logów"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UWAGA: plik logów jest pusty. Coś jest nie tak."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Logi zostały zresetowane"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Wiadomość z serwera: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pominięto pobranie %s, ponieważ żądany plik nie jest nowszy."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Pobieranie listy węzłów nie powiodło się."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Nie można otworzyć pobranego pliku kontroli wersji"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Uszkodzony plik kontorli wersji"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Używasz przestarzałej wersji aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Twoje wersja eMule to %i.%i.%i, najnowszą wersją jest %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UWAGA: Twoja wersja aMule jest przestarzała: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Twoja kopia aMule jest przestarzała."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Nie udało się pobrać pliku kontroli wersji"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Użytkowników: %s | Plików: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Użytkowników: E: %s K: %s | Plików: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nie wybrano sieci"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "z LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "z HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Połączony z %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Łączenie z %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Rozłączono z eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Włączono Kad."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Zatrzymano Kad."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Połączono z Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Połączono z Kad (za firewallem)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Rozłączono z Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nie można użyć sieci Kad, jeśli port UDP jest wyłączony w preferencjach, nie włączam."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Zablokowano sieć Kad w preferencjach, nie łączę."
 
@@ -2602,7 +2612,7 @@ msgstr "External Connection: Brak dostępu z powodu: "
 msgid "External Connection: Handshake failed."
 msgstr "External Connection: Brak nawiązania"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rozpoczęte pobranie wątku HTTP"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -202,8 +202,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -248,37 +248,42 @@ msgstr "Zamykanie aMule zakończone."
 msgid "Memory debug results for aMule exit:"
 msgstr "Wyniki debugu pamięci dla wyjścia aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Twoje ustawienia lokalne zostały zmienione na domyślne systemowe w związku ze zmianą konfiguracji. Przepraszamy."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informacje"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -286,56 +291,56 @@ msgstr ""
 "\n"
 "Konfiguracja EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "UWAGA"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sieci"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i serwer znaleziono w server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nie można było powiązać portów z określonym adresem: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u jest niedostępny. Będziesz mieć LowID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -350,48 +355,48 @@ msgstr ""
 "\n"
 "Sprawdź swoją sieć aby mieć pewność, że port jest otwarty dla wejścia i wyjścia."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Wybrane lokale wydają się być niezainstalowane. (Uwaga: I tak spróbuję je ustawić)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Po raz pierwszy uruchomiłeś aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ta wersja jest aktualizowaną codziennie wersją testową i\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nie dajemy żadnej gwarancji, że nie zniszczy ona niczego, nie spali twojego domu\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "lub zabije twojego psa. *Powinna* ona jednak mimo wszystko działać poprawnie.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Więcej informacji, pomoc i nowe wydania znajdziesz na naszej stronie \n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io lub na naszym kanale IRC: #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nie wahaj się zgłaszać jakichkolwiek błędów na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -399,137 +404,137 @@ msgstr ""
 "Katalog wybrany na pliki sygnatury online jest nieprawidłowy!\n"
 " Sygnatura online zostanie wyłączona dopóki nie poprawisz tego w preferencjach."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Zawiadomiono nazwę hostu serwera"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Wstępna alokacja dysku dla pliku '%s' nie powiodła się: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "BŁĄD: nie mogę otworzyć pliku logów"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UWAGA: plik logów jest pusty. Coś jest nie tak."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Logi zostały zresetowane"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Wiadomość z serwera: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pominięto pobranie %s, ponieważ żądany plik nie jest nowszy."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Pobieranie listy węzłów nie powiodło się."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Nie można otworzyć pobranego pliku kontroli wersji"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Uszkodzony plik kontorli wersji"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Używasz przestarzałej wersji aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Twoje wersja eMule to %i.%i.%i, najnowszą wersją jest %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UWAGA: Twoja wersja aMule jest przestarzała: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Twoja kopia aMule jest przestarzała."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Nie udało się pobrać pliku kontroli wersji"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Użytkowników: %s | Plików: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Użytkowników: E: %s K: %s | Plików: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nie wybrano sieci"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "z LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "z HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Połączony z %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Łączenie z %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Rozłączono z eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Włączono Kad."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Zatrzymano Kad."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Połączono z Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Połączono z Kad (za firewallem)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Rozłączono z Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nie można użyć sieci Kad, jeśli port UDP jest wyłączony w preferencjach, nie włączam."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Zablokowano sieć Kad w preferencjach, nie łączę."
 
@@ -890,7 +895,7 @@ msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nad
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2262,49 +2267,49 @@ msgstr "Nie"
 msgid "Yes"
 msgstr "Tak"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Pobieranie..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Pobranie HTTP anulowane"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "Adres URL do pobrania nie może być pusty"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Nieudane pobieranie udostępnionych plików od użytkownika '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Folder dla pobranych plików tymczasowych"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Pobrano %d bajtów"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "Adres URL %s zwrócił: %i - Błąd (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Pobranie HTTP anulowane"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2612,7 +2617,7 @@ msgstr "External Connection: Brak dostępu z powodu: "
 msgid "External Connection: Handshake failed."
 msgstr "External Connection: Brak nawiązania"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rozpoczęte pobranie wątku HTTP"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -27,20 +27,20 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Controle Remoto do aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -48,7 +48,7 @@ msgstr ""
 "Cliente p2p 'multi-plataforma' baseado no eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -56,59 +56,59 @@ msgstr ""
 "Direitos Reservados (c) 2003-2026 Equipe do aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Parte do aMule é baseado no \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: roteamento peer-to-peer baseado em métrica XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Direitos autorais reservados (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Página:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Fórum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr "Documentação:"
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr "Problemas:"
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Procurar por nova versão ao iniciar"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Conectando a rede Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Você está utilizando uma versão anterior do aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Não disponível"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -210,8 +210,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Não foi possível adicionar link %u do arquivo ED2KLinks (veja o log para detalhes)."
 msgstr[1] "Não foi possível adicionar %u links do arquivo ED2KLinks (veja o log para detalhes)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -226,47 +226,57 @@ msgstr "Falha ao abrir arquivo de Ligações ED2K."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "CUIDADO: Você não pode adicionar você mesmo como uma fonte para uma ligação eD2k quando tem um lowid."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Agora, deixando a aplicação principal..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Terminando a instância do amuleweb com o pid '%d'... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando a instância do amuleweb com o pid '%d'... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Falha"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Finalizando o núcleo."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Encerramento do aMule completo."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração da memória para a saída do aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Seu locale foi alterado para o padrão do Sistema devido a mudança na configuração. Desculpe."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -274,20 +284,20 @@ msgstr ""
 "\n"
 "Configuração EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Senha definida e conexões externas habilitadas."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "CUIDADO"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "Inicialização da Rede"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -295,34 +305,34 @@ msgstr ""
 "O aMule detectou que faltam arquivos de inicialização da rede.\n"
 "Selecione quais baixar:"
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nós de inicialização de Kad"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server rodando no pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível conectar às portas desse endereço: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u não disponível. Você ficará com LOWID (id baixa)\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -337,49 +347,49 @@ msgstr ""
 "\n"
 "Verifique sua rede para ver se essa porta está aberta para entrada e saída."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig do aMule"
 
 # src/amuled.cpp:1246:
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Parece que o idioma selecionado não está instalado no seu computador. (Nota: eu irei defini-lo mesmo assim)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Essa é a primeira vez que você executa o aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Essa é uma versão de testes, atualizada diariamente, e\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não daremos garantia se ela quebrar algo, queimar sua casa,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar seu cachorro. Mas ela *deve* ser segura para uso mesmo assim.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Maiores informações, suporte e novas versões podem ser encontradas em nossa\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "homepage https://amule-org.github.io ou em nosso canal de irc #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja a vontade para notificar qualquer bug em https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -387,137 +397,137 @@ msgstr ""
 "A pasta especificada para os arquivos da Online Signature é INVÁLIDA!\n"
 "OnlineSignature ficará DESATIVADA até você atualizar as preferências."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Nome do servidor notificado"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Pré-alocação de espaço em disco para arquivo '%s' falhou: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não foi possível abrir arquivo de log"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o arquivo de log está vazio. Algo está errado."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Arquivo de log resetado"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "MensagemDoServidor: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pulando o download de %s, pois o arquivo requerido não é o mais novo."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Falha ao obter a lista de nodes."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir arquivo de versão baixado"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Arquivo de versão corrompido"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Você está utilizando uma versão anterior do aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A mais recente versão pode ser obtida em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "CUIDADO: Sua versão do aMuled esta ultrapassada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Sua cópia do aMule está em dia."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Falha ao baixar arquivo de controle de versão"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuários:%s | Arquivos: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuários: E: %s K: %s | Arquivos: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nenhuma rede selecionada"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "com HighID (Id alta)"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad parado."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a rede Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a rede Kad (sob firewall)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Desconectado da rede Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se a porta UDP está desabilitada em preferências, não iniciará."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desabilitada em preferências, não iniciará."
 
@@ -556,15 +566,15 @@ msgstr "Esse é o aMule %s, baseado no eMule."
 msgid "Running on %s"
 msgstr "Executando em %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para ver se há nova versão disponível."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Timer"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -574,222 +584,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A mais recente versão pode ser obtida em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Não disponível"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "destruído caixa de diálogo do aMule"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectado"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de Firewall"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Cancelar as tentativas atuais de conexão"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes atualmente conectadas"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar às redes ativas"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Você realmente quer sair %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Lançar Comando: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- padrão -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "O diretório '%s' de skins não existe"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "CUIDADO: Incapaz de abrir o arquivo de pele '%s' para leitura"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Janela de redes"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Arquivos compartilhados"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Janela de compartilhados"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Ferramenta de importação de arquivos .part"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Sobre/Ajuda"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "rede Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Sem redes"
 
@@ -879,8 +889,8 @@ msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretór
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Desconhecido"
@@ -1243,19 +1253,19 @@ msgstr "Auto [Alto]"
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Baixo"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1287,7 +1297,7 @@ msgid "On Queue"
 msgstr "Na fila de espera"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Baixando"
 
@@ -1347,7 +1357,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1418,7 +1428,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1431,7 +1441,7 @@ msgid "Progress"
 msgstr "Progresso"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Fontes"
 
@@ -1441,7 +1451,7 @@ msgstr "Fontes"
 msgid "Priority"
 msgstr "Prioridade"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Status"
 
@@ -1474,7 +1484,7 @@ msgstr ""
 "Resposta de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2125,7 +2135,7 @@ msgstr "Falha em abrir lista de amigos do arquivo 'emfriends.met' para escrita!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - nenhum cliente em StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2409,8 +2419,8 @@ msgstr "Porta inválida para inicialização"
 msgid "Please fill all fields required"
 msgstr "Preencha todos os campos necessários"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Mensagem"
 
@@ -2482,7 +2492,7 @@ msgstr "Taxa de compartilhamento"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Requisitado"
 
@@ -2516,30 +2526,30 @@ msgstr "Erro desconhecido %d"
 msgid "Unable to get error description for error %d"
 msgstr "Incapaz obter descrição do erro para o erro %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Calculando hash"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Finalizando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Completo"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pausa"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Com Erro"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Esperando"
 
@@ -2583,7 +2593,7 @@ msgstr "Conexão Externa: Acesso negado porque: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexão Externa: Handshake falhou."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Iniciada a linha Asio %d"
@@ -2605,7 +2615,7 @@ msgid "WARNING: "
 msgstr "CUIDADO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Fechar"
 
@@ -2714,7 +2724,7 @@ msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2954,7 +2964,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3023,7 +3033,7 @@ msgstr "Limpar downloads completados"
 msgid "File sources:"
 msgstr "Fontes de arquivos:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Geral"
 
@@ -3044,7 +3054,7 @@ msgstr "Nome Completo:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3220,7 +3230,7 @@ msgstr "Usuário :"
 msgid "Userhash :"
 msgstr "Hash do usuário :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3229,15 +3239,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Download (Velocidade)"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Atual"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Média de execução"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3249,7 +3259,7 @@ msgstr "Upload (velocidade)"
 msgid "Connections"
 msgstr "Conexões"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Downloads ativos"
 
@@ -3257,7 +3267,7 @@ msgstr "Downloads ativos"
 msgid "Active connections (1:1)"
 msgstr "Conexões ativas (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Uploads ativos"
 
@@ -3458,8 +3468,8 @@ msgstr "Browser Padrão"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Insira o nome do seu navegador aqui. Deixe vazio para usar o navegador padrão do sistema."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3533,147 +3543,156 @@ msgstr "Casar endereço local ao IP (vazio para qualquer um):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Somente usuários avançados: Se você tem múltiplas interfaces de rede, insira o endereço da interface com a qual o aMule deverá conectar-se."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Casar endereço local ao IP (vazio para qualquer um):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Máximo de fontes para arquivos baixando:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Máximo de conexões simultâneas:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Auto-conectar ao iniciar"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Reconectar ao ser desconectado"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Remover servidores inativos após"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "tentativas"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Lista de servidores auto-atualizáveis na iniciação"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Atualizar lista de servidores quando conectar em um servidor"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Atualizar lista de servidores quando um cliente conectar"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Usar sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Usar verificação inteligente de LowID ao conectar"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Conexão segura"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Auto-conectar somente em servidores da lista estática"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Definir servidores adicionados manualmente com prioridade Alta"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manuseamento Inteligente de Corrupção (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Habilitado"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançado confia em todo hash (não recomendado)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Adicionar novos downloads em pausa"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Adicionar novos downloads com prioridade automática"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Tentar baixar o primeiro e o último pedaço do arquivo primeiro"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Começar o próximo arquivo pausado quando o arquivo completar"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Da mesma categoria"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "Em ordem alfabética"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Pré-alocar espaço em disco para novos arquivos"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos arquivos pré-alocar espaço em disco para todo o arquivo, isso reduz fragmentação"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar download quando espaço livre em disco acabar "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecione isso se você quer uqe o aMule cheque seu espaço em disco"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Digite aqui o espaço min. de disco desejado."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvar 10 fontes em arquivos raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos compartilhamentos com prioridade automática"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para baixados"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3681,599 +3700,599 @@ msgstr ""
 "Downloads finalizados são guardados aqui. Todos os arquivos nesta pasta são automaticamente compartilhados com outros pares.\n"
 "Se esta pasta também guarda arquivos que você não quer compartilhar, aponte para uma sub-pasta só para o aMule."
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolha a pasta onde os downloads terminados serão guardados. Todos os arquivos nesta pasta serão compartilhados com outros pares."
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos os arquivos nesta pasta são compartilhados com outros pares)"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Pasta para arquivos temporários baixados"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Botão direito na pasta para compartilhar recursivamente)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Compartilhar arquivos ocultos"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "Vasculha novamente automaticamente arquivos compartilhados que mudaram"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr "Segue links simbólicos em pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Tempo de atualização: 5s"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100min"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala dos gráficos das conexões: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Escala gráfica de download:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de upload:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Grade"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Download atual"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Média dos Downloads ativos"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Média dos Downloads da sessão"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Upload Atual"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Média dos Uploads ativos"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Média dos Uploads da sessão"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Conexões ativas"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "Ícone de barra de velocidade"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Kad-nodes atuais"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kad-nodes rodando"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Sessões Kad-nodes"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Selecione"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versões a exibir (0=sem limite)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! CUIDADO !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "No. Max. de conexões / 5s"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho do arquivo buffer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Atualizar conexão com servidor: desativado"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Desabilitar modo timed standby do computador"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Pele a usar: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar \"Manipulador Veloz de Ligações eD2k\" em cada janela."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar info. extras nas abas de categoria"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Exibir versão do aplicativo no título"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Exibir taxa de transferência no título"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Mostrar banda sobressalente"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientação Vertical da Barra de Ferramentas"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Fila de arquivos baixando"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Mostrar porcentagem do progresso"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Auto-escolha de arquivo (sobrecarrega CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "O aMule vai organizar automaticamente as colunas da lista de downloads"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parâmetros de conexão externa"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Aceitar conexões externas"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP da interface ouvindo:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Informe um IP válido no formato a.b.c.d para a interface EC que ficará aguardando. Um campo vazio ou 0.0.0.0 quer dizer 'qualquer interface'."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar redirecionamento de porta UPnP para porta EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Senha"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parâmetros do web server"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Rodar webserver na iniciação"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Modelo de rede"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Password para acesso completo"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Usuário com direitos limitados"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Password para acesso limitado"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar redirecionamento de porta UPnP da porta do servidor web"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo atualização (secs)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Ativar compactação Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações feitas."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Ignora todas as alterações feitas."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Título:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Comentário:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Dir incoming:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Alterar prioridade para novos arquivos:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Não alterar"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecione a cor para esta Categoria (selecionada):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Limpar"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Clique nesse botão para limpar o log."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de servidores..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Informe a URL com o arquivo server.met aqui e pressione o botão a esquerda para atualizar a lista de servidores."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Informe o nome do novo servidor aqui"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Informe o IP do servidor no formato x.x.x.x nesse espaço."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Informe a porta do servidor aqui."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencha os campos ao lado antes)."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Log do aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Informação de Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de nodes da URL..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Informe uma URL para um arquivo nodes.dat e pressione o botão da esquerda para atualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Estatísticas dos Nodes"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Novo node"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Inicializando de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Desconectar da rede Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Usuário"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendável ativar essa opção. Você não receberá seus créditos se a identificação segura não estiver ativada."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção habilita Obscurecimento de Protocolo, e faz o aMule aceitar conexões obscuras (criptografadas) de outros clientes."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar obscurecimento para conexões externas"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz o aMule usar Obscurecimento de Protocolo quando conectando outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar somente conexões obscuras"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz o aMule aceitar somente conexões obscurecidas. Você terá menos fontes, mas todo seu tráfego será obscurecido"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Nenhum"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver meus arquivos compartilhados:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecione quem pode pedir a sua lista de compartilhamentos."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtro de IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de clientes definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de servidores definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Recarregar lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar lista de IPs a filtrar do arquivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Atualizar agora"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-atualizar ipfilter ao iniciar"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Níveis de Filtro:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Sempre filtrar IPs de redes LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manuseio paranoico de IPs não-casados"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Rejeitar pacotes se o IP do cliente é diferente do IP onde o pacote foi recebido. Use com cuidado."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global se disponível"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se nenhum ipfilter.dat local for encontrado, permita o uso de um arquivo global."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Ativar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita a gravação do arquivo, que pode ser usado por programas externos."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de atualização (Seg):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar frequência (em segundos) da atualização da Assinatura."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Salvar arquivos de assinatura online em: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique aqui para definir pasta contendo os arquivos da Assinatura Online."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras nacionais para clientes"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Renderiza a coluna da bandeira do país nas transferências, filas e vistas de procura. Requer um banco de dados MMDB GeoIP válido (veja abaixo)."
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr "Banco de Dados"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr "Fonte:"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (grátis, sem conta)"
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (grátis, requer conta)"
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr "URL Customizada"
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Escolha qual provedor fornece o banco de dados MMDB GeoIP. DB-IP é o padrão - não requer conta. MaxMind requer uma conta grátis + chave de licensa. Use uma URL Customizada para apontar para qualquer outro anfitrião MMDB (e.g. um espelho local)."
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4285,11 +4304,11 @@ msgstr ""
 "Dados de IP-to-Country por DB-IP.com - https://db-ip.com\n"
 "Licensa: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr "Chave de Licensa:"
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4305,11 +4324,11 @@ msgstr ""
 "Licensa: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Requer atribuição e registro de conta; renove no mínimo a cada 30 dias."
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr "URL de Download:"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4319,211 +4338,211 @@ msgstr ""
 "A URL pode incluir credenciais (https://user:pass@host/...).\n"
 "License e termos de atribuição são realizados pela URL upstream - você é responsável."
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr "Baixe o banco de dados GeoIP da fonte selecionada."
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr "Auto-atualizar ao iniciar"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Baixe novamente o banco de dados GeoIP da fonte selecionada toda vez que o aMule iniciar."
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens (Exceto chat atual):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de pessoas que não estão em sua lista"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens contendo (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione aqui as palavras que o amule deve filtrar e bloquear nas mensagens"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no log"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários contendo (use '.' como separador):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Ativar autenticação"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Ativa/Desativa autenticação por usuário/senha"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Nome do usuário: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Nome do usuário para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Senha:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Senha utilizada para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Ativar proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Ativa/desativa suporte a proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Host do Proxy:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Nome do Host do proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Porta do Proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Porta do Proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Conectar em:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Fazer login em amule remoto"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Usuário"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Lembrar essas definições"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr "Força compressão ZLIB"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ativar log de debug detalhado."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Apenas para o arquivo de log"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Aguardando..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Adicionar importadas"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Tentar novamente selecionada"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Remover selecionada"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tipos de Eventos"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e filas de clientes para arquivo(s) selecionado(s) : Sessão / Sempre"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Porcentagem de total de arquivos"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Todos os arquivos"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Arquivos selecionados"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Somente uploads ativos"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Atualizar lista de compartilhados"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Enviar a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Encerrar sessão de Chat."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Arquivos Compartilhados"
 
@@ -4600,7 +4619,7 @@ msgstr "todos os outros"
 msgid "Incomplete"
 msgstr "Incompleto"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Parado"
 
@@ -4789,34 +4808,34 @@ msgstr "Não é possível ler as sementes para Partfile %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Erro lendo arquivo .seeds do arquivo (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Encontrada parte corrompida (%d) em %d arquivo .part %s - Resultado |%s| Hash |%s|"
 msgstr[1] "Encontradas partes corrompidas (%d) em %d arquivo .part %s - Resultado |%s| Hash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Achado parte completa (%i) em %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Terminado o rehash %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Erro inesperado quando completado %s. Arquivo parado"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Download concluído: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4825,306 +4844,306 @@ msgstr ""
 "Download concluído:\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Apagando arquivo: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "CUIDADO: Incapaz de fazer hash em part baixado - hashset incompleto para '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERRO: Incapaz de fazer hash de part baixado - hashset incompleto (%s). Isto nunca deveria acontecer"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Parte %u de '%s' marcada como completa, porém o arquivo parte é menor que o esperado (tem %llu bytes, precisa %llu); reabrindo o gap para re-download."
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF enquanto fazia hash de parte %u baixada com tamanho %u (max %u) de parte '%s' com tamanho %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISO: Não há espaço em disco suficiente! Colocando arquivo %s em pausa"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Parte baixada %i do arquivo %s está corrompida"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Recuperada parte corrompida %i para %s -> Bytes salvos: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Alocando"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Espaço em disco insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Baixado"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falha ao abrir partfile '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Padrão do sistema"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croácia"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Tcheco"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Inglês (UK)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr "Inglês (U.S.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estônia"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Hungria"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiano (Suíço)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituânia"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruega (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polonês"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Português (Portugal)"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Suécia"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turquia"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Mudar Idioma"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Não há traduções instaladas no aMule"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Nenhum idioma disponível"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "nenhuma opção disponível"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, pulando"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP não pode ser maior do que 65532, pois a UDP escuta em TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Porta padrão será utilizada (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Conexão"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Diretórios"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Arquivos"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Segurança"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avançado"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Debugando"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5134,15 +5153,15 @@ msgstr ""
 "    %PARTFILE - caminhos completo para o arquivo\n"
 "    %PARTNAME - somente nome do arquivo"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "O suporte para ícone da bandeja do sistema requer libayatana-appindicator3 em tempo de compilação."
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Não disponível no Wayland: o protocolo não avisa quando uma janela foi minimizada, portanto esta opção não pode interceptar o botão de minimização do sistema. Alternativa: lance o aMule com `GDK_BACKEND=x11` para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5158,26 +5177,26 @@ msgstr ""
 "O aMule funciona corretamente sem qualquer tipo de\n"
 "alteração nessas opções."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falha ao conectar Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Tipo de proxy ao qual você está conectado"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Widget para Cfg com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5185,31 +5204,36 @@ msgstr ""
 "O aMule deve ser reiniciado para habilitar estas mudanças:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "-Porta TCP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "-Porta UDP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Interface de conexão externa modificada.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Porta de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Aceitação da conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suporte de protocolo de ofuscamento mudou.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5217,7 +5241,7 @@ msgstr ""
 "Sua lista de Auto-atualização de servidor está vazia.\n"
 "'Auto-atualização de servidor na iniciação' será desativada."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5225,19 +5249,19 @@ msgstr ""
 "Você ativou as conexões externas mas não definiu uma senha.\n"
 "Conexões Externas só podem ser feitas se for especificada uma senha válida."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "-Idioma alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "-Diretório temporário alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K conectada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5245,7 +5269,7 @@ msgstr ""
 "Ambas rede eD2k e Kad estão desativadas.\n"
 "Você não será capaz de conectar senão habilitar pelo menos um deles."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5253,7 +5277,7 @@ msgstr ""
 "Kad não iniciará se sua porta UDP estiver desabilitada.\n"
 "Habilite a porta UDP ou desative a rede Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5263,19 +5287,19 @@ msgstr ""
 "Você DEVE reiniciar o aMule agora.\n"
 "Se você não reiniciá-lo agora, não reclame se algo de ruim acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Não foi possível registrar o aMule para início automático no login. A lista de autostart pode estar como apenas leitura."
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Não foi possível remover a entrada de início automático no login."
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr "Início automático"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5285,41 +5309,41 @@ msgstr ""
 "Coloque pelo menos uma linha que aponte para um server.met válido.\n"
 "Clique no botão \"Lista\" para abrir a caixa para digitar uma URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Arquivos Temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Arquivos Recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolha uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Defina seu Player de Vídeo preferido"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Selecione o Browser"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Editar lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5327,114 +5351,114 @@ msgstr ""
 "Adicione aqui URL's para baixar arquivo 'server.met'\n"
 "Somente uma URL por Linha."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr "Falha ao atualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dados por MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr "Fonte customizada"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr "Dados por DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Status: %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status: %s - %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: Falha ao carregar - clique 'Atualizar agora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: Não encontrado - clique 'Atualizar agora' para baixar."
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Delay na atualização: %d segundo"
 msgstr[1] "Delay na atualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo do gráfico de média: %d minuto"
 msgstr[1] "Tempo do gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do gráfico de conexões: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho do Buffer de Arquivo: %d byte"
 msgstr[1] "Tamanho do Buffer de Arquivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho de Espera de Upload: %d cliente"
 msgstr[1] "Tamanho de Espera de Upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Atualizar conexão com servidor: %d minuto"
 msgstr[1] "Atualizar conexão com servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo para atualizar conexão no servidor: Desativado"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "desativado"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comando em evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Habilitar execução de comando no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Comando do Núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execução de comando na GUI"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Comando da GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "As seguinte variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -5442,32 +5466,32 @@ msgstr ""
 "As seguintes pastas parecem ser de sistema ou locais sensíveis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartilha-los recursivamente vai publicar todos os arquivos sob as redes eD2k/Kad. Você realmente quer isto?"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr "Confirma pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr "Recarregando lista de arquivos compartilhados…"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr "Procurando por subdiretórios…"
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr "Atualizando pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr "Varridos %u diretórios…"
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -210,8 +210,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Não foi possível adicionar link %u do arquivo ED2KLinks (veja o log para detalhes)."
 msgstr[1] "Não foi possível adicionar %u links do arquivo ED2KLinks (veja o log para detalhes)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -256,37 +256,42 @@ msgstr "Encerramento do aMule completo."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração da memória para a saída do aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Seu locale foi alterado para o padrão do Sistema devido a mudança na configuração. Desculpe."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -294,20 +299,20 @@ msgstr ""
 "\n"
 "Configuração EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Senha definida e conexões externas habilitadas."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "CUIDADO"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "Inicialização da Rede"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -315,34 +320,34 @@ msgstr ""
 "O aMule detectou que faltam arquivos de inicialização da rede.\n"
 "Selecione quais baixar:"
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nós de inicialização de Kad"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server rodando no pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível conectar às portas desse endereço: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u não disponível. Você ficará com LOWID (id baixa)\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -357,49 +362,49 @@ msgstr ""
 "\n"
 "Verifique sua rede para ver se essa porta está aberta para entrada e saída."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig do aMule"
 
 # src/amuled.cpp:1246:
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Parece que o idioma selecionado não está instalado no seu computador. (Nota: eu irei defini-lo mesmo assim)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Essa é a primeira vez que você executa o aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Essa é uma versão de testes, atualizada diariamente, e\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não daremos garantia se ela quebrar algo, queimar sua casa,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar seu cachorro. Mas ela *deve* ser segura para uso mesmo assim.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Maiores informações, suporte e novas versões podem ser encontradas em nossa\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "homepage https://amule-org.github.io ou em nosso canal de irc #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja a vontade para notificar qualquer bug em https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -407,137 +412,137 @@ msgstr ""
 "A pasta especificada para os arquivos da Online Signature é INVÁLIDA!\n"
 "OnlineSignature ficará DESATIVADA até você atualizar as preferências."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Nome do servidor notificado"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Pré-alocação de espaço em disco para arquivo '%s' falhou: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não foi possível abrir arquivo de log"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o arquivo de log está vazio. Algo está errado."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Arquivo de log resetado"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "MensagemDoServidor: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pulando o download de %s, pois o arquivo requerido não é o mais novo."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Falha ao obter a lista de nodes."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir arquivo de versão baixado"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Arquivo de versão corrompido"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Você está utilizando uma versão anterior do aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A mais recente versão pode ser obtida em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "CUIDADO: Sua versão do aMuled esta ultrapassada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Sua cópia do aMule está em dia."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Falha ao baixar arquivo de controle de versão"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuários:%s | Arquivos: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuários: E: %s K: %s | Arquivos: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nenhuma rede selecionada"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "com HighID (Id alta)"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad parado."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a rede Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a rede Kad (sob firewall)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Desconectado da rede Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se a porta UDP está desabilitada em preferências, não iniciará."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desabilitada em preferências, não iniciará."
 
@@ -898,7 +903,7 @@ msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretór
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2259,49 +2264,49 @@ msgstr "Não"
 msgid "Yes"
 msgstr "Sim"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Baixando..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Download HTTP cancelado"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "A URL para baixar não pode estar vazia"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Falha ao criar requisição HTTP para %s"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP download: corpo da resposta vazio para %s"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Não foi possível mover arquivo baixado para %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Baixados %s (%llu bytes)"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "A URL %s retornou: %i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Baixa HTTP falhou para %s: %s"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 Não autorizado para %s"
@@ -2603,7 +2608,7 @@ msgstr "Conexão Externa: Acesso negado porque: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexão Externa: Handshake falhou."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Iniciada a linha Asio %d"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -210,8 +210,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "Não foi possível adicionar link %u do arquivo ED2KLinks (veja o log para detalhes)."
 msgstr[1] "Não foi possível adicionar %u links do arquivo ED2KLinks (veja o log para detalhes)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -256,27 +256,37 @@ msgstr "Encerramento do aMule completo."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração da memória para a saída do aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Seu locale foi alterado para o padrão do Sistema devido a mudança na configuração. Desculpe."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -284,20 +294,20 @@ msgstr ""
 "\n"
 "Configuração EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Senha definida e conexões externas habilitadas."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "CUIDADO"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "Inicialização da Rede"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -305,34 +315,34 @@ msgstr ""
 "O aMule detectou que faltam arquivos de inicialização da rede.\n"
 "Selecione quais baixar:"
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nós de inicialização de Kad"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server rodando no pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível conectar às portas desse endereço: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u não disponível. Você ficará com LOWID (id baixa)\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -347,49 +357,49 @@ msgstr ""
 "\n"
 "Verifique sua rede para ver se essa porta está aberta para entrada e saída."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig do aMule"
 
 # src/amuled.cpp:1246:
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Parece que o idioma selecionado não está instalado no seu computador. (Nota: eu irei defini-lo mesmo assim)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Essa é a primeira vez que você executa o aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Essa é uma versão de testes, atualizada diariamente, e\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não daremos garantia se ela quebrar algo, queimar sua casa,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar seu cachorro. Mas ela *deve* ser segura para uso mesmo assim.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Maiores informações, suporte e novas versões podem ser encontradas em nossa\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "homepage https://amule-org.github.io ou em nosso canal de irc #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja a vontade para notificar qualquer bug em https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -397,137 +407,137 @@ msgstr ""
 "A pasta especificada para os arquivos da Online Signature é INVÁLIDA!\n"
 "OnlineSignature ficará DESATIVADA até você atualizar as preferências."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Nome do servidor notificado"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Pré-alocação de espaço em disco para arquivo '%s' falhou: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não foi possível abrir arquivo de log"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o arquivo de log está vazio. Algo está errado."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Arquivo de log resetado"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "MensagemDoServidor: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pulando o download de %s, pois o arquivo requerido não é o mais novo."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Falha ao obter a lista de nodes."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir arquivo de versão baixado"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Arquivo de versão corrompido"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Você está utilizando uma versão anterior do aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A mais recente versão pode ser obtida em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "CUIDADO: Sua versão do aMuled esta ultrapassada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Sua cópia do aMule está em dia."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Falha ao baixar arquivo de controle de versão"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuários:%s | Arquivos: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuários: E: %s K: %s | Arquivos: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nenhuma rede selecionada"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "com HighID (Id alta)"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad parado."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a rede Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a rede Kad (sob firewall)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Desconectado da rede Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se a porta UDP está desabilitada em preferências, não iniciará."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desabilitada em preferências, não iniciará."
 
@@ -2593,7 +2603,7 @@ msgstr "Conexão Externa: Acesso negado porque: "
 msgid "External Connection: Handshake failed."
 msgstr "Conexão Externa: Handshake falhou."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Iniciada a linha Asio %d"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -28,20 +28,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Controlo remoto do aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -49,7 +49,7 @@ msgstr ""
 "Cliente p2p 'para todas as plataformas' baseado no eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -58,59 +58,59 @@ msgstr ""
 "Copyright (C) 2003-2019 Equipa aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Parte do aMule é baseado em \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Encaminhamento peer-to-peer baseado na métrica XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (C) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Website:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Fórum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verificar nova versão no arranque"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "A ligar à Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Está a usar uma versão antiga do aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Indisponível"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -206,8 +206,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -222,47 +222,57 @@ msgstr "Falha ao abrir ficheiro de ligações eD2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Não se pode adicionar a si próprio como fonte para um link eD2k enquanto tiver lowid."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "A fechar a aplicação..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "A terminar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "A matar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Falhas"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: A terminar núcleo."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule terminado."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração de memória para a saída do aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O seu idioma foi alterado para a predefinição do sistema devido a uma mudança de configuração. Desculpe."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informação"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -270,56 +280,56 @@ msgstr ""
 "\n"
 "Configuração das LE"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Foi encontrado %i servidor no server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível associar os portos ao endereço especificado: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u não está disponível. Ficará com LOWID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -334,48 +344,48 @@ msgstr ""
 "\n"
 "Verifique a sua rede para se certificar de que o porto está aberto para leitura e escrita."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Erro ao criar o ficheiro da Assinatura Online"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erro a criar o ficheiro da Assinatura Online do aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado parece não estar instalado no seu computador. (Nota: de qualquer das formas, irei tentar activá-lo)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que executa o aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta é uma versão de testes actualizada diariamente e\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não há qualquer garantia de que não irá partir nada, pegar fogo à sua casa,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar o seu cão. Mas, *em princípio*, deverá ser seguro usá-lo.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mais informação, suporte e novos lançamentos na nossa página,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "em amule-org.github.io ou no canal de IRC #aMule em irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja à vontade para comunicar erros para https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -383,137 +393,137 @@ msgstr ""
 "A pasta para os ficheiros da Assinatura Online é INVÁLIDA!\n"
 " A Assinatura Online será DESACTIVADA até que resolva a situação nas preferências."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Servidor notificado"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Reserva de espaço em disco para o ficheiro '%s' falhou: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não é possível abrir o ficheiro de relatório"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de relatório está vazio. Algo está mal."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "O relatório foi limpo"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensagem do servidor: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "O download de %s não foi feito porque o ficheiro requisitado não é mais recente."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Falha ao transferir a lista de nós."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir o ficheiro de verificação de versão transferido"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Ficheiro de verificação de versão corrompido"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Está a usar uma versão antiga do aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A sua versão do aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "A sua cópia do aMule está actualizada."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Falha ao transferir o ficheiro de verificação de versão"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizadores: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizadores: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Não foram seleccionadas redes"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "com HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ligado a %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "A ligar a %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Desligado da eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad iniciada."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad parada."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Ligado à Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Ligado à Kad (atrás de firewall)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Desligado da Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se o porto UDP estiver desactivado nas preferências, inicialização não efectuada."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rede Kad desligada nas preferências, a ligação não será efectuada."
 
@@ -553,15 +563,15 @@ msgstr "Este é o aMule %s, baseado no eMule."
 msgid "Running on %s"
 msgstr "A correr em %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para verificar se há novas versões."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Temporizador"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -571,223 +581,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponível"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Caixa de diálogo do aMule destruída"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "A Ligar"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: A Ligar"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desligado"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de firewall"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Ligado"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: A Ligar"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Cancela as tentativas de ligação actuais"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Desligar"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Desligar das redes presentemente ligadas"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Ligar"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Ligar às redes presentemente activadas"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f | Down: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ligado)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desligado)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Quer mesmo fechar o %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Executar Comando: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- predefinição -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Pasta para os temas '%s' não existe"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Não é possível abrir ficheiro de tema '%s' para leitura"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Janela de Redes"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Ficheiros partilhados"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Janela de Ficheiros Partilhados"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "A ferramenta de importação de ficheiro de partes"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Acerca/Ajuda"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Sem rede"
 
@@ -875,8 +885,8 @@ msgstr "Não é possível criar o directório '%s' para a categoria '%s', a mant
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Desconhecido"
@@ -1239,19 +1249,19 @@ msgstr "Automática [Alta]"
 msgid "Very low"
 msgstr "Muito baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1283,7 +1293,7 @@ msgid "On Queue"
 msgstr "Em Fila de Espera"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "A Receber"
 
@@ -1343,7 +1353,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1415,7 +1425,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1428,7 +1438,7 @@ msgid "Progress"
 msgstr "Progresso"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Fontes"
 
@@ -1438,7 +1448,7 @@ msgstr "Fontes"
 msgid "Priority"
 msgstr "Prioridade"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Estado"
 
@@ -1471,7 +1481,7 @@ msgstr ""
 "Comentário de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automática"
@@ -2124,7 +2134,7 @@ msgstr "Erro ao abrir o ficheiro de lista de amigos 'emfriends.met' para escrita
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - sem cliente no StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2409,8 +2419,8 @@ msgstr "Porto inválido para arranque"
 msgid "Please fill all fields required"
 msgstr "Por favor, preencha todos os campos pedidos"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Mensagem"
 
@@ -2482,7 +2492,7 @@ msgstr "Razão de partilha"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2516,30 +2526,30 @@ msgstr "Erro desconhecido %d"
 msgid "Unable to get error description for error %d"
 msgstr "Impossível obter descrição para o erro %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "A gerar chave"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "A completar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Completo"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Em Pausa"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Erróneo"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Em Espera"
 
@@ -2584,7 +2594,7 @@ msgstr "Ligação Externa: Acesso negado porque: "
 msgid "External Connection: Handshake failed."
 msgstr "Ligação Externa: Negociação inicial falhou."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Actualização automática iniciada"
@@ -2606,7 +2616,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Fechar"
 
@@ -2722,7 +2732,7 @@ msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2962,7 +2972,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "kB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3031,7 +3041,7 @@ msgstr "Limpa os downloads concluídos"
 msgid "File sources:"
 msgstr "Fontes de ficheiros:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Geral"
 
@@ -3052,7 +3062,7 @@ msgstr "Nome completo :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/D"
 
@@ -3228,7 +3238,7 @@ msgstr "Utilizador :"
 msgid "Userhash :"
 msgstr "Chave de utilizador :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3237,15 +3247,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Velocidade de Download"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Média actual"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3257,7 +3267,7 @@ msgstr "Velocidade de Upload"
 msgid "Connections"
 msgstr "Ligações"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Downloads activos"
 
@@ -3265,7 +3275,7 @@ msgstr "Downloads activos"
 msgid "Active connections (1:1)"
 msgstr "Ligações activas (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Uploads activos"
 
@@ -3466,8 +3476,8 @@ msgstr "Selecção de Navegador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indique aqui o nome do seu browser. Deixe este campo em branco para utilizar o browser por omissão do sistema."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3541,751 +3551,760 @@ msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Apenas para utilizadores avançados: Se possui múltiplos interfaces de rede indique o endereço do interface que o aMule deve usar."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Associar endereço local ao IP (em branco para qualquer um):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Máximo de fontes por ficheiro:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Máximo de ligações simultâneas:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Ligar automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Voltar a ligar se perder ligação"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Remover servidores inactivos após"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "tentativas"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Auto-actualizar lista de servidores no arranque"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar a lista de servidores quando se liga a um servidor"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Actualizar a lista de servidores quando um cliente se liga"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Usar o sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Usar verificação inteligente de LowID ao ligar"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Ligação segura"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Apenas ligar automaticamente a servidores estáticos"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Atribuir alta prioridade a servidores adicionados manualmente"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manipulação Inteligente de Corrupção (M.I.C.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Activar"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "M.I.C. Avançada confia em todas as chaves (não recomendado)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Adicionar ficheiros para transferir em modo de pausa"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Adicionar ficheiros para transferir com prioridade automática"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Tentar receber primeiro o início e o final dos ficheiros"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Iniciar o próximo ficheiro em pausa quando um ficheiro completa"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Da mesma categoria"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "Em ordem alfabética"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Reservar previamente espaço em disco para novos ficheiros"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos ficheiros, reserva o espaço em disco para o ficheiro completo, reduzindo assim a fragmentação"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar os downloads quando o espaço livre em disco atinge "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione se quiser que o aMule verifique o espaço em disco"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Insira o espaço mínimo no disco desejado."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes para ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos ficheiros partilhados com prioridade automática"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para downloads"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Pasta para ficheiros temporários"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clique com o botão do lado direito no ícone da pasta para partilha recursiva)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Partilhar ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Atraso de actualização: 5 segundos"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100 minutos"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do Gráfico de Ligações: 100"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de download:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de upload"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Grelha"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Download actual"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Média actual de download"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Média de download da sessão"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Upload actual"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Média actual de upload"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Média de upload da sessão"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Ligações activas"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade no ícone da área de notificação"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Nós Kad actuais"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Nós Kad a executar"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Nós Kad da sessão"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de Versões de Cliente mostradas (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! AVISO !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Máximo de novas ligações / 5 segundos"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho da memória temporária de ficheiro: 240000 Byte"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho da Lista de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualização da ligação ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Desactivar o modo de espera temporizado do computador"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Tema a utilizar: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar a barra de adição rápida de ligações eD2k em todas as janelas."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar informação extra nos separadores de categorias"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Mostrar sobrecarga na largura de banda"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientação vertical da barra de ferramentas"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Ficheiros na Fila de Espera dos Downloads"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Mostrar percentagem de progresso"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Ordenar ficheiros automaticamente (pode consumir muito CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "O aMule ordenará as colunas na sua lista de transferências automaticamente"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parâmetros de Ligação Externa"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Aceitar ligações externas"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP da interface a escutar:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Insira um endereço IP válido no formato a.b.c.d para a interface que irá aguardar as LE. Um campo vazio ou 0.0.0.0 significará qualquer interface."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar UPnP para configuração do encaminhamento no porto das LE"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Executar o servidor web no arranque"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Aspecto da página web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Palavra-passe para controlo total"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Activar utilizador com permissões reduzidas"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Palavra-passe para controlo reduzido"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activar UPnP para encaminhamento do porto do servidor web"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Taxa de Actualização de Páginas (em segundos)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Activar compressão Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Anular as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Título :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Comentário :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Pasta de completos :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Trocar prioridade nos novos ficheiros :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Não mudar"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar a cor para a categoria seleccionada :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Limpar"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Clique para limpar o relatório."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique neste botão para actualizar a lista de servidores a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Lista de Servidores"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Insira a localização de um ficheiro server.met e pressione o botão à esquerda para actualizar a lista de servidores conhecidos."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Insira o nome do novo servidor"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Insira o IP do servidor, usando o formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Insira o porto do servidor."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencher os campos ao lado) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Relatório"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Informação ED2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Informação Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique para actualizar a lista de nós a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Insira o endereço de um ficheiro nodes.dat e pressione o botão à esquerda para actualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Estado dos nós"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Novo nó"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Desligar Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Utilizador"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendado activar esta opção. Não receberá créditos se a Identificação Segura de Utilizador não estiver activada."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar a Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção activa a Ofuscação do Protocolo e faz com que o aMule aceite ligações ofuscadas de outros clientes."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscação em ligações para o exterior"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz com que o aMule use a Ofuscação do Protocolo quando ligado a outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar apenas ligações ofuscadas"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz com que o aMUle aceite apenas ligações ofuscadas. Terá menos fontes, mas todo o tráfego será ofuscado"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Ninguém"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver os meus ficheiros partilhados:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quem pode pedir a lista dos seus ficheiros partilhados."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtragem de IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem por IPs dos clientes definidos no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem da lista de IPs definida no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Recarregar a lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar a lista de IPs a filtrar a partir do ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Nível de filtragem:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre endereços IP de rede local"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Tratamento paranóico de IPs sem correspondência"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Rejeitar pacotes se o IP do cliente é diferente do IP de onde o pacote é recebido. Usar com cautela."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global do sistema se disponível"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se não existir um ficheiro ipfilter.dat, permitir a utilização de um ficheiro ipfilter global do sistema."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Activar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activa a escrita do ficheiro da AO, o qual pode ser usado por aplicações externas para criar assinaturas e afins."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de Actualização (segundos):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar a frequência (em segundos) das actualizações da assinatura Online."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Gravar a assinatura Online em: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique para seleccionar a pasta que contém os ficheiros de Assinatura Online"
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras de países para clientes"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Taxa de transferência :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4293,11 +4312,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4307,226 +4326,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens recebidas (excepto da conversa corrente):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de utilizadores que não pertençam à lista de amigos"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione as palavras que o aMule deve filtrar e bloquear as mensagens que as contenham"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no relatório"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Activar autenticação"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar autenticação utilizador/palavra-passe"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Utilizador: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de utilizador para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Palavra-passe:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "A palavra-passe a usar para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Activar Proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o suporte de proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Servidor:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "O nome da máquina proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Ligar a:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Autenticação remota"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nome de utilizador"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Lembrar estas preferências"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compressão gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Relatório detalhado para Depuração."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir o ficheiro"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "A aguardar..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Adicionar importações"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Reassumir seleccionados"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Remover seleccionados"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e clientes em espera para o(s) ficheiro(s) seleccionado(s) : Sessão / Desde sempre"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Uploads Activos"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Percentagem dos ficheiros totais"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Ficheiros seleccionados"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Apenas os uploads activos"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Envia a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Fechar esta conversa."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Ligar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Ficheiros Partilhados"
 
@@ -4603,7 +4622,7 @@ msgstr "todos os outros"
 msgid "Incomplete"
 msgstr "Incompleto"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Parado"
 
@@ -4793,342 +4812,342 @@ msgstr "Gravada %i semente de fontes para o ficheiro de partes: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Erro ao ler o ficheiro de sementes de ficheiro de partes (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Encontrada parte corrompida (%d) no ficheiro de %d parte %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Encontrada parte corrompida (%d) no ficheiro de %d partes %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Encontrada parte completa (%i) em %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Terminado a regeneração da chave de %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Erro inesperado ao completar %s. ficheiro em pausa"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Transferência concluída: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Transferência concluída: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "A eliminar o ficheiro: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVISO: Não é possível calcular a chave de uma parte recebida - conjunto de chaves incompleto para '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERRO: Impossível calcular a chave de uma parte recebida - conjunto de chaves incompleto (%s). Isto nunca deveria acontecer"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF ao gerar a chave da parte transferida %u de comprimento %u (máximo %u) do ficheiro de partes '%s' com comprimento %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISO: Espaço livre em disco insuficiente! A pausar o ficheiro: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Parte recebida %i está corrompida no ficheiro: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Recuperada parte corrompida %i para %s -> bytes guardados: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "A atribuir"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Espaço em disco insuficiente"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Transferido"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falhou ao abrir ficheiro de partes '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Predefinição do sistema"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estoniano"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiano (Suíço)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norueguês (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Português"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Alterar Idioma"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Indisponível"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "sem opções disponíveis"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, a ignorar"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP não pode ser superior a 65532 porque o socket UDP do servidor tem de ser TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "O porto predefinido será usado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Ligação"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Directórios"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Segurança"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Controlos remotos"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avançado"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Depuração"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5138,15 +5157,15 @@ msgstr ""
 "    %PARTFILE - caminho completo do ficheiro\n"
 "    %PARTNAME - apenas o nome do ficheiro"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5162,26 +5181,26 @@ msgstr ""
 "O aMule correrá perfeitamente sem ajustar qualquer\n"
 "uma destas opções."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falhou ao ligar Cfg ao widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Cfg para o Widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao qual está a ligar-se"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Widget para o Cfg com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5189,32 +5208,37 @@ msgstr ""
 "O aMule tem de ser reiniciado para activar estas alterações:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Alterada interface para ligações externas.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Porta para ligações externas alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Alterada a aceitação de ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Alterada interface para ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscação do Protocolo"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5222,7 +5246,7 @@ msgstr ""
 "A sua lista de actualização automática de servidores está vazia.\n"
 "A 'actualização automática no arranque' será desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5230,19 +5254,19 @@ msgstr ""
 "Activou as ligações externas mas não especificou uma palavra-passe.\n"
 "As ligações externas não podem ser activadas a menos que seja especificada uma palavra-passe válida."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- O idioma foi alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- A pasta Temp foi alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5250,7 +5274,7 @@ msgstr ""
 "As redes eD2K e Kad estão desactivados.\n"
 "Não vai conseguir uma ligação até activar pelo menos uma deles."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5258,7 +5282,7 @@ msgstr ""
 "A Kad não vai funcionar se o porto UDP estiver desactivado.\n"
 "Active o porto UDP ou desactive a Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5268,20 +5292,20 @@ msgstr ""
 "DEVE reiniciar o aMule agora.\n"
 "Se não o fizer, não se queixe se algo grave acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Actualização automática iniciada"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5291,41 +5315,41 @@ msgstr ""
 "Por favor, indique pelo menos uma localização que aponte para um ficheiro server.met válido.\n"
 "Clique no botão \"Lista\" para inserir uma localização."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Ficheiros temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Ficheiros recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Assinaturas Online"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Seleccione uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Procurar leitor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Seleccionar navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Editar a lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5333,149 +5357,149 @@ msgstr ""
 "Adicione localizações para obter ficheiros server.met\n"
 "Apenas uma localização por linha."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualização: %d segundo"
 msgstr[1] "Intervalo de actualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo para o gráfico de média: %d minuto"
 msgstr[1] "Tempo para o gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do Gráfico de Ligações: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho de memória temporária de ficheiros: %d byte"
 msgstr[1] "Tamanho de memória temporária de ficheiros: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho da fila de espera de upload: %d cliente"
 msgstr[1] "Tamanho da fila de espera de upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualização de ligação ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualização de ligação ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualização de ligação ao servidor: Desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar o comando quando ocorrer o evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Activar execução de comandos no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Comando de núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Activar execução de comando na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Comando da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega a lista de ficheiros partilhados."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -206,8 +206,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -252,27 +252,37 @@ msgstr "aMule terminado."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração de memória para a saída do aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O seu idioma foi alterado para a predefinição do sistema devido a uma mudança de configuração. Desculpe."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informação"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -280,56 +290,56 @@ msgstr ""
 "\n"
 "Configuração das LE"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Foi encontrado %i servidor no server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível associar os portos ao endereço especificado: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u não está disponível. Ficará com LOWID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,48 +354,48 @@ msgstr ""
 "\n"
 "Verifique a sua rede para se certificar de que o porto está aberto para leitura e escrita."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Erro ao criar o ficheiro da Assinatura Online"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erro a criar o ficheiro da Assinatura Online do aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado parece não estar instalado no seu computador. (Nota: de qualquer das formas, irei tentar activá-lo)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que executa o aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta é uma versão de testes actualizada diariamente e\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não há qualquer garantia de que não irá partir nada, pegar fogo à sua casa,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar o seu cão. Mas, *em princípio*, deverá ser seguro usá-lo.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mais informação, suporte e novos lançamentos na nossa página,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "em amule-org.github.io ou no canal de IRC #aMule em irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja à vontade para comunicar erros para https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -393,137 +403,137 @@ msgstr ""
 "A pasta para os ficheiros da Assinatura Online é INVÁLIDA!\n"
 " A Assinatura Online será DESACTIVADA até que resolva a situação nas preferências."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Servidor notificado"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Reserva de espaço em disco para o ficheiro '%s' falhou: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não é possível abrir o ficheiro de relatório"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de relatório está vazio. Algo está mal."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "O relatório foi limpo"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensagem do servidor: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "O download de %s não foi feito porque o ficheiro requisitado não é mais recente."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Falha ao transferir a lista de nós."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir o ficheiro de verificação de versão transferido"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Ficheiro de verificação de versão corrompido"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Está a usar uma versão antiga do aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A sua versão do aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "A sua cópia do aMule está actualizada."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Falha ao transferir o ficheiro de verificação de versão"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizadores: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizadores: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Não foram seleccionadas redes"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "com HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ligado a %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "A ligar a %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Desligado da eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad iniciada."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad parada."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Ligado à Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Ligado à Kad (atrás de firewall)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Desligado da Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se o porto UDP estiver desactivado nas preferências, inicialização não efectuada."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rede Kad desligada nas preferências, a ligação não será efectuada."
 
@@ -2594,7 +2604,7 @@ msgstr "Ligação Externa: Acesso negado porque: "
 msgid "External Connection: Handshake failed."
 msgstr "Ligação Externa: Negociação inicial falhou."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Actualização automática iniciada"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:12+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -206,8 +206,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -252,37 +252,42 @@ msgstr "aMule terminado."
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração de memória para a saída do aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O seu idioma foi alterado para a predefinição do sistema devido a uma mudança de configuração. Desculpe."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informação"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -290,56 +295,56 @@ msgstr ""
 "\n"
 "Configuração das LE"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Foi encontrado %i servidor no server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível associar os portos ao endereço especificado: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u não está disponível. Ficará com LOWID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -354,48 +359,48 @@ msgstr ""
 "\n"
 "Verifique a sua rede para se certificar de que o porto está aberto para leitura e escrita."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Erro ao criar o ficheiro da Assinatura Online"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erro a criar o ficheiro da Assinatura Online do aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado parece não estar instalado no seu computador. (Nota: de qualquer das formas, irei tentar activá-lo)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que executa o aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta é uma versão de testes actualizada diariamente e\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não há qualquer garantia de que não irá partir nada, pegar fogo à sua casa,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar o seu cão. Mas, *em princípio*, deverá ser seguro usá-lo.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mais informação, suporte e novos lançamentos na nossa página,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "em amule-org.github.io ou no canal de IRC #aMule em irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja à vontade para comunicar erros para https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -403,137 +408,137 @@ msgstr ""
 "A pasta para os ficheiros da Assinatura Online é INVÁLIDA!\n"
 " A Assinatura Online será DESACTIVADA até que resolva a situação nas preferências."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Servidor notificado"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Reserva de espaço em disco para o ficheiro '%s' falhou: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não é possível abrir o ficheiro de relatório"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de relatório está vazio. Algo está mal."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "O relatório foi limpo"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensagem do servidor: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "O download de %s não foi feito porque o ficheiro requisitado não é mais recente."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Falha ao transferir a lista de nós."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir o ficheiro de verificação de versão transferido"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Ficheiro de verificação de versão corrompido"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Está a usar uma versão antiga do aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A sua versão do aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "A sua cópia do aMule está actualizada."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Falha ao transferir o ficheiro de verificação de versão"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizadores: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizadores: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Não foram seleccionadas redes"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "com HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ligado a %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "A ligar a %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Desligado da eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad iniciada."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad parada."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Ligado à Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Ligado à Kad (atrás de firewall)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Desligado da Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se o porto UDP estiver desactivado nas preferências, inicialização não efectuada."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rede Kad desligada nas preferências, a ligação não será efectuada."
 
@@ -894,7 +899,7 @@ msgstr "Não é possível criar o directório '%s' para a categoria '%s', a mant
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2259,49 +2264,49 @@ msgstr "Não"
 msgid "Yes"
 msgstr "Sim"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "A Receber..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Download HTTP cancelado"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "O URL para download não pode estar vazio"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Erro ao receber ficheiros partilhados do utilizador '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Pasta para ficheiros temporários"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%d bytes transferidos"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "O URL %s devolveu: %i - Erro (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Download HTTP cancelado"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2604,7 +2609,7 @@ msgstr "Ligação Externa: Acesso negado porque: "
 msgid "External Connection: Handshake failed."
 msgstr "Ligação Externa: Negociação inicial falhou."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Actualização automática iniciada"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 "X-Generator: Lokalize 2.0\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Arată aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "control distant aMule"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Variantă versiune:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "Client p2p bazat pe eMule pentru toate platformele \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -50,59 +50,59 @@ msgstr ""
 "Drept de autor (c) 2003-2019 Echipa aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Părți din aMule sunt bazate pe \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Rutare P2P bazată pe XOR metric.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Drept de autor (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Site web:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verifică la pornire dacă au apărut versiuni noi"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Se conectează la Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Utilizați o versiune învechită de aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Indisponibil"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -199,8 +199,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -215,47 +215,57 @@ msgstr "A eșuat deschiderea fișierului legătură eD2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATENȚIE: Nu vă puteți adăuga ca sursă pentru o legătură eD2k cât timp aveți lowid."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Acum, se oprește aplicația principală..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Se termină instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Se omoară instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Eșuat"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule la ieșire: Se închide nucleul."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule închidere terminată."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultatele depanării memoriei pentru ieșirea aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Limba dumneavoastră a fost schimbată la cea implicită a sistemului datorită schimbării configurației. Regretăm."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -263,56 +273,56 @@ msgstr ""
 "\n"
 "configurație EC"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ATENȚIE"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rețele"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S-a găsit %i server în server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nu se pot lega porturile la adresa specificată: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portul %u nu este disponibil. Veți fi LOWID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -327,48 +337,48 @@ msgstr ""
 "\n"
 "Verificați rețeaua pentru a vă asigura că portul este deschis pentru intrare și ieșire."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "A eșuat crearea fișierului Semnătură Online"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "A eșuat crearea fișierului aMule Semnătură Online"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Localizarea selectată se pare că nu este instalată pe computer. (Notă: Se va încerca configurarea acesteia oricum)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Aceasta este prima dată când rulați aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Această versiune este o versiune de testare, actualizată zilnic și\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nu vă dăm nici un fel de garanție dacă nu se va strica nimic, ardeți-vă casa,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "sau omorâți-vă câinele. Dar * ar trebui să fie * sigur de utilizat oricum.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mai multe informații, suport și versiuni noi pot fi găsite pe pagina noastră web,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "la https://amule-org.github.io, sau în canalul nostru IRC #aMule at irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportați orice fel de probleme la https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -376,137 +386,137 @@ msgstr ""
 "Dosarul specificat pentru Semnătura Online NU ESTE VALID!\n"
 "Semnătura Online va fi DEZACTIVATĂ până va fi reparată problema în preferințe."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "S-a notificat numele serverului"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Prealocarea spațiului pe disc pentru fișierul '%s' a eșuat: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "EROARE: nu se poate deschide fișierul jurnal"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ATENȚIE: fișierul jurnal este gol. Ceva este greșit."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Jurnalul a fost resetat"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesaj server: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se omite descărcarea a %s, fiindcă fișierul solicitat nu este mai nou."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "A eșuat descărcarea listei de noduri."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "A eșuat deschiderea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Fișierul de verificare a versiunii este corupt"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Utilizați o versiune învechită de aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versiunea dumneavoastră de aMule este %i.%i.%i iar ultima versiune este %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATENȚIE: Versiunea dumneavoastră aMuled este învechită: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Copia dumneavoastră aMule este actualizată."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "A eșuat descărcarea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizatori: %s | Fișiere: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizatori: E: %s K: %s | Fișiere: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nu este selectată nicio rețea"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "cu LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "cu HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectat la %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectare la %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Deconectat de la eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad este pornit."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad este oprit."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Conectat la Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectat la Kad (prin firewall)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Deconectat de la Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nu se poate utiliza rețeaua Kad dacă portul UDP este dezactivat în preferințe, nu se pornește."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rețeaua Kad este dezactivată în preferințe, nu se conectează."
 
@@ -546,15 +556,15 @@ msgstr "Acesta este aMule %s bazat pe eMule."
 msgid "Running on %s"
 msgstr "Rulând pe %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitați https://github.com/amule-org/amule/releases/latest pentru a verifica dacă este disponibilă o nouă versiune."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "EROARE FATALĂ: A eșuat crearea temporizatorului"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -564,223 +574,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponibil"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "dialogul aMule distrus"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Se conecteză"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Se conectează"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deconectat"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Prin firewall"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Conectat"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Se conectează"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Închis"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Anulare"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Oprește încercările curente de conectare"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Deconectează"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Deconectează de la rețelele curent conectate"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Conectează"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Conectează la rețelele activate curent"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "În: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MO/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "În: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectat)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Deconectat)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Sigur doriți să închideți %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Confirmare închidere"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Lansare comandă:"
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- implicit -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Directorul aspectului aplicației '%s' nu există"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENȚIE: Nu se poate deschide fișierul aspect '%s' pentru citit"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Rețele"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Fereastra rețelelor"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Căutări"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Fereastra căutărilor"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Descărcări"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Fereastra descărcărilor"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Fișiere partajate"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Fereastra fișierelor partajate"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Mesaje"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Fereastra mesajelor"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistici"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Fereastra graficului statisticilor"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferințe"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Fereastra configurare preferințe"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importă"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Unealta de importat fișiere parțiale"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Despre"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Despre/Ajutor"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Rețea eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Rețea Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Nicio rețea"
 
@@ -868,8 +878,8 @@ msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează d
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Necunoscut"
@@ -1237,19 +1247,19 @@ msgstr "Automat [În]"
 msgid "Very low"
 msgstr "Foarte joasă"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Joasă"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1281,7 +1291,7 @@ msgid "On Queue"
 msgstr "În coadă"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Se descarcă"
 
@@ -1341,7 +1351,7 @@ msgstr "Server local"
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1413,7 +1423,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensiune"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Transferat"
 
@@ -1426,7 +1436,7 @@ msgid "Progress"
 msgstr "Progres"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Surse"
 
@@ -1436,7 +1446,7 @@ msgstr "Surse"
 msgid "Priority"
 msgstr "Prioritate"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Stare"
 
@@ -1469,7 +1479,7 @@ msgstr ""
 "Feedback de la: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automat"
@@ -2122,7 +2132,7 @@ msgstr "A eșuat deschiderea fișierului listă prieteni 'emfriends.met' pentru 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - niciun client în StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Prieteni"
 
@@ -2409,8 +2419,8 @@ msgstr "Port nevalid la bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completați toate câmpurile solicitate"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Mesaj"
 
@@ -2485,7 +2495,7 @@ msgstr "Rată de partajare"
 msgid "Uploaded"
 msgstr "Încărcat"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Cerut"
 
@@ -2519,30 +2529,30 @@ msgstr "Eroare necunoscută %d"
 msgid "Unable to get error description for error %d"
 msgstr "Nu se poate obține descrierea erorii pentru eroarea %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Se indexează"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Finalizat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Terminat"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Întrerupt"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Eronat"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Se așteaptă"
 
@@ -2587,7 +2597,7 @@ msgstr "Conexiune externă; Acces interzis fiindcă:"
 msgid "External Connection: Handshake failed."
 msgstr "Conexiune externă: A eșuat strângerea de mână."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Procesul Asio %d pornit"
@@ -2609,7 +2619,7 @@ msgid "WARNING: "
 msgstr "ATENȚIE:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Închide"
 
@@ -2725,7 +2735,7 @@ msgstr "Ieşire"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2965,7 +2975,7 @@ msgstr "Baiți"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MO"
@@ -3034,7 +3044,7 @@ msgstr "Curăță descărcările terminate"
 msgid "File sources:"
 msgstr "Surse fișier:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "General"
 
@@ -3055,7 +3065,7 @@ msgstr "Nume complet :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "NU SE APLICĂ"
 
@@ -3231,7 +3241,7 @@ msgstr "Nume utilizator:"
 msgid "Userhash :"
 msgstr "Index utilizator :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adaugă"
@@ -3240,15 +3250,15 @@ msgstr "Adaugă"
 msgid "Download-Speed"
 msgstr "Viteză-descărcare"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Curentul"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Medie rulare"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Medie sesiune"
 
@@ -3260,7 +3270,7 @@ msgstr "Viteză-încărcare"
 msgid "Connections"
 msgstr "Conexiuni"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Descărcări active"
 
@@ -3268,7 +3278,7 @@ msgstr "Descărcări active"
 msgid "Active connections (1:1)"
 msgstr "Conexiuni active (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Încărcări active"
 
@@ -3469,8 +3479,8 @@ msgstr "Selecție navigator"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduceți aici numele navigatorului. Lăsați acest câmp necompletat pentru utilizarea navigatorului implicit de sistem."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3544,750 +3554,759 @@ msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Numai pentru utilizatorii avansați: Dacă aveți mai multe interfețe de rețea, introduceți adresa interfeței la care aMule ar trebui să fie legat."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Leagă adresa locală la IP (gol pentru oricare):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Număr maxim de surse pe fișier descărcat:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Număr maxim de conexiuni simultane:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Conectare automată la pornire"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Reconectare la pierdere"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Elimină serverele moarte după"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "încercări"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Actualizează automat lista serverelor la pornire"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Listă"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Actualizează lista serverelor la conectarea la un server"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Actualizează lista serverelor când se conectează un client"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Utilizează prioritatea sistemului"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Utilizează verificarea inteligentă LowID la conectare"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Conectare sigură"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Conectează automat numai la serverele din lista statică"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Configurează serverele adăugate manual la prioritate înaltă"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestionare inteligentă a fișierelor corupte (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Activează"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avansat acordă încredere fiecărui index (nu este recomandat)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Adaugă fișiere la descărcare în modul pauză"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Adaugă fișiere la descărcare cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Încearcă să descarci întâi prima și ultima bucată"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Pornește următorul fișier pauzat când un fișier s-a terminat"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Din aceeași categorie"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "În ordine alfabetică"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Prealocare spațiu pe disc pentru noile fișiere"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pentru noile fișiere se prealocă spațiu pe disc pentru întreg fișierul, astfel se reduce fragmentarea"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Oprește descărcarea când s-a atins limita spațiului disponibil"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selectați asta dacă doriți ca aMule să verifice spațiul liber pe disk"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Introduceți aici minimum de spațiu pe disc dorit."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvează 10 surse de fișiere rare (< 20 surse)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Încărcări"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Adaugă noile fișiere partajate cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Dosar destinație pentru descărcări"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Dosar pentru fișiere descărcate temporar"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Dosare partajate"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click dreapta pe miniatura dosarului pentru partajare recursivă)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Partajează fișierele ascunse"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafice"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Întârziere actualizare : 5 secunde"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Timp pentru media graficului: 100 minute"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Scală grafic conexiuni: 100"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Scală grafic descărcare:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Scală grafic încărcare:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Colori:"
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Fundal"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Grilă"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Descărcare actuală"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Medie rulare descărcare"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Medie descărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Încărcare actuală"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Medie rulare încărcare"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Medie încărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Conexiuni active"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Miniatură rapidă pe bara de sistem"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Noduri Kad curente"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Noduri Kad care rulează"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Noduri Kad pe sesiune"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Selectează"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Arbore"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Număr de versiuni client arătate (0=nelimitat)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! ATENȚIE !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Maxim conexiuni noi /5 secunde"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensiune fișier tampon: 240000 octeți"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensiune coadă încărcare: 5000 clienți"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval reîmprospătare conexiune server: Dezactivat"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Dezactivează temporizarea modului de st-by al computerului"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Aspect interfață de utilizat:"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Arată \"Manipulator linkuri rapide eD2k\" în fiecare fereastră."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Arată informații extinse în fila categoriilor"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Arată în titlu versiunea aplicației"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Arată rata de transfer în titlu"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Înaintea numelui aplicației"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "După numele aplicației"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Arată lățimea de bandă globală"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientare verticală a barei de unelte"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Descărcare coadă fișiere"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Arată procentul progresului"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Arată bara de progres"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Rotund"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Sortare automată fișiere (consum mare de CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule va sorta automat coloanele în lista descărcărilor"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parametrii conexiune externă"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Acceptă conexiuni externe"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP a interfeței de ascultare:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduceți aici un ip valid în formatul a.b.c.d pentru ascultarea interfeței EC. Un câmp gol sau 0.0.0.0 va însemna orice interfață."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activează înaintarea portului UPnP pe portul EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parolă"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Rulează la pornire serverul web"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Șablon web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Parolă cu drepturi depline"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Activează utilizatorul cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Parolă cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activează înaintarea portului UPnP pe portul serverului web"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port UPnP TCP server web (facultativ)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Timp reîmprospătare pagină (în secunde)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Activează compresia Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Bine"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Apăsați aici pentru a aplica orice modificare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Resetează orice schimbare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titlu :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Comentariu :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Director intrare :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Schimbă prioritatea pentru noile fișiere alocate :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Nu modifica"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selectați culoarea pentru această categorie (selectată curent):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Resetare"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Apăsați acest buton pentru resetarea jurnalului."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Apăsați acest buton pentru a se actualiza lista serverelor din URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Listă server"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduceți aici adresa URL pentru un fișier server.met și apăsați butonul din stânga pentru a actualiza lista serverelor. cunoscute."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Adăugare server manual: Nume"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Introduceți aici numele noului server"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduceți aici adresa IP a serverului, utilizând formatul x.x.x.x  ."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Introduceți aici portul serverului."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adăugați un server manual (completați întâi câmpurile din stânga) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Jurnal aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Informație server"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Informație eD2k"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Informație Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Apăsați pe acest buton pentru a actualiza lista nodurilor din URL ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Noduri (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduceți aici adresa url către un fișier nodes.dat și apăsați butonul din stânga pentru actualizarea listei nodurilor cunoscute."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Stare noduri"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nod nou"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap de la clienții cunoscuți"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Deconectare Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Utilizează identificarea securizată a utilizatorilor"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Este recomandat să activați această opțiune. Nu veți primii credite dacă SUI nu este activat."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protocol disimulare"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Suport protocol disimulare"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Această opțiune activează Protocolul Disimulare, și determină aMule să accepte conexiuni disimulate de la alți clienți."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizați disimularea pentru conexiunile de ieșire"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Această opțiune determină aMule să utilizeze Protocolul Disimulare când conectează alți clienți/servere."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Acceptă numai conexiuni disimulate"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Această opțiune face aMule să accepte numai conexiuni disimulate. Veți avea mai puține surse, dar tot traficul va fi disimulat"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Fiecare"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Nimănui"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Cine poate vedea fișierele mele partajate:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selectați cine poate solicita să vizualizeze o listă a fișierelor partajate."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtrare-IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtru clienți"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor client cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtrare servere"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor server cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Reîncarcă lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Reîncarcă lista IP-urilor de filtrat din fișierul ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Actualizează acum"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Nivel de filtrare:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filtrează mereu IP-urile LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manipulare paranoică a IP-urilor care nu se potrivesc"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Respinge pachetele dacă adresa ip a clientului este diferită de adresa ip de unde este primit pachetul. Utilizați cu precauție."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizați în tot sistemul ipfilter.dat dacă este disponibil"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Dacă nu s-a găsit local ipfilter.dat, permite utilizarea unui fișier ipfilter din sistem."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Activare semnătură online"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activați scrierea fișierului OS, care poate fi utilizat de aplicații exterioare la crearea semnăturilor și aprecierii."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frecvență actualizare (secunde)"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Schimbați frecvența (în secunde) a actualizărilor semnăturii online."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Salvează fișierul semnăturii online în:"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Apăsați aici pentru a selecta directorul care conține fișierele cu semnătura online."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Arată steagul țării pentru clienți"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Rată date :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Surse"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4295,11 +4314,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4309,225 +4328,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descărcare:"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrare mesaje de intrare (cu excepția chat-ului curent):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtrează toate mesajele"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrare mesaje de la persoane care nu sunt în lista de prieteni"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtrare mesaje de la clienți necunoscuți"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrare mesaje conținând )utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adăugați aici cuvintele pe care amule trebuie să le filtreze și să blocheze mesajele care le includ"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Arată în jurnal mesajele primite"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Comentarii"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrare comentarii conținând (utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Activează autentificarea"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Activează/dezactivează autentificarea cu nume utilizator/parolă"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Utilizator:"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Numele de utilizator de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Parolă:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Parola de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Activează proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Activează/dezactivează suportul proxy"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Tip proxy:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Gazdă proxy:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Numele de gazdă proxy"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Portul proxy"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Conectează la:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Autentificare la amule distant"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Nume utilizator"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Amintește aceste configurări"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Utilizează compresia gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activează jurnalizarea de depanare detaliată."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Numai la fișierul jurnal"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Categorii mesaje:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Așteptați..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Adaugă importurile"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Reîncearcă selectatele"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Elimină selecția"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Tipuri de evenimente"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistici și clienți în coadă pentru fișier(ele) selectate : Sesiune / Tot timpul"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Încărcări active"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Procentul din totalul fișierelor"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Toate fișierele"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Fișierele selectate"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Numai încărcările active"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Reîncarcă:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Trimite"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Trimite mesajul specificat"
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Închide această sesiune de chat."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Conectare la orice server și/sau Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Fișiere partajate"
 
@@ -4606,7 +4625,7 @@ msgstr "toți ceilalți"
 msgid "Incomplete"
 msgstr "incomplet"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Oprit"
 
@@ -4797,7 +4816,7 @@ msgstr "Nu se poate citi fișierul semințe pentru fișierul parțial %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Eroare la citirea fișierului sămânță al fișierului parțial (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -4805,334 +4824,334 @@ msgstr[0] "S-a găsit partea coruptă (%d) în %d fișierul parțial %s - Rezult
 msgstr[1] "S-a găsit partea coruptă (%d) în %d fișiere parțiale %s - Rezultat index fișier |%s| Index fișier |%s|"
 msgstr[2] "S-a găsit partea coruptă (%d) în %d de fișiere parțiale %s - Rezultat index fișier |%s| Index fișier |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "S-au găsit părți complete (%i) în %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "S-a finalizat reindexarea %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Eroare neașteptată în timpul finalizării %s. Fișier pauzat"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "S-a finalizat descărcarea: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "S-a finalizat descărcarea: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Se șterge fișierul: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "Atenție: Nu se poate indexa partea descărcată - indexare incompletă pentru '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "EROARE: Nu se poate indexa partea descărcătă - indexare incompletă (%s). Aceasta nu ar trebui să se întâmple"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF  în timpul indexării părții descărcate %u cu lungimea %u (max %u) de fișiere parțiale '%s' cu lungimea %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ATENȚIE: Nu este suficient spațiu liber pe disc! Se pauzează fișierul: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Partea descărcată %i este coruptă în fișierul: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: S-a recuperat partea coruptă %i pentru %s -> Octeți salvați: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Se alocă"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Spațiu pe disc insuficient"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descărcat"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "EROARE: A eșuat deschiderea fișierului parțial '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Valoare implicită a sistemului"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albaneză"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabă"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturian"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Bască"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgară"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Catalană"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Chineză (Simplificat)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Chinez (tradițional)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Croată"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Cehă"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Daneză"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Olandeză"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonă"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandeză"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Franceză"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galiciană"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Germană"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grecesc"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Ebraică"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Maghiară"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiană"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italian (elvețian)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japoneză"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Koreană"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituaniană"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegian"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Poloneză"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugheză"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugheză (Brazilia)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Română"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Rusă"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovenă"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spaniolă"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Suedeză"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turcă"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ucraineană"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Schimbă limba"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Nu sunt instalate traduceri pentru aMule"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Nu sunt limbi disponibile"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "Nu sunt opțiuni disponibile"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "S-a găsit o categorie nevalidă, se omite"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Portul TCP nu poate fi mai mare decât 65532 fiindcă soclul UDP al serverului trebuie să fie TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Va fi folosit portul implicit (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Conexiune"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Directoare"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servere"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Fișiere"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Securitate"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Interfaţă"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtre"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Control la distanță"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Semnătură online"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avansat"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Evenimente"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Depanare"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5142,15 +5161,15 @@ msgstr ""
 "    %PARTFILE - calea completă la fișier\n"
 "    %PARTNAME - numai nume fișier"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5165,26 +5184,26 @@ msgstr ""
 "aMule va rula perfect fără să ajustați nimic\n"
 "din aceste configurări."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "A eșuat conectarea Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Tipul de proxy la care sunteți conectat"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la widget la Cfg cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5192,31 +5211,36 @@ msgstr ""
 "aMule trebuie repornit pentru ca aceste modificări să fie activate:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- Portul TCP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- Portul UDP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Interfața conexiunii externe s-a schimbat.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Portul conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Conectarea externă acceptă modificarea.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Interfața conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suportul protocolului disimulare s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5224,7 +5248,7 @@ msgstr ""
 "Lista de actualizare automată a serverelor este goală.\n"
 "'Actualizează automat lista serverelor la pornire' va fi dezactivată."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5232,19 +5256,19 @@ msgstr ""
 "Ați activat conexiunile externe dar nu ați specificat o parolă.\n"
 "Conexiunile externe nu se pot activa până ce nu va fi specificată o parolă validă."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Limba s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Dosarul temporar s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- Rețeaua ED2K s-a activat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5252,7 +5276,7 @@ msgstr ""
 "Ambele rețele eD2k și Kad sunt dezactivate.\n"
 "Nu vă puteți conecta doar după ce veți activa cel puțin una dintre ele."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5260,7 +5284,7 @@ msgstr ""
 "Kad nu va porni dacă portul UDP este dezactivat.\n"
 "Activați portul UDP sau dezactivați Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5270,20 +5294,20 @@ msgstr ""
 "Trebuie să reporniți aMule acum.\n"
 "Dacă nu îl reporniți acum, nu vă plângeți dacă ceva rău se întâmplă.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Reîmprospătarea automată pornită"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5293,41 +5317,41 @@ msgstr ""
 "Introduceți în listă cel puțin o adresă URL pentru a se indica un fișier server.met valid.\n"
 "Apăsați butonul \"List\" cu această căsuță pentru a introduce o adresă URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Fișiere temporare"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Fișiere de intrare"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Semnături online"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Alegeți un dosar pentru %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Navigați pentru playerul video"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Selectare navigator"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Executabil%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Editare listă server"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5335,42 +5359,42 @@ msgstr ""
 "Adăugați aici adresele URL pentru descărcat fișierele server.met.\n"
 "Numai o singură adresă URL pe fiecare linie."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Surse complete"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -5378,7 +5402,7 @@ msgstr[0] "Întârziere actualizare: %d secundă"
 msgstr[1] "Întârziere actualizare: %d secunde"
 msgstr[2] "Întârziere actualizare: %d de secunde"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -5386,12 +5410,12 @@ msgstr[0] "Timp pentru media graficului: %d minut"
 msgstr[1] "Timp pentru media graficului: %d minute"
 msgstr[2] "Timp pentru media graficului: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scală grafic conexiuni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5399,7 +5423,7 @@ msgstr[0] "Dimensiune fișier tampon: %d octet"
 msgstr[1] "Dimensiune fișier tampon: %d octeți"
 msgstr[2] "Dimensiune fișier tampon: %d de octeți"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -5407,7 +5431,7 @@ msgstr[0] "Dimensiune coadă încărcări: %d client"
 msgstr[1] "Dimensiune coadă încărcări: %d clienți"
 msgstr[2] "Dimensiune coadă încărcări: %d de clienți"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -5415,74 +5439,74 @@ msgstr[0] "Interval reâmprospătare conexiune server: %d minut"
 msgstr[1] "Interval reâmprospătare conexiune server: %d minute"
 msgstr[2] "Interval reâmprospătare conexiune server: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval reâmprospătare conexiune server: Dezactivat"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "dezactivată"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Execută comanda la evenimentul '%s' "
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Activați executarea de comenzi în nucleu"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Comandă nucleu:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Activează execuția comenzi pe GUI"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Comandă GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Următoarele variabile vor fi înlocuite:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Reîncarcă lista fișierelor partajate."

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -199,8 +199,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,27 +245,37 @@ msgstr "aMule închidere terminată."
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultatele depanării memoriei pentru ieșirea aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Limba dumneavoastră a fost schimbată la cea implicită a sistemului datorită schimbării configurației. Regretăm."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -273,56 +283,56 @@ msgstr ""
 "\n"
 "configurație EC"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ATENȚIE"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rețele"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S-a găsit %i server în server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nu se pot lega porturile la adresa specificată: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portul %u nu este disponibil. Veți fi LOWID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -337,48 +347,48 @@ msgstr ""
 "\n"
 "Verificați rețeaua pentru a vă asigura că portul este deschis pentru intrare și ieșire."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "A eșuat crearea fișierului Semnătură Online"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "A eșuat crearea fișierului aMule Semnătură Online"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Localizarea selectată se pare că nu este instalată pe computer. (Notă: Se va încerca configurarea acesteia oricum)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Aceasta este prima dată când rulați aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Această versiune este o versiune de testare, actualizată zilnic și\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nu vă dăm nici un fel de garanție dacă nu se va strica nimic, ardeți-vă casa,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "sau omorâți-vă câinele. Dar * ar trebui să fie * sigur de utilizat oricum.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mai multe informații, suport și versiuni noi pot fi găsite pe pagina noastră web,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "la https://amule-org.github.io, sau în canalul nostru IRC #aMule at irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportați orice fel de probleme la https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -386,137 +396,137 @@ msgstr ""
 "Dosarul specificat pentru Semnătura Online NU ESTE VALID!\n"
 "Semnătura Online va fi DEZACTIVATĂ până va fi reparată problema în preferințe."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "S-a notificat numele serverului"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Prealocarea spațiului pe disc pentru fișierul '%s' a eșuat: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "EROARE: nu se poate deschide fișierul jurnal"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ATENȚIE: fișierul jurnal este gol. Ceva este greșit."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Jurnalul a fost resetat"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesaj server: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se omite descărcarea a %s, fiindcă fișierul solicitat nu este mai nou."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "A eșuat descărcarea listei de noduri."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "A eșuat deschiderea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Fișierul de verificare a versiunii este corupt"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Utilizați o versiune învechită de aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versiunea dumneavoastră de aMule este %i.%i.%i iar ultima versiune este %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATENȚIE: Versiunea dumneavoastră aMuled este învechită: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Copia dumneavoastră aMule este actualizată."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "A eșuat descărcarea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizatori: %s | Fișiere: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizatori: E: %s K: %s | Fișiere: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nu este selectată nicio rețea"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "cu LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "cu HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectat la %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectare la %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Deconectat de la eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad este pornit."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad este oprit."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Conectat la Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectat la Kad (prin firewall)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Deconectat de la Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nu se poate utiliza rețeaua Kad dacă portul UDP este dezactivat în preferințe, nu se pornește."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rețeaua Kad este dezactivată în preferințe, nu se conectează."
 
@@ -2597,7 +2607,7 @@ msgstr "Conexiune externă; Acces interzis fiindcă:"
 msgid "External Connection: Handshake failed."
 msgstr "Conexiune externă: A eșuat strângerea de mână."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Procesul Asio %d pornit"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -199,8 +199,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,37 +245,42 @@ msgstr "aMule închidere terminată."
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultatele depanării memoriei pentru ieșirea aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Limba dumneavoastră a fost schimbată la cea implicită a sistemului datorită schimbării configurației. Regretăm."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -283,56 +288,56 @@ msgstr ""
 "\n"
 "configurație EC"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ATENȚIE"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rețele"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S-a găsit %i server în server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nu se pot lega porturile la adresa specificată: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portul %u nu este disponibil. Veți fi LOWID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -347,48 +352,48 @@ msgstr ""
 "\n"
 "Verificați rețeaua pentru a vă asigura că portul este deschis pentru intrare și ieșire."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "A eșuat crearea fișierului Semnătură Online"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "A eșuat crearea fișierului aMule Semnătură Online"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Localizarea selectată se pare că nu este instalată pe computer. (Notă: Se va încerca configurarea acesteia oricum)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Aceasta este prima dată când rulați aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Această versiune este o versiune de testare, actualizată zilnic și\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nu vă dăm nici un fel de garanție dacă nu se va strica nimic, ardeți-vă casa,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "sau omorâți-vă câinele. Dar * ar trebui să fie * sigur de utilizat oricum.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mai multe informații, suport și versiuni noi pot fi găsite pe pagina noastră web,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "la https://amule-org.github.io, sau în canalul nostru IRC #aMule at irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportați orice fel de probleme la https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -396,137 +401,137 @@ msgstr ""
 "Dosarul specificat pentru Semnătura Online NU ESTE VALID!\n"
 "Semnătura Online va fi DEZACTIVATĂ până va fi reparată problema în preferințe."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "S-a notificat numele serverului"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Prealocarea spațiului pe disc pentru fișierul '%s' a eșuat: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "EROARE: nu se poate deschide fișierul jurnal"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ATENȚIE: fișierul jurnal este gol. Ceva este greșit."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Jurnalul a fost resetat"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesaj server: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se omite descărcarea a %s, fiindcă fișierul solicitat nu este mai nou."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "A eșuat descărcarea listei de noduri."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "A eșuat deschiderea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Fișierul de verificare a versiunii este corupt"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Utilizați o versiune învechită de aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versiunea dumneavoastră de aMule este %i.%i.%i iar ultima versiune este %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATENȚIE: Versiunea dumneavoastră aMuled este învechită: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Copia dumneavoastră aMule este actualizată."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "A eșuat descărcarea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizatori: %s | Fișiere: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizatori: E: %s K: %s | Fișiere: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Nu este selectată nicio rețea"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "cu LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "cu HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectat la %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectare la %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Deconectat de la eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad este pornit."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad este oprit."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Conectat la Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectat la Kad (prin firewall)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Deconectat de la Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nu se poate utiliza rețeaua Kad dacă portul UDP este dezactivat în preferințe, nu se pornește."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rețeaua Kad este dezactivată în preferințe, nu se conectează."
 
@@ -887,7 +892,7 @@ msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează d
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2257,49 +2262,49 @@ msgstr "Nu"
 msgid "Yes"
 msgstr "Da"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Se descarcă..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Descărcare HTTP anulată"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "Adresa URL de descărcat nu poate fi goală"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "A eșuat preluarea fișierelor partajate de la utilizatorul '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Dosar pentru fișiere descărcate temporar"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Descărcat %d octeți"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "Adresa URL %s a returnat: %i - Eroare (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Descărcare HTTP anulată"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2607,7 +2612,7 @@ msgstr "Conexiune externă; Acces interzis fiindcă:"
 msgid "External Connection: Handshake failed."
 msgstr "Conexiune externă: A eșuat strângerea de mână."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Procesul Asio %d pornit"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -26,21 +26,21 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Показать aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Удаленное управление aMule"
 
 # Used only in CVS!
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Версия CVS:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -48,7 +48,7 @@ msgstr ""
 "Многоплатформенный p2p клиент основанный на eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -57,59 +57,59 @@ msgstr ""
 "Copyright (c) 2003-2019 команда aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Часть aMule основана на \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: пиринговый роутинг на основе XOR-метрики.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr "Copyright (c) 2002-2011 Петр Маймунков ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Сайт:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Форум:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Проверка наличия новой версии при запуске"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Подключаюсь к Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Вы используете устаревшую версию aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Недоступен"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -206,8 +206,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -222,47 +222,57 @@ msgstr "Не удалось открыть файл ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Вы не можете добавить себя в качестве источника для eD2k ссылки если у вас lowid."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Выходим из основного приложения..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Завершаем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Убиваем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Неудачно"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Прекращаем работу ядра."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "выключение aMule завершено."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Результаты дебага памяти при выходе из aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "В связи со сменой версии, значение вашей локали было изменено на значение по умолчанию. Извините."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Сведения"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -270,56 +280,56 @@ msgstr ""
 "\n"
 "EC конфигурация"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ПРЕДУПРЕЖДЕНИЕ"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Сети"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "В файле 'server.met' найден %i сервер"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Невозможно связать порты с указанными адресами: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u не доступен. У вас будет LowID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -334,48 +344,48 @@ msgstr ""
 "\n"
 "Проверьте вашу сетевую конфигурацию, убедитесь что необходимый порт открыт."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Выбранная локаль отсутствует в вашей системе (тем не менее, будет произведена попытка ее использовать)."
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Это первый запуск aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Эта версия является тестовой и обновляется ежедневно.\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "мы не предоставляем никаких гарантий на случай каких либо повреждений, пожара \n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "или же смерти вашей любимой собачки. И все же использование ее *должно* быть безопасным. \n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Дополнительную информацию, поддержку и обновленные версии вы найдете на нашем сайте \n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, или на нашем irc-канале #aMule, находящемся на сервере irc.libera.chat. \n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Сообщайте нам о найденных ошибках на форум https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -383,141 +393,141 @@ msgstr ""
 "Указан неверный каталог для файлов Online-подписей!\n"
 "Online-подписи будут отключены пока вы не исправите это в настройках."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Имя сервера подтверждено"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Выделение место под файл '%s' не удалось: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "Ошибка: невозможно открыть файл журнала"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: файл журнала пуст. Что-то здесь не так :-("
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Журнал был очищен"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Сообщение сервера: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Пропущена загрузка %s, так как запрашиваемый файл не новее."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Ошибка при загрузке списка узлов."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Поврежден файл контроля версии"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Вы используете устаревшую версию aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Версия вашего aMule - %i.%i.%i, тогда как актуальная версия - %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ВНИМАНИЕ: Версия вашего aMule устарела: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копия aMule актуальна."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Польз.: %s | Файлов: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Польз.: E: %s K: %s | Файлов: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Нет выделенной сети"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Соединен с %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Подключение к %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Отсоединен от eD2k"
 
 # Kad как сеть, или служба - поэтому в женском роде
 # да, согласен
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad запущена."
 
 # Kad как сеть, или служба - поэтому в женском роде
 # согласен
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad остановлена."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Подключен к Kad (норм.)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Подключен к Kad (за брандмауэром)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Отключился от Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Сеть Kad не может быть использована если порт UDP выключен в настройках. Отменяю запуск."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Сеть Kad выключена в настройках. Отменяю соединение."
 
@@ -557,15 +567,15 @@ msgstr "aMule %s (основан на eMule)."
 msgid "Running on %s"
 msgstr "Работает на %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Посетите https://github.com/amule-org/amule/releases/latest для проверки наличия новой версии."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ФАТАЛЬНАЯ ОШИБКА: не удалось создать таймер"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -575,223 +585,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступен"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "диалоговое окно aMule уничтожено"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Идет подключение"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Соединение"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: не соединено"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: За брандмауэром"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Подключена"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Идет подключение"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr " Kad: Выключено"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Прекратить попытки соединения"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Отключиться"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Отключиться от работающих сетей"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Подключиться"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Подключиться к разрешенным сетям"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Передача: %.1f(%.1f) | Прием: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "МБ/с"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr "kB/сек"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Передача: %.1f | Прием: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Подключен)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Отключен)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Вы действительно хотите выйти из %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Подтверждение выхода"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Команда запуска:"
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- по умолчанию -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Каталог с темами оформления '%s' не существует."
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: невозможно открыть для чтения файл скина '%s'"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Сети"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Окно сетей"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Поиск"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Окно поиска"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Загрузки"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Окно загрузки"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Публикуемые файлы"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Окно публикуемых файлов"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Окно настроек клиента"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Импорт"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Инструмент импортирования частично загруженных файлов (part files)"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "О программе"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "О программе/Помощь"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Сеть eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Сеть Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Нет сети"
 
@@ -879,8 +889,8 @@ msgstr "Не удается создать директорию '%s' для ка
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Неизвестно"
@@ -1248,19 +1258,19 @@ msgstr "Авто [Выс]"
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Низкий"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Нормальный"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1292,7 +1302,7 @@ msgid "On Queue"
 msgstr "В очереди"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Загружается"
 
@@ -1352,7 +1362,7 @@ msgstr "Локальный сервер"
 msgid "Remote Server"
 msgstr "Удаленный сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1425,7 +1435,7 @@ msgstr "Часть"
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Передано"
 
@@ -1438,7 +1448,7 @@ msgid "Progress"
 msgstr "Выполнено"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Источники"
 
@@ -1448,7 +1458,7 @@ msgstr "Источники"
 msgid "Priority"
 msgstr "Приоритет"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Состояние"
 
@@ -1481,7 +1491,7 @@ msgstr ""
 "Ответ от: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Авто"
@@ -2138,7 +2148,7 @@ msgstr "Не удалось открыть список друзей 'emfriends.
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - нет клиентов на StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Друзья"
 
@@ -2426,8 +2436,8 @@ msgstr "Неверный порт для инициализации"
 msgid "Please fill all fields required"
 msgstr "Пожалуйста, заполните все необходимые поля"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Сообщение"
 
@@ -2503,7 +2513,7 @@ msgstr "Рейтинг"
 msgid "Uploaded"
 msgstr "Загружено"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Запрошено"
 
@@ -2537,30 +2547,30 @@ msgstr "Неизвестная ошибка %d"
 msgid "Unable to get error description for error %d"
 msgstr "Невозможно получить описание ошибки %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Хешируется"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Завершается"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Завершен"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Приостановлен"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Ошибочный"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Ожидает"
 
@@ -2605,7 +2615,7 @@ msgstr "Внешнее Соединение: В доступе отказано 
 msgid "External Connection: Handshake failed."
 msgstr "Внешнее Соединение: авторизация неудачна."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Автоматическое обновление начато"
@@ -2627,7 +2637,7 @@ msgid "WARNING: "
 msgstr "ПРЕДУПРЕЖДЕНИЕ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Закрыть"
 
@@ -2743,7 +2753,7 @@ msgstr "Выйти"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/сек"
@@ -2987,7 +2997,7 @@ msgstr "Байт"
 msgid "KB"
 msgstr "КБ"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "МБ"
@@ -3056,7 +3066,7 @@ msgstr "Очистить результаты"
 msgid "File sources:"
 msgstr "Источников:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Общие"
 
@@ -3077,7 +3087,7 @@ msgstr "Полное имя :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3255,7 +3265,7 @@ msgstr "Имя пользователя :"
 msgid "Userhash :"
 msgstr "Хеш пользователя :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавить"
@@ -3264,15 +3274,15 @@ msgstr "Добавить"
 msgid "Download-Speed"
 msgstr "Скорость приема"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Текущая"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Средняя за все время"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "В среднем за сеанс"
 
@@ -3284,7 +3294,7 @@ msgstr "Скорость отдачи"
 msgid "Connections"
 msgstr "Соединения"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Активные загрузки"
 
@@ -3292,7 +3302,7 @@ msgstr "Активные загрузки"
 msgid "Active connections (1:1)"
 msgstr "Активные соединения (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Активные передачи"
 
@@ -3493,8 +3503,8 @@ msgstr "Выбор браузера"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введите имя предпочитаемого браузера. Оставьте поле пустым чтобы использовать системный браузер по умолчанию."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3568,757 +3578,766 @@ msgstr "Закрепить локальный адрес за IP (пустой �
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Только для продвинутых пользователей: если у вас несколько сетевых интерфейсов введите адрес того, которым будет пользоваться aMule."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Закрепить локальный адрес за IP (пустой для любого):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Максимум источников на файл:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Максимум одновременных соединений:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Соединяться автоматически после запуска"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Восстановить соединение в случае разрыва"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Удалить нерабочий сервер после"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "попыток"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Автоматически обновлять список серверов при запуске"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Список"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Обновлять список серверов при подключении к серверу"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Обновлять список серверов при подключении к клиенту"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Использовать систему приоритетов"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Проверка на LowID при подключении к серверу"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Безопасное подключение"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Автоподключение только к статическим серверам"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Высокий приоритет серверов, добавленных вручную"
 
 # слишком уж частая аббривеатура. написать И.О.О. - никто не поймет
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Интеллектуальная Обработка Ошибок (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Разрешить"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "AICH-доверие для каждого хэша (не рекомендуется)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Добавлять файлы на загрузку в режиме паузы"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Добавлять файлы в загрузку с авто приоритетом"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Пытаться сначала загрузить первую и последнюю части"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Возобновлять следующий файл на паузе при завершении загрузки"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Из той же категории"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "В алфавитном порядке"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Заранее выделять место для новых фалов"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Сразу выделяет место под весь файл. Таким образом уменьшается фрагментация"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Останавливать загрузки по окончанию свободного места на диске"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Отметьте это если  хотите чтобы aMule проверял наличие свободного места"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Введите здесь минимальное количество свободного места на диске."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Оставлять 10 источников для редких файлов (<20 источников)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Отдача"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Добавлять новые файлы для публикации с авто приоритетом"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Папка для загружаемых файлов"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Папка для временных файлов"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Публикуемые папки"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(кликните правой кнопкой на значке каталога для рекурсивной публикации)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Включая скрытые файлы"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Графики"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Интервал обновления: 5 сек"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Время для среднестатического графика: 100 минут"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Масштаб графика соединений: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Масштаб графика загрузки:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Масштаб графика отдачи:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Цвета:"
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Сетка"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Текущая загрузка"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Средняя общая загрузка"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Средняя загрузка за сеанс"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Текущая отдача"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Средняя общая отдача"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Средняя отдача за сеанс"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Активные соединения"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Скорость передачи в области уведомлений"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Узлы Kad (текущие)"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Узлы Kad (действующие)"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Узлы Kad (сессия)"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Выбрать"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Число отображаемых версий клиентов (0=неогр.)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Предел количества новых соединений за 5 секунд"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Размер буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Размер очереди: 5000 клиентов"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Интервал обновления соединения с сервером: Отключено"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Отключить засыпание компьютера"
 
 # в LA помнится так и перевели - "шкурка", но по-моему глупо.
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Скин:"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показывать строку \"быстрой загрузки\" в каждой вкладке."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Показывать дополнительную информацию на закладках категорий"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Перед именем приложения"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "После имени приложения"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Показывать скорость служебного трафика"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальное расположение панели инструментов"
 
 # This is the heading for the preference options regarding the files in the
 # transfer list.
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Загружаемые файлы"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Показывать процент загрузки"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Показывать полосу выполнения"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Плоская"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Круглая"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Авто-сортировка файлов (нагружает процессор)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule будет сортировать файлы в списке загрузок автоматически."
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Параметры внешних соединений"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Принимать внешние соединения"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP прослушиваемого интерфейса:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введите сюда IP в формате a.b.c.d для прослушиваемого интерфейса ВС. Пустое поле или значение 0.0.0.0 означают любой интерфейс."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Включить UPnP для порта ВС"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Запускать веб-сервер при старте"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Веб-шаблон"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Пароль для обычного доступа"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Разрешить ограниченный доступ"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Пароль ограниченного доступа"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Разрешить UPnP форвардинг порта веб-сервера"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP порт веб-сервера (не обязательно):"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Период обновления страницы (в секундах)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Включить сжатие Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "ОК"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Кликните тут, чтобы сохранить внесенные вами изменения."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Сбросить все изменения, внесенные вами."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Заголовок :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Комментарий :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Каталог загрузок:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Установить приоритет для новых файлов:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Не изменять"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Выбрать цвет для этой категории:"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Сбросить"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Кликните тут для очистки журнала."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Кликните здесь чтобы обновить список серверов через URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Список серверов"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введите URL к файлу 'server.met' и нажмите кнопку слева для обновления списка известных серверов."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Добавить сервер вручную: Имя"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Введите имя нового сервера"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Введите здесь IP-адрес сервера в формате: x.x.x.x"
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Введите здесь порт сервера."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Добавить сервер (предварительно заполните поля слева) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Журнал aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Сообщение сервера"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Инфо ED2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Инфо Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Нажмите на эту кнопку чтобы обновить список узлов из URL..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Узлы (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ведите сюда URL к файлу nodes.dat и нажмите кнопку слева чтобы обновить список известных узлов."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Статистика узлов"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Инициализация"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Новый узел"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Порт:"
 
 # Похоже, bootstrap в eMule перевели как инициализация
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Инициализация от известных клиентов"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Отключить Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Использовать безопасную идентификацию пользователя"
 
 # интересно, что на самом деле подразумевалось под 'credits'
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендуется включить данную опцию. Вы не будете получать рейтинга если БИП выключена."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Вуалирование протокола"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Поддержка вуалирования протокола"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Включает вуалирование протокола и позволяет aMule принимать завуалированные соединения от других клиентов."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Использовать вуалирование исходящих соединений"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Включает вуалирование протокола при соединении с другими клиентами и серверами."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Принимать только завуалированные соединения"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "aMule будет принимать только завуалированные соединения. У вас будет меньше источников, но зато весь трафик будет завуалирован."
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Все"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Никто"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Кто может запрашивать публикуемые файлы:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Выберите, кому показывать список ваших файлов."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Фильтрование IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Фильтровать клиентов."
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP клиентов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Фильтровать сервера"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP серверов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Обновить список"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Прочесть список IP адресов, указанных в файле '~/.aMule/ipfilter.dat'."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Обновить сейчас"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Уровень фильтрации:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Всегда фильтровать IP-адреса LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноидная обработка несовпадающих IP "
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Отбрасывает пакеты у которых IP клиента отличается от IP с которого пришел пакет. Используйте осторожно."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Использовать системный ipfilter.dat если возможно"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Если не найден локальный ipfilter.dat разрешить использовать системный"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Включить Online-подпись"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Включает запись файла OS, который может использоваться другими приложениями для создания подписей."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Частота обновления (в секундах):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Изменить частоту обновления для Online-подписи в секундах."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Сохранять Online-подпись в:"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Кликните здесь, чтобы выбрать каталок для файлов Online-подписи."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Показывать национальные флаги клиентов"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Скорость передачи:"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Источники"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4326,11 +4345,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4340,227 +4359,227 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Прием: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фильтровать входящие сообщения (кроме текущего чата):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Фильтровать все сообщения"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Фильтровать сообщения пользователей не из вашего списка друзей"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Фильтровать сообщения от неизвестных клиентов"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фильтровать сообщения по содержанию (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Добавьте сюда ключевые слова, при наличии которых aMule будет отфильтровывать и блокировать входящие сообщения."
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Показывать полученные сообщения в логе"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Комментарии"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фильтровать комментарии содержащие (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Включить идентификацию"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Включить/выключить использование пароля и логина"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Имя:"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Имя пользователя для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Использовать прокси-сервер"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Включить/выключить поддержку прокси-сервера"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Тип прокси-сервера:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Прокси-сервер:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Имя прокси-сервера"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Порт прокси-сервера"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Соединиться с:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Войти на удаленный aMule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Имя пользователя"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Запомнить настройки"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Использовать gzip-сжатие"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Записывать в журнал подробные сообщения отладчика."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Открыть файл"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Категории сообщений:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ожидание..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Добавить файлы"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Перезапустить выбранное"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Удалить выбранное"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Типы Событий"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Статистика и очередь клиентов для выбранных файлов: За сессию / За все время"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Активные загрузки"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Процент от всех файлов"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Все файлы"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Выбранные файлы"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Только активные передачи"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Обновить:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Обновить список публикуемых файлов"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Отправить"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Отправить данное сообщение."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Закрыть данный чат."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Соединиться с произвольным сервером и/или Kad"
 
 # подпись в главном окне. длинная просто не влезет.
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Файлы"
 
@@ -4639,7 +4658,7 @@ msgstr "все остальные"
 msgid "Incomplete"
 msgstr "Незавершенные"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Остановлен"
 
@@ -4833,7 +4852,7 @@ msgstr "Сохранен %i источник для файла %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Ошибка при чтении источников частично загруженного файла (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -4841,335 +4860,335 @@ msgstr[0] "Найдена испорченная часть (%d) в %d част�
 msgstr[1] "Найдена испорченная часть (%d) в %d частях файла %s - FileResultHash |%s| FileHash |%s|"
 msgstr[2] "Найдена испорченная часть (%d) в %d частях файла %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Найдена завершенная часть (%i) в %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Завершено повторное хеширование %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Неожиданная ошибка во время завершения %s. Файл приостановлен."
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Загрузка завершена: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Загрузка завершена: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Удаление файла: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Не удается схэшировать загруженную часть - хэш-набор неполон для '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ОШИБКА: Не удается схэшировать загруженную часть - хэш-набор неполон (%s). Это никогда не должно происходить"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF при хешировании загруженной части %u с длиной %u (макс %u) файла '%s' с длиной %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: не достаточно свободного места на диске. Файл приостановлен: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Загруженная часть %i повреждена: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Восстановлена поврежденная часть %i для %s -> Выигрыш: %s Б"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Выделяется место"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Недостаточно места на диске"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Загружено"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ОШИБКА: не удалось открыть частично закаченный '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Системный"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Албанский"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Арабский"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Астурианский"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Баскский"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Болгарский"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Каталонский"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Китайский (упрощенный)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Китайский (традиционный)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Хорватский"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Чешский"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Датский"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Голландский"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Эстонский"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Финский"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Французский"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Гальский"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Немецкий"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Греческий"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Израильский"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Итальянский"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Итальянский (Швеция)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Японский"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Корейский"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Литовский"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвежский (Нюнорск)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Польский"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Португальский"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Португальский (Бразилия)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Румынский"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Русский"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Словакский"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Испанский"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Шведский"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Турецкий"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Украинский"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Изменить язык"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступен"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "нет доступных опций"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Обнаружена неверная категория, пропускаем"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP порт не может быть выше 65532, так как UDP сокет - TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Используется порт по умолчанию (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Соединение"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Каталоги"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Сервера"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Файлы"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Безопасность"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Интерфейс"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Прокси"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Фильтры"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Удаленный контроль"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Online-подпись"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "События"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Отладчик"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5179,15 +5198,15 @@ msgstr ""
 "   %PARTFILE - полный путь к файлу\n"
 "   %PARTNAME - только имя файла"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5203,26 +5222,26 @@ msgstr ""
 "aMule будет превосходно работать и БЕЗ ИЗМЕНЕНИЯ вами\n"
 "этих настроек."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Не удалось подключить Cfg к widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Не удалось передать данные из Cfg к Widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Тип прокси-сервера, который вы используете"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Не удалось передать данные из Widget к Cfg с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5230,32 +5249,37 @@ msgstr ""
 "Необходимо перезапустить aMule чтобы следующие изменения вступили в силу:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- изменен порт TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- изменен порт UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Интерфейс внешних соединений изменен.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Порт для внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Принятие внешних соединений изменено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Интерфейс внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Вуалирование протокола"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5263,7 +5287,7 @@ msgstr ""
 "Список авто обновления пуст.\n"
 "Автоматическое обновление списка серверов отключено."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5271,19 +5295,19 @@ msgstr ""
 "Вы включили внешние соединения, но не указали пароль.\n"
 "Внешние соединения нельзя включить до тех пор, пока не указан пароль."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Изменен язык.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Изменен временный каталог.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- сеть eD2k включена. \n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5291,7 +5315,7 @@ msgstr ""
 "Сети eD2k и Kad обе отключены.\n"
 "Вы не сможете подсоединиться пока не подключите хотя бы одну из них."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5299,7 +5323,7 @@ msgstr ""
 "Kad не будет запущена, если UDP-порт выключен.\n"
 "Включите UDP-порт или выключите Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5309,20 +5333,20 @@ msgstr ""
 "Вам НЕОБХОДИМО перезапустить aMule немедленно.\n"
 "Иначе не жалуйтесь, если произойдет какая-нибудь неприятность.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматическое обновление начато"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5332,41 +5356,41 @@ msgstr ""
 "Пожалуйста, внесите в список хотя бы один URL, указывающий на корректный 'server.met'.\n"
 "Щелкните на кнопке \"Список\" чтобы ввести URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Временные файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Входящие файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Online-подписи"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Выберите каталог для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Выбрать видео-проигрыватель"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Выберите броузер"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Команда запуска%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Редактировать список серверов"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5374,42 +5398,42 @@ msgstr ""
 "Впишите сюда адреса для получения файлов 'server.met'.\n"
 "Только один URL в одной строчке."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Полных источников"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -5417,7 +5441,7 @@ msgstr[0] "Интервал обновления: %d с"
 msgstr[1] "Интервал обновления: %d сек"
 msgstr[2] "Интервал обновления: %d сек"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -5425,12 +5449,12 @@ msgstr[0] "Отрезок времени, охватывающийся граф�
 msgstr[1] "Отрезок времени, охватывающийся графиком: %d минут"
 msgstr[2] "Отрезок времени, охватывающийся графиком: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Масштаб графика соединений: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5438,7 +5462,7 @@ msgstr[0] "Файловый буфер: %d Б"
 msgstr[1] "Размер буфера: %d байт"
 msgstr[2] "Размер буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -5446,7 +5470,7 @@ msgstr[0] "Размер очереди отдачи: %d"
 msgstr[1] "Размер очереди отдачи: %d клиентов"
 msgstr[2] "Размер очереди отдачи: %d клиентов"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -5454,75 +5478,75 @@ msgstr[0] "Частота связи с сервером: %d м"
 msgstr[1] "Интервал обновления соединения с сервером: %d минут"
 msgstr[2] "Интервал обновления соединения с сервером: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Обновление соединения с сервером: Отключено"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "выключена"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Выполнить команду при событии '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Включить выполнение команд в ядре"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Команда ядра:"
 
 # никто ни в жизни не поймет переведенную аббревиатуру
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Включить выполнение команд в GUI"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Команда GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Следующие переменные будут заменены:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Обновить список публикуемых файлов"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Обновить список публикуемых файлов."

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -206,8 +206,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -252,37 +252,42 @@ msgstr "выключение aMule завершено."
 msgid "Memory debug results for aMule exit:"
 msgstr "Результаты дебага памяти при выходе из aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "В связи со сменой версии, значение вашей локали было изменено на значение по умолчанию. Извините."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Сведения"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -290,56 +295,56 @@ msgstr ""
 "\n"
 "EC конфигурация"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ПРЕДУПРЕЖДЕНИЕ"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Сети"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "В файле 'server.met' найден %i сервер"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Невозможно связать порты с указанными адресами: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u не доступен. У вас будет LowID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -354,48 +359,48 @@ msgstr ""
 "\n"
 "Проверьте вашу сетевую конфигурацию, убедитесь что необходимый порт открыт."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Выбранная локаль отсутствует в вашей системе (тем не менее, будет произведена попытка ее использовать)."
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Это первый запуск aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Эта версия является тестовой и обновляется ежедневно.\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "мы не предоставляем никаких гарантий на случай каких либо повреждений, пожара \n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "или же смерти вашей любимой собачки. И все же использование ее *должно* быть безопасным. \n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Дополнительную информацию, поддержку и обновленные версии вы найдете на нашем сайте \n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, или на нашем irc-канале #aMule, находящемся на сервере irc.libera.chat. \n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Сообщайте нам о найденных ошибках на форум https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -403,141 +408,141 @@ msgstr ""
 "Указан неверный каталог для файлов Online-подписей!\n"
 "Online-подписи будут отключены пока вы не исправите это в настройках."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Имя сервера подтверждено"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Выделение место под файл '%s' не удалось: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "Ошибка: невозможно открыть файл журнала"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: файл журнала пуст. Что-то здесь не так :-("
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Журнал был очищен"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Сообщение сервера: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Пропущена загрузка %s, так как запрашиваемый файл не новее."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Ошибка при загрузке списка узлов."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Поврежден файл контроля версии"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Вы используете устаревшую версию aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Версия вашего aMule - %i.%i.%i, тогда как актуальная версия - %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ВНИМАНИЕ: Версия вашего aMule устарела: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копия aMule актуальна."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Польз.: %s | Файлов: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Польз.: E: %s K: %s | Файлов: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Нет выделенной сети"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Соединен с %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Подключение к %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Отсоединен от eD2k"
 
 # Kad как сеть, или служба - поэтому в женском роде
 # да, согласен
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad запущена."
 
 # Kad как сеть, или служба - поэтому в женском роде
 # согласен
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad остановлена."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Подключен к Kad (норм.)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Подключен к Kad (за брандмауэром)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Отключился от Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Сеть Kad не может быть использована если порт UDP выключен в настройках. Отменяю запуск."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Сеть Kad выключена в настройках. Отменяю соединение."
 
@@ -898,7 +903,7 @@ msgstr "Не удается создать директорию '%s' для ка
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2273,49 +2278,49 @@ msgstr "Нет"
 msgid "Yes"
 msgstr "Да"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Принимается..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "загрузка HTTP отменена"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "URL загрузки не может быть пустым"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Не удалось получить список доступных файлов от '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Папка для временных файлов"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Загружено %d байт"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "Обработка URL %s: %i - Ошибка (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "загрузка HTTP отменена"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2625,7 +2630,7 @@ msgstr "Внешнее Соединение: В доступе отказано 
 msgid "External Connection: Handshake failed."
 msgstr "Внешнее Соединение: авторизация неудачна."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Автоматическое обновление начато"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -206,8 +206,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -252,27 +252,37 @@ msgstr "выключение aMule завершено."
 msgid "Memory debug results for aMule exit:"
 msgstr "Результаты дебага памяти при выходе из aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "В связи со сменой версии, значение вашей локали было изменено на значение по умолчанию. Извините."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Сведения"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -280,56 +290,56 @@ msgstr ""
 "\n"
 "EC конфигурация"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ПРЕДУПРЕЖДЕНИЕ"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Сети"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "В файле 'server.met' найден %i сервер"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Невозможно связать порты с указанными адресами: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u не доступен. У вас будет LowID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,48 +354,48 @@ msgstr ""
 "\n"
 "Проверьте вашу сетевую конфигурацию, убедитесь что необходимый порт открыт."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Выбранная локаль отсутствует в вашей системе (тем не менее, будет произведена попытка ее использовать)."
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Это первый запуск aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Эта версия является тестовой и обновляется ежедневно.\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "мы не предоставляем никаких гарантий на случай каких либо повреждений, пожара \n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "или же смерти вашей любимой собачки. И все же использование ее *должно* быть безопасным. \n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Дополнительную информацию, поддержку и обновленные версии вы найдете на нашем сайте \n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, или на нашем irc-канале #aMule, находящемся на сервере irc.libera.chat. \n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Сообщайте нам о найденных ошибках на форум https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -393,141 +403,141 @@ msgstr ""
 "Указан неверный каталог для файлов Online-подписей!\n"
 "Online-подписи будут отключены пока вы не исправите это в настройках."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Имя сервера подтверждено"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Выделение место под файл '%s' не удалось: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "Ошибка: невозможно открыть файл журнала"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: файл журнала пуст. Что-то здесь не так :-("
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Журнал был очищен"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Сообщение сервера: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Пропущена загрузка %s, так как запрашиваемый файл не новее."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Ошибка при загрузке списка узлов."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Поврежден файл контроля версии"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Вы используете устаревшую версию aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Версия вашего aMule - %i.%i.%i, тогда как актуальная версия - %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ВНИМАНИЕ: Версия вашего aMule устарела: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копия aMule актуальна."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Польз.: %s | Файлов: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Польз.: E: %s K: %s | Файлов: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Нет выделенной сети"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Соединен с %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Подключение к %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Отсоединен от eD2k"
 
 # Kad как сеть, или служба - поэтому в женском роде
 # да, согласен
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad запущена."
 
 # Kad как сеть, или служба - поэтому в женском роде
 # согласен
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad остановлена."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Подключен к Kad (норм.)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Подключен к Kad (за брандмауэром)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Отключился от Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Сеть Kad не может быть использована если порт UDP выключен в настройках. Отменяю запуск."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Сеть Kad выключена в настройках. Отменяю соединение."
 
@@ -2615,7 +2625,7 @@ msgstr "Внешнее Соединение: В доступе отказано 
 msgid "External Connection: Handshake failed."
 msgstr "Внешнее Соединение: авторизация неудачна."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Автоматическое обновление начато"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -202,8 +202,8 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -248,37 +248,42 @@ msgstr "Zaustavitev aMule zaključena."
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultati razhroščevanja pomnilnika za izhod iz aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše področne nastavitve so bile spremenjene na sistemsko privzete zaradi spremembe v nastavitvah. Oprostite."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Podatki"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -286,56 +291,56 @@ msgstr ""
 "\n"
 "Nastavitev zunanje povezave"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "OPOZORILO"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Omrežja"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i najdenih strežnikov v server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Vrat ni bilo moč povezati z navedenim naslovom: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Vrata %u niso razpoložljiva. Imeli boste nizek ID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -350,49 +355,49 @@ msgstr ""
 "\n"
 "Preverite omrežje in se prepričajte, da so vrata odprta za izhod in vhod."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti datoteke spletnega podpisa"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti aMule datoteke spletnega podpisa"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Kot kaže izbrana področna nastavitev ni nameščena na vašem računalniku. (Opomba: vseeno se jo bo poskusilo nastaviti)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "To je vaš prvi zagon aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "To je testna različica, posodobljena dnevno in\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo zagotovila, da ne bo ničesar poškodovala, zažgala vaše hiše\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ali ubila vašega psa. Vendar bi vseeno morala biti varna za uporabo.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Več informacij, podporo in nove različice, lahko najdete na naši domači strani,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, ali na kanalu IRC #aMule, na strežniku irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 #, fuzzy
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Morebitne hrošče lahko sporočite na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -400,138 +405,138 @@ msgstr ""
 "Navedena mapa za datoteke za spletni podpis je NEVELJAVNA.\n"
 "Spletni podpis bo ONEMOGOČEN, dokler težave ne odpravite v nastavitvah."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Gostitelj strežnika obveščen"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Vnaprejšnja dodelitev prostora na disku za datoteko »%s« ni uspela: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "NAPAKA: ni mogoče odpreti dnevniške datoteke"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "OPOZORILO: dnevniška datoteka je prazna. Nekaj je narobe."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Dnevnik je bil ponastavljen"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sporočilo strežnika: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Prejemanje %s je bilo preskočeno, ker zahtevana datoteka ni novejša."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Ni bilo mogoče prejeti seznama vozlišč."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Ni bilo mogoče odpreti prejete datoteke za preverjanje različice"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Datoteka za preverjanje različice je pokvarjena"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Uporabljate zastarelo različico aMule."
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Različica vaše aMule je %i.%i.%i, najnovejša različica pa je %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 #, fuzzy
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OPOZORILO: vaša različica aMule je zastarela: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Uporabljate najnovejšo različico aMule."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Ni bilo mogoče prejeti datoteke za preverjanje različice"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uporabniki: %s | Datoteke: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uporabniki: E: %s K: %s | Datoteke: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Izbranega ni nobenega omrežja"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "z nizkim ID-jem"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "z visokim ID-jem"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Povezano na %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Povezovanje z %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Povezava z eD2k prekinjena"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad zagnan."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad ustavljen."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Povezano v Kad (v redu)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Povezano v Kad (za požarnim zidom)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Povezava s Kad prekinjena"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Omrežja Kad ni mogoče uporabljati, če so vrata UDP onemogočena v nastavitvah. Kad ni zagnan."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Omrežje Kad je onemogočeno v nastavitvah. Ni povezave."
 
@@ -892,7 +897,7 @@ msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2272,49 +2277,49 @@ msgstr "Ne"
 msgid "Yes"
 msgstr "Da"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Prejemanje …"
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "Prejemanje HTTP preklicano"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "URL za prejemanje ne sme biti prazen"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Ni bilo mogoče dobiti deljenih datotek od uporabnika »%s«"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Mapa za začasne datoteke prejemanj"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Prejetih %d bajtov"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s je vrnil: %i – Napaka (%i)."
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Prejemanje HTTP preklicano"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2627,7 +2632,7 @@ msgstr "Zunanja povezava: dostop je bil zavrnjen. Razlog: "
 msgid "External Connection: Handshake failed."
 msgstr "Zunanja povezava: rokovanje ni uspelo."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asinhrona nit %d se je začela"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -202,8 +202,8 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -248,27 +248,37 @@ msgstr "Zaustavitev aMule zaključena."
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultati razhroščevanja pomnilnika za izhod iz aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše področne nastavitve so bile spremenjene na sistemsko privzete zaradi spremembe v nastavitvah. Oprostite."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Podatki"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -276,56 +286,56 @@ msgstr ""
 "\n"
 "Nastavitev zunanje povezave"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "OPOZORILO"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Omrežja"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i najdenih strežnikov v server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Vrat ni bilo moč povezati z navedenim naslovom: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Vrata %u niso razpoložljiva. Imeli boste nizek ID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -340,49 +350,49 @@ msgstr ""
 "\n"
 "Preverite omrežje in se prepričajte, da so vrata odprta za izhod in vhod."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti datoteke spletnega podpisa"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti aMule datoteke spletnega podpisa"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Kot kaže izbrana področna nastavitev ni nameščena na vašem računalniku. (Opomba: vseeno se jo bo poskusilo nastaviti)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "To je vaš prvi zagon aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "To je testna različica, posodobljena dnevno in\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo zagotovila, da ne bo ničesar poškodovala, zažgala vaše hiše\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ali ubila vašega psa. Vendar bi vseeno morala biti varna za uporabo.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Več informacij, podporo in nove različice, lahko najdete na naši domači strani,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, ali na kanalu IRC #aMule, na strežniku irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 #, fuzzy
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Morebitne hrošče lahko sporočite na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -390,138 +400,138 @@ msgstr ""
 "Navedena mapa za datoteke za spletni podpis je NEVELJAVNA.\n"
 "Spletni podpis bo ONEMOGOČEN, dokler težave ne odpravite v nastavitvah."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Gostitelj strežnika obveščen"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Vnaprejšnja dodelitev prostora na disku za datoteko »%s« ni uspela: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "NAPAKA: ni mogoče odpreti dnevniške datoteke"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "OPOZORILO: dnevniška datoteka je prazna. Nekaj je narobe."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Dnevnik je bil ponastavljen"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sporočilo strežnika: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Prejemanje %s je bilo preskočeno, ker zahtevana datoteka ni novejša."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Ni bilo mogoče prejeti seznama vozlišč."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Ni bilo mogoče odpreti prejete datoteke za preverjanje različice"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Datoteka za preverjanje različice je pokvarjena"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Uporabljate zastarelo različico aMule."
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Različica vaše aMule je %i.%i.%i, najnovejša različica pa je %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 #, fuzzy
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OPOZORILO: vaša različica aMule je zastarela: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Uporabljate najnovejšo različico aMule."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Ni bilo mogoče prejeti datoteke za preverjanje različice"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uporabniki: %s | Datoteke: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uporabniki: E: %s K: %s | Datoteke: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Izbranega ni nobenega omrežja"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "z nizkim ID-jem"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "z visokim ID-jem"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Povezano na %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Povezovanje z %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Povezava z eD2k prekinjena"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad zagnan."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad ustavljen."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Povezano v Kad (v redu)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Povezano v Kad (za požarnim zidom)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Povezava s Kad prekinjena"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Omrežja Kad ni mogoče uporabljati, če so vrata UDP onemogočena v nastavitvah. Kad ni zagnan."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Omrežje Kad je onemogočeno v nastavitvah. Ni povezave."
 
@@ -2617,7 +2627,7 @@ msgstr "Zunanja povezava: dostop je bil zavrnjen. Razlog: "
 msgid "External Connection: Handshake failed."
 msgstr "Zunanja povezava: rokovanje ni uspelo."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asinhrona nit %d se je začela"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:13+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -22,20 +22,20 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);\n"
 "X-Generator: Poedit 3.9\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Prikaži aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Oddaljen nadzor aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Posnetek:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -43,7 +43,7 @@ msgstr ""
 "Odjemalec P2P, ki temelji na eMule in je za vse platforme\n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -52,59 +52,59 @@ msgstr ""
 "Avtorske pravice © 2003–2019 ekipa aMule\n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Del aMule temelji na\n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: usmerjanje med enakovrednimi, ki temelji na metriki XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Avtorske pravice 2002–2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Ob zagonu preveri za novo različico"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Povezovanje s Kad …"
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Uporabljate zastarelo različico aMule."
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ni na voljo"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -202,8 +202,8 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -218,47 +218,57 @@ msgstr "Ni bilo mogoče odpreti datoteke ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "OPOZORILO: če imete nizek ID, sebe ne morete dodati kot vira za povezavo eD2k."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Sedaj, zapuščanje glavnega programa …"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Končanje izvoda amuleweb s PID »%d« … "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Ubijanje izvoda amuleweb s PID »%d« … "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Neuspeh"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Končevanje jedra."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Zaustavitev aMule zaključena."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultati razhroščevanja pomnilnika za izhod iz aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše področne nastavitve so bile spremenjene na sistemsko privzete zaradi spremembe v nastavitvah. Oprostite."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Podatki"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -266,56 +276,56 @@ msgstr ""
 "\n"
 "Nastavitev zunanje povezave"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "OPOZORILO"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Omrežja"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i najdenih strežnikov v server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Vrat ni bilo moč povezati z navedenim naslovom: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Vrata %u niso razpoložljiva. Imeli boste nizek ID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -330,49 +340,49 @@ msgstr ""
 "\n"
 "Preverite omrežje in se prepričajte, da so vrata odprta za izhod in vhod."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti datoteke spletnega podpisa"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti aMule datoteke spletnega podpisa"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Kot kaže izbrana področna nastavitev ni nameščena na vašem računalniku. (Opomba: vseeno se jo bo poskusilo nastaviti)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "To je vaš prvi zagon aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "To je testna različica, posodobljena dnevno in\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo zagotovila, da ne bo ničesar poškodovala, zažgala vaše hiše\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ali ubila vašega psa. Vendar bi vseeno morala biti varna za uporabo.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Več informacij, podporo in nove različice, lahko najdete na naši domači strani,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, ali na kanalu IRC #aMule, na strežniku irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 #, fuzzy
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Morebitne hrošče lahko sporočite na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -380,138 +390,138 @@ msgstr ""
 "Navedena mapa za datoteke za spletni podpis je NEVELJAVNA.\n"
 "Spletni podpis bo ONEMOGOČEN, dokler težave ne odpravite v nastavitvah."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Gostitelj strežnika obveščen"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Vnaprejšnja dodelitev prostora na disku za datoteko »%s« ni uspela: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "NAPAKA: ni mogoče odpreti dnevniške datoteke"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "OPOZORILO: dnevniška datoteka je prazna. Nekaj je narobe."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Dnevnik je bil ponastavljen"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sporočilo strežnika: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Prejemanje %s je bilo preskočeno, ker zahtevana datoteka ni novejša."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Ni bilo mogoče prejeti seznama vozlišč."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Ni bilo mogoče odpreti prejete datoteke za preverjanje različice"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Datoteka za preverjanje različice je pokvarjena"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Uporabljate zastarelo različico aMule."
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Različica vaše aMule je %i.%i.%i, najnovejša različica pa je %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 #, fuzzy
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OPOZORILO: vaša različica aMule je zastarela: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Uporabljate najnovejšo različico aMule."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Ni bilo mogoče prejeti datoteke za preverjanje različice"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uporabniki: %s | Datoteke: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uporabniki: E: %s K: %s | Datoteke: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Izbranega ni nobenega omrežja"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "z nizkim ID-jem"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "z visokim ID-jem"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Povezano na %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Povezovanje z %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Povezava z eD2k prekinjena"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad zagnan."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad ustavljen."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Povezano v Kad (v redu)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Povezano v Kad (za požarnim zidom)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Povezava s Kad prekinjena"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Omrežja Kad ni mogoče uporabljati, če so vrata UDP onemogočena v nastavitvah. Kad ni zagnan."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Omrežje Kad je onemogočeno v nastavitvah. Ni povezave."
 
@@ -551,16 +561,16 @@ msgstr "To je aMule %s, ki temelji na eMule."
 msgid "Running on %s"
 msgstr "Operacijski sistem: %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 #, fuzzy
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Obiščite https://github.com/amule-org/amule/releases/latest da preverite, če je na voljo nova različica."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "USODNA NAPAKA: ustvaritev časomerilnika ni uspela"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -570,222 +580,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Ni na voljo"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Pogovorno okno aMule je bilo uničeno"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Povezovanje"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: povezovanje"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: povezava prekinjena"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: za požarnim zidom"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: povezano"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: povezovanje"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: izklopljen"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Ustavi trenutne poskuse povezovanja"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekini povezavo s trenutno povezanimi omrežji"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Poveži se"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Poveži se s trenutno omogočenimi omrežji"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gor: %.1f%s (%.1f) | Dol: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MiB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gor: %.1f%s | Dol: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Povezano)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ni povezave)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ali res želite zapustiti %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Potrditev izhoda"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Zaženi ukaz: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "– privzeto –"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Mapa za preobleke »%s« ne obstaja"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OPOZORILO: datoteke s preobleko »%s« ni moč odpreti za branje"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Omrežja"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Okno z omrežji"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Iskanja"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Okno z iskanji"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Prejemanja"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Okno s prejemanji"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Deljene datoteke"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Okno z deljenimi datotekami"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Sporočila"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Okno s sporočili"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Okno s statističnimi grafi"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavitve"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Okno z nastavitvami"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Uvoz"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Orodje za uvažanje delnih datotek"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "O programu/pomoč"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Omrežje eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Omrežje Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Brez omrežja"
 
@@ -873,8 +883,8 @@ msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Neznano"
@@ -1247,19 +1257,19 @@ msgstr "Samod. [Vi]"
 msgid "Very low"
 msgstr "Zelo nizka"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Nizka"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Običajna"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1291,7 +1301,7 @@ msgid "On Queue"
 msgstr "V vrsti"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Prejemanje"
 
@@ -1351,7 +1361,7 @@ msgstr "Krajevni strežnik"
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1423,7 +1433,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Preneseno"
 
@@ -1436,7 +1446,7 @@ msgid "Progress"
 msgstr "Napredek"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Viri"
 
@@ -1446,7 +1456,7 @@ msgstr "Viri"
 msgid "Priority"
 msgstr "Prednost"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Stanje"
 
@@ -1479,7 +1489,7 @@ msgstr ""
 "Odziv od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Samod."
@@ -2137,7 +2147,7 @@ msgstr "Datoteke s seznamom prijateljev »emfriends.met« ni bilo moč odpreti z
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIČNO – ni odjemalca za StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2426,8 +2436,8 @@ msgstr "Neveljavna vrata za začetno nalaganje"
 msgid "Please fill all fields required"
 msgstr "Prosimo, izpolnite vsa zahtevana polja"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Sporočilo"
 
@@ -2505,7 +2515,7 @@ msgstr "Delilno razmerje"
 msgid "Uploaded"
 msgstr "Poslano"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Zahtevano"
 
@@ -2539,30 +2549,30 @@ msgstr "Neznana napaka %d"
 msgid "Unable to get error description for error %d"
 msgstr "Ni moč dobiti opisa napake za napako %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Ustvarjanje kode"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Zaključevanje"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Zaključeno"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Prekinjeno"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Vsebuje napake"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Na čakanju"
 
@@ -2607,7 +2617,7 @@ msgstr "Zunanja povezava: dostop je bil zavrnjen. Razlog: "
 msgid "External Connection: Handshake failed."
 msgstr "Zunanja povezava: rokovanje ni uspelo."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asinhrona nit %d se je začela"
@@ -2629,7 +2639,7 @@ msgid "WARNING: "
 msgstr "OPOZORILO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Zapri"
 
@@ -2745,7 +2755,7 @@ msgstr "Končaj"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2985,7 +2995,7 @@ msgstr "Bajtov"
 msgid "KB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MiB"
@@ -3054,7 +3064,7 @@ msgstr "Počisti zaključena prejemanja"
 msgid "File sources:"
 msgstr "Viri datoteke:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Splošno"
 
@@ -3075,7 +3085,7 @@ msgstr "Polno Ime:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "Ni na voljo"
 
@@ -3251,7 +3261,7 @@ msgstr "Uporabniško ime:"
 msgid "Userhash :"
 msgstr "Koda uporabnika:"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3260,15 +3270,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Hitrost prejemanja"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Trenutno povprečje"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Povprečje seje"
 
@@ -3280,7 +3290,7 @@ msgstr "Hitrost pošiljanja"
 msgid "Connections"
 msgstr "Povezave"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Dejavna prejemanja"
 
@@ -3288,7 +3298,7 @@ msgstr "Dejavna prejemanja"
 msgid "Active connections (1:1)"
 msgstr "Dejavne povezave (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Dejavna pošiljanja"
 
@@ -3490,8 +3500,8 @@ msgstr "Izbira brskalnika"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sem vnesite ime brskalnika. Za uporabo privzetega sistemskega brskalnika pustite prazno."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3565,752 +3575,761 @@ msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Samo za napredne uporabnike: če imate več omrežnih vmesnikov, vnesite naslov vmesnika, s katerim bo povezan aMule."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Največ virov na prejemanje:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Največ istočasnih povezav:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Samodejno se poveži ob zagonu"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Ponovno se poveži ob prekinjeni povezavi"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Izbriši nedosegljiv strežnik po"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "poskusih"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Ob zagonu samodejno posodobi seznam strežnikov"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Seznam"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Ob povezavi na strežnik posodobi seznam strežnikov"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Ob povezavi odjemalca posodobi seznam strežnikov"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Uporabi sistem prednosti"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Uporabi preverjanje za nizek ID ob povezavi"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Varno povezovanje"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Samodejna povezava samo na strežnike na statičnem seznamu"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Nastavi ročno dodane strežnike na visoko prednost"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentno rokovanje s poškodbami (I.R.P.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Omogoči"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Napredni I.R.P. zaupa vsaki kodi (ni priporočeno)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Na novo dodani prejemi naj bodo zaustavljeni"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Na novo dodani prejemi naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Najprej poskusi prejeti prvi in zadnji del"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Po zaključku datoteke začni naslednjo prekinjeno"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Iz iste kategorije"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "Po abecednem vrstnem redu"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Novim datotekam vnaprej dodeli prostor na disku"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Za nove datoteke v naprej dodeli prostor na disku v velikosti celotne datoteke, kar zmanjša razdrobljenost."
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Ustavi prejemanja, ko prostor na disku doseže "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Izberite, če želite, da aMule preverja prostor na disku"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Sem vnesite min. želen prostor na disku."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shrani 10 virov pri redkih datotekah (< 20 virov)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Pošiljanja"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Nove deljene datoteke naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Ciljna mapa za prejeto"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Mapa za začasne datoteke prejemanj"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Deljene mape"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(desni klik na ikono mape izbere tudi podmape)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Deli skrite datoteke"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafi"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Zamik posodabljanja: 5 sek."
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Čas za graf povprečja: 100 min."
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Merilo za graf povezav: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Merilo za graf prejemanj:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Merilo za graf pošiljanj:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Barve: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Ozadje"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Mreža"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Trenutno prejemanje"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Povprečje prejemanja"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Povprečje seje za prejemanje"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Trenutno pošiljanje"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Povprečje pošiljanja"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Povprečje seje za pošiljanje"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Dejavne povezave"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Prikaz hitrosti v sistemski vrstici"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Trenutna vozlišča Kad"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Vozlišča Kad v teku"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Vozlišča Kad te seje"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Izberi"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Drevo"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Število prikazanih različic odjemalcev (0 = neomejeno)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! OPOZORILO !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Maks. novih povezav / 5 sek."
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datotečni medpomnilnik: 240000 bajtov"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost vrste za pošiljanje: 5000 odjemalcev"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogoči"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Onemogoči prehod računalnika v pripravljenost"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Uporabljena preobleka: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Prikaži hitri rokovalnik s povezavami eD2k v vsakem oknu."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Prikaži razširjene podatke na zavihkih kategorij"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "V naslovni vrstici pokaži različico programa"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Kaži hitrosti prenosa v naslovni vrstici"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Pred imenom programa"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Za imenom programa"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Kaži presežek prenosov"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Usmeri orodjarno navpično"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Datoteke v vrsti prejemanj"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Prikaži odstotek napredka"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Prikaži črto napredka"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Plosko"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Zaokroženo"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Samodejno razvrščaj datoteke"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule bo samodejno razvrstil datoteke na vašem seznamu pprejemanj, kar potrebuje precej procesorske moči."
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parametri za zunanje povezave"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Sprejmi zunanje povezave"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP vmesnika, ki posluša:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sem vnesite veljaven IP v formatu a.b.c.d za poslušalen vmesnik. Prazno polje ali 0.0.0.0 pomeni poljuben vmesnik."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata zunanjih povezav"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Geslo"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Spletni strežnik zaženi ob zagonu"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Spletna predloga"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Geslo za vse pravice"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Omogoči uporabnika z nizkimi pravicami"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Geslo za nizke pravice"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata spletnega strežnika"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Vrata TCP za UPnP za spletni strežnik (neobvezno)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Čas med osvežitvami strani (v sek.)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Omogoči stiskanje gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "V redu"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknite tukaj za uveljavitev sprememb v nastavitvah."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Razveljavi vse spremembe v nastavitvah."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Naslov:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Mapa za prejeto:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Spremeni prednost novo dodeljenim datotekam:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Ne spremeni"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izberite barvo za to kategorijo (trenutno izbrano):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Ponastavi"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Kliknite ta gumb, da ponastavite dnevnik."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama strežnikov iz URL-ja."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Seznam strežnikov"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Vnesite URL do datoteke server.met in kliknite gumb na levi, da posodobite seznam strežnikov."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Ročno dodaj strežnik: ime"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Sem vnesite ime novega strežnika"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Vrata"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sem vnesite IP strežnika v formatu x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Sem vnesite vrata strežnika."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ročno dodaj strežnik (najprej izpolnite vsa polja) …"
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule dnevnik"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Podatki o strežniku"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Podatki o eD2k"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Podatki o Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama vozlišč iz URL-ja."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Vozlišča (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Vnesite URL do datoteke nodes.dat in pritisnite gumb na levi za posodobitev seznama vozlišč."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Statistika vozlišč"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Začetno nalaganje"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Novo vozlišče"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Vrata:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 "Naloži od znanih \n"
 "odjemalcev"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Prekini povezavo s Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Uporabi varno identifikacijo uporabnikov"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Priporočamo, da omogočite to možnost. Če to ni omogočeno, ne boste prejeli točk za zasluge."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Omogoči maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal maskirane povezave od drugih odjemalcev."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Uporabi maskiranje za izhodne povezave"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ob vklopu te možnosti, bo aMule uporabil maskiranje pri povezavi z drugimi odjemalci in na strežnike."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Dovoli samo maskirane povezave"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal samo maskirane povezave. Imeli boste manj virov, vendar bodo vse povezave maskirane."
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Vsi"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Nihče"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Kdo lahko vidi moje deljene datoteke:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Izberite, kdo lahko zahteva vaš seznam deljenih datotek."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtriranje IP-jev"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtriraj odjemalce"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje odjemalčevih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtriraj strežnike"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje strežnikovih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Znova naloži seznam"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ponovno naloži seznam IP-jev za filtriranje iz ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Posodobi zdaj"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Stopnja filtriranja:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Vedno filtriraj IP-je krajevnega omrežja"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoično rokovanje z ne-ujemajočimi IP-ji"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Zavrne paket, če se odjemalčev IP razlikuje od IP-ja kjer paket izvira. Bodite pazljivi pri uporabi te možnosti."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Uporabi sistemsko ipfilter.dat, če je na voljo"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Če krajevne datoteke ipfilter.dat ni moč najti, omogoči uporabo sistemske datoteke."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Omogoči spletni podpis"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Omogoči pisanje v datoteko spletnega podpisa, katero lahko uporabljajo zunanji programi za izdelavo podpisov in podobnih stvari."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Pogostost posodobitev (sek.):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Spremeni pogostost (v sekundah) posodobitev spletnega podpisa."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Spletni podpis shrani v datoteko: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknite tukaj, da nastavite mapo, ki vsebuje datoteke za spletni podpis."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Prikaži zastave držav za odjemalce"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Podatkovna hitrost:"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Viri"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4318,11 +4337,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4332,225 +4351,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Prejemanje: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtriraj prejeta sporočila (razen v trenutnem pogovoru):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtriraj vsa sporočila"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtriraj sporočila vseh, ki niso na seznamu prijateljev"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtriraj sporočila neznanih uporabnikov"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtriraj sporočila, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Sem dodajte besede, ki naj jih aMule filtrira, vključno s sporočili v katerih se nahajajo."
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Prejeta sporočila prikaži v dnevniku"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Komentarji"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtriraj komentarje, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Omogoči overjanje"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Omogoči/onemogoči overjanje z uporabniškim imenom/geslom"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Uporabniško ime: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Uporabniško ime za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Geslo:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Geslo za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Omogoči posrednika"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Omogoči/onemogoči podporo za posrednika"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Vrsta posrednika:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Gostitelj posrednika:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Ime gostitelja posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Vrata posrednika:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Vrata posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Poveži se z:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Prijavi se pri oddaljenem aMule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Uporabniško ime"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Zapomni si te nastavitve"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Uporabi stiskanje gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Omogoči podrobno beleženje za razhroščevanje."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Samo v dnevniško datoteko"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Kategorije sporočil:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čakanje …"
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Dodaj uvoze"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Ponovno poskusi izbrane"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Odstrani izbrane"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Vrste dogodkov"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika in odjemalci v vrsti za izbrane datoteke: seja / ves čas"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Odstotek vseh datotek"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Vse datoteke"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Izbrane datoteke"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Samo dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Znova naloži"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Pošlje navedeno sporočilo."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Zapri to pogovorno sejo."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Deljene datoteke"
 
@@ -4631,7 +4650,7 @@ msgstr "vse ostalo"
 msgid "Incomplete"
 msgstr "Nezaključeno"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Ustavljeno"
 
@@ -4823,7 +4842,7 @@ msgstr "Ni moč brati datoteke s semeni za delno datoteko %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Napaka pri branju datoteke s semeni delne datoteke (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -4832,27 +4851,27 @@ msgstr[1] "Najden pokvarjen del (%d) v %d delni datoteki %s - - FileResultHash |
 msgstr[2] "Najden pokvarjen del (%d) v %d delnih datotekah %s - - FileResultHash |%s| FileHash |%s|"
 msgstr[3] "Najden pokvarjen del (%d) v %d delnih datotekah %s - - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Najden zaključen del (%i) v %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Zaključeno ponovno ustvarjanje kode za %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Nepričakovana napaka med zaključevanjem %s. Datoteka prekinjena."
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Zaključeno prejemanje: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4861,307 +4880,307 @@ msgstr ""
 "Zaključeno prejemanje:\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Brisanje datoteke: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "OPOZORILO: ni moč ustvariti kode za prejet del – nabor kod za »%s« ni popoln"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "NAPAKA: ni moč ustvariti kode za prejet del – nabor kod ni popoln (%s). To se nikoli ne bi smelo zgoditi."
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Konec datoteke med ustvarjanjem kode prejetega dela %u z dolžino %u (maks. %u) delne datoteke »%s« z dolžino %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "OPOZORILO: na disku ni dovolj prostora. Datoteka prekinjena: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Prejet del %i v datoteki je pokvarjen: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "IRP: rešen pokvarjen del %i za %s → Rešenih bajtov: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Dodeljevanje"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Premalo prostora na disku"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Prejeto"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "NAPAKA: delne datoteke »%s« ni bilo moč odpreti"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Sistemsko privzet"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albansko"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabsko"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturijsko"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskovsko"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bolgarsko"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalonsko"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Kitajsko (poenostavljeno)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Kitajsko (tradicionalno)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Hrvaško"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Češko"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Dansko"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Nizozemsko"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonsko"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finsko"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Francosko"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galicijsko"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Nemško"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grško"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebrejsko"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Madžarsko"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italijansko"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italijansko (Švica)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonsko"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Korejsko"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litvansko"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveško (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Poljsko"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugalsko"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalsko (brazilsko)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Romunsko"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Rusko"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovensko"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Špansko"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Švedsko"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turško"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukrajinsko"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Spremeni jezik"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Za aMule ni nameščenega nobenega prevoda"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Na voljo ni nobenega jezika"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "na voljo ni nobene možnosti"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Najdena neveljavna kategorija, preskočena"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Vrata TCP ne smejo biti večja od 65532, ker so vrata UDP TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Uporabljena bodo privzeta vrata (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Povezava"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Mape"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Strežniki"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Varnost"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Vmesnik"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Posrednik"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Oddaljeno upravljanje"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Spletni podpis"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Napredno"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Dogodki"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Razhroščevanje"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5171,15 +5190,15 @@ msgstr ""
 "    %PARTFILE – polna pot do datoteke\n"
 "    %PARTNAME – samo ime datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5195,26 +5214,26 @@ msgstr ""
 "aMule bo deloval dobro tudi brez\n"
 "spreminjanja teh nastavitev."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Nastavitve ni bilo moč povezati z gradnikom z ID-jem %d in ključem %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Podatkov iz nastavitev ni bilo moč prenesti v gradnik z ID-jem %d in ključem %s."
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Vrsta posrednika s katerim se hočete povezati"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Podatkov iz gradnika ni bilo moč prenesti v nastavitve z ID-jem %d in ključem %s."
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5222,31 +5241,36 @@ msgstr ""
 "Potreben je ponoven zagon aMule za uveljavitev teh sprememb:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "• Vrata TCP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "• Vrata UDP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "• Vrata za zunanje povezave so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "• Sprejemljivost zunanjih povezav je spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "• Podpora za maskiranje protokola je bila spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5254,7 +5278,7 @@ msgstr ""
 "Seznam za samodejno posodobitev strežnikov je prazen.\n"
 "Možnost »Ob zagonu samodejno posodobi seznam strežnikov« bo onemogočena."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5262,19 +5286,19 @@ msgstr ""
 "Omogočili ste zunanje povezave, vendar niste navedli gesla.\n"
 "Zunanje povezave ne morejo biti omogočene, dokler ne navedete veljavnega gesla."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "• Jezik je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "• Mapa za začasne datoteke spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "• Omrežje eD2k je omogočeno.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5282,7 +5306,7 @@ msgstr ""
 "Omrežji eD2k in Kad sta onemogočeni.\n"
 "Ne boste se mogli povezati, dokler ne omogočite vsaj enega izmed njih."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5290,7 +5314,7 @@ msgstr ""
 "Kad se ne bo zagnal, če so vrata UDP onemogočena.\n"
 "Omogočite vrata UDP ali pa onemogočite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5300,20 +5324,20 @@ msgstr ""
 "aMule morate NUJNO ponovno zagnati.\n"
 "Če tega ne storite zdaj, se ne pritožujte, če se zgodi kaj slabega.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Samodejno osveževanje začeto"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5323,41 +5347,41 @@ msgstr ""
 "Vnesite vsaj en URL do veljavne datoteke server.met.\n"
 "Kliknite na gumb »Seznam«, zraven potrditvenega polja, za vnos URL-ja."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Začasne datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Prejete datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Spletni podpisi"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Izberite mapo za %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Prebrskajte za video predvajalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Izberite brskalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Izvedljiva datoteka %s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Uredi seznam strežnikov"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5365,42 +5389,42 @@ msgstr ""
 "Sem dodajte URL-je do datotek server.met.\n"
 "Po en URL v vsako vrstico."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Popolnih virov"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -5409,7 +5433,7 @@ msgstr[1] "Osveži vsakih: %d sekundo"
 msgstr[2] "Osveži vsakih: %d sekundi"
 msgstr[3] "Osveži vsakih: %d sekunde"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -5418,12 +5442,12 @@ msgstr[1] "Čas za graf trenutnega povprečja: %i minuta"
 msgstr[2] "Čas za graf trenutnega povprečja: %i minuti"
 msgstr[3] "Čas za graf trenutnega povprečja: %i minute"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Merilo za graf povezav: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5432,7 +5456,7 @@ msgstr[1] "Datotečni medpomnilnik: %d bajt"
 msgstr[2] "Datotečni medpomnilnik: %d bajta"
 msgstr[3] "Datotečni medpomnilnik: %d bajti"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -5441,7 +5465,7 @@ msgstr[1] "Velikost vrste za pošiljanje: %d odjemalec"
 msgstr[2] "Velikost vrste za pošiljanje: %d odjemalca"
 msgstr[3] "Velikost vrste za pošiljanje: %d odjemalci"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -5450,74 +5474,74 @@ msgstr[1] "Čas med osvežitvama povezave na strežnik: %d minuta"
 msgstr[2] "Čas med osvežitvama povezave na strežnik: %d minuti"
 msgstr[3] "Čas med osvežitvama povezave na strežnik: %d minute"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Izvrši ukaz ob dogodku »%s«"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Omogoči izvrševanje ukazov na jedru"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Ukaz jedra:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Omogoči izvrševanje ukazov v vmesniku"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Ukaz vmesnika:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Sledeče spremenljivke bodo nadomeščene:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ponovno naloži seznam deljenih datotek."

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -195,8 +195,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -246,93 +246,98 @@ msgstr "Shkarkimi Perfundoi"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vendndodhja juaj eshte ndryshuar tek System Default i pershtatur per nje nderrim konfigurimi. Me vjen keq."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informacion"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Konfirmimi i daljes"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "KUJDES"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rrjetet"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i u gjet server ne server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nuk mund te lidh portat tek adresa e dhene: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u nuk eshte me vlere. Ju do te keni ID te ulet\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -347,48 +352,48 @@ msgstr ""
 "\n"
 "KOntrolloni rrjetin tuaj per tu siguruar qe porta eshte hapur per hyrje dhe dalje."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online te aMule-s"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Vendi i zgjedur duket se nuk do te instalohet ne kutine tuaj. (Shenim: Une do te mundohem ta vendos ate)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Kjo eshte hera e pare qe ju po persorni aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ky eshte nje version per testim,i azhornuar per dite, dhe\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne nuk japim siguri per te ai nuk do te thyej asgje,nuk do te djegi shtepine tuaj,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ose te vrasi qenin tuaj. Por ai *do te* behet i sigurte per tu perdorur.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Me shume informacion,mbeshtetje dhe leshime te reja do ti gjeni tek faqet tona,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "tek amule-org.github.io ose ne kanalin tone IRC #amule tek irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -396,138 +401,138 @@ msgstr ""
 "Kartela e faileve per Firmen Online qe ju specifikuat eshte e PAVLERE!\n"
 " Firma Online do te C'AKTIVIZOHET deri sa ju ta rregulloni tek Preferencat."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Emri i Serverit:"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "GABIM: nuk mund te hapet logfile"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "KUJDES: faili i log-ve eshte bosh. Dicka nuk shkon."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Faili i Log eshte risetuar"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesazhe nga Serveri: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Deshtoi ne shkarkimin e listave nod."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Deshtoi te hapi failin per kontrollin e versionit qe sapo shkarkuat"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Fili per kontrollin e versionit eshte i demtuar"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Ju po perdorni nje version te vjeter te aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versioni juaj i amUle eshte %i.%i-%i dhe versioni i fundit eshte %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "KUJDES: Versioni juaj i aMule-s eshte i vjeteruar: %i.%i-%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Kopja juaj e aMule eshte azhornuar."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Deshtoi ne shkarkimin e failit per kontrollin e versionit"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "me ID te ulet"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "me ID te larte"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "I lidhur tek %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Duke u lidhur tek %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad filloi."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad u ndalua."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "I lidhur ne Kad (Ne rregull)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "I lidhur ne Kad (Me firewall)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "I shkeputur nga Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Rrjeti Kad nuk mund te perdoret nqs porta UDP eshte c'aktivizuar tek Preferencat, nuk po filloj."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rrjeti Kad eshte c'aktivizuar tek Preferencat,nuk eshte duke u lidhur."
 
@@ -893,7 +898,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2262,49 +2267,49 @@ msgstr "Jo"
 msgid "Yes"
 msgstr "Po"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Duke shkarkuar..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Deshtoi te rimarri failet e ndara nga perdoruesi '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Duke shkarkuar %s"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Shkarkimet (%i)"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2610,7 +2615,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Fjalekalimi per Lidhjet e Jashtme."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rifreskimi Automatik filloi"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -195,8 +195,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -246,83 +246,93 @@ msgstr "Shkarkimi Perfundoi"
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vendndodhja juaj eshte ndryshuar tek System Default i pershtatur per nje nderrim konfigurimi. Me vjen keq."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informacion"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Konfirmimi i daljes"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "KUJDES"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rrjetet"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i u gjet server ne server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nuk mund te lidh portat tek adresa e dhene: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u nuk eshte me vlere. Ju do te keni ID te ulet\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -337,48 +347,48 @@ msgstr ""
 "\n"
 "KOntrolloni rrjetin tuaj per tu siguruar qe porta eshte hapur per hyrje dhe dalje."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online te aMule-s"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Vendi i zgjedur duket se nuk do te instalohet ne kutine tuaj. (Shenim: Une do te mundohem ta vendos ate)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Kjo eshte hera e pare qe ju po persorni aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ky eshte nje version per testim,i azhornuar per dite, dhe\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne nuk japim siguri per te ai nuk do te thyej asgje,nuk do te djegi shtepine tuaj,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ose te vrasi qenin tuaj. Por ai *do te* behet i sigurte per tu perdorur.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Me shume informacion,mbeshtetje dhe leshime te reja do ti gjeni tek faqet tona,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "tek amule-org.github.io ose ne kanalin tone IRC #amule tek irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -386,138 +396,138 @@ msgstr ""
 "Kartela e faileve per Firmen Online qe ju specifikuat eshte e PAVLERE!\n"
 " Firma Online do te C'AKTIVIZOHET deri sa ju ta rregulloni tek Preferencat."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Emri i Serverit:"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "GABIM: nuk mund te hapet logfile"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "KUJDES: faili i log-ve eshte bosh. Dicka nuk shkon."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Faili i Log eshte risetuar"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesazhe nga Serveri: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Deshtoi ne shkarkimin e listave nod."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Deshtoi te hapi failin per kontrollin e versionit qe sapo shkarkuat"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Fili per kontrollin e versionit eshte i demtuar"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Ju po perdorni nje version te vjeter te aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versioni juaj i amUle eshte %i.%i-%i dhe versioni i fundit eshte %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "KUJDES: Versioni juaj i aMule-s eshte i vjeteruar: %i.%i-%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Kopja juaj e aMule eshte azhornuar."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Deshtoi ne shkarkimin e failit per kontrollin e versionit"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "me ID te ulet"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "me ID te larte"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "I lidhur tek %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Duke u lidhur tek %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad filloi."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad u ndalua."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "I lidhur ne Kad (Ne rregull)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "I lidhur ne Kad (Me firewall)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "I shkeputur nga Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Rrjeti Kad nuk mund te perdoret nqs porta UDP eshte c'aktivizuar tek Preferencat, nuk po filloj."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rrjeti Kad eshte c'aktivizuar tek Preferencat,nuk eshte duke u lidhur."
 
@@ -2600,7 +2610,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Fjalekalimi per Lidhjet e Jashtme."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rifreskimi Automatik filloi"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -20,26 +20,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Trego aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Kontrolli remote i aMule "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -48,59 +48,59 @@ msgstr ""
 "Copyright (C) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing i bazuar ne metriken XOR.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kerko per versione te reja sapo te filloje"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Duke u lidhur me Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Ju po perdorni nje version te vjeter te aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -195,8 +195,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -212,107 +212,117 @@ msgstr "Deshtoi ne hapjen %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Ne rregull, duke dalur %s...\n"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "E Deshtuar"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Shkarkimi Perfundoi"
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vendndodhja juaj eshte ndryshuar tek System Default i pershtatur per nje nderrim konfigurimi. Me vjen keq."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Informacion"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Konfirmimi i daljes"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "KUJDES"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rrjetet"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i u gjet server ne server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nuk mund te lidh portat tek adresa e dhene: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u nuk eshte me vlere. Ju do te keni ID te ulet\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -327,48 +337,48 @@ msgstr ""
 "\n"
 "KOntrolloni rrjetin tuaj per tu siguruar qe porta eshte hapur per hyrje dhe dalje."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online te aMule-s"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Vendi i zgjedur duket se nuk do te instalohet ne kutine tuaj. (Shenim: Une do te mundohem ta vendos ate)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Kjo eshte hera e pare qe ju po persorni aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ky eshte nje version per testim,i azhornuar per dite, dhe\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne nuk japim siguri per te ai nuk do te thyej asgje,nuk do te djegi shtepine tuaj,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ose te vrasi qenin tuaj. Por ai *do te* behet i sigurte per tu perdorur.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Me shume informacion,mbeshtetje dhe leshime te reja do ti gjeni tek faqet tona,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "tek amule-org.github.io ose ne kanalin tone IRC #amule tek irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -376,138 +386,138 @@ msgstr ""
 "Kartela e faileve per Firmen Online qe ju specifikuat eshte e PAVLERE!\n"
 " Firma Online do te C'AKTIVIZOHET deri sa ju ta rregulloni tek Preferencat."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Emri i Serverit:"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "GABIM: nuk mund te hapet logfile"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "KUJDES: faili i log-ve eshte bosh. Dicka nuk shkon."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Faili i Log eshte risetuar"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesazhe nga Serveri: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Deshtoi ne shkarkimin e listave nod."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Deshtoi te hapi failin per kontrollin e versionit qe sapo shkarkuat"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Fili per kontrollin e versionit eshte i demtuar"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Ju po perdorni nje version te vjeter te aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versioni juaj i amUle eshte %i.%i-%i dhe versioni i fundit eshte %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "KUJDES: Versioni juaj i aMule-s eshte i vjeteruar: %i.%i-%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Kopja juaj e aMule eshte azhornuar."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Deshtoi ne shkarkimin e failit per kontrollin e versionit"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "me ID te ulet"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "me ID te larte"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "I lidhur tek %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Duke u lidhur tek %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad filloi."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad u ndalua."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "I lidhur ne Kad (Ne rregull)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "I lidhur ne Kad (Me firewall)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "I shkeputur nga Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Rrjeti Kad nuk mund te perdoret nqs porta UDP eshte c'aktivizuar tek Preferencat, nuk po filloj."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rrjeti Kad eshte c'aktivizuar tek Preferencat,nuk eshte duke u lidhur."
 
@@ -547,15 +557,15 @@ msgstr "Kjo eshte aMule %s dhe bazohet ne eMule."
 msgid "Running on %s"
 msgstr "Duke punuar ne %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitoni https://github.com/amule-org/amule/releases/latest per te kontrolluar nqs eshte ne dispozicion nje version i ri."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -565,224 +575,224 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Duke u lòidhur"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Me Firewall"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: I lidhur"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Po lidhet"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Fikur"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Fshij"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Ndalo tentativat e lidhjes qe po behen"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Shkeputu"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Shkeputu nga rrjetet e lidhura"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Lidhu"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Lidhu tek rrjetet"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Larte: %.1f(%.1f) | Poshte: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Larte: %.1f | Poshte: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | e lidhur)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | e shkeputur)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vertet deshironi qe te dilni nga aMule?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Konfirmimi i daljes"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Direktoria e skin '%s' nuk ekziston"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Rrjetet"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Dritaret e rrjeteve"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Kerkimet"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Dritaret e kerkimeve"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Shkarkime"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Duke shkarkuar"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Dritarja e faileve te ndara"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Mesazhe"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Dritarja e mesazheve"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistikat"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Dritarja e grafikut te statistikave"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencat"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Dritarja e rregullimeve te preferencave"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importimi"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Veglat per importimin e pjeseve te faileve"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Rreth"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Rreth/Ndihme"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Rrjeti Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Nuk ka rrjet"
 
@@ -874,8 +884,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "E panjohur"
@@ -1239,19 +1249,19 @@ msgstr "Automatike [Larte]"
 msgid "Very low"
 msgstr "Shume ngadale"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Ngadale"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1283,7 +1293,7 @@ msgid "On Queue"
 msgstr "Ne radhe"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Duke shkarkuar"
 
@@ -1343,7 +1353,7 @@ msgstr "Server Lokal"
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1415,7 +1425,7 @@ msgstr ""
 msgid "Size"
 msgstr "Madhesia"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Te transferuara"
 
@@ -1428,7 +1438,7 @@ msgid "Progress"
 msgstr "Avancimi"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Burime"
 
@@ -1438,7 +1448,7 @@ msgstr "Burime"
 msgid "Priority"
 msgstr "Perparesia"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Gjendja"
 
@@ -1469,7 +1479,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Automatike"
@@ -2124,7 +2134,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Shkoket"
 
@@ -2413,8 +2423,8 @@ msgstr "Porte e pavlefshme per bootstrap"
 msgid "Please fill all fields required"
 msgstr "Ju lutem plotesoni te gjitha fushat e kerkuara"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Mesazh"
 
@@ -2486,7 +2496,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2520,30 +2530,30 @@ msgstr "Version i panjohur"
 msgid "Unable to get error description for error %d"
 msgstr "Kujdes: E pamundur te lexohet skin nga faili '%s'"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Hashing"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Duke perfunduar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "E kompletuar"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Ne pritje"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "E gabuar"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Duke pritur"
 
@@ -2590,7 +2600,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr "Fjalekalimi per Lidhjet e Jashtme."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rifreskimi Automatik filloi"
@@ -2612,7 +2622,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Mbylle"
 
@@ -2727,7 +2737,7 @@ msgstr "Dlje"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2967,7 +2977,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3037,7 +3047,7 @@ msgstr "Pastro shkarkimet e perfunduara"
 msgid "File sources:"
 msgstr "Burime te gjetura :"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Te pergjithshme"
 
@@ -3058,7 +3068,7 @@ msgstr "Emri i plote :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3232,7 +3242,7 @@ msgstr "Emri i Perdoruesit :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Shto"
@@ -3241,15 +3251,15 @@ msgstr "Shto"
 msgid "Download-Speed"
 msgstr "Shpejtesia-Shkarkimit"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Aktualisht"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Mesatarja e Punes"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Mesatarja e Sesionit"
 
@@ -3261,7 +3271,7 @@ msgstr "Shpejtesia-Ngarkimit"
 msgid "Connections"
 msgstr "Lidhjet"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Shkarkime Aktive"
 
@@ -3269,7 +3279,7 @@ msgstr "Shkarkime Aktive"
 msgid "Active connections (1:1)"
 msgstr "Lidhje Aktive (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Ngarkime Aktive"
 
@@ -3471,8 +3481,8 @@ msgstr "Zgjedhesi i shfletuesit"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3546,754 +3556,762 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Lidje automatike sapo programi te hapet"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Rilidhu mbas humbjes se lidhjes"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Largo serverat e papune mbas"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "tentativa"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Perdor sistemin e prioritetit"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Perdor kontrollin e zgjuar per ID e ulet kur lidhesh"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Lidhje e sigurte"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Lidhu automatikisht vetem me serverat e qendrueshem"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Vendosni ne menyre manuale serverat e shtuar ne Prioritet te Larte"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Shto failet tek shkarkimi duke i vene ne pushim"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Shto failet tek shkarkimi me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Mundohu te shkarkosh pjesen e pare dhe te fundit te failit"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Nga e njejta kategori"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Futni ketu hapesiren minimale qe deshironi per diskun."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shpeto 10 burime per failet e rralla (< 20 burime)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Ngarkimi"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Shto faile te reja te ndara me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "( Klikoni me butonin e djathte ne ikonene e karteles per te ndare ne menyre rekursive)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Nda failet e fshehur"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafiket"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Intervali i azhornimit : 5 sek"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Intervali grafik i vlerave mesatare: 100 minuta"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Shkalla grafike e lidhjeve: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Sfondi"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Zgara"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Shkarkimi aktual"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Mesatarja e shkarkimeve ne punim"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Mesatarja e sesioneve te shkarkimit"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Ngarkimi aktual"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Mesatarja e ngarkimit ne punim"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Mesatarja e sesionit te ngarkimeve"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Lidhjet aktive"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona e Speedbar-it ne Systray"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Nyjet e Kad aktuale"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Nyjet e Kad jane duke punuar"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Sesioni i Nyjeve te Kad"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Zgjidh"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numera te treguar te versioneve te klienteve (0= pa kufij)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! KUJDES !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Lidhe maksimale te reja / 5 sek"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Madhesia e Buffer-it te failit: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Madhesia e Radhes ne Ngarkim: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval i azhornimit te lidhjes se serverit: C'aktivizuar"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Trego informacion te zgjeruar ne tabelat e kategorive"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Orientim Vertikal i toolbar-it"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "E sheshte"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "E rrumbullakosur"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule do te rreshtoje automatikisht kollonat ne listen tuaj te shkarkimeve"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Parametrat e Lidhjeve te Jashtme"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Prano lidhje te jashtme"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Futni ketu nje ip te vlefshem ne formatin a.b.c.d per te degjuar nderfaqesin EC. Nje fushe boshe ose 0.0.0.0 do te nenkuptoje cdo nderfaqe."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivizo port forwarding UPnP tek porta EC"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Fjalekalim"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Modeli Web"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Fjalekalim per te drejta komplete"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Aktivizo Perdorues me te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Fjalekalim per te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Koha e Rifreskimit te Faqes (ne sek)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Aktivizo kompresimin Gzip"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Ne rregull"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliko ketu per te bere aktive ndryshimet qe u bene tek Preferencat."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Rikthe ne gjendjen e meparshme ndryshimet te bera tek Preferencat."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titulli :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Komente :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Direktoria e Hyrjeve :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Nderro perparesine per failet e reja te caktuara :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "Mos nderro"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Zgjidh ngjyren per kete kategori (e zgjedhur aktualisht) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Rivendos"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Kliko ne kete buton per te resetuar log-un."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e serverave nga URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Futni url tek nje fail server.met dhe shtypni butonin ne te majte per te azhornuar listen e serverave te njohur."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Futni emrin e serverit te ri ketu"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Futni IP-ne e serverit ketu. duke perdorur formatin x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Futni porten e serverit ketu."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Shto ne menyre manuale nje server (mbushni fushen ne te majte me pare) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Log i aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Informacion mbi serverin"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Informacioni i ED2K"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Informacioni i Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e nyjeve nga URL ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Nyjet (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Fut url e nje faili nodes.dat dhe shtyp butonin ne te majte per te azhornuar listen e nyjeve te njohura."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Statistikat e Nyjeve"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Nyje e re"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Bootstrap nga \n"
 "kliente te njohur"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Shkeput Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Perdor Identifikimin e Sigurte te Perdoruesve"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Eshte e rekomandueshme qe ta lejoni kete opsion. Ju nuk mund te merrni kredite nqs SUI nuk eshte i aktivizuar."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokolli i Turbullimit"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Mbeshtet Protokollin e Turbullimit"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ky opsion lejon Protokollin e Turbullimit, dhe ben qe aMule te pranoje lidhje te turbulluara nga kliente te tjere."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Perdor turbullimin per lidhjet ne dalje"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ky opsion lejon aMule-n qe te perdori protokollin e turbullimit kur lidhet me klientet/serverat e tjere."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Prano vetem lidhje te turbulluara"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ky opsion e ben aMule-n qe te lejoje lidhje te turbulluara. Ju do te keni me pak burime, por i gjithe trafiku juaj do te turbullohet"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Te gjithe"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Zgjidh se kush ka kerkuar te shikoje listene faileve qe ju keni ndare."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "Filtrimi-IP"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtro klientet"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te klientave te percaktuar ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtron Serverat"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te serverave te percaktuara ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ringarko listen e IP-ve per te filtruar nga faili ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Azhorno tani"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Niveli i Filtrimit:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Gjithmone filtro IP-te LAN"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Perdorim Paranoik te IP-ve qe nuk korrespondojne"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Refuzo paketat nqs IP e klientit eshte e ndryshme nga IP se ku paketat kane ardhur. Perdore me kujdes."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Perdor ipfilter.dat te sistemit nqs eshte i disponueshem"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Nese nuk eshte gjetur ndonje ipfilter.dat lokal, lejo perdorimin e failit ipfilter te sistemit."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Lejo Firmen-Online"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Lejon shkrimin e faileve OS, qe mund te perdorren nga aplikacione te jashtme per te krijuar firma dhe te ngjashme."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Frekuenca e azhornimeve (sek):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Nderron frekuqncen (ne sekonda) te azhornimit te Firmes Online."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Shtypni ketu per te zgjedhur direktorine qe permban failet e Firmes Online."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Shpejtesia :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Burime"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4301,11 +4319,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4315,232 +4333,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Shkarkim: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtron mesazhet ne hyrje (pervec chatit qe po zhvilloni):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtron te gjithe mesazhet"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtron mesazhet nga njerezit qe nuk ndohen ne listen e miqve tuaj"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtron mesazhet qe permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "shto ketu fjalet qe aMule do te filtroje duke bllokuar mesazhet qe ato mbajne"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Komente"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Komente e filtrave permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Aktivizo njohjen"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivizo/C'aktivizo emri i perdoruesit/njohja e fjalekalimit"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Emri i perdorimit qe do perdoret per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Fjalekalimi:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Fjalekalimi per te perdorur per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Aktivizo Proksin(Proxy)"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Aktivizo/C'aktivizo mbeshtetjen e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Lloji i Proksit(Proxy):"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Hosti i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Host Name i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Porta e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Lidhu me:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Futu tek Remote i aMule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Emri i Perdoruesit"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Mbaji mend keto rregullime"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Perdor kompresimin gzip"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivizon logging-un e detajuar te mesazheve te debug-ut."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Hap failin"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Kategorite e Mesazheve:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ne pritje..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Shton importimet"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Provoji perseri te perzgjedhurit"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Zhvendos te perzgjedhurat"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Fshih failet e ndara"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Zgjidh filtrin e shikimit"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ngarkime Aktive"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Ringarko failet e ndara"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Dergo"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Dergo mesazhin e specifikuar."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Mbylle kete sesion chati."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Lidhu me ndonje server dhe/ose Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "File te ndara"
 
@@ -4617,7 +4635,7 @@ msgstr "te gjithe te tjeret"
 msgid "Incomplete"
 msgstr "E pakompletuar"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "E ndalur"
 
@@ -4809,360 +4827,360 @@ msgstr "Te shpetuar %i burimi seed per partfile: %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Gabim ne leximin e failit seeds tek partfile-t (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "U gjend pjese e prishur (%d) ne %d pjesen e failit %s - Rezultati Hash i Failit |%s| Hash i Failit |%s|"
 msgstr[1] "U gjend pjese e prishur (%d) ne %d pjeset e failit %s - Rezultati Hash i Failit !%s| Hash i Failit |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "U gjend pjese e kompletuar (%i) ne %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Hashing i ri i kompletuar %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Shkarkim i perfunduar: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Shkarkim i perfunduar: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Duke fshire failin: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "KUJDES: Nuk ka hapesire te mjaftueshme ne disk! Duke vene ne pushim failet: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Pjesa e shkarkuar %i eshte e prishur ne failin: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Rekuperohet pjesa e demtuar %i per %s -> Bytes te kursyera: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "E vendosur nga sistemi"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baske"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bullgare"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katallanase"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Kineze (E thjeshtesuar)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "KIneze (Tradicionale)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Kroate"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Ceke"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Daneze"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Holandeze"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finlandeze"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Frengjisht"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galiciane"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Gjermanisht"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Greqisht"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Cifut"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Hungarisht"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italiane"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italiane (Zvic)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonisht"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Koreane"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Lituane"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegjeze (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polake"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugeze"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugeze (Braziliane)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Ruse"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Sllovene"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spanjolle"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Suedeze"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turqisht"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "Gjuha"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP nuk mund te jene me te medha se 65532  sepse socket i UDP eshte fiksuar ne TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Do te perdoret porta e vendosur (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Lidhje"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Direktorite"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servera"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Failet"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Sigurimi"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proksi"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Kontrollet e remote"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Firma online"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Ngjarje"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Debug"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5178,26 +5196,26 @@ msgstr ""
 "aMule do te punoje ne rregull pa modifikuarr asnje nga\n"
 "keto rregullime"
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Lloji i Proksit(Proxy) qe ju po lidheni"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5205,41 +5223,46 @@ msgstr ""
 "aMule duhet qe te ristartohet qe keto ndryshime te aplikohen:\n"
 " \n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "Porta TCP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "Porta UDP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Lidhja e jashtme u mbyll."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli i Turbullimit"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5247,26 +5270,26 @@ msgstr ""
 "Ju keni lejuar lidhjet e jashtme por nuk keni specifikuar nje fjalekalim.\n"
 "Lidhjet e jashtme nuk mund te lejohen derisa te specifikohet nje fjalekalim."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Gjuha ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "Kartela Temp ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Te gjithe rrjetet jane c'aktivizuar."
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5274,7 +5297,7 @@ msgstr ""
 "Kad nuk mund te filloje nqs porta juaj UDP eshte c'aktivizuar.\n"
 "Aktivizoni porten UDP ose c'aktivizoni Kad-in."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5284,20 +5307,20 @@ msgstr ""
 "Ju duhet te ristartoni aMule-n tani.\n"
 "Nqs nuk e ristartoni tani mos u anko nqs te ndodh dicka e keqe.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Rifreskimi Automatik filloi"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5307,41 +5330,41 @@ msgstr ""
 "Ju lutem mbushni te pakten nje URL te vlefshme ne failin e server.met.\n"
 "Klikoni ne butonin \"List\" per te futur nje URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Failet e perkohshme"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Failet e shkarkuara"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Firma online"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zgjidhni nje kartele per %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Shfletoni per nje videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Perzgjidhni shfletuesin"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Te ekzekutueshme%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5349,150 +5372,150 @@ msgstr ""
 "Futni ketu URL-te per te shkarkuar failet server.met.\n"
 "Vetem nga nje URL per c'do linje."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Burime te kompletuara"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervali i azhornimit: %d sekonde"
 msgstr[1] "Intervali i azhornimit: %d sekonda"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Koha per mesataren grafike: %d minute"
 msgstr[1] "Koha per mesataren grafike: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Shkalla grafike e lidhjeve: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Madhesia buffer e failit: %d byte"
 msgstr[1] "Madesia Buffer e failit: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Madhesia e radhes se ngarkimit: %d klienti"
 msgstr[1] "Madhesia e radhes se ngarkimit: %d klientet"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervali i rifreskimit te lidhjeve te serverit: %d minute"
 msgstr[1] "Intervali i rifreskimit te lidhjeve te serverit: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervali i rifreskimit te lidhjeve te serverit: I c'aktivizuar"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 #, fuzzy
 msgid "disabled"
 msgstr "c'aktivizo"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ekzekuto komanden ne kete ngjarje `%s' "
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Lejo ekzekutimin e komandes ne core"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "KOmanda Core:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Lejo ekzekutimin e komandes ne GUI"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Komanda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Variacionet qe vijojne do te rivendosen:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Duke lexuar kartelen temp"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ringarko listen e faileve te ndara."

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Visa aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule fjärrkontroll"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "'Alla-Platformar' p2p-klient basserad på eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -50,59 +50,59 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Delar av aMule är baserad på \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing baserad på XOR metric.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Webbsida:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Sök efter ny version vid start"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Ansluter till Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Du använder en gammal version av aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Inte tillgänglig"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -198,8 +198,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -214,47 +214,57 @@ msgstr "Kunde inte öppna ED2KLinks-filen"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VARNING: Du kan inte lägga till dig själv som källa för en eD2k-länk när du har lowid."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Nu, avslutar huvudapplikationen..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Avslutar  amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Dödar amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Misslyckades"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule VidAvslut: Avslutar huvudprogrammet."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMules avslutning slutförd"
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Minnes-debug-resultat för aMules avslut"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Din plats har ändrats till systemets standard på grund av en konfigurationsändring. Ledsen."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -262,56 +272,56 @@ msgstr ""
 "\n"
 "EC-konfiguration"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "VARNING"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nätverk"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server hittad i server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kunde inte binda portarna till specificerad adress: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u är inte tillgänglig. Du kommer att bli LOWID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -326,48 +336,48 @@ msgstr ""
 "\n"
 "Kontrollera ditt nätverk för att se att porten är öppen för ut och in-trafik."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Misslyckades med att skapa OnlineSig-fil"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Misslyckades med att skapa aMule OnlineSig-fil"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Den valda platsen verkar inte vara installerad på din burk. (OBS: Jag försöker ändå)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Det här är första gången du kör aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Den här versionen är en testversion, uppdateras dagligen, och\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi ger inga garantier att den inte förstör allt, bränner ner huset,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller dödar din hund. Men den *bör* vara säker att använda.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mer information, support och nya versioner kan hittas på vår hemsida,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, eller i vår IRC-kanal #aMule på irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Rapportera gärna eventuella fel på https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -375,137 +385,137 @@ msgstr ""
 "Katalogen för Online Signaturefiler som du angav är OGILTIG!\n"
 " OnlineSignatur kommer vara INAKTIVERAD tills du ändrar inställningarna."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Serverns hostname underrättad"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Förallokerad diskutrymme för filen '%s' misslyckades: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "FEL: kan inte öppna loggfilen"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VARNING: loggfilen är tom. Någonting är fel."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Loggen har nollställts"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servermeddelande: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Avslutade nerladdningen av %s eftersom begärd fil inte är nyare."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Misslyckades med att hämta nodlistan."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Misslyckades med att öppna den hämtade versionskontrollfilen"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Korrupt versionskontrollfil"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Du använder en gammal version av aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMuleversion är %i.%i.%i och den senaste versionen är %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VARNING: Din version av aMuled är gammal: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Din version av aMule är den senaste."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Misslyckades med att hämta versionskontrollfilen"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Användare: %s | Filer: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Användare: E: %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Inga nätverk valda"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "med LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "med HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ansluten till %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ansluter till %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Frånkopplad från eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad startad."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad stoppad."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Ansluten till Kad (ok)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Ansluten till Kad (brandvägg)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Frånkopplad från Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kadnätverket kan inte användas om UDP-porten är inaktiverad i inställningarna, startar inte."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadnätverket är inaktiverad i inställningarna, ansluter inte."
 
@@ -545,15 +555,15 @@ msgstr "Det här är aMule %s baserad på eMule."
 msgid "Running on %s"
 msgstr "Kör på %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besök https://github.com/amule-org/amule/releases/latest för att se om en ny version finns tillgänglig."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ALLVARLIGT FEL: Kunde inte skapa Timer"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -563,223 +573,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Inte tillgänglig"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMule-dialog avslutad"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Ansluter"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ansluter"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Frånkopplad"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Via brandvägg"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Ansluten"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Ansluter"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Stoppa de nuvarande anslutningsförsöken"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Koppla från"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Koppla från de nätverk som nu är anslutna."
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Anslut"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Anslut till de nätverk som är aktiverade."
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upp: %.1f(%.1f) | Ner: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upp: %.1f | Ner: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ansluten)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Frånkopplad)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vill du verkligen avsluta %s?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Bekräfta avslutning"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Kör kommando:"
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- standard -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-mappen '%s' finns inte"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "Varning: Kan inte öppna skin-filen '%s' för läsning"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Nätverk"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Nätverksfönster"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Sökningar"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Sökfönster"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Hämtningar"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "Hämtningsfönster"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Delade filer"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Delade filer-fönster"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Meddelanden"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Meddelandefönster"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Statistiksgrafsfönster"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Inställningar"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Inställningsfönster"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Importera"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Partfile-importerings-verktyget"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Om/Hjälp"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k-nätverk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad-nätverk"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Inget nätverk"
 
@@ -867,8 +877,8 @@ msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Okänd"
@@ -1231,19 +1241,19 @@ msgstr "Auto [Hö]"
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1275,7 +1285,7 @@ msgid "On Queue"
 msgstr "I kö"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Hämtar"
 
@@ -1335,7 +1345,7 @@ msgstr "Lokal server"
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1407,7 +1417,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Storlek"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Överfört"
 
@@ -1420,7 +1430,7 @@ msgid "Progress"
 msgstr "Förlopp"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Källor"
 
@@ -1430,7 +1440,7 @@ msgstr "Källor"
 msgid "Priority"
 msgstr "Prioritet"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Status"
 
@@ -1463,7 +1473,7 @@ msgstr ""
 "Återkoppling från: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Auto"
@@ -2116,7 +2126,7 @@ msgstr "Kunde inte öppna vän-list-filen 'emfriends.met' för skrivning!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISKT - ingen klient för StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Vänner"
 
@@ -2401,8 +2411,8 @@ msgstr "Ogiltig port till bootstrap"
 msgid "Please fill all fields required"
 msgstr "Fyll i alla fält som krävs"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Meddelande"
 
@@ -2474,7 +2484,7 @@ msgstr "Dela-förhållande"
 msgid "Uploaded"
 msgstr "Uppladdad"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Begärda"
 
@@ -2508,30 +2518,30 @@ msgstr "Okänd version %d"
 msgid "Unable to get error description for error %d"
 msgstr "Det går inte att få felbeskrivning för fel %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Hashing"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Färdigställer"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Färdig"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Pausad"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Felaktig"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Väntar"
 
@@ -2576,7 +2586,7 @@ msgstr "Extern Anslutning: Åtkomst nekad på grund av: "
 msgid "External Connection: Handshake failed."
 msgstr "Extern anslutning: Handskakning misslyckades."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio tråd %d startad"
@@ -2598,7 +2608,7 @@ msgid "WARNING: "
 msgstr "VARNING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Stäng"
 
@@ -2714,7 +2724,7 @@ msgstr "Avsluta"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2954,7 +2964,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3023,7 +3033,7 @@ msgstr "Rensar färdiga nedladdningar"
 msgid "File sources:"
 msgstr "Filkällor:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Allmänt"
 
@@ -3044,7 +3054,7 @@ msgstr "Hela namnet :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3220,7 +3230,7 @@ msgstr "Användarnamn :"
 msgid "Userhash :"
 msgstr "Userhash:"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lägg till"
@@ -3229,15 +3239,15 @@ msgstr "Lägg till"
 msgid "Download-Speed"
 msgstr "Nedladdningshastighet"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Löpande medelvärde"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Sessionens genomsnittliga"
 
@@ -3249,7 +3259,7 @@ msgstr "Uppladdningshastighet"
 msgid "Connections"
 msgstr "Anslutningar"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktiva hämtningar"
 
@@ -3257,7 +3267,7 @@ msgstr "Aktiva hämtningar"
 msgid "Active connections (1:1)"
 msgstr "Aktiva anslutningar (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktiva uppladdningar"
 
@@ -3458,8 +3468,8 @@ msgstr "Webbläsarval"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ange din webbläsares namn här. Lämna detta fält tomt för att använda systemets standardwebbläsare."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3533,750 +3543,759 @@ msgstr "Bind lokal adress till IP (tom för alla):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Endast avancerade användare: Om du har flera nätverksgränssnitt, ange adressen för gränssnittet till vilket aMule ska bindas."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Bind lokal adress till IP (tom för alla):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Max källor per hämtad fil:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Max samtidiga anslutningar:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Autoanslut vid start"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Återanslut vid nedkoppling"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Ta bort död server efter"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "försök"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Auto-uppdatera serverlistan vid start"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Uppdatera serverlistan vid anslutning till en server"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Uppdatera serverlistan när en klient ansluter"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Använd prioriteringssystem"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Använda smart LowID kontroll vid anslutning"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Säker anslutning"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoanslut endast till servrar i statisk-listan"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Ställ in hög prioritet på manuellt tillagda servrar"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligent Corruption Handling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Aktivera"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Avancerad I.C.H. litar på varje hash (rekommenderas inte)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Lägg till filer för nerladdning i pausläge"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Lägg till filer för nerladdning med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Försök att hämta första och sista bitarna först"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Börja nästa pausade fil när en fil är klar"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Från samma kategori"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "I alfabetisk ordning"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Förallokera diskutrymme för nya filer"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "För nya filer förallokeras diskutrymme för hela filen, detta minskar fragmentering"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppa nedladdningar när ledigt diskutrymme når "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Välj detta om du vill aMule att kontrollera diskutrymmet"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Ange här min diskutrymme."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Spara 10 källor för sällsynta filer (<20 källor)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Uppladdningar"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Lägg till nya delade filer med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Målmapp för hämtningar"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Mapp för temporära nerladdningsfiler"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Delade mappar"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Högerklicka på mappikonen för rekursiv delning)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Dela ut dolda filer"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Diagram"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Uppdateringsfördröjning: 5 sekunder"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Tid för genomsnittlig graf: 100 minuter"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Anslutningar Diagramskala: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Hämtningsgrafskala:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Uppladdningsgraf-skala:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Färger: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Bakgrund"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Rutnät"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Hämtning nu"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Hämtningar session, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Hämtningar nu"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Uppladdningsession, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktiva anslutningar"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systray Ikon Speedbar"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Kad-noder nuvarande"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Kad-noder körs"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Kad-noder session"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Välj"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Träd"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Antal klientversioner visas (0 = obegränsat)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! VARNING !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Max nya anslutningar / 5 sek"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbuffertstorlek: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Uppladdningsköstorlek: 5000 klienter"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktivera"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Inaktivera datorns inställda standby-läge"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Skin att använda: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Visa \"Snabb eD2k-Länkhanterare\" i varje fönster."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Visa utökad information på kategoriflikar"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Visa programversionen på titel"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Visa överföringshastigheter på titel"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Före programnamn"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Efter programnamn"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Visa overheadsbandbredd"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktygsfältsorientering"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Nedladdningsköfiler"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Visa framsteg i procent"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Visa förloppsindikator"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Platt"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Auto-sortera filer (hög CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule sorterar kolumnerna i din nedladdningslista automatiskt"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Externa Anslutningsparametrar "
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Acceptera externa anslutningar"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP för lyssningsgränssnitt:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Ange här en giltig ip i ABCD format för att lyssna EC-gränssnittet. Ett tomt fält eller 0.0.0.0 kommer att innebära alla gränssnitt."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivera UPnP-portforwarding på EC-port"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lösenord"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Kör webbserver vid start"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Web mall"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Fullständiga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Aktivera låga användarrättigheter"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Låga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktivera UPnP-port-forwarding för webbserverport"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webbserverns UPnP TCP-port (tillval)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Siduppdateringstid (i sek)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Aktivera Gzip-komprimering"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klicka här för att tillämpa eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Återställ eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Titel :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Inkommande mapp:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Ändra prioritet för nya tilldelade filer:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Ändra inte"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Välj färg för denna kategori (den valda):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Nollställ"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Klicka på den här knappen för att återställa loggen."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klicka på knappen för att uppdatera servrerlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Serverlista"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Ange URL till en server.met-fil här och tryck på knappen till vänster för att uppdatera listan över kända servrar."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Lägg till server manuellt: Namn"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Skriv in namnet på den nya servern här"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Ange IP på servern här, med hjälp av xxxx format."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Ange porten på servern här."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lägg manuellt till en server (fyll fälten till vänster innan) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule-logg"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klicka på knappen för att uppdatera nodlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Noder (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ange URL till en nodes.dat fil här och tryck på knappen till vänster för att uppdatera listan över kända noder."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Nodstatistik"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Ny nod"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap från kända klienter"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Koppla från Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Använd säker användarIdentifiering"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det rekommenderas att aktivera det här alternativet. Du kommer inte att få poäng om SUI är inte aktiverat."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Stöd protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Det här alternativet aktiverat protokollffördunkling och låter aMule acceptera dålda anslutningar från andra klienter."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Använd obfuscation (fördunkling) för utgående anslutningar"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Det här alternativet gör aMule använder protokoll-Obfuscation (fördunkling) vid anslutning till andra klienter/servrar."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Accepterar endast fördunklade anslutningar"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Det här alternativet gör aMule endast acceptera fördunklade anslutningar. Du kommer att ha mindre källor, men all din trafik kommer att döljas"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Alla"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Ingen."
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Vem kan se mina delade filer:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Välj vem som kan begära att få se en lista över dina delade filer."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Filtrera klienter"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av klient-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Filtrera servrar"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av server-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Återladda lista"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Återladda listan över IP-adresser att filtrera bort från filen ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Uppdatera nu"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Filtreringsnivå:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Filtrera alltid LAN-IP-adresser"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid hantering av icke-matchande IP"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Förkastar paketet om klient-ip skiljer sig från ip där paketet hämtas från. Används med försiktighet."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Använd systemvidd ipfilter.dat om sådan finns"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Om det inte en lokal ipfilter.dat hittas, tillåt användning av systemvidd ipfilterfil."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Aktivera Onlinesignaturer"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Möjliggör skrivning av OS-filen, som kan användas av externa program för att skapa signaturer och liknande."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Uppdateringsfrekvens (Sek):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändra frekvensen (i sekunder) av OnlineSignaturuppdateringar."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Spara onlinesignaturfil i: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klicka här för att välja den katalog som innehåller onlineSignaturFilerna."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "Visa landsflagger för klienter"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Datahastighet :"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Källor"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4284,11 +4303,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4298,225 +4317,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Hämta: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrera inkommande meddelanden (utom nuvarande chatt):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Filtrera alla meddelanden"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrera meddelanden från folk som inte finns i din kompislista"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Filtrera meddelanden från okända klienter"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrera meddelanden som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "skriv här orden amule ska filtrera och blockera meddelanden med dem"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Visa mottagna meddelanden i loggen"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrera kommentarer som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Aktivera autentisering"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivera/inaktivera användarnamn/lösenordsautentisering"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Användarnamn: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Användarnamnet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Lösenord:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Lösenordet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Aktivera proxy"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Aktivera/inaktivera proxy-stöd"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Proxytyp:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Proxyserver:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Proxyserverns värdnamn"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Proxyport:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Proxyporten"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Anslut till:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Logga in på fjärr-amule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Användarnamn"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Kom ihåg dessa inställningar"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Använd gzip-komprimering"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivera Utförlig Debug-loggning."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Endast till loggfil"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Meddelandekategorier:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Väntar..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Lägg till importer"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Återförsök den valda"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Ta bort vald"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Händelsetyper"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistik och köade klienter för vald fil(er): Session / All tid"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Procent av den totala filer"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Alla filer"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Valda filer"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Endast aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Återladda:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Återladda dina delade filer"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Skicka"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Skickar det specificerade meddelandet."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Stäng denna chat-session."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Anslut till någon server och/eller Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Utdelade filer"
 
@@ -4593,7 +4612,7 @@ msgstr "alla andra"
 msgid "Incomplete"
 msgstr "Ofullständig"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Stoppad"
 
@@ -4783,341 +4802,341 @@ msgstr "Kan inte läsa frö-filen för Partfile %s ( %s )"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Fel vid läsning partfile frö-fil ( %s - %s ): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Hittade skadade delen (%d) i %d del fil %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Hittade skadade delen (%d) i %d dels fil %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Hittade avslutande del (%i) i %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Klar med återhashning av %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Oväntat fel vid färdigställande %s . Fil pausad"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Hämtat färdigt: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Hämtat färdigt: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Tar bort fil: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "VARNING: Det går inte att hasha nedladdade delen - hashset ofullständig för '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "FEL: Det går inte att hasha nedladdade delen - hashset ofullständig (%s). Detta bör aldrig hända"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF medan hashning av hämtade del %u med längd %u (max %u) av partfile %s med längd %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "VARNING: Inte tillräckligt med ledigt diskutrymme! Pausa fil: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Nedladdade del %i är skadad i fil: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Återvunnen skadad del %i för %s -> Sparade bytes: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Allokera"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Otillräckligt diskutrymme"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Nedladdad"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEL: Det gick inte att öppna partfile ' %s '"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Systemets standard"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arabiska"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturiska"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskiska"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgariska"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalanska"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Kinesiska (Förenklad)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Kinesiska (Traditionell)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Kroatiska"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Checkiska"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danska"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Nederländska"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estniska"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Finska"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Franska"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galiciska"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Tyska"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Grekisk"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Hebreiska"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Ungerska"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Italienska"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Italienska (Schweiz)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japanska"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Koreanska"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norska (nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Polska"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portugisiska"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisiska (Brasilien)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Romänska"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Ryska"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovenska"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Spanska"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Svenska"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Turkiska"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Byt språk"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "Det finns inga översättningar installerade för aMule"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Inga språk tillgängliga"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "Inga alternativ tillgängliga"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Ogiltig kategori hittad, hoppar över"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-port kan inte vara högre än 65532 på grund av server UDP-socket är TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardporten kommer att användas ( %d )"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Anslutning"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Kataloger"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Servrar"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Säkerhet"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Gränssnitt"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Filter"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Fjärrkontroller"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Onlinesignatur"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Avancerad"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Händelser"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Felsökning"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5127,15 +5146,15 @@ msgstr ""
 "    %PARTFILE - hela sökvägen till filen\n"
 "    %PARTNAME - endast filnamnet"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5151,26 +5170,26 @@ msgstr ""
 "aMule kommer fungera bra utan att justera några av\n"
 "dessa inställningar."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Det gick inte att ansluta Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Den typen av proxy du ansluter till"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från widget till Cfg med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5178,31 +5197,36 @@ msgstr ""
 "aMule måste startas om för att aktivera dessa ändringar:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Extern anslutningsgränssnitt ändrad.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Extern anslutningsport ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Extern anslutningsacceptans ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Extern anslutningsgränssnitt ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Stöd för fördunkling av protokoll ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5210,7 +5234,7 @@ msgstr ""
 "Din automatiska uppdateringsserverlista är tom.\n"
 "'Auto-uppdateringsserverlista vid start' inaktiveras."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5218,19 +5242,19 @@ msgstr ""
 "Du har aktiverat externa anslutningar men har inte angett ett lösenord.\n"
 "External anslutningar kan inte aktiveras om inte ett giltigt lösenord anges."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Språk ändrat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Mappen Temp ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-nätverk aktiverad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5238,7 +5262,7 @@ msgstr ""
 "Både eD2k- och Kad-nätverk är inaktiverade.\n"
 "Du kommer inte att kunna ansluta förrän du aktiverar åtminstone en av dem."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5246,7 +5270,7 @@ msgstr ""
 "Kad startar inte om din UDP-port är inaktiverad.\n"
 "Aktivra UDP-port eller inaktivera Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5256,20 +5280,20 @@ msgstr ""
 "Du MÅSTE starta om aMule nu.\n"
 "Om du inte startar nu, klaga inte om något dåligt händer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Refresh startad"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5279,41 +5303,41 @@ msgstr ""
 "Vänligen fylla i åtminstone en URL för att peka på en giltig server.met-fil.\n"
 "Klicka på knappen \"lista\" i denna kryssruta för att ange en URL."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Temporära filer"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Inkommande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Online-signaturer"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Välj en mapp för %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Bläddra efter videospelare"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Välj webbläsare"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Körbar %s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Redigera serverlista"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5321,149 +5345,149 @@ msgstr ""
 "Lägg här URL för att hämta server.met filer.\n"
 "Endast en webbadress på varje rad."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletta källor"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Uppdateringsfördröjning: %d sekund"
 msgstr[1] "Uppdateringsfördröjning: %d sekunder"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid för genomsnittlig graf: %d minut"
 msgstr[1] "Tid för genomsnittlig graf: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Anslutningsdiagramskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbuffertstorlek: %d byte"
 msgstr[1] "Filbuffertstorlek: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Uppladdningsköstorlek: %d klient"
 msgstr[1] "Uppladdningsköstorlek: %d klienter"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveranslutninguppdateringsintervall: %d minut"
 msgstr[1] "Serveranslutninguppdateringsintervall: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exekvera kommando på '%s' händelse"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Aktivera kommandokörning på kärnan"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Kommando till kärnan:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Aktivera kommandokörning via GUI"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "GUI kommando:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Följande variabler kommer att ersättas:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Återladda dina delade filer"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ladda om listan med delade filer."

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -198,8 +198,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -244,37 +244,42 @@ msgstr "aMules avslutning slutförd"
 msgid "Memory debug results for aMule exit:"
 msgstr "Minnes-debug-resultat för aMules avslut"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Din plats har ändrats till systemets standard på grund av en konfigurationsändring. Ledsen."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -282,56 +287,56 @@ msgstr ""
 "\n"
 "EC-konfiguration"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "VARNING"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nätverk"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server hittad i server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kunde inte binda portarna till specificerad adress: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u är inte tillgänglig. Du kommer att bli LOWID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -346,48 +351,48 @@ msgstr ""
 "\n"
 "Kontrollera ditt nätverk för att se att porten är öppen för ut och in-trafik."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Misslyckades med att skapa OnlineSig-fil"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Misslyckades med att skapa aMule OnlineSig-fil"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Den valda platsen verkar inte vara installerad på din burk. (OBS: Jag försöker ändå)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Det här är första gången du kör aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Den här versionen är en testversion, uppdateras dagligen, och\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi ger inga garantier att den inte förstör allt, bränner ner huset,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller dödar din hund. Men den *bör* vara säker att använda.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mer information, support och nya versioner kan hittas på vår hemsida,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, eller i vår IRC-kanal #aMule på irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Rapportera gärna eventuella fel på https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -395,137 +400,137 @@ msgstr ""
 "Katalogen för Online Signaturefiler som du angav är OGILTIG!\n"
 " OnlineSignatur kommer vara INAKTIVERAD tills du ändrar inställningarna."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Serverns hostname underrättad"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Förallokerad diskutrymme för filen '%s' misslyckades: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "FEL: kan inte öppna loggfilen"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VARNING: loggfilen är tom. Någonting är fel."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Loggen har nollställts"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servermeddelande: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Avslutade nerladdningen av %s eftersom begärd fil inte är nyare."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Misslyckades med att hämta nodlistan."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Misslyckades med att öppna den hämtade versionskontrollfilen"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Korrupt versionskontrollfil"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Du använder en gammal version av aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMuleversion är %i.%i.%i och den senaste versionen är %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VARNING: Din version av aMuled är gammal: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Din version av aMule är den senaste."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Misslyckades med att hämta versionskontrollfilen"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Användare: %s | Filer: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Användare: E: %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Inga nätverk valda"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "med LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "med HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ansluten till %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ansluter till %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Frånkopplad från eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad startad."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad stoppad."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Ansluten till Kad (ok)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Ansluten till Kad (brandvägg)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Frånkopplad från Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kadnätverket kan inte användas om UDP-porten är inaktiverad i inställningarna, startar inte."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadnätverket är inaktiverad i inställningarna, ansluter inte."
 
@@ -886,7 +891,7 @@ msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2251,49 +2256,49 @@ msgstr "Nej"
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Hämtar..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP-hämtning avbryten"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "URLen för hämtningen kan inte vara tom"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Misslyckades med att hämta filer från användaren '%s'"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Mapp för temporära nerladdningsfiler"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Hämtat %d bytes"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URLen %s returnerade: %i - Fel (%i)!"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP-hämtning avbryten"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2596,7 +2601,7 @@ msgstr "Extern Anslutning: Åtkomst nekad på grund av: "
 msgid "External Connection: Handshake failed."
 msgstr "Extern anslutning: Handskakning misslyckades."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio tråd %d startad"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -198,8 +198,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -244,27 +244,37 @@ msgstr "aMules avslutning slutförd"
 msgid "Memory debug results for aMule exit:"
 msgstr "Minnes-debug-resultat för aMules avslut"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Din plats har ändrats till systemets standard på grund av en konfigurationsändring. Ledsen."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -272,56 +282,56 @@ msgstr ""
 "\n"
 "EC-konfiguration"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "VARNING"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nätverk"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server hittad i server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kunde inte binda portarna till specificerad adress: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u är inte tillgänglig. Du kommer att bli LOWID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -336,48 +346,48 @@ msgstr ""
 "\n"
 "Kontrollera ditt nätverk för att se att porten är öppen för ut och in-trafik."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Misslyckades med att skapa OnlineSig-fil"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Misslyckades med att skapa aMule OnlineSig-fil"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Den valda platsen verkar inte vara installerad på din burk. (OBS: Jag försöker ändå)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Det här är första gången du kör aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Den här versionen är en testversion, uppdateras dagligen, och\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi ger inga garantier att den inte förstör allt, bränner ner huset,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller dödar din hund. Men den *bör* vara säker att använda.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mer information, support och nya versioner kan hittas på vår hemsida,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, eller i vår IRC-kanal #aMule på irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Rapportera gärna eventuella fel på https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -385,137 +395,137 @@ msgstr ""
 "Katalogen för Online Signaturefiler som du angav är OGILTIG!\n"
 " OnlineSignatur kommer vara INAKTIVERAD tills du ändrar inställningarna."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Serverns hostname underrättad"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Förallokerad diskutrymme för filen '%s' misslyckades: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "FEL: kan inte öppna loggfilen"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VARNING: loggfilen är tom. Någonting är fel."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Loggen har nollställts"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servermeddelande: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Avslutade nerladdningen av %s eftersom begärd fil inte är nyare."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Misslyckades med att hämta nodlistan."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Misslyckades med att öppna den hämtade versionskontrollfilen"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Korrupt versionskontrollfil"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Du använder en gammal version av aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMuleversion är %i.%i.%i och den senaste versionen är %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VARNING: Din version av aMuled är gammal: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Din version av aMule är den senaste."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Misslyckades med att hämta versionskontrollfilen"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Användare: %s | Filer: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Användare: E: %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Inga nätverk valda"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "med LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "med HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ansluten till %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ansluter till %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Frånkopplad från eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad startad."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad stoppad."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Ansluten till Kad (ok)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Ansluten till Kad (brandvägg)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Frånkopplad från Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kadnätverket kan inte användas om UDP-porten är inaktiverad i inställningarna, startar inte."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadnätverket är inaktiverad i inställningarna, ansluter inte."
 
@@ -2586,7 +2596,7 @@ msgstr "Extern Anslutning: Åtkomst nekad på grund av: "
 msgid "External Connection: Handshake failed."
 msgstr "Extern anslutning: Handskakning misslyckades."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio tråd %d startad"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:16+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -184,8 +184,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -230,79 +230,89 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -312,184 +322,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -2517,7 +2527,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:16+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,80 +17,80 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -184,8 +184,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -200,99 +200,109 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -302,184 +312,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -518,15 +528,15 @@ msgstr ""
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -536,221 +546,221 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr ""
 
@@ -838,8 +848,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr ""
@@ -1202,19 +1212,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1246,7 +1256,7 @@ msgid "On Queue"
 msgstr ""
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr ""
 
@@ -1306,7 +1316,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "காட்"
@@ -1377,7 +1387,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr ""
 
@@ -1390,7 +1400,7 @@ msgid "Progress"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr ""
 
@@ -1400,7 +1410,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr ""
 
@@ -1431,7 +1441,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr ""
@@ -2055,7 +2065,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr ""
 
@@ -2333,8 +2343,8 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr ""
 
@@ -2406,7 +2416,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr ""
 
@@ -2440,30 +2450,30 @@ msgstr ""
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr ""
 
@@ -2507,7 +2517,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
@@ -2529,7 +2539,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr ""
 
@@ -2638,7 +2648,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -2878,7 +2888,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr ""
@@ -2947,7 +2957,7 @@ msgstr ""
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr ""
 
@@ -2968,7 +2978,7 @@ msgstr ""
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr ""
 
@@ -3142,7 +3152,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3151,15 +3161,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr ""
 
@@ -3171,7 +3181,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr ""
 
@@ -3179,7 +3189,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr ""
 
@@ -3380,8 +3390,8 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3455,745 +3465,753 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+msgid "Bind to network interface (empty for any):"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4201,11 +4219,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4215,222 +4233,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr ""
 
@@ -4507,7 +4525,7 @@ msgstr ""
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr ""
 
@@ -4696,355 +4714,355 @@ msgstr ""
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "முடிக்கப்பட்ட பகுதி (%i) கண்டறியப்பட்டது %s இல்"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "முடிந்ததாக %u பகுதி '%s' இன் குறிக்கப்பட்டது, ஆனால் பார்ட்ஃபைல் எதிர்பார்த்ததை விடக் குறைவாக உள்ளது (%llu பைட்டுகள் உள்ளன, %llu தேவை); மீண்டும் பதிவிறக்குவதற்கான இடைவெளியை மீண்டும் திறக்கிறது."
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "%u பகுதி %u (அதிகஅளவு %u) நீளம் கொண்ட கொத்து செய்யும் போது கோப்புமுடிவு ஆனது நீளம் கொண்ட '%s' பகுதி கோப்பு %u: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: சிதைந்த பகுதி %i %s க்காக மீட்கப்பட்டது -> சேமிக்கப்பட்ட பைட்டுகள்: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr ""
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5054,296 +5072,300 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+msgid "- Network interface binding changed.\n"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:16+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -184,8 +184,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -230,89 +230,94 @@ msgstr ""
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -322,184 +327,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -857,7 +862,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2185,49 +2190,49 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr ""
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2527,7 +2532,7 @@ msgstr ""
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.9\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "aMule'yi Göster"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule uzak denetimi "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Bilgileri:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "eMule üzerine kurulu 'Sistem-Üstü' p2p yazılımı \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -49,59 +49,59 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Ekibi \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "aMule'nin üzerinde kurulduğu parçalar: \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: XOR matrisi üzerine kurulu eşten eşe iletişim.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Web Sitemiz:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Forumumuz:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr "Belgelendirme:"
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr "Hata raporları:"
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Yeni sürümü başlangıçta denetle."
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kad ağına bağlanıyor…"
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "aMule'nin eski bir sürümünü kullanıyorsunuz!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Devre dışı"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -203,8 +203,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "ED2Links dosyasından %u bağlantı eklenemedi (ayrıntılar için kütüğe bakın)."
 msgstr[1] "ED2Links dosyasından %u bağlantı eklenemedi (ayrıntılar için kütüğe bakın)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -219,47 +219,57 @@ msgstr "ED2KBağlantı dosyası açılamadı."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UYARI: DüşükID olduğunuz sürece kendinizi bir kaynak olarak eD2k bağlantılarına ekleyemezsiniz."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Ana uygulamadan çıkılıyor…"
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb oturumu pid `%d' ile sonlandırılıyor… "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "pid `%d' ile ilişkili amuleweb oturumu öldürülüyor… "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Başarısız"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Çıkışında: Çekirdek imha ediliyor."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule kapatılma işlemi tamamlandı."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule çıkışı için hafıza hata raporlama sonuçları:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Bir yapılandırma değişikliği nedeniyle dil ayarınız 'Sistem Varsayılanı'na çevrildi. Üzgünüm. Vallahi…"
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Bilgi"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -267,20 +277,20 @@ msgstr ""
 "\n"
 "EC yapılandırması"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Parola ayarlandı ve dış bağlantılar etkinleştirildi."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "UYARI"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "Ağ başlatması"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -288,34 +298,34 @@ msgstr ""
 "aMule, eksik ağ başlatma dosyaları olduğunu tespit etti.\n"
 "Hangilerinin indirileceklerini seçin:"
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "eD2k sunucu listesi (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad başlangıç düğümleri (nodes.dat)"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web sunucusu pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Belirtilen şu adrese portlar bağlanamıyor: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port. %u kullanılamıyor. DÜŞÜKID alacaksınız.\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -330,48 +340,48 @@ msgstr ""
 "\n"
 "Ağ ayarlarınıza göz atarak portun giriş ve çıkışlar için açık olup olmadığını denetleyiniz."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMule Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Seçilen yerelleştirme görünüşe göre bilgisayarınızda yüklü değil. (Not: Bunu yine de yapmaya çalışacağım)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Hoş geldiniz! aMule %s sürümünü ilk kez kullanıyorsunuz."
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bu sürüm bir deneme sürümü, her gün güncellenir ve\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "bir şeyleri bozmayacağını veya evinizi yakmayacağını \n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "yahut da köpeğinizi öldürmeyeceğini garanti edemeyiz. Fakat bir *sorun* yaratmayacağını da umuyoruz.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daha fazla bilgi, destek ve yeni sürümler ana sayfamızda bulunabilir\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io veya IRC kanalımız: irc.libera.chat sunucusunda #aMule \n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Her türlü hatayı bize bildirmekten çekinmeyin https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -379,137 +389,137 @@ msgstr ""
 "Belirlediğiniz Çevrim içi İmza dosyaları dizini GEÇERSİZ!\n"
 " Çevrim içi İmza, ayarlarınızda düzeltene kadar DEVRE DIŞI bırakıldı."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Sunucu makine adı uyarıldı"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "%s dosyası için diskte yer ayırma başarısız oldu: %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "HATA: Günlük dosyası açılamıyor."
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UYARI: Günlük dosyası boş, bir şeyler yanlış."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Günlük kaydı silindi"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sunucu İletisi: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s indirilmeyecek; çünkü istenen dosya yeni değil."
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Nod listesini indirme başarısız."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "İndirilen sürüm denetleme dosyasını açma başarısız oldu."
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Bozuk sürüm denetleme dosyası"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "aMule'nin eski bir sürümünü kullanıyorsunuz!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "aMule sürümünüz %i.%i.%i ve en güncel sürüm %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "En güncel sürüm her zaman https://github.com/amule-org/amule/releases/latest adresinde bulunabilir."
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UYARI: aMuled sürümünüz eski: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "aMule sürümünüz güncel."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Sürüm denetleme dosyasını indirme başarısız oldu."
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kullanıcılar: %s | Dosyalar: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kullanıcılar: E: %s K: %s | Dosyalar: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Hiç bir ağ seçilmedi"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "DüşükID ile"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "YüksekID ile"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Bağlandı: %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "Bağlanıyor: %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "eD2k Bağlantısı kesildi"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kademlia başladı."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kademlia durdu."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "Kademlia ağına bağlanıldı (tamam)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "Kademlia ağına bağlanıldı (Güvenlik duvarı arkasında)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Kademlia bağlantısı kesildi."
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDP portu ayarlarda devre dışı bırakılmışsa Kad ağı kullanılamaz. Başlatılmıyor."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad ağı ayarlarda devre dışı bırakılmış, bağlanılmıyor."
 
@@ -548,15 +558,15 @@ msgstr "Bu, eMule üzerine kurulu olan aMule %s yazılımıdır."
 msgid "Running on %s"
 msgstr "%s üzerinde çalışıyor"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Yeni sürüm denetimi için https://github.com/amule-org/amule/releases/latest adresini ziyaret ediniz."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ÖNEMLİ HATA: Zamanlayıcı oluşturulamadı"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -566,222 +576,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "En güncel sürüm her zaman https://github.com/amule-org/amule/releases/latest adresinde bulunabilir."
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Devre dışı"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMule diyaloğu imha edildi"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "Bağlanıyor"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: Bağlanıyor"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Bağlantı kesildi"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: Güvenlik Duvarı"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: Bağlandı"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: Bağlanıyor"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: Kapalı"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Durdur"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Bağlanılmış olan ağlar ile bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "Bağlan"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "Etkinleştirilmiş olan ağlara bağlan"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gön: %.1f%s (%.1f) | İnd: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/sn"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gön: %.1f%s | İnd: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Bağlandı)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Bağlantı kesildi)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s üzerinden çıkmayı gerçekten istiyor musunuz?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Çıkışı onaylayınız"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Çalıştırma Komutu: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- ön tanımlı -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Kaplama dizini '%s' yok"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "UYARI: Kaplama dosyası '%s' okuma için açılamıyor"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Ağlar"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Ağ Penceresi"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Aramalar"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Arama Penceresi"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "İndirmeler"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "İndirme Penceresi"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Paylaşılan dosyalar"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Paylaşılan Dosya Penceresi"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Sohbet"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Sohbet Penceresi"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "İstatistikler"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "İstatistik Grafik Penceresi"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Ayarlar"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Ayar Penceresi"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Parça dosyası içe aktarım aracı"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Hakkında"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Hakkında/Yardım"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k ağı"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kademlia ağı"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Ağ yok"
 
@@ -871,8 +881,8 @@ msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanıl
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Bilinmiyor"
@@ -1235,19 +1245,19 @@ msgstr "Oto (Yük)"
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Düşük"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1279,7 +1289,7 @@ msgid "On Queue"
 msgstr "Sırada"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Aktarılıyor"
 
@@ -1339,7 +1349,7 @@ msgstr "Sunucu"
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1410,7 +1420,7 @@ msgstr "Parça"
 msgid "Size"
 msgstr "Boyut"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Aktarıldı"
 
@@ -1423,7 +1433,7 @@ msgid "Progress"
 msgstr "İşlem"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Kaynaklar"
 
@@ -1433,7 +1443,7 @@ msgstr "Kaynaklar"
 msgid "Priority"
 msgstr "Öncelik"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Durum"
 
@@ -1466,7 +1476,7 @@ msgstr ""
 "Geri besleme: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Otomatik"
@@ -2117,7 +2127,7 @@ msgstr "Arkadaş listesi 'emfriends.met' dosyasına yazılamıyor!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRİTİK - SohbetOturumunuBaşlat' ta istemci yok"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Arkadaşlar"
 
@@ -2401,8 +2411,8 @@ msgstr "Ön yükleme için geçersiz port"
 msgid "Please fill all fields required"
 msgstr "İstenilen tüm alanları doldurunuz."
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "İleti"
 
@@ -2474,7 +2484,7 @@ msgstr "Paylaşım oranı"
 msgid "Uploaded"
 msgstr "Gönderilen"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "İstenen"
 
@@ -2508,30 +2518,30 @@ msgstr "Bilinmeyen hata %d"
 msgid "Unable to get error description for error %d"
 msgstr "%d hatası için tanımlama alınamadı!"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Adresleniyor"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Tamamlanıyor"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Tamamlandı"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Duraklatıldı"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Hatalı"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Bekliyor"
 
@@ -2575,7 +2585,7 @@ msgstr "Dış Bağlantı: Erişim engellendi çünkü: "
 msgid "External Connection: Handshake failed."
 msgstr "Dış Bağlantı: Tanılama engellendi."
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio iş parçacığı %d başladı"
@@ -2597,7 +2607,7 @@ msgid "WARNING: "
 msgstr "UYARI: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Kapat"
 
@@ -2706,7 +2716,7 @@ msgstr "Çıkış"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -2946,7 +2956,7 @@ msgstr "Bayt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3015,7 +3025,7 @@ msgstr "Tamamlanan aktarımları temizler."
 msgid "File sources:"
 msgstr "Dosya kaynakları:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Genel"
 
@@ -3036,7 +3046,7 @@ msgstr "Tam Ad :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3212,7 +3222,7 @@ msgstr "Kullanıcı Adı :"
 msgid "Userhash :"
 msgstr "Kullanıcı Adreslemesi :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ekle"
@@ -3221,15 +3231,15 @@ msgstr "Ekle"
 msgid "Download-Speed"
 msgstr "İndirme Hızı"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Şimdiki"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Oturum ortalaması"
 
@@ -3241,7 +3251,7 @@ msgstr "Gönderim Hızı"
 msgid "Connections"
 msgstr "Bağlantılar"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Aktif İndirmeler"
 
@@ -3249,7 +3259,7 @@ msgstr "Aktif İndirmeler"
 msgid "Active connections (1:1)"
 msgstr "Aktif Bağlantılar (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Aktif Göndermeler"
 
@@ -3450,8 +3460,8 @@ msgstr "Tarayıcı Seçimi"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Tarayıcı adını buraya giriniz. Sisteminizin ön tanımlı tarayıcısını kullanmak için boş bırakınız."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3525,147 +3535,156 @@ msgstr "Yerel adresi IP' ye bağla (herhangi biri için boş bırakın):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Sadece ileri düzey kullanıcılar: Birden fazla ağ arayüzünüz varsa; aMule'nin izleyeceği arayüz adresini giriniz."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Yerel adresi IP' ye bağla (herhangi biri için boş bırakın):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "İndirilen dosya başına en fazla kaynak sayısı:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "En cazla eş bağlantı sayısı:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Başlangıçta otomatik bağlan"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Bağlantı koptuğunda yeniden bağlan"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Ölü sunucuları"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "denemeden sonra kaldır"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Otomatik başlangıç"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Bir sunucuya bağlandığında sunucu listesini güncelle"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Bir kullanıcı bağlandığında sunucu listesini güncelle"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Öncelik sistemini kullan"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Bağlanırken akıllı DüşükID denetimi yap"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Güvenli Bağlantı"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Sadece statik listesindeki sunuculara otomatikman bağlan"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Elle eklenmiş sunuculara Yüksek Öncelik ata"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Akıllı Bozulma Yakalayıcısı (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Gelişmiş I.C.H. her adreslemeye güvensin. ( önerilmez )"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Dosyaları aktarımlara duraklatılmış kipte ekle"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Dosyaları, aktarımlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "İlk ve son parçaları en önce indirmeye çalış"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Bir dosya tamamlandığında duraklatılan sonraki dosyaya başla"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "Aynı sınıftan"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "Alfabetik sırayla"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Yeni dosyalar için diskte yer ayır"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Yeni dosyalarda, dosyanın tamamı için sabit diskte yer ayrılarak parçalanma azaltılır"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Boş disk alanı şu kadar kaldığında aktarımları durdur "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "aMule'nin diskteki alanı denetlemesini istiyorsanız bunu seçiniz."
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Buraya istenilen en az disk alanını giriniz."
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Nadir bulunan dosyalarda 10 kaynak sakla (<20 kaynak)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Gönderilenler"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Dosyaları paylaşılanlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "İndirmeler için hedef dizin"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3673,599 +3692,599 @@ msgstr ""
 "Tamamlanmış indirmeler burada muhafaza edilir. Bu dizindeki tüm dosyalar otomatik olarak diğer eşler ile paylaşılır.\n"
 "Şayet bu dizin paylaşmak istemediğiniz dosyalar da içeriyorsa, aMule'e özel bir alt dizini seçin."
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Tamamlanmış indirmelerin muhafaza edilecekleri dizini seçin. Bu dizindeki tüm dosyalar diğer eşler ile paylaşılacaktır."
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Bu dizindeki tüm dosyalar diğer eşler ile paylaşılmaktadır)"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Geçici dosyalar için dizin"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Paylaşılan dizinler"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Özyinelemeli paylaşım için dizin simgesine sağ tıklayınız.)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Gizli dosyaları paylaş"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "Paylaşılan dizinleri değişiklikler için otomatik olarak tekrar tara"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr "Paylaşılan dizinlerdeki simgesel bağlantıları takip et"
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Grafikler"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Güncelleme gecikmesi: 5 sn"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Ortalama grafiği için süre: 100 dk"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Bağlantı Grafik Ölçüsü: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "İndirme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Gönderme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "Renkler: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Arka plan"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Izgara"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Şu anki aktarımlar"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Aktarım çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Aktarım oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Şu anki gönderme"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Gönderme çalışma Ortalaması"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Gönderme oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Aktif bağlantılar"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "Sistem Tepsisi İkonu Hız Göstergesi"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Şu anki Kad düğümleri"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "İşlemdeki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Oturumdaki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Seçiniz"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Ağaç"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Gösterilen Yazılım Sürümü Sayısı (0=sınırsız)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! UYARI !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "En fazla yeni bağlantı / 5 sn"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dosya Tampon Boyutu: 240000 bayt"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Gönderme Sıra Boyutu: 5000 kullanıcı"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Sunucu bağlantısı yenileme sıklığı: devre dışı"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "Bilgisayarın devre dışı kalma kipini etkisiz hale getir"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Kullanılacak kaplama: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "\"Hızlı eD2k Bağlantı Yakalayıcısı\"nı her pencerede göster.."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Sınıf sekmelerinde genişletilmiş bilgi göster."
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "Başlık çubuğunda uygulama sürümünü göster"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Başlık çubuğunda aktarım oranlarını göster."
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Uygulama adından önce"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Uygulama adından sonra"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Ek yük ağ genişliğini göster"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Dikey araç çubuğu yerleşimi"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Sıradaki Dosyaları İndir"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "İşlem yüzdesini göster"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "İşlem çubuğunu göster"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Düz"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Yuvarlatılmış"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Dosyaları otomatik sırala (yüksek CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule aktarım listenizdeki sütunları otomatikman sıralayacaktır."
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Dışarıdan Bağlantı Parametreleri"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Dışarıdan bağlantıları kabul et."
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "Dinlenen arayüzün IP' si:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Dinleme EC arayüzü için a.b.c.d biçiminde geçerli bir ip giriniz. Boş bırakılan alan veya 0.0.0.0 arayüz yok demektir."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP portu:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC portuna UPnP port yönlendirmesi etkin."
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Şifre"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Web sunucusu değerleri"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Başlangıçta web sunucusunu başlat"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Web şablonu"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Tam hak şifresi"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Düşük hakka sahip kullanıcıyı etkin kıl."
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Düşük hak şifresi"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Web sunucu portunun UPnp port iletimini etkinleştir"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web sunucusu UPnp TCP portu (İsteğe bağlı)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Sayfa yenileme zamanı (sn)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Gzip sıkıştırmayı etkinleştir."
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Tamam"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişikliklerin uygulanması için buraya tıklayınız."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişiklikleri sil."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Başlık :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Yorum:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Gelen Dosyalar Dizini :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Yeni eklenen dosyalar için öncelikleri değiştir:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "Değiştirme"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Bu sınıf için renk seçiniz (varsayılan) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Günlük kayıtlarını silmek için bu düğmeye basınız."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sunucu listesini İnternet'den güncellemek için bu düğmeye basınız…"
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Sunucu"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adresi server.met dosyasına buradan giriniz. Sonra, bilinen sunucuları güncellemek için soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Sunucuyu elle ekle: İsim"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Yeni sunucunun adını buraya giriniz."
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Yeni sunucun IP numarasını x.x.x.x biçiminde buraya giriniz."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Sunucunu portunu buraya giriniz."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Sunucuyu elle ekle (önce soldaki alanları doldurunuz) …"
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule Günlüğü"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Sunucu Bilgisi"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K Bilgileri"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kademlia Bilgileri"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Düğüm listesini İnternet'den güncellemek için bu düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Düğümler (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Bilinen düğümleri güncellemek için buraya adresi giriniz ve soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Düğüm istatistikleri"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Yeni düğüm"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Kad Bağlantısını Kes"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Güvenli Kullanıcı Kimlik Doğrulamasını Kullan"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Bu seçeneği aktifleştirmeniz önerilir. SUI aktif değilse, kredi alamazsınız."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Protokol Gizleme"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Protokol Gizleme etkin"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Bu seçenek Protokol Gizleme'yi etkinleştirir ve aMule'nin gizlenmiş bağlantıları kabul etmesini sağlar."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Giden bağlantılar için gizleme kullan"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Bu seçenek diğer kullanıcı veya sunucularla olan bağlantılarda Protokol Gizleme'yi etkinleştirir."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Sadece gizlenmiş bağlantıları kabul et"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Bu seçenek aMule'nin sadece gizlenmiş bağlantıları kabul etmesini sağlar. Daha az kaynak bulursunuz; ancak tüm trafiğiniz de karartılmış olur."
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Herkes"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Hiç kimse"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Paylaşılan dosyalarımı kim görebilir:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Paylaşılan dosyalarınızı kime göstereceğinizi seçiniz."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP_Süzme"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Kullanıcıları Süz"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan kullanıcı IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Sunucuları süz"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan sunucu IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Listeyi yeniden yükle"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat dosyasından IP'leri süzgece yeniden yükle."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "Adres:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Şimdi güncelle"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Ip süzgecini başlangıçta otomatikman güncelle."
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Süzme Seviyesi:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Her zaman LAN IP'lerini süz."
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Uyuşmayan IP'lere şüpheci yaklaşım."
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Paketin alındığı ip ile kullanıcı ip numarası farklıysa paket reddedilir. Dikkatli kullanın."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Varsa, sistem geneli ipfilter.dat kullan"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Yerel bir ipfilter.dat dosyası bulunamazsa, sistem geneli ipfilter kullanımına izin ver."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Çevrimiçi-İmza' yı Etkinleştir"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Diğer uygulamaların imzalar ve benzerlerini oluşturabilmesi için kullanabileceği Çev.İmza dosyasını yazmayı etkinleştirir."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Güncelleme Sıklığı (Sn.):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Çevrim içi İmza güncellemeleri için (saniye bazında) sıklığı değiştirir."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Çevrim içi imza dosyasını buraya sakla: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Çevrim içi İmza dosyalarını içeren dizini seçiniz."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "İstemciler için ülke bayraklarını göster"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Transferler, kuyruklar ve arama görünümlerinde ülkelerin bayrakları sütununu görüntüle. Geçerli bir MMDB GeoIP veri tabanı gerektirir (aşağıya bakınız)."
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr "Veri Tabanı"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr "Kaynak:"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ücretsiz, hesap gerektirmez)"
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ücretsiz, hesap gerektirir)"
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr "Kişiselleştirilmiş URL"
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Hangi tedarikçinin GeoIP MMDB veri tabanını sağlayacağını seçin. DB-IP varsayılan değerdir - hesap gerektirmez. MaxMind ücretsiz bir hesap + lisans anahtarı gerektirir. Herhangi başka bir MMDB makinesine (mesela yerel bir yansıya) yönlendirme yapmak için kişiselleştirilmiş URL kullanın."
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4277,11 +4296,11 @@ msgstr ""
 "IP-Ülke verileri DB-IP.com tarafından sağlanmaktadır - https://db-ip.com\n"
 "Lisans: Creative Commons Atıf 4.0 - https://creativecommons.org/licenses/by/4.0/deed.tr"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr "Lisans anahtarı:"
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4297,11 +4316,11 @@ msgstr ""
 "Lisans: MaxMind GeoLite2 Kullanıcı Lisans Anlaşması - https://www.maxmind.com/en/geolite2/eula\n"
 "Atıf ve hesap oluşturulması gerektirir; en az her 30 günde bir güncelleyin."
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr "İndirme Bağlantısı:"
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4311,211 +4330,211 @@ msgstr ""
 "Bağlantı kimlik doğrulama bilgileri içerebilir (https://kullanıcı:parola@makine/…)\n"
 "Lisans ve atıf koşulları kaynak URL tarafından belirlenir - bunlardan siz sorumlu olursunuz."
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr "Seçili kaynaktan GeoIP veri tabanını indir."
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr "Başlangıçta otomatik olarak güncelle"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "aMule her başladığında, GeoIP veri tabanını seçili kaynaktan tekrar indir."
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Gelen iletileri süz (o anki sohbet dışında):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Hepsini süz."
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Arkadaş listesindekiler dışında herkesi süz."
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Bilinmeyen yazılımlardan gelenleri süz."
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "buraya ekleyeceğiniz sözcükleri içeren iletiler aMule tarafından engellenir."
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Günlükte alınan iletileri göster"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Yetkilendirmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Kullanıcı adı/şifre yetkilendirmeyi etkinleştir/devre dışı bırak."
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Kullanıcı adı: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli kullanıcı adı"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Şifre:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli şifre"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Vekil sunucuyu Etkinleştir."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Vekil sunucu desteğini etkinleştir/devre dışı bırak"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Vekil sunucu Türü:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Vekil sunucu makine:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Vekil sunucu makine adı"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Vekil sunucu Portu:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Vekil sunucu portu"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "Bağlan:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Uzaktan aMule'ye giriş yapınız."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Kullanıcı adı"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Bu ayarları hatırla"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr "ZLIB sıkıştırmasını zorla"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Fazladan Hata Çıktısı Kaydını Etkinleştir."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "Sadece Kütük Dosyasına"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "İleti Sınıfları:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Bekliyor…"
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "İçe aktarımları ekle"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Seçileni tekrar dene"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Seçileni çıkar"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Olay Türleri"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Seçili dosya(lar) için kuyruktaki istemciler ve istatistikler: Oturum / Bütün zamanlar"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "Toplam dosyaların yüzdesi"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "Tüm dosyalar"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "Seçilen dosyalar"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "Sadece aktif Göndermeler"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "Yeniden yükle:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Paylaşılan dosyalarınızı yeniden yükleyin"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Gönder"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Belirlenen iletiyi gönderir."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Bu sohbet oturumunu kapatır."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Paylaşılan Dosyalar"
 
@@ -4592,7 +4611,7 @@ msgstr "diğerleri"
 msgid "Incomplete"
 msgstr "Tamamlanmamış"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Durduruldu"
 
@@ -4781,34 +4800,34 @@ msgstr "Kısmi dosya %s (%s) için tohum dosyası okunamadı"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Parça dosyasına ait girdi dosyası (%s - %s): %s okunamıyor."
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Bozuk parça (%d) %d parça dosyası %s içinde bulundu -Dosya sonuç adreslemesi |%s| Dosya adreslemesi |%s|"
 msgstr[1] "Bozuk parça (%d) %d parça dosyası %s içinde bulundu -Dosya sonuç adreslemesi |%s| Dosya adreslemesi |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Tamamlanmış (%i) parçası %s içinde bulundu."
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "%s dosyasının yeniden adreslenmesi bitti"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "%s tamamlanırken beklenmeyen bir hata oluştu. Dosya duraklatıldı"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Aktarım tamamlandı: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4817,306 +4836,306 @@ msgstr ""
 "Şu indirme tamamlandı:\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Dosya siliniyor: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "UYARI: İndirilen parça adreslenemiyor - adresleme seti '%s' için eksik"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "HATA: Aktarılan parça adreslenemiyor.- adres seti tamamlanmamış (%s). Bu hiç olmamalıydı"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "%u kısmı ('%s' dosyasının) tamamlanmış olarak işaretlendi ama kısmi dosya beklenenden daha küçük (%llu bayt bulunduruyor halbuki %llu bayt gerektiriyor); yeniden indirme için boşluk tekrar açılıyor."
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "İndirilen %u bölümünün %u uzunluğunda (maksimum %u) parçasının ('%s' parça dosyasına ait (%u uzunluğunda)), adreslenmesinde EOF: %s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "UYARI: Yetersiz disk alanı! %s dosyası duraklatılıyor."
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "İndirilen %i parçası %s dosyasındaydı ve bozuk."
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Bozulan %i parçası %s dosyasındaydı ve kurtarıldı -> Kaydedilen miktar: %s bayt"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Ayrılıyor"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Yetersiz disk alanı"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "İndirildi"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HATA: Parça dosyası '%s' açılamıyor"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Sistem öntanımlısı"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Arnavutça"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Arapça"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "Asturyasça"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Baskça"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Bulgarca"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Katalanca"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Çince (Basitleştirilmiş)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Çince (Geleneksel)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Hırvatça"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Çekçe"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Danca"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Felemenkçe"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "İngilizce (U.K)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr "İngilizce (ABD)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Estonca"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Fince"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Fransızca"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Galce"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Almanca"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Yunanca"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "İbranice"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Macarca"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "İtalyanca"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "İtalyanca (İsviçre)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Japonca"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Korece"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Litvanyaca"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveççe (Nynorsk)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Lehçe"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Portekizce"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Portekizce (Brezilya)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "Rumence"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Rusça"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Slovence"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "İspanyolca"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "İsveççe"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Türkçe"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Ukraynaca"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "Dili Değiştirin"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "aMule tercümeleri kurulu değildir"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "Diller mevcut değil"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "mevcut seçenek yok"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Geçersiz sınıf bulundu, atlanıyor"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP portu numarası, UDP soketi TCP+3 olduğundan 65532' den yüksek olamaz"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Varsayılan port kullanılacak (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "Bağlantı"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Dizinler"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Sunucular"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Dosyalar"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Güvenlik"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Arayüz"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Vekil sunucu"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Süzgeçler"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Uzak Denetimler"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Çevrimiçi İmza"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Gelişmiş"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Olaylar"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Hata Çıktısı"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5126,15 +5145,15 @@ msgstr ""
 "    %PARTFILE - dosyanın tam yolu\n"
 "    %PARTNAME - dosyanın sadece adı"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Sistem tepsisi ikon desteği, derleme esnasında libayatana-appindicator3'e ihtiyaç duyar."
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Wayland ile kullanılamaz: protokol bir pencere küçültüldüğünde bunu iletmez, yani bu seçenek sistemin küçült düğmesi tıklamasını yakalayamaz. Çözüm: yerine XWayland kullanmak için aMule'ü `GDK_BACKEND=x11` ile başlatın."
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5150,26 +5169,26 @@ msgstr ""
 "Bu ayarlarla oynanmasa da\n"
 "aMule gayet iyi işleyecektir."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg %d Kimliği ve %s anahtarı ile parçacığa bağlanamadı"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Cfg' den %d Kimliği ve %s anahtarı ile Parçacığa veri aktarılamadı"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Bağlanacağınız vekil sunucu türü"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Parçacıktan %d Kimliği ve %s anahtarı ile Cfg' ye veri aktarılamadı"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5177,31 +5196,36 @@ msgstr ""
 "Değişikliklerin uygulanması için, aMule yeniden başlatılmalı\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP Portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- Dışarıdan bağlantı arayüzü değişti.\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- Dışarıdan bağlantı portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- Dışarıdan bağlantı kabul edilme işlemi değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- Dışarıdan bağlantı arayüzü değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokol gizleme desteği değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5209,7 +5233,7 @@ msgstr ""
 "Otomatik Sunucu güncelleme listeniz boş.\n"
 "'Sunucu listesini başlangıçta otomatikman güncelle' devre dışı bırakılacak."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5217,19 +5241,19 @@ msgstr ""
 "Dışarıdan bağlantıları aktifleştirmiş ama bir şifre belirlememişsiniz.\n"
 "Geçerli bir şifre belirlenmedikçe dışarıdan bağlantılar devre dışı kalacaktır."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Dil ayarları değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Geçici Dosyalar dizini değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K ağı etkinleştirildi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5237,7 +5261,7 @@ msgstr ""
 "Hem eD2k hem de Kad ağları devre dışı bırakılmış.\n"
 "En az birini etkinleştirmeden bağlanamayacaksınız."
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5245,7 +5269,7 @@ msgstr ""
 "UDP portu devre dışı bırakılmışsa Kad başlamayacaktır.\n"
 "UDP portu açın veya Kademlia'yı devre dışı bırakın."
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5255,19 +5279,19 @@ msgstr ""
 "aMule' yi ŞİMDİ yeniden başlatmalısınız.\n"
 "Şimdi yeniden başlatmazsanız, kötü şeyler olabilir.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Oturum açıldığında otomatik başlatma için aMule kaydedilemedi. Otomatik başlatma deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Oturum açılışında otomatik başlatma unsuru kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr "Otomatik başlatma"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5277,41 +5301,41 @@ msgstr ""
 "Lütfen geçerli bir server.met dosyasını gösteren en az bir adres yazınız.\n"
 "Bir adres girmek için bu kutucuğun yanındaki \"Liste\" düğmesine basınız."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Geçici dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Gelen dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Çevrimiçi İmzalar"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s için bir dizin seçiniz."
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Ortam Çalıcısı için göz at"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Tarayıcı Seçiniz"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Çalıştırılabilir %s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Sunucu listesini düzenle"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5319,114 +5343,114 @@ msgstr ""
 "Server.met dosyasını indirmek için buraya bağlantı adresi girin.\n"
 "Her satıra sadece bir adres yazılmalıdır."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr "IP2Country güncellemesi başarısız oldu"
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr "Veriler MaxMind GeoLite2 tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr "Kişiselleştirilmiş kaynak"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr "Veriler DB-IP.com tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Durum: %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Durum: %s - %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Durum: yükleme başarısız oldu - güncellemek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Durum: bulunamadı - indirmek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Güncelleme gecikmesi: %d saniye"
 msgstr[1] "Güncelleme gecikmesi: %d saniye"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Ortalama grafiği için süre: %d dakika"
 msgstr[1] "Ortalama grafiği için süre: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Bağlantı Grafik Ölçüsü: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dosya Alım Boyutu: %d bayt"
 msgstr[1] "Dosya Alım Boyutu: %d bayt"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Gönderme Sıra Boyutu: %d kullanıcı"
 msgstr[1] "Gönderme Sıra Boyutu: %d kullanıcı"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 msgstr[1] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Sunucu bağlantısı yenileme döngüsü: Devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "'%s' olayında komut çalıştır."
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Çekirdekte komut çalıştırmayı aktifleştir."
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Çekirdek komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Arayüzde komut çalıştırmayı etkinleştir."
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Arayüz komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Şu girdiler değiştirilecek:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -5434,32 +5458,32 @@ msgstr ""
 "Şu dizinler sistem dizinleri veya hassas konumlar gibi görünüyor:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Bunları yinelemeli olarak paylaşmanız, kapsadıkları her dosyayı eD2k/Kad ağlarında yayınlayacaktır. Bunu hakikaten yapmak istiyor musunuz?"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr "Paylaşılan dizinleri teyit et"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr "Paylaşılan dosyalar yeniden yükleniyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr "Alt dizinler taranıyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr "Paylaşılan dizinler güncelleniyor"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr "%u dizin tarandı…"
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -203,8 +203,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "ED2Links dosyasından %u bağlantı eklenemedi (ayrıntılar için kütüğe bakın)."
 msgstr[1] "ED2Links dosyasından %u bağlantı eklenemedi (ayrıntılar için kütüğe bakın)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -249,27 +249,37 @@ msgstr "aMule kapatılma işlemi tamamlandı."
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule çıkışı için hafıza hata raporlama sonuçları:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Bir yapılandırma değişikliği nedeniyle dil ayarınız 'Sistem Varsayılanı'na çevrildi. Üzgünüm. Vallahi…"
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Bilgi"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -277,20 +287,20 @@ msgstr ""
 "\n"
 "EC yapılandırması"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Parola ayarlandı ve dış bağlantılar etkinleştirildi."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "UYARI"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "Ağ başlatması"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -298,34 +308,34 @@ msgstr ""
 "aMule, eksik ağ başlatma dosyaları olduğunu tespit etti.\n"
 "Hangilerinin indirileceklerini seçin:"
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "eD2k sunucu listesi (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad başlangıç düğümleri (nodes.dat)"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web sunucusu pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Belirtilen şu adrese portlar bağlanamıyor: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port. %u kullanılamıyor. DÜŞÜKID alacaksınız.\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -340,48 +350,48 @@ msgstr ""
 "\n"
 "Ağ ayarlarınıza göz atarak portun giriş ve çıkışlar için açık olup olmadığını denetleyiniz."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMule Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Seçilen yerelleştirme görünüşe göre bilgisayarınızda yüklü değil. (Not: Bunu yine de yapmaya çalışacağım)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Hoş geldiniz! aMule %s sürümünü ilk kez kullanıyorsunuz."
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bu sürüm bir deneme sürümü, her gün güncellenir ve\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "bir şeyleri bozmayacağını veya evinizi yakmayacağını \n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "yahut da köpeğinizi öldürmeyeceğini garanti edemeyiz. Fakat bir *sorun* yaratmayacağını da umuyoruz.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daha fazla bilgi, destek ve yeni sürümler ana sayfamızda bulunabilir\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io veya IRC kanalımız: irc.libera.chat sunucusunda #aMule \n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Her türlü hatayı bize bildirmekten çekinmeyin https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -389,137 +399,137 @@ msgstr ""
 "Belirlediğiniz Çevrim içi İmza dosyaları dizini GEÇERSİZ!\n"
 " Çevrim içi İmza, ayarlarınızda düzeltene kadar DEVRE DIŞI bırakıldı."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Sunucu makine adı uyarıldı"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "%s dosyası için diskte yer ayırma başarısız oldu: %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "HATA: Günlük dosyası açılamıyor."
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UYARI: Günlük dosyası boş, bir şeyler yanlış."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Günlük kaydı silindi"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sunucu İletisi: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s indirilmeyecek; çünkü istenen dosya yeni değil."
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Nod listesini indirme başarısız."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "İndirilen sürüm denetleme dosyasını açma başarısız oldu."
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Bozuk sürüm denetleme dosyası"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "aMule'nin eski bir sürümünü kullanıyorsunuz!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "aMule sürümünüz %i.%i.%i ve en güncel sürüm %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "En güncel sürüm her zaman https://github.com/amule-org/amule/releases/latest adresinde bulunabilir."
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UYARI: aMuled sürümünüz eski: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "aMule sürümünüz güncel."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Sürüm denetleme dosyasını indirme başarısız oldu."
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kullanıcılar: %s | Dosyalar: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kullanıcılar: E: %s K: %s | Dosyalar: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Hiç bir ağ seçilmedi"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "DüşükID ile"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "YüksekID ile"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Bağlandı: %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "Bağlanıyor: %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "eD2k Bağlantısı kesildi"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kademlia başladı."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kademlia durdu."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "Kademlia ağına bağlanıldı (tamam)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "Kademlia ağına bağlanıldı (Güvenlik duvarı arkasında)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Kademlia bağlantısı kesildi."
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDP portu ayarlarda devre dışı bırakılmışsa Kad ağı kullanılamaz. Başlatılmıyor."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad ağı ayarlarda devre dışı bırakılmış, bağlanılmıyor."
 
@@ -2585,7 +2595,7 @@ msgstr "Dış Bağlantı: Erişim engellendi çünkü: "
 msgid "External Connection: Handshake failed."
 msgstr "Dış Bağlantı: Tanılama engellendi."
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio iş parçacığı %d başladı"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -203,8 +203,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "ED2Links dosyasından %u bağlantı eklenemedi (ayrıntılar için kütüğe bakın)."
 msgstr[1] "ED2Links dosyasından %u bağlantı eklenemedi (ayrıntılar için kütüğe bakın)."
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -249,37 +249,42 @@ msgstr "aMule kapatılma işlemi tamamlandı."
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule çıkışı için hafıza hata raporlama sonuçları:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Bir yapılandırma değişikliği nedeniyle dil ayarınız 'Sistem Varsayılanı'na çevrildi. Üzgünüm. Vallahi…"
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Bilgi"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -287,20 +292,20 @@ msgstr ""
 "\n"
 "EC yapılandırması"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Parola ayarlandı ve dış bağlantılar etkinleştirildi."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "UYARI"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "Ağ başlatması"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -308,34 +313,34 @@ msgstr ""
 "aMule, eksik ağ başlatma dosyaları olduğunu tespit etti.\n"
 "Hangilerinin indirileceklerini seçin:"
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "eD2k sunucu listesi (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad başlangıç düğümleri (nodes.dat)"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web sunucusu pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Belirtilen şu adrese portlar bağlanamıyor: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port. %u kullanılamıyor. DÜŞÜKID alacaksınız.\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -350,48 +355,48 @@ msgstr ""
 "\n"
 "Ağ ayarlarınıza göz atarak portun giriş ve çıkışlar için açık olup olmadığını denetleyiniz."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMule Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Seçilen yerelleştirme görünüşe göre bilgisayarınızda yüklü değil. (Not: Bunu yine de yapmaya çalışacağım)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Hoş geldiniz! aMule %s sürümünü ilk kez kullanıyorsunuz."
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bu sürüm bir deneme sürümü, her gün güncellenir ve\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "bir şeyleri bozmayacağını veya evinizi yakmayacağını \n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "yahut da köpeğinizi öldürmeyeceğini garanti edemeyiz. Fakat bir *sorun* yaratmayacağını da umuyoruz.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daha fazla bilgi, destek ve yeni sürümler ana sayfamızda bulunabilir\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io veya IRC kanalımız: irc.libera.chat sunucusunda #aMule \n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Her türlü hatayı bize bildirmekten çekinmeyin https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -399,137 +404,137 @@ msgstr ""
 "Belirlediğiniz Çevrim içi İmza dosyaları dizini GEÇERSİZ!\n"
 " Çevrim içi İmza, ayarlarınızda düzeltene kadar DEVRE DIŞI bırakıldı."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Sunucu makine adı uyarıldı"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "%s dosyası için diskte yer ayırma başarısız oldu: %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "HATA: Günlük dosyası açılamıyor."
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UYARI: Günlük dosyası boş, bir şeyler yanlış."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Günlük kaydı silindi"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sunucu İletisi: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s indirilmeyecek; çünkü istenen dosya yeni değil."
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Nod listesini indirme başarısız."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "İndirilen sürüm denetleme dosyasını açma başarısız oldu."
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Bozuk sürüm denetleme dosyası"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "aMule'nin eski bir sürümünü kullanıyorsunuz!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "aMule sürümünüz %i.%i.%i ve en güncel sürüm %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "En güncel sürüm her zaman https://github.com/amule-org/amule/releases/latest adresinde bulunabilir."
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UYARI: aMuled sürümünüz eski: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "aMule sürümünüz güncel."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Sürüm denetleme dosyasını indirme başarısız oldu."
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kullanıcılar: %s | Dosyalar: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kullanıcılar: E: %s K: %s | Dosyalar: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Hiç bir ağ seçilmedi"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "DüşükID ile"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "YüksekID ile"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Bağlandı: %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "Bağlanıyor: %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "eD2k Bağlantısı kesildi"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kademlia başladı."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kademlia durdu."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "Kademlia ağına bağlanıldı (tamam)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "Kademlia ağına bağlanıldı (Güvenlik duvarı arkasında)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Kademlia bağlantısı kesildi."
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDP portu ayarlarda devre dışı bırakılmışsa Kad ağı kullanılamaz. Başlatılmıyor."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad ağı ayarlarda devre dışı bırakılmış, bağlanılmıyor."
 
@@ -890,7 +895,7 @@ msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanıl
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2251,49 +2256,49 @@ msgstr "Hayır"
 msgid "Yes"
 msgstr "Evet"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Aktarılıyor…"
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP aktarımı iptal edildi"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "İndirme bağlantısı boş olamaz."
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "'%s' için HTTP talebi oluşturulması başarısız oldu"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP indirmesi: %s için boş cevap gövdesi"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "İndirilen dosyanın %s konumuna taşınması başarısız oldu."
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%s (%llu bayt) indirildi."
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "%s bağlantısı şunu geri gönderdi: %i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "%s için HTTP indirmesi başarısız oldu: %s"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "%s için HTTP 401 Yetkisiz"
@@ -2595,7 +2600,7 @@ msgstr "Dış Bağlantı: Erişim engellendi çünkü: "
 msgid "External Connection: Handshake failed."
 msgstr "Dış Bağlantı: Tanılama engellendi."
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio iş parçacığı %d başladı"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -199,8 +199,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,27 +245,37 @@ msgstr "Завершення роботи aMule закінчене."
 msgid "Memory debug results for aMule exit:"
 msgstr "Наслідки зневадження пам'яті для виходу aMule:"
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Ваша локаль змінена на системну за замовчуванням із-за зміни налаштувань. Вибачте."
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Інфо"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -273,56 +283,56 @@ msgstr ""
 "\n"
 "Налаштування зовнішніх з'єднань"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ЗАСТЕРЕЖЕННЯ"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Мережі"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сервер знайдено в server.met"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Неможливо прив'язати порт до визначеної адреси: %s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u недоступний. Ви будете мати LowID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -337,48 +347,48 @@ msgstr ""
 "\n"
 "Перевірте вашу мережу, щоб впевнитись, що порт відкритий."
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису aMule"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Обрана локаль здається не встановлена. (примітка: спроба встановити її в будь-якому випадку)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ви запускаєте aMule %s вперше"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Це тестова версія, оновлюється щодня, та\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ми не даємо жодної гарантії, якщо вона щось пошкодить, спалить ваш будинок,\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "або вб'є собаку. Але вона *має бути* безпечною у використанні всюди.\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Більше подробиць, підтримка та нові випуски можуть бути знайдені на нашій сторінці,\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "на https://amule-org.github.io, або у нашому IRC-каналі #aMule на irc.libera.chat.\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Не соромтеся повідомити про будь-які помилки на https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -386,137 +396,137 @@ msgstr ""
 "Тека для файлів онлайн-підпису НЕВІРНА!\n"
 "Онлайн-підпис буде ВИМКНЕНО поки ви не виправите це в налаштуваннях."
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "Назва сервера повідомлена"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Не вдалося виділити місце на диску для файлу '%s': %s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "ПОМИЛКА: не можу відкрити файл часопису"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ЗАСТЕРЕЖЕННЯ: журнал порожній. Щось негаразд."
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "Часопис очищено"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Повідомлення сервера: %s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "Не вдалося звантажити перелік вузлів."
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "Не вдалося відкрити звантажений файл перевірки версії"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "Файл перевірки версії зіпсований"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "Ви використовуєте застарілу версію aMule!"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ваша версія aMule %i.%i.%i, а остання %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ЗАСТЕРЕЖЕННЯ: Ваша версія aMuled застаріла: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копія aMule оновлена."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "Неможливо звантажити файл перевірки версії"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Користувачі: %s | Файли: %s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Користувачі: %s K: %s | Файли: E: %s K: %s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Не вибрано жодної мережі"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "з LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "з HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "З'єднано з %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "З'єднується з %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "Від'єднано від eD2k"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad запущена."
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad зупинена."
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "З'єднано з Kad (все гаразд)"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "З'єднано з Kad (за фаєрволом)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "Від'єднано від Kad"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Мережа Kad не може бути використана якщо UDP-порт вимкнено в налаштуваннях, не починаю."
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Мережа Kad вимкнена в налаштуваннях, не з'єднуюсь."
 
@@ -2616,7 +2626,7 @@ msgstr "Зовнішнє з'єднання: в доступі відмовлен
 msgid "External Connection: Handshake failed."
 msgstr "Зовнішнє з'єднання: в доступі відмовлено"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Потік звантаження HTTP розпочатий"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -199,8 +199,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -245,37 +245,42 @@ msgstr "Завершення роботи aMule закінчене."
 msgid "Memory debug results for aMule exit:"
 msgstr "Наслідки зневадження пам'яті для виходу aMule:"
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Ваша локаль змінена на системну за замовчуванням із-за зміни налаштувань. Вибачте."
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Інфо"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -283,56 +288,56 @@ msgstr ""
 "\n"
 "Налаштування зовнішніх з'єднань"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ЗАСТЕРЕЖЕННЯ"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Мережі"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сервер знайдено в server.met"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Неможливо прив'язати порт до визначеної адреси: %s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u недоступний. Ви будете мати LowID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -347,48 +352,48 @@ msgstr ""
 "\n"
 "Перевірте вашу мережу, щоб впевнитись, що порт відкритий."
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису aMule"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Обрана локаль здається не встановлена. (примітка: спроба встановити її в будь-якому випадку)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ви запускаєте aMule %s вперше"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Це тестова версія, оновлюється щодня, та\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ми не даємо жодної гарантії, якщо вона щось пошкодить, спалить ваш будинок,\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "або вб'є собаку. Але вона *має бути* безпечною у використанні всюди.\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Більше подробиць, підтримка та нові випуски можуть бути знайдені на нашій сторінці,\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "на https://amule-org.github.io, або у нашому IRC-каналі #aMule на irc.libera.chat.\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Не соромтеся повідомити про будь-які помилки на https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -396,137 +401,137 @@ msgstr ""
 "Тека для файлів онлайн-підпису НЕВІРНА!\n"
 "Онлайн-підпис буде ВИМКНЕНО поки ви не виправите це в налаштуваннях."
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "Назва сервера повідомлена"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Не вдалося виділити місце на диску для файлу '%s': %s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "ПОМИЛКА: не можу відкрити файл часопису"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ЗАСТЕРЕЖЕННЯ: журнал порожній. Щось негаразд."
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "Часопис очищено"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Повідомлення сервера: %s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "Не вдалося звантажити перелік вузлів."
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "Не вдалося відкрити звантажений файл перевірки версії"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "Файл перевірки версії зіпсований"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "Ви використовуєте застарілу версію aMule!"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ваша версія aMule %i.%i.%i, а остання %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ЗАСТЕРЕЖЕННЯ: Ваша версія aMuled застаріла: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копія aMule оновлена."
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "Неможливо звантажити файл перевірки версії"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Користувачі: %s | Файли: %s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Користувачі: %s K: %s | Файли: E: %s K: %s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Не вибрано жодної мережі"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "з LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "з HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "З'єднано з %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "З'єднується з %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "Від'єднано від eD2k"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad запущена."
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad зупинена."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "З'єднано з Kad (все гаразд)"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "З'єднано з Kad (за фаєрволом)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "Від'єднано від Kad"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Мережа Kad не може бути використана якщо UDP-порт вимкнено в налаштуваннях, не починаю."
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Мережа Kad вимкнена в налаштуваннях, не з'єднуюсь."
 
@@ -888,7 +893,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2272,49 +2277,49 @@ msgstr "Ні"
 msgid "Yes"
 msgstr "Так"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "Звантажування..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP завантаження скасоване"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Неможливо отримати спільні файли користувача %s"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Тека для тимчасових звантажуваних файлів"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Звантажені"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP завантаження скасоване"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2626,7 +2631,7 @@ msgstr "Зовнішнє з'єднання: в доступі відмовлен
 msgid "External Connection: Handshake failed."
 msgstr "Зовнішнє з'єднання: в доступі відмовлено"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Потік звантаження HTTP розпочатий"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "Показати aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "Віддалене керування aMule"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Знімок:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "'Багатоплатформений' p2p-клієнт, що оснований на eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -50,59 +50,59 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "Частина aMule основана на \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr "Сторінка в Інтернет:"
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr "Форум:"
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Перевірити наявність нової версії під час запуску"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "З'єднується з Kad"
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Ви використовуєте застарілу версію aMule!"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Недоступний"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -199,8 +199,8 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -215,47 +215,57 @@ msgstr "Не вдалося відкрити файл ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ЗАСТЕРЕЖЕННЯ: ви не можете додати себе як джерело для eD2k-посилання маючи LowID."
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "Тепер, виходимо з головної програми..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "Невдалі"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Завершується core."
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "Завершення роботи aMule закінчене."
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "Наслідки зневадження пам'яті для виходу aMule:"
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Ваша локаль змінена на системну за замовчуванням із-за зміни налаштувань. Вибачте."
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "Інфо"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -263,56 +273,56 @@ msgstr ""
 "\n"
 "Налаштування зовнішніх з'єднань"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "ЗАСТЕРЕЖЕННЯ"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Мережі"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сервер знайдено в server.met"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Неможливо прив'язати порт до визначеної адреси: %s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u недоступний. Ви будете мати LowID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -327,48 +337,48 @@ msgstr ""
 "\n"
 "Перевірте вашу мережу, щоб впевнитись, що порт відкритий."
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису aMule"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Обрана локаль здається не встановлена. (примітка: спроба встановити її в будь-якому випадку)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ви запускаєте aMule %s вперше"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Це тестова версія, оновлюється щодня, та\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ми не даємо жодної гарантії, якщо вона щось пошкодить, спалить ваш будинок,\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "або вб'є собаку. Але вона *має бути* безпечною у використанні всюди.\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Більше подробиць, підтримка та нові випуски можуть бути знайдені на нашій сторінці,\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "на https://amule-org.github.io, або у нашому IRC-каналі #aMule на irc.libera.chat.\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Не соромтеся повідомити про будь-які помилки на https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -376,137 +386,137 @@ msgstr ""
 "Тека для файлів онлайн-підпису НЕВІРНА!\n"
 "Онлайн-підпис буде ВИМКНЕНО поки ви не виправите це в налаштуваннях."
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "Назва сервера повідомлена"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Не вдалося виділити місце на диску для файлу '%s': %s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "ПОМИЛКА: не можу відкрити файл часопису"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ЗАСТЕРЕЖЕННЯ: журнал порожній. Щось негаразд."
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "Часопис очищено"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Повідомлення сервера: %s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "Не вдалося звантажити перелік вузлів."
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "Не вдалося відкрити звантажений файл перевірки версії"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "Файл перевірки версії зіпсований"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "Ви використовуєте застарілу версію aMule!"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ваша версія aMule %i.%i.%i, а остання %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ЗАСТЕРЕЖЕННЯ: Ваша версія aMuled застаріла: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копія aMule оновлена."
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "Неможливо звантажити файл перевірки версії"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Користувачі: %s | Файли: %s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Користувачі: %s K: %s | Файли: E: %s K: %s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "Не вибрано жодної мережі"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "з LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "з HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "З'єднано з %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "З'єднується з %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "Від'єднано від eD2k"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad запущена."
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad зупинена."
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "З'єднано з Kad (все гаразд)"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "З'єднано з Kad (за фаєрволом)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "Від'єднано від Kad"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Мережа Kad не може бути використана якщо UDP-порт вимкнено в налаштуваннях, не починаю."
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Мережа Kad вимкнена в налаштуваннях, не з'єднуюсь."
 
@@ -546,15 +556,15 @@ msgstr "Це aMule %s оснований на eMule."
 msgid "Running on %s"
 msgstr "Запущений на %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Відвідайте https://github.com/amule-org/amule/releases/latest, щоб перевірити наявність нових версій."
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ЖАХЛИВА ПОМИЛКА: не вдалося створити Timer"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -564,224 +574,224 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступний"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "Діалог aMule знищений"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "З'єднується"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: з'єднання"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: від'єднаний"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: за фаєрволом"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: з'єднаний"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: з'єднуюсь"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: вимкнена"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "Зупинити поточні спроби з'єднань"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "Від'єднатися від з'єднаних мереж"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "З'єднатися"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "З'єднатися з дозволеними мережами"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Вивантаження: %.1f(%.1f) | Звантаження: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "Мбайт/с"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кбайт/с"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Вивантаження: %.1f | Звантаження: %.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | З'єднано)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Від'єднано)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ви справді хочете вийти з aMule?"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "Підтвердження виходу"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "Команда для запуску: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- за замовчуванням -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Тека з шкірами '%s' не існує"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ЗАСТЕРЕЖЕННЯ: Неможливо відкрити файл шкіри '%s' для читання"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "Мережі"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "Вікно мереж"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "Пошук"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "Вікно пошуку"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "Звантаження"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Звантажується"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "Спільні файли"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "Вікно спільних файлів"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "Повідомлення"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "Вікно повідомлень"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "Вікно статистики"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Налаштування"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "Вікно налаштувань"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "Зовн. внесення"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "Засіб зовнішнього внесення частково звантажених файлів"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Про програму"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "Про/Допомога"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "Мережа eD2k"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Мережа Kad"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "Немає мережі"
 
@@ -869,8 +879,8 @@ msgstr ""
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "Невідомо"
@@ -1242,19 +1252,19 @@ msgstr "Авто [висока]"
 msgid "Very low"
 msgstr "Дуже низька"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "Низька"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "Звичайна"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1286,7 +1296,7 @@ msgid "On Queue"
 msgstr "В черзі"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "Звантажується"
 
@@ -1347,7 +1357,7 @@ msgstr "Місцевий сервер"
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1419,7 +1429,7 @@ msgstr "Частина"
 msgid "Size"
 msgstr "Розмір"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "Переданих"
 
@@ -1432,7 +1442,7 @@ msgid "Progress"
 msgstr "Перебіг"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "Джерела"
 
@@ -1442,7 +1452,7 @@ msgstr "Джерела"
 msgid "Priority"
 msgstr "Перевага"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "Стан"
 
@@ -1475,7 +1485,7 @@ msgstr ""
 "Відгук від: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "Автоматично"
@@ -2134,7 +2144,7 @@ msgstr "Неможливо відкрити перелік друзів 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - немає клієнта на StartChatSession"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "Друзі"
 
@@ -2425,8 +2435,8 @@ msgstr "Недопустимий порт для початкового запу
 msgid "Please fill all fields required"
 msgstr "Будь ласка, заповніть потрібні поля"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "Повідомлення"
 
@@ -2501,7 +2511,7 @@ msgstr "Відношення передачі"
 msgid "Uploaded"
 msgstr "Вивантажено"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "Запитано"
 
@@ -2535,31 +2545,31 @@ msgstr "Невідома версія"
 msgid "Unable to get error description for error %d"
 msgstr "Тека призначення для звантажень"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "Обчислюється хеш"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "Завершується"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "Завершений"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "Призупинений"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "Помилковий"
 
 # файл
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "Очікує"
 
@@ -2606,7 +2616,7 @@ msgstr "Зовнішнє з'єднання: в доступі відмовлен
 msgid "External Connection: Handshake failed."
 msgstr "Зовнішнє з'єднання: в доступі відмовлено"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Потік звантаження HTTP розпочатий"
@@ -2628,7 +2638,7 @@ msgid "WARNING: "
 msgstr "ЗАСТЕРЕЖЕННЯ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "Закрити"
 
@@ -2744,7 +2754,7 @@ msgstr "Вийти"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кбайт/с"
@@ -2984,7 +2994,7 @@ msgstr "байт"
 msgid "KB"
 msgstr "кбайт"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "Мбайт"
@@ -3054,7 +3064,7 @@ msgstr "Очистити завершені звантаження"
 msgid "File sources:"
 msgstr "Завершених джерел"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "Загальні"
 
@@ -3075,7 +3085,7 @@ msgstr "Повна назва:"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "недоступні"
 
@@ -3251,7 +3261,7 @@ msgstr "Ім'я користувача:"
 msgid "Userhash :"
 msgstr "Хеш користувача:"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Додати"
@@ -3260,15 +3270,15 @@ msgstr "Додати"
 msgid "Download-Speed"
 msgstr "Швидкість звантаження"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "Поточна"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "Середня"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "Середня за сесію"
 
@@ -3280,7 +3290,7 @@ msgstr "Швидкість вивантаження"
 msgid "Connections"
 msgstr "З'єднання"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "Чинні звантаження"
 
@@ -3288,7 +3298,7 @@ msgstr "Чинні звантаження"
 msgid "Active connections (1:1)"
 msgstr "Чинні з'єднання (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "Чинні вивантаження"
 
@@ -3490,8 +3500,8 @@ msgstr "Обрати переглядач тенет"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введіть тут назву вашого переглядача тенет. Залиште це поле порожнім, щоб використовувати переглядач встановлений за замовчуванням."
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3565,755 +3575,764 @@ msgstr "Використовувати IP-адресу (пусто для буд
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Тільки досвідченим користувачам: якщо ви маєте багато мережевих інтерфейсів, введіть адресу інтерфейсу до якого слід прив'язатися aMule."
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "Використовувати IP-адресу (пусто для будь-якої):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "Найбільше джерел на звантажуваний файл:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "Найбільше одночасних з'єднань:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "Автоматичне з'єднання після запуску"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "Перез'єднатись при втраті з'єднання"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "Вилучити мертвий сервер після"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "спроб"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "Автоматичне оновлення переліку серверів після запуску"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "Перелік"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "Оновити перелік серверів після з'єднання з сервером"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "Оновити перелік серверів після з'єднання з клієнтами"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "Використовувати систему переваг"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "Використовувати розумну перевірку LowID під час з'єднання"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "Безпечне з'єднання"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "Автоматично з'єднуватись тільки з серверами з переліку постійних"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "Встановити високу перевагу доданим вручну серверам"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Розумна обробка пошкоджень (Р.О.П.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "Ввімкнено"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Вдосконалена Р.О.П. довіряє всім хешам (не радимо)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "Додати файли для звантаження призупиненими"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "Додати файли для звантаження з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "Спробувати спершу звантажити перший та останній шматки"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "Запустити наступний призупинений файл, коли файл завершиться"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "З тієї самої категорії"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "Попереднє виділення місця на диску для нових файлів"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Повністю виділяти місце для всього нового файлу, це зменшить фрагментування"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "Припинити звантаження коли вільне місце на диску досягнуло "
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Виберіть це якщо хочете, щоб aMule перевіряв ваше місце на диску"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "Введіть найменше бажане місце на диску"
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Зберегти 10 джерел рідкісних файлів (менше ніж 20 джерел)"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "Вивантаження"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "Додати нові спільні файли з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "Тека призначення для звантажень"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "Тека для тимчасових звантажуваних файлів"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "Спільні теки"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Праве клацання по значку теки для рекурсивного додавання)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "Робити спільними приховані файли"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "Графіки"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "Час оновлення: 5 с"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "Час для середніх графіків: 100 хв"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "Шкала графіку з'єднань: 100"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "Шкала графіку звантаження"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "Шкала графіку вивантаження"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "Кольори: "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "Сітка"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "Звантаження зараз"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "Звантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "Звантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "Вивантаження поточні"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "Вивантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "Вивантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "Чинні з'єднання"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Показувати стовпчик швидкості в системному лотку"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "Вузлів Kad зараз"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "Вузлів Kad запущено"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "Вузлів Kad за сесію"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "Вибрати"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Кількість відображуваних версій клієнтів (0=необмежено)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! ЗАСТЕРЕЖЕННЯ !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "Найбільше зовнішніх з'єднань за 5 с"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Розмір файлу буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Розмір черги вивантаження: 5000 клієнтів"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "Час оновлення з'єднання з сервером: вимкнено"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "Використати шкіру: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показати \"Швидкий оброблювач eD2k-посилань\" в кожному вікні."
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "Показати розширену інформацію на вкладках категорій"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "Перед назвою програми"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "Після назви програми"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "Показати ширину смуги службового трафіку"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальне розміщення панелі інструментів"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "Звантажити файли в черзі"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "Показувати поступ у відсотках"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "Показувати панель поступу"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "Плаский"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "Круглий"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "Автоматично впорядковувати файли (багато ресурсів CPU)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule буде автоматично впорядковувати стовпці в переліку звантажень"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "Параметри зовнішніх з'єднань"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "Дозволити зовнішні з'єднання"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "IP-адреса інтерфейса:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введіть IP-адресу в вірному форматі a.b.c.d для прослуховування EC-інтерфейсу. Порожнє поле або 0.0.0.0 означатиме всі."
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ввімкнути UPnP перенаправлення для EC-порту"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "Запустити веб-сервер під час запуску"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Веб шаблон"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "Пароль повних прав"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "Ввімкнути користувача з низькими правами"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "Пароль низьких прав"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ввімкнути UPnP перенаправлення портів для порту веб-сервера"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP-порт веб-сервера (не обов'язково)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "Час оновлення сторінки (с)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "Дозволити Gzip-стиснення"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "Гаразд"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Натисніть тут щоб застосувати зміни зроблені в налаштуваннях."
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "Скинути всі зміни внесені в налаштування."
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "Назва:"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "Вхідна тека:"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "Змінити перевагу для нового призначеного файлу:"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 #, fuzzy
 msgid "Don't change"
 msgstr "Не змінювати"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "Виберіть колір для цієї категорії (зараз вибрано):"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "Очистити"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "Натисніть цю кнопку, щоб очистити часопис."
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Натисніть на кнопку щоб оновити перелік серверів з адреси..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "Перелік серверів"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введіть адресу файлу server.met та натисніть кнопку ліворуч щоб оновити перелік відомих серверів."
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "Додати сервер вручну: Назва"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "Введіть тут назву нового сервера"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Тут введіть IP-адресу сервера, використовуючи формат x.x.x.x."
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "Введіть тут порт сервера."
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Додати сервер вручну (заповніть поля ліворуч)..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "Часопис aMule"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "Інфо сервера"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "Інфо eD2k"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Інфо Kad"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Натисніть на цю кнопку щоб оновити перелік вузлів з URL..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "Вузли (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Введіть адресу файлу nodes.dat та натисніть кнопку ліворуч щоб оновити перелік відомих вузлів. "
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "Статистика вузлів"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "Початковий запуск"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "Новий вузол"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Початковий запуск\n"
 "відомого клієнта"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "Від'єднатися від Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "Використовувати безпечну ідентифікацію користувача"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендовано ввімкнути цю опцію. Ви не отримаєте довіру якщо безпечна ідентифікація вимкнена."
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "Приховування протоколу"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "Підтримка приховування протоколу"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ця опція вмикає приховування протоколу та дозволяє aMule приймати приховані з'єднання від інших клієнтів."
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "Використовувати приховування для вихідних з'єднань"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ця опція вмикає приховування протоколу під час з'єдання з іншими клієнтами/серверами."
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "Приймати тільки приховані з'єднання"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Приймати приховані з'єднання. Будете мати менше джерел, але весь ваш трафік буде приховано"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "Кожен"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "Жоден"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "Хто може бачити мої спільні файли:"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "Оберіть тих, хто може запитати перелік ваших спільних файлів."
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP-фільтрування"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "Фільтрувати клієнтів"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес клієнтів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "Фільтрувати сервери"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес серверів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Перезавантажити перелік IP-адрес для фільтрування з файлу ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "Оновити зараз"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "Рівень фільтра:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "Завжди відфільтровувати IP-адреси локальних мереж"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноїдальна обробка IP-адрес, що не співпали"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "Відкинути пакет якщо IP-адреса клієнта відрізняється від IP-адреси з якої прийшов пакет. Використовуйте обережно."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Використовувати системний ipfilter.dat якщо наявний"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Якщо не знайдено місцевий ipfilter.dat, дозволити використання системного."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "Ввімкнути онлайн-підпис"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ввімкнути запис файлу ОС, який може бути використано зовнішніми програмами для створення підписів та подібного."
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "Частота оновлення (с)"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Змінити частоту (в секундах) оновлень онлайн-підписів."
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "Зберегти файл онлайн-підпису в: "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Натисніть тут, щоб вибрати теку, що містить файли з онлайн-підписами."
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "Швидкість передачі:"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "Джерела"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4321,11 +4340,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4335,232 +4354,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "Звантаження: "
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фільтрувати вхідні повідомлення (окрім поточної розмови):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "Фільтрувати всі повідомлення"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "Фільтрувати повідомлення від людей, що не в вашому переліку друзів"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фільтрувати повідомлення, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "додати слова, які aMule буде фільтрувати, та забороняти повідомлення, що їх містять"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "Показувати отримані повідомлення в часописі"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "Коментарі"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фільтрувати коментарі, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "Включити авторизацію"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "Ввімкнути/вимкнути аутентифікацію з ім'ям/паролем"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "Ім'я користувача: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "Ім'я користувача для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "Ввімкнути проксі"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "Ввімкнути/вимкнути підтримку проксі"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "Тип проксі:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "Хост проксі:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "Ім'я хосту проксі"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "Порт проксі:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "Порт проксі"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "З'єднатись з:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "Вхід до віддаленого aMule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "Ім'я користувача"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "Запам'ятати ці налаштування"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Використовувати gzip-стиснення"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ввімкнути докладне ведення часопису."
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Відкрити файл"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "Категорія повідомлення:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Очікується..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "Додати зовнішні внесення"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "Повторити вибрані"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "Вилучити вибрані"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "Типи подій"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 #, fuzzy
 msgid "All files"
 msgstr "Сховати спільні файли"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 #, fuzzy
 msgid "Selected files"
 msgstr "Вибрати фільтр перегляду"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Чинні вивантаження"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 #, fuzzy
 msgid "Reload:"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "Надіслати"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "Надіслати вказане повідомлення."
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "Закрити цю розмову."
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "З'єднатися з будь-яким сервером та/чи Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "Спільні файли"
 
@@ -4639,7 +4658,7 @@ msgstr "всі інші"
 msgid "Incomplete"
 msgstr "Незавершені"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "Зупинені"
 
@@ -4831,7 +4850,7 @@ msgstr "Збережено %i джерело для часткового фай�
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Помилка читання файлу-джерела часткового файлу (%s - %s): %s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -4839,353 +4858,353 @@ msgstr[0] "Знайдена підробна частина (%d) в (%d) час�
 msgstr[1] "Знайдена підробна частина (%d) в (%d) часткових файлах %s - FileResultHash |%s| FileHash |%s|"
 msgstr[2] "Знайдена підробна частина (%d) в (%d) часткових файлах %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Знайдено завершену частину (%i) в %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Завершене повторне обчислення хешу: %s"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Неочікувана помилка під час завершення %s. Файл призупинено"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Завершене звантаження: %s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Завершене звантаження: %s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Видаляється файл: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ЗАСТЕРЕЖЕННЯ: неможливо обчислити хеш звантаженого файлу - набір хешів неповний для '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ПОМИЛКА: неможливо обчислити хеш звантаженого файлу - набір хешів неповний (%s). Такого ніколи не повинно бути"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ЗАСТЕРЕЖЕННЯ: недостатньо вільного місця на диску! Призупиняється файл: %s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Звантажена частина %i зіпсована в файлі: %s"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "Р.О.П.: відновлено зіпсовану частину %i для %s -> Збережено байт: %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "Виділяється"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "Не вистачає місця на диску"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Звантажені"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ПОМИЛКА: не вдалося відкрити частковий файл '%s'"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "Мова системи"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "Арабська"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 #, fuzzy
 msgid "Asturian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "Баскська"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "Болгарська"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "Каталонська"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "Китайська (спрощена)"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "Китайська (традиційна)"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "Хорватська"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "Чеська"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "Данська"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "Нідерландська"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "Фінська"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "Французька"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "Галісійська"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "Німецька"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "Грецька"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "Іврит"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "Угорська"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "Італійська"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "Італійська (Швейцарія)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "Японська"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "Корейська"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "Литовська"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвезька (Нюнорск)"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "Польська"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "Португальська"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "Португальська (Бразилія)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 #, fuzzy
 msgid "Romanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "Російська"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "Словенська"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "Іспанська"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "Шведська"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "Турецька"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "Українська"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 #, fuzzy
 msgid "Change Language"
 msgstr "Мова: "
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступний"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "немає наявних опцій"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "Знайдена помилкова категорія, пропущена"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Порт TCP не може бути більшим ніж 65532, оскільки UDP-порт сервера є TCP+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Буде використовуватися порт за замовчуванням (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "З'єднання"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "Теки"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "Сервери"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "Файли"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "Безпека"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "Зовнішній вигляд"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "Проксі"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "Фільтри"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "Віддалене керування"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "Онлайн-підпис"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "Розширені"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "Події"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "Налагоджувач"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5201,26 +5220,26 @@ msgstr ""
 "aMule чудово працює без зміни будь-яких\n"
 "з цих параметрів."
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Помилка з'єднання Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Помилка передавання даних з Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "Тип проксі з яким ви з'єднуєтесь"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Помилка передавання даних з Widget до Cfg з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5228,35 +5247,40 @@ msgstr ""
 "aMule має бути перезапущений, щоб зміни подіяли:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "Зовнішнє з'єднання розірвано."
+
+#: src/PrefsUnifiedDlg.cpp:919
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Дозволено нове зовнішнє з'єднання"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Приховування протоколу"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5264,7 +5288,7 @@ msgstr ""
 "Ваш перелік автоматичного оновлення серверів порожній.\n"
 "'Автоматичне оновлення серверів під час завантаження буде вимкнено."
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5272,20 +5296,20 @@ msgstr ""
 "Ви увімкнули зовнішні з'єднання, але не визначили пароль.\n"
 "Зовнішні з'єднання не можуть бути ввімкнені поки не вказано вірний пароль."
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- Мова змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- Тимчасова тека змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Всі мережі вимкнені."
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5293,7 +5317,7 @@ msgstr ""
 "Обидві eD2k та Kad-мережі вимкнені.\n"
 "Ви не зможете з'єднатися поки не увімкнете хоча б одну з них"
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5301,7 +5325,7 @@ msgstr ""
 "Kad не розпочне роботу, якщо UDP-порт вимкнено.\n"
 "Увімкніть UDP-порт або вимкніть Kad"
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5311,20 +5335,20 @@ msgstr ""
 "Ви ЗОБОВ'ЯЗАНІ перезапустити aMule зараз.\n"
 "Якщо ж не перезапустите, не скаржтеся, коли станеться щось жахливе.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматичне оновлення розпочато"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5334,41 +5358,41 @@ msgstr ""
 "Будь ласка заповніть принаймні одну адресу, що посилається на існуючий файл server.met.\n"
 "Натисніть на кнопку \"Перелік\" щоб ввести адресу."
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "Тимчасові файли"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "Вхідні файли"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "Онлайн-підписи"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Виберіть теку для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "Переглянути, щоб знайти відеопрогравач"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "Вибрати переглядач тенет"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "Виконуваний %s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "Редагувати перелік серверів"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5376,42 +5400,42 @@ msgstr ""
 "Додайте тут адреси файлів server.met.\n"
 "Тільки одна адреса на рядок."
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "Завершених джерел"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -5419,7 +5443,7 @@ msgstr[0] "Затримка оновлення: %d секунда"
 msgstr[1] "Затримка оновлення: %d секунди"
 msgstr[2] "Затримка оновлення: %d секунд"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -5427,12 +5451,12 @@ msgstr[0] "Час усереднення графіків: %d хвилина"
 msgstr[1] "Час усереднення графіків: %d хвилини"
 msgstr[2] "Час усереднення графіків: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Зміна розміру графіка з'єднань: %d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5440,7 +5464,7 @@ msgstr[0] "Розмір файлу буфера: %d байт"
 msgstr[1] "Розмір файлу буфера: %d байти"
 msgstr[2] "Розмір файлу буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -5448,7 +5472,7 @@ msgstr[0] "Розмір черги вивантаження: %d клієнт"
 msgstr[1] "Розмір черги вивантаження: %d клієнти"
 msgstr[2] "Розмір черги вивантаження: %d клієнтів"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -5456,74 +5480,74 @@ msgstr[0] "Інтервал оновлення з'єднання з сервер
 msgstr[1] "Інтервал оновлення з'єднання з сервером: %d хвилини"
 msgstr[2] "Інтервал оновлення з'єднання з сервером: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "Інтервал оновлення з'єднання з сервером: вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Виконати команду на подію '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "Ввімкнути виконання команди в ядрі"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "Команда ядра:"
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "Ввімкнути виконання команд в ГІК"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "Команда ГІК:"
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "Наступні змінні будуть замінені:"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Перезавантажується перелік спільних файлів."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-26 15:01+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -24,20 +24,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.5\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "显示 aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule 远程控制 "
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -45,7 +45,7 @@ msgstr ""
 "基于 eMule 的“全平台” P2P客户端 \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -53,59 +53,59 @@ msgstr ""
 "版权所有 (c) 2003-2026 aMule 团队 \n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "aMule 的一部分是基于 \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: 基于异或算法的点对点路由。\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " 版权所有 (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr "文档："
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "启动时检查新版本"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "正在连接至 Kad..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "您使用的是老版本的aMule！"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "不可用"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -207,8 +207,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "无法添加 ED2KLinks 文件的 %u 个链接（详情见日志）。"
 msgstr[1] "无法添加 ED2KLinks 文件的 %u 个链接（详情见日志）。"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -223,47 +223,57 @@ msgstr "打开 ED2K 链接文件失败。"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：在 Low ID 的情况下，你不能添加自己作为 ed2k 链接的源。"
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "现在，正在退出主程序..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleweb 实例 ... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleweb 实例 ... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "失败"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule 正在退出：中止内核。"
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "aMule 已经关闭。"
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "对 aMule 退出的内存 Debug 结果："
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "对不起，由于配置变动，您的地区设置已经变为系统默认值。"
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "信息"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -271,20 +281,20 @@ msgstr ""
 "\n"
 "EC 配置"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "密码已设置，启用远程连接。"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 msgid "Network bootstrap"
 msgstr "网络引导"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -292,34 +302,34 @@ msgstr ""
 "aMule 检测到缺少网络引导文件。\n"
 "请选择需要下载的文件："
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 msgid "eD2k server list (server.met)"
 msgstr "eD2k 服务器列表 (server.met)"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad 引导节点 (nodes.dat)"
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web 服务器正在运行，pid 为 %d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "无法绑定端口到指定的地址：%s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "端口 %u 不可用，你会成为 Low ID\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -334,48 +344,48 @@ msgstr ""
 "\n"
 "请检测网络设置以确保端口可用于输入输出。"
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "创建在线统计文件失败"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "创建 aMule 在线统计文件失败"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "您所选择的地区设置在您的计算机上似乎没有安装。(注意：我还是会尝试您所选择的地区设置。)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "这是您第一次运行 aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "此版本是测试版，更新频繁， \n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "我们无法承诺它不会损坏任何东西，烧毁您的房子，\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或杀死你的狗，但 * 一般来讲 * 它应该是安全的。\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "如要获取使用信息、用户支持以及下载最新版本，请访问我们的首页\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或进入我们在 irc.libera.chat 的 IRC 频道 #aMule。\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "欢迎您到 https://github.com/amule-org/amule/issues 去提交错误报告"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -383,137 +393,137 @@ msgstr ""
 "您为在线统计文件所选择的文件夹无效！\n"
 "在您更正设置之前在线统计将被禁用。"
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "获取服务器名称"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "为文件 '%s' 预分配磁盘空间失败：%s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "错误：无法打开日志文件"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：日志文件为空。肯定有什么地方出错了。"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "记录文件已被重置"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "服务器消息：%s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "跳过下载%s，因为请求的文件不是最新的。"
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "下载节点列表失败。"
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "打开已下载的版本检查文件失败"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "损坏的版本检查文件"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是老版本的aMule！"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可从这里下载：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本太旧：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "您的aMule是最新版本。"
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "下载版本检查文件失败"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "用户：%s | 文件：%s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "用户：E：%s K：%s | 文件：E：%s K：%s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "没有选择网络"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "是 Low ID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "是 High ID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已连接到 %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在连接到 %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "已从 eD2k 断开"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad 已启动。"
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "已连接至 Kad (ok）"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "已连接至 Kad 网络 (有防火墙)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "已断开 Kad 连接"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "如果在设置中禁用了 UDP 端口，Kad 网络将不能使用，没有启动。"
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 网络在设置中被禁用了，没有连接。"
 
@@ -552,15 +562,15 @@ msgstr "这是基于 eMule 的 aMule %s。"
 msgid "Running on %s"
 msgstr "运行于 %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "访问 https://github.com/amule-org/amule/releases/latest 来检查 是否有新版本。"
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "致命错误：创建计时器失败"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -570,222 +580,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新版本可从这里下载：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "不可用"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMule 对话框损坏"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "正在连接"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k: 正在连接"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k: 已断开"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad: 通过防火墙"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad: 已连接"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad: 正在连接"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad: 关闭"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "终止本次连接尝试"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "断开连接"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "从当前已连接的网络断开"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "连接"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "连接至当前已启用的网络"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上传: %.1f%s（%.1f） | 下载: %.1f%s（%.1f）"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上传: %.1f%s | 下载: %.1f%s"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule（%s | 已连接）"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule（%s | 已断开）"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您确定要退出 %s 吗？"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "退出确认"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "运行命令: "
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- 默认 -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "皮肤目录 %s 不存在"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：无法打开皮肤文件 %s 进行读取"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "网络"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "网络窗口"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "搜索"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "搜索窗口"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "下载"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "下载窗口"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "共享文件"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "共享文件窗口"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "消息"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "消息窗口"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "统计"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "统计图窗口"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "设置"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "设置窗口"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "导入"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "part 文件导入工具"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "关于"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "关于/帮助"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k 网络"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "Kad 网络"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "无网络"
 
@@ -875,8 +885,8 @@ msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "未知"
@@ -1239,19 +1249,19 @@ msgstr "自动 [高]"
 msgid "Very low"
 msgstr "极低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1283,7 +1293,7 @@ msgid "On Queue"
 msgstr "正在排队"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "正在下载"
 
@@ -1343,7 +1353,7 @@ msgstr "本地服务器"
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1414,7 +1424,7 @@ msgstr "块"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "已传输"
 
@@ -1427,7 +1437,7 @@ msgid "Progress"
 msgstr "进度"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "源"
 
@@ -1437,7 +1447,7 @@ msgstr "源"
 msgid "Priority"
 msgstr "优先级"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "状态"
 
@@ -1470,7 +1480,7 @@ msgstr ""
 "报告来自: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "自动"
@@ -2121,7 +2131,7 @@ msgstr "写好友列表文件emfriends.met失败！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "严重错误 - 开始聊天进程没有客户端"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "好友"
 
@@ -2403,8 +2413,8 @@ msgstr "无效端口"
 msgid "Please fill all fields required"
 msgstr "请填写所有必要信息"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "消息"
 
@@ -2476,7 +2486,7 @@ msgstr "共享率"
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "已请求"
 
@@ -2510,30 +2520,30 @@ msgstr "未知错误 %d"
 msgid "Unable to get error description for error %d"
 msgstr "无法获取错误 %d 的错误描述"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "正在计算哈希"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "即将完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "已完成"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "已暂停"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "已出错"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "等待中"
 
@@ -2577,7 +2587,7 @@ msgstr "远程连接：访问被拒绝，原因："
 msgid "External Connection: Handshake failed."
 msgstr "远程连接：握手失败。"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio 线程 %d 已启动"
@@ -2599,7 +2609,7 @@ msgid "WARNING: "
 msgstr "警告: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "关闭"
 
@@ -2708,7 +2718,7 @@ msgstr "退出"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -2948,7 +2958,7 @@ msgstr "字节"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3017,7 +3027,7 @@ msgstr "清除已完成的下载"
 msgid "File sources:"
 msgstr "文件源:"
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "常规"
 
@@ -3038,7 +3048,7 @@ msgstr "全名 :"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3214,7 +3224,7 @@ msgstr "用户名 :"
 msgid "Userhash :"
 msgstr "用户哈希 :"
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "添加"
@@ -3223,15 +3233,15 @@ msgstr "添加"
 msgid "Download-Speed"
 msgstr "下载速度"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "当前"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "动态平均值"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "本次运行平均值"
 
@@ -3243,7 +3253,7 @@ msgstr "上传速度"
 msgid "Connections"
 msgstr "连接"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "活跃下载"
 
@@ -3251,7 +3261,7 @@ msgstr "活跃下载"
 msgid "Active connections (1:1)"
 msgstr "活跃连接 (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "活跃上传"
 
@@ -3452,8 +3462,8 @@ msgstr "浏览器"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "在此处输入您的浏览器名称，如要使用系统默认浏览器则请留空。"
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3527,147 +3537,156 @@ msgstr "为本地地址绑定 IP (全部绑定则留空):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "只限高级用户：如果您有多个网络接口，请输入 aMule 将要绑定接口的地址。"
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "为本地地址绑定 IP (全部绑定则留空):"
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "每个下载文件的最大的源数量:"
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "最大同时连接数:"
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "启动后自动连接"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "断线后自动重连"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "如果"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "次连接失败，则删除该服务器"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "启动时自动更新服务器列表"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "列表"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "与服务器连接时更新服务器列表"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "与其他用户连接时更新服务器列表"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "启用优先级系统"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "连接时启用智能 Low ID 检测"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "安全连接"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "只自动连接到静态服务器列表里的服务器"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "设置手动添加的服务器为高优先级"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智能损坏数据处理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "启用"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "高级 I.C.H. 信任全部哈希值 (不推荐)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "添加新下载文件时设为暂停状态"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "添加新下载文件时设定优先级为自动"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "尝试先下载文件的第一段和最后一段"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "当一个文件完成时开始下一个暂停的文件"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "来自同一分类"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "依照字母顺序"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "为新文件预分配磁盘空间"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "为新文件分配全部所需的磁盘空间，这样可以减少碎片"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "停止下载当可用磁盘空间只有"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "要求检查磁盘空间"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "请输入最低硬盘空间。"
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "保存稀有文件（少于20个源）的10个源"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "上传"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "添加新共享文件时设优先级为自动"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "存放下载文件的文件夹"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -3675,599 +3694,599 @@ msgstr ""
 "已完成下载的文件存储在此处。此文件夹中的所有文件将自动与其他对等点共享。\n"
 "如果此文件夹中还包含您不想共享的文件，请为 aMule 选择一个专用子文件夹。"
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "选择完成下载文件的存储文件夹。该文件夹中的所有文件都将与其他对等节点共享。"
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr "（此文件夹中的所有文件均与其他对等方共享）"
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "存放临时下载文件的文件夹"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "共享的文件夹"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(鼠标右键单击文件夹图标来递归共享)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "共享隐藏文件"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr "自动重新扫描共享文件夹以检测更改"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr "在共享文件夹中跟踪符号链接"
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "图表"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "刷新延迟：5 秒"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "平均值图表显示时间：100 分钟"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "连接图表尺寸: 100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "下载图表尺寸："
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "上传图表尺寸："
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 msgid "Colors: "
 msgstr "颜色： "
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "网格"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "目前下载"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "动态平均下载"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "本次运行平均下载"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "目前上传"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "动态平均上传"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "本次运行平均上传"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "活跃连接"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 msgid "Systray Icon Speed Bar"
 msgstr "系统状态栏图标速度显示"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "当前 Kad 节点"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "本次运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "选择"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "树"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "显示用户软件版本的数量(0代表不限制)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "！！！警告！！！"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "5 秒内最大新连接数"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "文件缓冲：24000 字节"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上传队列长度：5000 用户"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "服务器连接刷新周期：禁用"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "停用电脑自动进入待命模式功能"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "要使用的皮肤: "
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在全部窗口都显示“快捷 eD2k 链接处理栏”。"
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "在分类页中显示附加信息"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "在标题栏显示应用程序版本"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "在标题栏显示传输速度"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "在应用程序名称之前"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "在应用程序名称之后"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "显示额外开销的带宽"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "垂直显示工具栏"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "下载队列文件"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "显示进度百分比"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "显示进度条"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "圆柱"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "自动排序文件 (高 CPU 占用)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule 会自动将下载列表按列排序"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "远程连接参数"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "接受远程连接"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "监听接口的 IP:"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "在此输入正确的 IP(格式：a.b.c.d)用于监听远程连接接口。空着不填或者 0.0.0.0 表示任何接口。"
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP 端口："
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "为远程连接端口启用 UPnP"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密码"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "Web 服务参数"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "启动时运行 Web 服务"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "Web 模板"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "最高权限密码"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "启用低权限用户"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "低权限密码"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "为 Web 服务端口启用 UPn P端口转发"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web 服务器 UPnP 的 TCP 端口(可选)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "页面刷新周期(秒)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "启用 Gzip 压缩"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "确定"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "点击这里立即使用新的设置。"
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有设置改动。"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "标题 :"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "注释 :"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "下载目录 :"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "设置新加入的文件优先级为 :"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "不要改变"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "选择该分类颜色 (当前选择) :"
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "重置"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "按此按钮清空日志。"
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "按此按钮从该网址更新服务器列表 ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "服务器列表"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "输入 server.met 文件的地址，再按此按钮更新服务器列表。"
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "手动添加服务器：名称"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "在此输入新服务器的名称"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP 地址:端口"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "输入新服务器的 IP 地址 (x.x.x.x格式)。"
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "在此请输入服务器端口。"
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "添加新服务器 (先填写左侧的内容) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule 日志"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "服务器信息"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "ED2K 信息"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad 信息"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "按此更新节点列表自网址..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "节点 (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "输入 nodes.dat 文件的地址并按左边的按钮以更新已知节点列表"
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "节点状态"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "启动"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "新节点"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "端口："
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "从已知用户启动"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "断开 Kad"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "使用安全用户认证"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建议使用此选项，如果安全用户认证没有启用，将不会接收信用证明。"
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "模糊协议"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "支持模糊协议"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "此选项启用了模糊协议，可让aMule接受其他用户用迷糊协议的连接"
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "为传出连接使用模糊协议"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "此选项使aMule在连接其他用户或服务器时使用模糊协议。"
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "仅接受模糊协议连接"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "此选项让aMule只接受模糊协议连接，源相对来说会更少，但全部数据包都将进行迷惑处理"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "没有人"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "谁可查看我的共享文件："
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "选择可以浏览共享文件列表的用户。"
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP 过滤"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "过滤用户"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的用户IP"
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "过滤服务器"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的服务器IP"
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "刷新列表"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "更新 IP 地址过滤列表自文件 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "地址:"
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "启动后自动更新IP 地址过滤列表"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "过滤级别:"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "始终过滤局域网 IP"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "处理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "如果客户端 ip 和发送数据包的 ip 不同则拒绝数据包。请谨慎使用。"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "在可用的情况下使用系统级别的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果没有找到本地 ipfilter.dat 文件，则允许使用系统级的IP过滤文件。"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "启用在线统计"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "输出该文件以用于在线统计等等。"
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "更新频率 (秒):"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "更改在线统计文件的更新频率 (秒) 。"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "保存在线签名位置： "
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "单击此处选择包含在线签名文件的目录。"
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "为客户端显示国旗"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "在传输、队列和搜索视图中渲染地区旗帜列。需要有效的 MMDB GeoIP 数据库（见下文）。"
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 msgid "Database"
 msgstr "数据库"
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 msgid "Source:"
 msgstr "源："
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP（免费，无需账户）"
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2（免费，需注册账户）"
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr "自定义 URL"
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "选择哪个提供商提供 GeoIP MMDB 数据库。DB-IP 是默认选项，无需账户。MaxMind 需要一个免费账户和许可证密钥。使用自定义 URL 指向任何其他 MMDB 主机（例如本地镜像）。"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4279,11 +4298,11 @@ msgstr ""
 "IP-to-Country 数据由 DB-IP.com 提供 - https://db-ip.com\n"
 "许可证：知识共享署名 4.0 国际版 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr "许可证密钥："
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4299,11 +4318,11 @@ msgstr ""
 "许可证：MaxMind GeoLite2 最终用户许可协议 - https://www.maxmind.com/en/geolite2/eula\n"
 "需要注明出处并注册账户；至少每 30 天刷新一次。"
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 msgid "Download URL:"
 msgstr "下载地址："
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4313,211 +4332,211 @@ msgstr ""
 "URL 可包含凭据（例如 https://user:pass@host/...）。\n"
 "许可和署名条款由上游 URL 决定——你需自行负责。"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr "从所选源下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 msgid "Auto-update on startup"
 msgstr "启动后自动更新"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "每次启动 aMule 时，从所选源重新下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "过滤收到的消息 (不包括当前对话):"
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "过滤所有消息"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "过滤来自好友列表外的消息"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "过滤来自未知用户的消息"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "过滤包含以下内容的消息 (用半角逗号分隔):"
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "输入需过滤的词组"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "在日志中显示接收的消息"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "备注"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "过滤包含以下内容的备注 (使用“,”作为分隔符):"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "启用验证："
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "启用/禁用用户名/密码验证"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "用户名: "
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "连接代理服务器的用户名"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "密码:"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "连接代理服务器的密码"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "启用代理"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "启用/禁用代理支持"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "代理类型:"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "代理服务器:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "代理服务器名称"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "代理端口:"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "代理端口"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "连接到:"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "登录远程 amule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "用户名"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "记住这些设置"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 msgid "Force ZLIB compression"
 msgstr "强制使用 ZLIB 压缩"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "启用详细调试日志。"
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 msgid "Only to Logfile"
 msgstr "只记录到日志文件"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "消息分类:"
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等待中..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "添加导入文件"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "重试所选"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "删除所选"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "事件类型"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "所选文件的统计和队列用户：会话/全部时间"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "活跃上传"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "全部文件的百分比"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "所有文件"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "选择的文件"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "仅活跃上传"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "显示客户端"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "重新载入:"
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "刷新共享文件"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "发送"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "发送指定消息。"
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "结束本次聊天。"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "连接至任何服务器和/或 Kad"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "共享文件"
 
@@ -4594,7 +4613,7 @@ msgstr "其它"
 msgid "Incomplete"
 msgstr "未完成"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "已停止"
 
@@ -4783,34 +4802,34 @@ msgstr "无法为 part 文件 %s（%s）读取源"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "读取 part 文件的种子文件出错（%s - %s）：%s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "发现损坏的数据块 (%d) 于%d段文件 %s - 文件结果校检码 |%s| 文件校检码 |%s|"
 msgstr[1] "发现损坏的数据块 (%d) 于%d段文件 %s - 文件结果校检码 |%s| 文件校检码 |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "发现了已完成的数据段 %i 在%s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "重新校验 %s 完成"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "在完成文件%s时遇到意外文件错误，文件已暂停"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "完成下载：%s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -4819,306 +4838,306 @@ msgstr ""
 "完成下载：\n"
 "%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "正在删除文件: %s"
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "警告：无法为已下载的数据段计算校检码 - 校检码集不完整 '%s'"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "警告：无法生成校检码 - 校检码集不完整（%s）， 正常情况下这是不应该发生的"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "分块 %u（属于文件 '%s'）标记为已完成，但该分片文件大小小于预期（现有 %llu 字节，需要 %llu 字节）；正在重新开放该区间以重新下载。"
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "计算已下载部分 %u (长度 %u，最多 %u) 的哈希值时出现 EOF 错误，它属于part 文件 “%s”（长度 %u）：%s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "警告：硬盘空间不足！暂停文件：%s"
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "下载的数据段 %i 已损坏 文件： (%s)"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH：修复了损坏的数据段 %i（%s），挽救数据（字节）： %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "正在分配"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "磁盘空间不足"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "已下载"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "错误：打开part文件'%s'失败"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "系统默认"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "阿拉伯语"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "澳大利亚"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "巴斯克语"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "保加利亚语"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "加泰罗尼亚语"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "简体中文"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "繁体中文"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "克罗的亚语"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "捷克语"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "丹麦语"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "英语（英国）"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 msgid "English (U.S.)"
 msgstr "英语（美国）"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "爱斯托尼亚语"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "法语"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "德语"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "希腊语"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "希伯来语"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "意大利语"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "意大利语（瑞士）"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "日语"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "韩语"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "立陶宛语"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威语"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙语（巴西）"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "俄语"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "乌克兰"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "更改语言"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "没有为 aMule 安装语言文件"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "语言文件不可用"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "选项不可用"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "发现无效的分类，跳过"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP端口不可高于65532，因为服务器UDP端口值为TCP端口值+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "缺省端口将被使用（%d）"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "连接"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "目录"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "服务器"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "文件"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "安全"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "界面"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "代理"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "过滤"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "远程控制"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "在线签名"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "高级"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "事件"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "调试"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5128,15 +5147,15 @@ msgstr ""
 "    %PARTFILE - 文件的完整路径\n"
 "    %PARTNAME - 仅文件名"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "系统托盘图标支持在编译时需要 libayatana-appindicator3。"
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "在 Wayland 上不可用：该协议无法报告窗口何时被最小化，因此此选项无法拦截系统的最小化按钮。解决方法：使用 `GDK_BACKEND=x11` 启动 aMule，以改用 XWayland。"
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5152,26 +5171,26 @@ msgstr ""
 "即使不改动这些设置，aMule\n"
 "也完全可以正常运行。"
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "使用ID %d和密匙%s连接Cfg到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从Cfg转移到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "正在连接的代理服务器类型"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从小插件转移到Cfg失败"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5179,31 +5198,36 @@ msgstr ""
 "重启aMule后这些更改才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- 更改了外部连接接口。\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- 外部连接端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- 更改了外部连接接受。\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- 更改了外部连接接口。\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- 模糊协议支持已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5211,7 +5235,7 @@ msgstr ""
 "您的自动更新服务器列表是可空的，\n"
 "启动时自动更新服务器列表功能将被禁用。"
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5219,19 +5243,19 @@ msgstr ""
 "您已经启用了远程连接但还没有设置密码。\n"
 "远程连接在没有有效密码的情况下不能使用。"
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- 语言已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- 临时文件目录已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "-ED2K网络已启用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5239,7 +5263,7 @@ msgstr ""
 "eD2k 和 Kad 网络都已被禁用，\n"
 "你至少要启用其中的一项才能连接。"
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5247,7 +5271,7 @@ msgstr ""
 "如果你的 UDP 端口被禁用，Kad 将不能启动。\n"
 "启动 UDP 端口或禁用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5257,19 +5281,19 @@ msgstr ""
 "你必须现在重启aMule，\n"
 "如果现在不重启的话，出现任何问题可别怪别人。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "无法将 aMule 注册为登录时自动启动。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr "无法移除登录时自动启动的条目。"
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 msgid "Autostart"
 msgstr "自启动"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5279,41 +5303,41 @@ msgstr ""
 "请输入至少一个指向有效 server.met 的网址，\n"
 "点击这个勾选框旁边的\"列表\"按钮然后输入网址。"
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "临时文件"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "传入文件"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "在线签名"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "为%s选择文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "浏览寻找视频播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "选择浏览器"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "可执行%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "编辑服务器列表"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5321,114 +5345,114 @@ msgstr ""
 "在此添加下载 server.met 文件的地址\n"
 "每行只限一个。"
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr "IP2Country 更新失败"
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr "数据来自 MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 msgid "Custom source"
 msgstr "自定义源"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr "数据来源：DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "状态：已加载%s"
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "状态：已加载%s~%s"
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "状态：加载失败 - 点击“立即更新”以刷新。"
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "状态：未找到 - 点击“立即更新”进行下载。"
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延迟：%d秒"
 msgstr[1] "更新延迟：%d秒"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值图表显示时间：%d分钟"
 msgstr[1] "平均值图表显示时间：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "网络连接图表缩放：%d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "文件缓冲区大小：%d字节"
 msgstr[1] "文件缓冲区大小：%d字节"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上传队列长度：%d个用户"
 msgstr[1] "上传队列长度：%d个用户"
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "服务器连接刷新周期：%d分钟"
 msgstr[1] "服务器连接刷新周期：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "服务器连接刷新周期：已禁用"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "禁用"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "在“%s”事件时执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "在核心启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "核心命令："
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "在图形界面端启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "图形界面命令："
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr "以下变量将被替换："
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -5436,32 +5460,32 @@ msgstr ""
 "以下文件夹看起来像是系统或敏感位置：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "递归共享会将每个子文件发布到 eD2k/Kad 网络上。您确定要这样做吗？"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 msgid "Confirm shared folders"
 msgstr "确认共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Reloading shared files…"
 msgstr "正重新加载共享文件…"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr "正在扫描子目录…"
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 msgid "Updating shared folders"
 msgstr "正在上传共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr "已扫描 %u 个目录……"
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "正重新加载共享文件：扫描了 %u 个文件"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-26 15:01+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -207,8 +207,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "无法添加 ED2KLinks 文件的 %u 个链接（详情见日志）。"
 msgstr[1] "无法添加 ED2KLinks 文件的 %u 个链接（详情见日志）。"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -253,27 +253,37 @@ msgstr "aMule 已经关闭。"
 msgid "Memory debug results for aMule exit:"
 msgstr "对 aMule 退出的内存 Debug 结果："
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "对不起，由于配置变动，您的地区设置已经变为系统默认值。"
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "信息"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -281,20 +291,20 @@ msgstr ""
 "\n"
 "EC 配置"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "密码已设置，启用远程连接。"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 msgid "Network bootstrap"
 msgstr "网络引导"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -302,34 +312,34 @@ msgstr ""
 "aMule 检测到缺少网络引导文件。\n"
 "请选择需要下载的文件："
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 msgid "eD2k server list (server.met)"
 msgstr "eD2k 服务器列表 (server.met)"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad 引导节点 (nodes.dat)"
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web 服务器正在运行，pid 为 %d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "无法绑定端口到指定的地址：%s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "端口 %u 不可用，你会成为 Low ID\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,48 +354,48 @@ msgstr ""
 "\n"
 "请检测网络设置以确保端口可用于输入输出。"
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "创建在线统计文件失败"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "创建 aMule 在线统计文件失败"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "您所选择的地区设置在您的计算机上似乎没有安装。(注意：我还是会尝试您所选择的地区设置。)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "这是您第一次运行 aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "此版本是测试版，更新频繁， \n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "我们无法承诺它不会损坏任何东西，烧毁您的房子，\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或杀死你的狗，但 * 一般来讲 * 它应该是安全的。\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "如要获取使用信息、用户支持以及下载最新版本，请访问我们的首页\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或进入我们在 irc.libera.chat 的 IRC 频道 #aMule。\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "欢迎您到 https://github.com/amule-org/amule/issues 去提交错误报告"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -393,137 +403,137 @@ msgstr ""
 "您为在线统计文件所选择的文件夹无效！\n"
 "在您更正设置之前在线统计将被禁用。"
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "获取服务器名称"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "为文件 '%s' 预分配磁盘空间失败：%s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "错误：无法打开日志文件"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：日志文件为空。肯定有什么地方出错了。"
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "记录文件已被重置"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "服务器消息：%s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "跳过下载%s，因为请求的文件不是最新的。"
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "下载节点列表失败。"
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "打开已下载的版本检查文件失败"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "损坏的版本检查文件"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是老版本的aMule！"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可从这里下载：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本太旧：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "您的aMule是最新版本。"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "下载版本检查文件失败"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "用户：%s | 文件：%s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "用户：E：%s K：%s | 文件：E：%s K：%s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "没有选择网络"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "是 Low ID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "是 High ID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已连接到 %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在连接到 %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "已从 eD2k 断开"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad 已启动。"
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "已连接至 Kad (ok）"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "已连接至 Kad 网络 (有防火墙)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "已断开 Kad 连接"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "如果在设置中禁用了 UDP 端口，Kad 网络将不能使用，没有启动。"
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 网络在设置中被禁用了，没有连接。"
 
@@ -2587,7 +2597,7 @@ msgstr "远程连接：访问被拒绝，原因："
 msgid "External Connection: Handshake failed."
 msgstr "远程连接：握手失败。"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio 线程 %d 已启动"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-26 15:01+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -207,8 +207,8 @@ msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] "无法添加 ED2KLinks 文件的 %u 个链接（详情见日志）。"
 msgstr[1] "无法添加 ED2KLinks 文件的 %u 个链接（详情见日志）。"
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -253,37 +253,42 @@ msgstr "aMule 已经关闭。"
 msgid "Memory debug results for aMule exit:"
 msgstr "对 aMule 退出的内存 Debug 结果："
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "对不起，由于配置变动，您的地区设置已经变为系统默认值。"
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "信息"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -291,20 +296,20 @@ msgstr ""
 "\n"
 "EC 配置"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "密码已设置，启用远程连接。"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 msgid "Network bootstrap"
 msgstr "网络引导"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -312,34 +317,34 @@ msgstr ""
 "aMule 检测到缺少网络引导文件。\n"
 "请选择需要下载的文件："
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 msgid "eD2k server list (server.met)"
 msgstr "eD2k 服务器列表 (server.met)"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad 引导节点 (nodes.dat)"
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web 服务器正在运行，pid 为 %d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "无法绑定端口到指定的地址：%s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "端口 %u 不可用，你会成为 Low ID\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -354,48 +359,48 @@ msgstr ""
 "\n"
 "请检测网络设置以确保端口可用于输入输出。"
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "创建在线统计文件失败"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "创建 aMule 在线统计文件失败"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "您所选择的地区设置在您的计算机上似乎没有安装。(注意：我还是会尝试您所选择的地区设置。)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "这是您第一次运行 aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "此版本是测试版，更新频繁， \n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "我们无法承诺它不会损坏任何东西，烧毁您的房子，\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或杀死你的狗，但 * 一般来讲 * 它应该是安全的。\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "如要获取使用信息、用户支持以及下载最新版本，请访问我们的首页\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或进入我们在 irc.libera.chat 的 IRC 频道 #aMule。\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "欢迎您到 https://github.com/amule-org/amule/issues 去提交错误报告"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -403,137 +408,137 @@ msgstr ""
 "您为在线统计文件所选择的文件夹无效！\n"
 "在您更正设置之前在线统计将被禁用。"
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "获取服务器名称"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "为文件 '%s' 预分配磁盘空间失败：%s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "错误：无法打开日志文件"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：日志文件为空。肯定有什么地方出错了。"
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "记录文件已被重置"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "服务器消息：%s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "跳过下载%s，因为请求的文件不是最新的。"
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "下载节点列表失败。"
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "打开已下载的版本检查文件失败"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "损坏的版本检查文件"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是老版本的aMule！"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可从这里下载：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本太旧：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "您的aMule是最新版本。"
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "下载版本检查文件失败"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "用户：%s | 文件：%s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "用户：E：%s K：%s | 文件：E：%s K：%s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "没有选择网络"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "是 Low ID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "是 High ID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已连接到 %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在连接到 %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "已从 eD2k 断开"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad 已启动。"
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "已连接至 Kad (ok）"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "已连接至 Kad 网络 (有防火墙)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "已断开 Kad 连接"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "如果在设置中禁用了 UDP 端口，Kad 网络将不能使用，没有启动。"
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 网络在设置中被禁用了，没有连接。"
 
@@ -894,7 +899,7 @@ msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2255,49 +2260,49 @@ msgstr "否"
 msgid "Yes"
 msgstr "是"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "正在下载..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "HTTP 下载已经取消"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "要下载的地址不能为空"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "创建 %s 的 HTTP 请求失败"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP 下载：%s 返回的响应体为空"
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "无法移动已下载文件到 %s"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "已下载 %s （%llu 字节）"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s 返回了：%i"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "%s HTTP 下载失败：%s"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 未授权访问 %s"
@@ -2597,7 +2602,7 @@ msgstr "远程连接：访问被拒绝，原因："
 msgid "External Connection: Handshake failed."
 msgstr "远程连接：握手失败。"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio 线程 %d 已启动"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-02 19:51+0200\n"
+"POT-Creation-Date: 2026-07-03 12:27+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -26,20 +26,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: src/AboutDialog.cpp:60
+#: src/AboutDialog.cpp:62
 #, fuzzy
 msgid "About aMule"
 msgstr "顯示 aMule"
 
-#: src/AboutDialog.cpp:70
+#: src/AboutDialog.cpp:74
 msgid "aMule remote control "
 msgstr "aMule 遠端控制"
 
-#: src/AboutDialog.cpp:75
+#: src/AboutDialog.cpp:79
 msgid "Snapshot:"
 msgstr "快照："
 
-#: src/AboutDialog.cpp:77
+#: src/AboutDialog.cpp:81
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -47,7 +47,7 @@ msgstr ""
 "源自 eMule 的「跨平台」P2P 客戶端程式\n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -56,59 +56,59 @@ msgstr ""
 "Copyright (c) 2003-2019 aMule 團隊\n"
 "\n"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp:85
 msgid "Part of aMule is based on \n"
 msgstr "部份 aMule 源自 \n"
 
-#: src/AboutDialog.cpp:82
+#: src/AboutDialog.cpp:86
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr " KAD：基於 XOR 演算法的 P2P 路由。\n"
 
-#: src/AboutDialog.cpp:83
+#: src/AboutDialog.cpp:87
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:96
+#: src/AboutDialog.cpp:100
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:97
+#: src/AboutDialog.cpp:101
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:98
+#: src/AboutDialog.cpp:102
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:99
+#: src/AboutDialog.cpp:103
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:107
+#: src/AboutDialog.cpp:112
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "啓動時檢查新版本"
 
-#: src/AboutDialog.cpp:108
+#: src/AboutDialog.cpp:113
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:150
+#: src/AboutDialog.cpp:162
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kad 連線中..."
 
-#: src/AboutDialog.cpp:160
+#: src/AboutDialog.cpp:172
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "您使用的是過期的 aMule 版本！"
 
-#: src/AboutDialog.cpp:164
+#: src/AboutDialog.cpp:176
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "不可用"
 
-#: src/AboutDialog.cpp:168
+#: src/AboutDialog.cpp:180
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
@@ -203,8 +203,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1008 src/amule.cpp:1122
-#: src/amule.cpp:1424 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
+#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -219,47 +219,57 @@ msgstr "無法開啟 ED2K 連結檔。"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：LowID 時不可以將自己加入 eD2k 連結來源。"
 
-#: src/amule.cpp:251
+#: src/amule.cpp:252
 msgid "Now, exiting main app..."
 msgstr "正在離開主程式..."
 
-#: src/amule.cpp:281
+#: src/amule.cpp:282
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "正在終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:285
+#: src/amule.cpp:286
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在強行終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:287 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
+#: src/amule.cpp:288 src/ClientRef.cpp:180 src/ServerListCtrl.cpp:96
 msgid "Failed"
 msgstr "失敗"
 
-#: src/amule.cpp:293
+#: src/amule.cpp:294
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule 離開中：正在終止主程式。"
 
-#: src/amule.cpp:395
+#: src/amule.cpp:396
 msgid "aMule shutdown completed."
 msgstr "已關閉 aMule 。"
 
-#: src/amule.cpp:399
+#: src/amule.cpp:400
 msgid "Memory debug results for aMule exit:"
 msgstr "離開 aMule 時記憶體除錯結果："
 
-#: src/amule.cpp:612
+#: src/amule.cpp:571
+#, c-format
+msgid "Binding all network traffic to interface: %s"
+msgstr ""
+
+#: src/amule.cpp:573
+#, c-format
+msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
+msgstr ""
+
+#: src/amule.cpp:633
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "對不起，由於版本變更，您的地區設定已經被變更爲系統預設值。"
 
-#: src/amule.cpp:614 src/amule.cpp:1412 src/CatDialog.cpp:129
+#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "資訊"
 
-#: src/amule.cpp:621
+#: src/amule.cpp:642
 msgid ""
 "\n"
 "EC configuration"
@@ -267,56 +277,56 @@ msgstr ""
 "\n"
 "外部連線設定"
 
-#: src/amule.cpp:624
+#: src/amule.cpp:645
 msgid "Password set and external connections enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/amule.cpp:634 src/KadDlg.cpp:174 src/KadDlg.cpp:183
-#: src/PrefsUnifiedDlg.cpp:1035 src/SharedFilesCtrl.cpp:321
+#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:883
+#: src/amule.cpp:904
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "網路"
 
-#: src/amule.cpp:888
+#: src/amule.cpp:909
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:897
+#: src/amule.cpp:918
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "在 server.met 中找到 %i 個伺服器"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:925
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:990
+#: src/amule.cpp:1011
 #, c-format
 msgid "web server running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:1003
+#: src/amule.cpp:1024
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1090
+#: src/amule.cpp:1111
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "無法選定使用此位址的通訊埠：%s"
 
-#: src/amule.cpp:1114
+#: src/amule.cpp:1135
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "通訊埠 %u 已被佔用。您會變成 LOWID。\n"
 
-#: src/amule.cpp:1119
+#: src/amule.cpp:1140
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -331,48 +341,48 @@ msgstr ""
 "\n"
 "請檢查網路設定以確保通訊埠可正常使用。"
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "Failed to create OnlineSig File"
 msgstr "無法建立線上簽名識別檔"
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid "Failed to create aMule OnlineSig File"
 msgstr "無法建立 aMule 線上簽名識別檔"
 
-#: src/amule.cpp:1387
+#: src/amule.cpp:1408
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "在您的電腦上似乎沒有安裝您所選取的地區設定。 (但仍會採用您所選擇的設定)"
 
-#: src/amule.cpp:1397
+#: src/amule.cpp:1418
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "這是您第一次執行 aMule %s"
 
-#: src/amule.cpp:1400
+#: src/amule.cpp:1421
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "這個版本是測試版，每日有更新，\n"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1422
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "但我們無法擔保它不會造成任何損害、燒掉您的房子、\n"
 
-#: src/amule.cpp:1402
+#: src/amule.cpp:1423
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或害死您的狗。但一般來講它「應該」是安全的。\n"
 
-#: src/amule.cpp:1407
+#: src/amule.cpp:1428
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "在我們的網頁可找到更多資訊、使用者支援以及程式最新版本：\n"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1429
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或我們在 irc.libera.chat 的 IRC 頻道 #aMule。\n"
 
-#: src/amule.cpp:1410
+#: src/amule.cpp:1431
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "歡迎您到 https://github.com/amule-org/amule/issues 提出錯誤報告"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1443
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -380,137 +390,137 @@ msgstr ""
 "您選擇的線上簽名識別檔案所在資料夾無效！\n"
 " 在您變更偏好設定之前，線上簽名識別功能將被停用。"
 
-#: src/amule.cpp:1485
+#: src/amule.cpp:1506
 msgid "Server hostname notified"
 msgstr "已通伺服器主機名稱"
 
-#: src/amule.cpp:1794
+#: src/amule.cpp:1815
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "無法為檔案 %s 預先分配磁碟空間：%s"
 
-#: src/amule.cpp:1923
+#: src/amule.cpp:1944
 msgid "ERROR: can't open logfile"
 msgstr "錯誤：無法開啟記錄檔"
 
-#: src/amule.cpp:1927
+#: src/amule.cpp:1948
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：沒有記錄檔，肯定有什麽地方出錯了。"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1965
 msgid "Log has been reset"
 msgstr "記錄已被清除"
 
-#: src/amule.cpp:1968
+#: src/amule.cpp:1989
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "伺服器訊息：%s"
 
-#: src/amule.cpp:2009 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "略過不下載 %s ，因為並不是新近檔案。"
 
-#: src/amule.cpp:2012
+#: src/amule.cpp:2035
 msgid "Failed to download the nodes list."
 msgstr "無法下載節點清單。"
 
-#: src/amule.cpp:2032
+#: src/amule.cpp:2056
 msgid "Failed to open the downloaded version check file"
 msgstr "無法開啟下載的版本檢查檔"
 
-#: src/amule.cpp:2035 src/amule.cpp:2054 src/amule.cpp:2085 src/amule.cpp:2107
+#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
 msgid "Corrupted version check file"
 msgstr "損壞的版本檢查檔"
 
-#: src/amule.cpp:2118
+#: src/amule.cpp:2142
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是過期的 aMule 版本！"
 
-#: src/amule.cpp:2120
+#: src/amule.cpp:2144
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2124
+#: src/amule.cpp:2148
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2127
+#: src/amule.cpp:2151
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本已經過期：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2133
+#: src/amule.cpp:2157
 msgid "Your copy of aMule is up to date."
 msgstr "您的 aMule 是最新版本。"
 
-#: src/amule.cpp:2140
+#: src/amule.cpp:2164
 msgid "Failed to download the version check file"
 msgstr "無法下載版本檢查檔"
 
-#: src/amule.cpp:2308 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "使用者：%s | 檔案：%s"
 
-#: src/amule.cpp:2309 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "使用者：E:%s K:%s | 檔案：E:%s K:%s"
 
-#: src/amule.cpp:2323 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "未選取網路"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:855
+#: src/amule.cpp:2416 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "有 LowID"
 
-#: src/amule.cpp:2391 src/TextClient.cpp:856
+#: src/amule.cpp:2416 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "有 HighID"
 
-#: src/amule.cpp:2393
+#: src/amule.cpp:2418
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已連線到 %s %s"
 
-#: src/amule.cpp:2397
+#: src/amule.cpp:2422
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在連線到 %s"
 
-#: src/amule.cpp:2399
+#: src/amule.cpp:2424
 msgid "Disconnected from eD2k"
 msgstr "已中斷 eD2k 網路連線"
 
-#: src/amule.cpp:2407
+#: src/amule.cpp:2432
 msgid "Kad started."
 msgstr "Kad 已啓動。"
 
-#: src/amule.cpp:2409
+#: src/amule.cpp:2434
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2417
+#: src/amule.cpp:2442
 msgid "Connected to Kad (ok)"
 msgstr "已連線到 Kad"
 
-#: src/amule.cpp:2419
+#: src/amule.cpp:2444
 msgid "Connected to Kad (firewalled)"
 msgstr "已連線到 Kad 網路 (防火牆內)"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2447
 msgid "Disconnected from Kad"
 msgstr "已中斷 Kad 網路連線"
 
-#: src/amule.cpp:2453
+#: src/amule.cpp:2478
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 網路未啟動：如果在偏好設定中停用了 UDP 埠，Kad 網路將不能使用。"
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2482
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 網路在偏好設定中被停用了，沒有連線。"
 
@@ -550,15 +560,15 @@ msgstr "這是 aMule %s (源自 eMule)。"
 msgid "Running on %s"
 msgstr "執行於 %s"
 
-#: src/amuleDlg.cpp:267
+#: src/amuleDlg.cpp:268
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "請到 https://github.com/amule-org/amule/releases/latest 下載最新版本。"
 
-#: src/amuleDlg.cpp:294
+#: src/amuleDlg.cpp:296
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "嚴重錯誤：無法建立計時器"
 
-#: src/amuleDlg.cpp:601
+#: src/amuleDlg.cpp:606
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -568,223 +578,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:605
+#: src/amuleDlg.cpp:610
 #, fuzzy
 msgid "New version available"
 msgstr "不可用"
 
-#: src/amuleDlg.cpp:623
+#: src/amuleDlg.cpp:631
 msgid "aMule dialog destroyed"
 msgstr "aMule 對話方塊已銷毀"
 
-#: src/amuleDlg.cpp:646 src/DataToText.cpp:68 src/IPFilter.cpp:539
+#: src/amuleDlg.cpp:654 src/DataToText.cpp:68 src/IPFilter.cpp:539
 msgid "Connecting"
 msgstr "正在連線"
 
-#: src/amuleDlg.cpp:815
+#: src/amuleDlg.cpp:823
 msgid "eD2k: Connecting"
 msgstr "eD2k：正在連線"
 
-#: src/amuleDlg.cpp:819
+#: src/amuleDlg.cpp:827
 msgid "eD2k: Disconnected"
 msgstr "eD2k：已中斷連線"
 
-#: src/amuleDlg.cpp:825
+#: src/amuleDlg.cpp:833
 msgid "Kad: Firewalled"
 msgstr "Kad：防火牆內"
 
-#: src/amuleDlg.cpp:829
+#: src/amuleDlg.cpp:837
 msgid "Kad: Connected"
 msgstr "Kad：已連線"
 
-#: src/amuleDlg.cpp:834
+#: src/amuleDlg.cpp:842
 msgid "Kad: Connecting"
 msgstr "Kad：正在連線"
 
-#: src/amuleDlg.cpp:838
+#: src/amuleDlg.cpp:846
 msgid "Kad: Off"
 msgstr "Kad：關閉"
 
-#: src/amuleDlg.cpp:886 src/DownloadListCtrl.cpp:408
+#: src/amuleDlg.cpp:894 src/DownloadListCtrl.cpp:408
 #: src/DownloadListCtrl.cpp:647 src/FriendListCtrl.cpp:177
 #: src/muuli_wdr.cpp:682 src/muuli_wdr.cpp:733 src/muuli_wdr.cpp:795
-#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1969 src/muuli_wdr.cpp:2051
-#: src/muuli_wdr.cpp:2774 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
+#: src/muuli_wdr.cpp:847 src/muuli_wdr.cpp:1978 src/muuli_wdr.cpp:2060
+#: src/muuli_wdr.cpp:2783 src/ServerListCtrl.cpp:160 src/ServerListCtrl.cpp:537
 #: src/ServerListCtrl.cpp:558 src/TransferWnd.cpp:373
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:887
+#: src/amuleDlg.cpp:895
 msgid "Stop the current connection attempts"
 msgstr "停止連線作業"
 
-#: src/amuleDlg.cpp:892 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
-#: src/muuli_wdr.cpp:2173
+#: src/amuleDlg.cpp:900 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:963
+#: src/muuli_wdr.cpp:2182
 msgid "Disconnect"
 msgstr "中斷連線"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:901
 msgid "Disconnect from the currently connected networks"
 msgstr "中斷已連線的網路"
 
-#: src/amuleDlg.cpp:898 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:2322 src/muuli_wdr.cpp:2771 src/muuli_wdr.cpp:3103
+#: src/amuleDlg.cpp:906 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:966
+#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2780 src/muuli_wdr.cpp:3112
 msgid "Connect"
 msgstr "連線"
 
-#: src/amuleDlg.cpp:899
+#: src/amuleDlg.cpp:907
 msgid "Connect to the currently enabled networks"
 msgstr "連線到目前已啟用的網路"
 
-#: src/amuleDlg.cpp:975
+#: src/amuleDlg.cpp:983
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上傳：%.1f (%.1f) | 下載：%.1f (%.1f)"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:977 src/amuleDlg.cpp:979 src/amuleDlg.cpp:983
-#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:996 src/amuleDlg.cpp:998
+#: src/amuleDlg.cpp:985 src/amuleDlg.cpp:987 src/amuleDlg.cpp:991
+#: src/amuleDlg.cpp:993 src/amuleDlg.cpp:1004 src/amuleDlg.cpp:1006
 #: src/MuleTrayIcon.cpp:783 src/MuleTrayIcon.cpp:786
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:982
+#: src/amuleDlg.cpp:990
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上傳：%.1f | 下載：%.1f"
 
-#: src/amuleDlg.cpp:1014
+#: src/amuleDlg.cpp:1022
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 已連線)"
 
-#: src/amuleDlg.cpp:1016
+#: src/amuleDlg.cpp:1024
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 已中斷連線)"
 
-#: src/amuleDlg.cpp:1064
+#: src/amuleDlg.cpp:1072
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您確定要離開 %s 嗎？"
 
-#: src/amuleDlg.cpp:1066
+#: src/amuleDlg.cpp:1074
 msgid "Exit confirmation"
 msgstr "確認離開"
 
-#: src/amuleDlg.cpp:1380
+#: src/amuleDlg.cpp:1388
 msgid "Launch Command: "
 msgstr "執行指令："
 
-#: src/amuleDlg.cpp:1399 src/muuli_wdr.cpp:1774 src/Preferences.cpp:887
+#: src/amuleDlg.cpp:1407 src/muuli_wdr.cpp:1783 src/Preferences.cpp:888
 msgid "- default -"
 msgstr "- 預設 -"
 
-#: src/amuleDlg.cpp:1427
+#: src/amuleDlg.cpp:1435
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "面板目錄 %s 不存在"
 
-#: src/amuleDlg.cpp:1430
+#: src/amuleDlg.cpp:1438
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：無法開啟面板檔案 %s 供讀取"
 
-#: src/amuleDlg.cpp:1518 src/amuleDlg.cpp:1734 src/muuli_wdr.cpp:1403
-#: src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1526 src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:1412
+#: src/muuli_wdr.cpp:3114
 msgid "Networks"
 msgstr "網路"
 
-#: src/amuleDlg.cpp:1522 src/muuli_wdr.cpp:3105
+#: src/amuleDlg.cpp:1530 src/muuli_wdr.cpp:3114
 msgid "Networks Window"
 msgstr "網路 視窗"
 
-#: src/amuleDlg.cpp:1524 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1532 src/muuli_wdr.cpp:3115
 msgid "Searches"
 msgstr "搜尋"
 
-#: src/amuleDlg.cpp:1528 src/muuli_wdr.cpp:3106
+#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:3115
 msgid "Searches Window"
 msgstr "搜尋 視窗"
 
-#: src/amuleDlg.cpp:1530 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
-#: src/muuli_wdr.cpp:1505 src/muuli_wdr.cpp:3107 src/Statistics.cpp:824
+#: src/amuleDlg.cpp:1538 src/DownloadListCtrl.cpp:638 src/muuli_wdr.cpp:380
+#: src/muuli_wdr.cpp:1514 src/muuli_wdr.cpp:3116 src/Statistics.cpp:824
 msgid "Downloads"
 msgstr "下載"
 
-#: src/amuleDlg.cpp:1534 src/muuli_wdr.cpp:3107
+#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:3116
 msgid "Downloads Window"
 msgstr "下載 視窗"
 
-#: src/amuleDlg.cpp:1536 src/muuli_wdr.cpp:2998
+#: src/amuleDlg.cpp:1544 src/muuli_wdr.cpp:3007
 msgid "Shared files"
 msgstr "檔案分享"
 
-#: src/amuleDlg.cpp:1540 src/muuli_wdr.cpp:3109
+#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3118
 msgid "Shared Files Window"
 msgstr "檔案分享 視窗"
 
-#: src/amuleDlg.cpp:1542 src/muuli_wdr.cpp:2638 src/muuli_wdr.cpp:3063
-#: src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1550 src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:3072
+#: src/muuli_wdr.cpp:3119
 msgid "Messages"
 msgstr "訊息"
 
-#: src/amuleDlg.cpp:1546 src/muuli_wdr.cpp:3110
+#: src/amuleDlg.cpp:1554 src/muuli_wdr.cpp:3119
 msgid "Messages Window"
 msgstr "訊息 視窗"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:3111 src/PrefsUnifiedDlg.cpp:204
+#: src/amuleDlg.cpp:1556 src/muuli_wdr.cpp:3120 src/PrefsUnifiedDlg.cpp:271
 #: src/Statistics.cpp:779 src/Statistics.cpp:1161
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:1552 src/muuli_wdr.cpp:3111
+#: src/amuleDlg.cpp:1560 src/muuli_wdr.cpp:3120
 msgid "Statistics Graph Window"
 msgstr "統計 視窗"
 
-#: src/amuleDlg.cpp:1555 src/muuli_wdr.cpp:3113 src/PrefsUnifiedDlg.cpp:220
+#: src/amuleDlg.cpp:1563 src/muuli_wdr.cpp:3122 src/PrefsUnifiedDlg.cpp:287
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "偏好設定"
 
-#: src/amuleDlg.cpp:1559 src/muuli_wdr.cpp:3113
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:3122
 msgid "Preferences Settings Window"
 msgstr "偏好設定 視窗"
 
-#: src/amuleDlg.cpp:1562 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1570 src/muuli_wdr.cpp:3123
 msgid "Import"
 msgstr "匯入"
 
-#: src/amuleDlg.cpp:1566 src/muuli_wdr.cpp:3114
+#: src/amuleDlg.cpp:1574 src/muuli_wdr.cpp:3123
 msgid "The partfile importer tool"
 msgstr "暫存檔匯入工具"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "關於"
 
-#: src/amuleDlg.cpp:1569 src/muuli_wdr.cpp:3115
+#: src/amuleDlg.cpp:1577 src/muuli_wdr.cpp:3124
 msgid "About/Help"
 msgstr "關於/幫助"
 
-#: src/amuleDlg.cpp:1737
+#: src/amuleDlg.cpp:1745
 msgid "eD2k network"
 msgstr "eD2k 網路"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "Kad network"
 msgstr "kad 網路"
 
-#: src/amuleDlg.cpp:1740
+#: src/amuleDlg.cpp:1748
 msgid "No network"
 msgstr "無網路"
 
@@ -872,8 +882,8 @@ msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
 #: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
-#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2770
-#: src/PartFile.cpp:2776 src/Server.cpp:134 src/Server.cpp:210
+#: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
+#: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
 msgid "Unknown"
 msgstr "不明"
@@ -1231,19 +1241,19 @@ msgstr "自動 [高]"
 msgid "Very low"
 msgstr "極低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2020
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:641 src/muuli_wdr.cpp:2029
 #: src/ServerListCtrl.cpp:244 src/ServerListCtrl.cpp:408
 #: src/SharedFilesCtrl.cpp:132
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2021
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:642 src/muuli_wdr.cpp:2030
 #: src/ServerListCtrl.cpp:247 src/ServerListCtrl.cpp:409
 #: src/SharedFilesCtrl.cpp:133
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2022
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:2031
 #: src/ServerListCtrl.cpp:250 src/ServerListCtrl.cpp:410
 #: src/SharedFilesCtrl.cpp:134
 msgid "High"
@@ -1275,7 +1285,7 @@ msgid "On Queue"
 msgstr "等候中"
 
 #: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4312 src/TransferWnd.cpp:346
+#: src/OtherFunctions.cpp:695 src/PartFile.cpp:4344 src/TransferWnd.cpp:346
 msgid "Downloading"
 msgstr "正在下載"
 
@@ -1335,7 +1345,7 @@ msgstr "本地伺服器"
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2891
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:205 src/muuli_wdr.cpp:2900
 #: src/SearchDlg.cpp:108 src/TextClient.cpp:863
 msgid "Kad"
 msgstr "Kad"
@@ -1407,7 +1417,7 @@ msgstr "部份"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2958
+#: src/DownloadListCtrl.cpp:159 src/muuli_wdr.cpp:2967
 msgid "Transferred"
 msgstr "已傳輸"
 
@@ -1420,7 +1430,7 @@ msgid "Progress"
 msgstr "進度"
 
 #: src/DownloadListCtrl.cpp:163 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4358 src/SearchListCtrl.cpp:92
+#: src/PartFile.cpp:4390 src/SearchListCtrl.cpp:92
 msgid "Sources"
 msgstr "來源"
 
@@ -1430,7 +1440,7 @@ msgstr "來源"
 msgid "Priority"
 msgstr "優先等級"
 
-#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4361 src/SearchListCtrl.cpp:95
+#: src/DownloadListCtrl.cpp:165 src/PartFile.cpp:4393 src/SearchListCtrl.cpp:95
 msgid "Status"
 msgstr "狀態"
 
@@ -1463,7 +1473,7 @@ msgstr ""
 "%s (%s) 回覆訊息\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2023
+#: src/DownloadListCtrl.cpp:644 src/muuli_wdr.cpp:2032
 #: src/SharedFilesCtrl.cpp:137
 msgid "Auto"
 msgstr "自動"
@@ -2114,7 +2124,7 @@ msgstr "無法開啟好友清單檔案 emfriends.met 供寫入！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "重大錯誤 - 開始交談時沒有客戶端"
 
-#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2387 src/muuli_wdr.cpp:3039
+#: src/FriendListCtrl.cpp:125 src/muuli_wdr.cpp:2396 src/muuli_wdr.cpp:3048
 msgid "Friends"
 msgstr "好友"
 
@@ -2395,8 +2405,8 @@ msgstr "無效的通訊埠"
 msgid "Please fill all fields required"
 msgstr "請填寫所有必要資訊"
 
-#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:854
-#: src/PrefsUnifiedDlg.cpp:982 src/PrefsUnifiedDlg.cpp:1167
+#: src/KadDlg.cpp:190 src/PartFile.cpp:1015 src/PrefsUnifiedDlg.cpp:942
+#: src/PrefsUnifiedDlg.cpp:1070 src/PrefsUnifiedDlg.cpp:1255
 msgid "Message"
 msgstr "訊息"
 
@@ -2465,7 +2475,7 @@ msgstr "分享率"
 msgid "Uploaded"
 msgstr "已上傳"
 
-#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2942
+#: src/KnownFile.cpp:1667 src/muuli_wdr.cpp:2951
 msgid "Requested"
 msgstr "已要求"
 
@@ -2499,30 +2509,30 @@ msgstr "不明的錯誤 %d"
 msgid "Unable to get error description for error %d"
 msgstr "無法取得關於錯誤 %d 的說明"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4290
+#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4322
 msgid "Hashing"
 msgstr "正在計算 hash 值"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4296
+#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4328
 msgid "Completing"
 msgstr "正在完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4299
+#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4331
 msgid "Complete"
 msgstr "完成"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4302 src/TransferWnd.cpp:348
+#: src/PartFile.cpp:4334 src/TransferWnd.cpp:348
 msgid "Paused"
 msgstr "已暫停"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:697
-#: src/PartFile.cpp:4305 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4337 src/TransferWnd.cpp:347
 msgid "Erroneous"
 msgstr "錯誤的"
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:693
-#: src/PartFile.cpp:4314 src/TransferWnd.cpp:345
+#: src/PartFile.cpp:4346 src/TransferWnd.cpp:345
 msgid "Waiting"
 msgstr "正在等候"
 
@@ -2567,7 +2577,7 @@ msgstr "外部連線：拒絕存取，原因： "
 msgid "External Connection: Handshake failed."
 msgstr "外部連線：訊號交換失敗"
 
-#: src/LibSocketAsio.cpp:1575
+#: src/LibSocketAsio.cpp:1742
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "已開始 HTTP 下載執行緒"
@@ -2589,7 +2599,7 @@ msgid "WARNING: "
 msgstr "警告："
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:766 src/muuli_wdr.cpp:1182
-#: src/muuli_wdr.cpp:2846 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2855 src/muuli_wdr.cpp:3088
 msgid "Close"
 msgstr "關閉"
 
@@ -2705,7 +2715,7 @@ msgstr "離開"
 
 #: src/MuleTrayIcon.cpp:566 src/MuleTrayIcon.cpp:932 src/MuleTrayIcon.cpp:952
 #: src/muuli_wdr.cpp:1325 src/muuli_wdr.cpp:1333 src/muuli_wdr.cpp:1340
-#: src/muuli_wdr.cpp:1649 src/muuli_wdr.cpp:1655 src/OtherFunctions.cpp:89
+#: src/muuli_wdr.cpp:1658 src/muuli_wdr.cpp:1664 src/OtherFunctions.cpp:89
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -2945,7 +2955,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1537
+#: src/muuli_wdr.cpp:262 src/muuli_wdr.cpp:281 src/muuli_wdr.cpp:1546
 #: src/OtherFunctions.cpp:62
 msgid "MB"
 msgstr "MB"
@@ -3014,7 +3024,7 @@ msgstr "清除已完成的檔案"
 msgid "File sources:"
 msgstr "檔案來源："
 
-#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:189
+#: src/muuli_wdr.cpp:467 src/muuli_wdr.cpp:1018 src/PrefsUnifiedDlg.cpp:256
 msgid "General"
 msgstr "一般"
 
@@ -3035,7 +3045,7 @@ msgstr "全名︰"
 #: src/muuli_wdr.cpp:1120 src/muuli_wdr.cpp:1125 src/muuli_wdr.cpp:1132
 #: src/muuli_wdr.cpp:1137 src/muuli_wdr.cpp:1144 src/muuli_wdr.cpp:1158
 #: src/muuli_wdr.cpp:1165 src/muuli_wdr.cpp:1170 src/muuli_wdr.cpp:1177
-#: src/muuli_wdr.cpp:2944 src/muuli_wdr.cpp:2952 src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2953 src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2969
 msgid "N/A"
 msgstr "N/A"
 
@@ -3211,7 +3221,7 @@ msgstr "使用者名稱︰"
 msgid "Userhash :"
 msgstr "使用者 hash 值："
 
-#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:844 src/muuli_wdr.cpp:2177
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "加入"
@@ -3220,15 +3230,15 @@ msgstr "加入"
 msgid "Download-Speed"
 msgstr "下載速度"
 
-#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2266
+#: src/muuli_wdr.cpp:903 src/muuli_wdr.cpp:940 src/muuli_wdr.cpp:2275
 msgid "Current"
 msgstr "目前"
 
-#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:911 src/muuli_wdr.cpp:948 src/muuli_wdr.cpp:2283
 msgid "Running average"
 msgstr "執行中平均值"
 
-#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:919 src/muuli_wdr.cpp:956 src/muuli_wdr.cpp:2291
 msgid "Session average"
 msgstr "本次平均值"
 
@@ -3240,7 +3250,7 @@ msgstr "上傳速度"
 msgid "Connections"
 msgstr "連線"
 
-#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:977 src/muuli_wdr.cpp:1683
 msgid "Active downloads"
 msgstr "目前下載數"
 
@@ -3248,7 +3258,7 @@ msgstr "目前下載數"
 msgid "Active connections (1:1)"
 msgstr "目前連線數 (1:1)"
 
-#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:1684
 msgid "Active uploads"
 msgstr "目前上傳數"
 
@@ -3449,8 +3459,8 @@ msgstr "瀏覽器設定"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "請輸入瀏覽器的名稱，空白則使用系統預設。"
 
-#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1570
-#: src/muuli_wdr.cpp:1582 src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:1276 src/muuli_wdr.cpp:1293 src/muuli_wdr.cpp:1579
+#: src/muuli_wdr.cpp:1591 src/muuli_wdr.cpp:2490
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3524,750 +3534,759 @@ msgstr "選定本機使用 IP (留白或輸入)："
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "進階使用者用：如果您有多網路介面，請輸入要給 aMule 使用的的網路位址。"
 
-#: src/muuli_wdr.cpp:1392
+#: src/muuli_wdr.cpp:1389
+#, fuzzy
+msgid "Bind to network interface (empty for any):"
+msgstr "選定本機使用 IP (留白或輸入)："
+
+#: src/muuli_wdr.cpp:1395
+msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1401
 msgid "Max sources per downloading file:"
 msgstr "每個檔案最大來源數："
 
-#: src/muuli_wdr.cpp:1396
+#: src/muuli_wdr.cpp:1405
 msgid "Max simultaneous connections:"
 msgstr "最大同時連線數："
 
-#: src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1415
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/muuli_wdr.cpp:1409 src/muuli_wdr.cpp:2886
+#: src/muuli_wdr.cpp:1418 src/muuli_wdr.cpp:2895
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1416
+#: src/muuli_wdr.cpp:1425
 msgid "Autoconnect on startup"
 msgstr "啟動後自動連線"
 
-#: src/muuli_wdr.cpp:1419
+#: src/muuli_wdr.cpp:1428
 msgid "Reconnect on loss"
 msgstr "斷線後自動重新連線"
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1450
 msgid "Remove dead server after"
 msgstr "移除無法連線伺服器：如果"
 
-#: src/muuli_wdr.cpp:1445
+#: src/muuli_wdr.cpp:1454
 msgid "retries"
 msgstr "次重試"
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1459
 msgid "Auto-update server list at startup"
 msgstr "啟動時自動更新伺服器清單"
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1462
 msgid "List"
 msgstr "清單"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1465
 msgid "Update server list when connecting to a server"
 msgstr "連線到伺服器時更新伺服器清單"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1468
 msgid "Update server list when a client connects"
 msgstr "連線到客戶端時更新伺服器清單"
 
-#: src/muuli_wdr.cpp:1462
+#: src/muuli_wdr.cpp:1471
 msgid "Use priority system"
 msgstr "啟用優先等級系統"
 
-#: src/muuli_wdr.cpp:1466
+#: src/muuli_wdr.cpp:1475
 msgid "Use smart LowID check on connect"
 msgstr "連線時啟用智慧 LowID 偵測"
 
-#: src/muuli_wdr.cpp:1470
+#: src/muuli_wdr.cpp:1479
 msgid "Safe connect"
 msgstr "安全連線"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1483
 msgid "Autoconnect to servers in static list only"
 msgstr "只自動連線到靜態伺服器清單裏的伺服器"
 
-#: src/muuli_wdr.cpp:1477
+#: src/muuli_wdr.cpp:1486
 msgid "Set manually added servers to High Priority"
 msgstr "手動輸入的伺服器設為高優先等級"
 
-#: src/muuli_wdr.cpp:1495
+#: src/muuli_wdr.cpp:1504
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智慧型損壞處理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1507
 msgid "Enable"
 msgstr "啟用"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1510
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "進階 I.C.H. 信任所有 hash 值 (不建議)"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1517
 msgid "Add files to download in pause mode"
 msgstr "加入新下載檔案時設為暫停狀態"
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1519
 msgid "Add files to download with auto priority"
 msgstr "加入新下載檔案時設定優先等級為自動狀態"
 
-#: src/muuli_wdr.cpp:1513
+#: src/muuli_wdr.cpp:1522
 msgid "Try to download first and last chunks first"
 msgstr "嘗試先下載檔案的第一段和最後一段"
 
-#: src/muuli_wdr.cpp:1516
+#: src/muuli_wdr.cpp:1525
 msgid "Start next paused file when a file completes"
 msgstr "完成後自動傳輸下一個暫停的檔案"
 
-#: src/muuli_wdr.cpp:1519
+#: src/muuli_wdr.cpp:1528
 msgid "From the same category"
 msgstr "同一分類檔案"
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1530
 msgid "In alphabetic order"
 msgstr "依字母順序"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1532
 msgid "Preallocate disk space for new files"
 msgstr "新檔案預先分配磁碟空間"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1533
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新檔案預先分配所需的完整磁碟空間，這樣可以減少檔案分散度"
 
-#: src/muuli_wdr.cpp:1529
+#: src/muuli_wdr.cpp:1538
 msgid "Stop downloads when free disk space reaches "
 msgstr "磁碟可用空間不足時停止下載"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1539
 msgid "Select this if you want aMule to check your disk space"
 msgstr "讓 aMule 檢查磁碟可用空間"
 
-#: src/muuli_wdr.cpp:1534
+#: src/muuli_wdr.cpp:1543
 msgid "Enter here the min disk space desired."
 msgstr "請輸入最小磁碟可用空間。"
 
-#: src/muuli_wdr.cpp:1540
+#: src/muuli_wdr.cpp:1549
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "為來源稀少 (< 20) 的檔案儲存 10 個來源"
 
-#: src/muuli_wdr.cpp:1544 src/Statistics.cpp:789
+#: src/muuli_wdr.cpp:1553 src/Statistics.cpp:789
 msgid "Uploads"
 msgstr "上傳"
 
-#: src/muuli_wdr.cpp:1547
+#: src/muuli_wdr.cpp:1556
 msgid "Add new shared files with auto priority"
 msgstr "新加入分享檔案優先等級設定為自動"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1573
 msgid "Destination folder for downloads"
 msgstr "下載資料夾"
 
-#: src/muuli_wdr.cpp:1568
+#: src/muuli_wdr.cpp:1577
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
+#: src/muuli_wdr.cpp:1580
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1575
+#: src/muuli_wdr.cpp:1584
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1577
+#: src/muuli_wdr.cpp:1586
 msgid "Folder for temporary download files"
 msgstr "暫存資料夾"
 
-#: src/muuli_wdr.cpp:1585
+#: src/muuli_wdr.cpp:1594
 msgid "Shared folders"
 msgstr "分享資料夾"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1597
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(滑鼠右鍵點選檔案夾圖示可全部遞迴分享)"
 
-#: src/muuli_wdr.cpp:1594
+#: src/muuli_wdr.cpp:1603
 msgid "Share hidden files"
 msgstr "分享隱藏檔"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1609
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1615
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1634
 msgid "Graphs"
 msgstr "圖表"
 
-#: src/muuli_wdr.cpp:1628 src/muuli_wdr.cpp:1690
+#: src/muuli_wdr.cpp:1637 src/muuli_wdr.cpp:1699
 msgid "Update delay : 5 secs"
 msgstr "更新延遲時間：5 秒"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp:1641
 msgid "Time for average graph: 100 mins"
 msgstr "平均圖表顯示時間：100 分鐘"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1645
 msgid "Connections Graph Scale: 100 "
 msgstr "連線圖表比例：100 "
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1652
 msgid "Download graph scale:"
 msgstr "下載統計圖比例："
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1660
 msgid "Upload graph scale:"
 msgstr "上傳統計圖比例："
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1670
 #, fuzzy
 msgid "Colors: "
 msgstr "顏色："
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1674
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1666
+#: src/muuli_wdr.cpp:1675
 msgid "Grid"
 msgstr "格線"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1676
 msgid "Download current"
 msgstr "目前下載"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1677
 msgid "Download running average"
 msgstr "執行中平均下載"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1678
 msgid "Download session average"
 msgstr "本次平均下載"
 
-#: src/muuli_wdr.cpp:1670
+#: src/muuli_wdr.cpp:1679
 msgid "Upload current"
 msgstr "目前上傳"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1680
 msgid "Upload running average"
 msgstr "執行中平均上傳"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1681
 msgid "Upload session average"
 msgstr "本次平均上傳"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1682
 msgid "Active connections"
 msgstr "目前連線數"
 
-#: src/muuli_wdr.cpp:1676
+#: src/muuli_wdr.cpp:1685
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "狀態列圖示顯示速度"
 
-#: src/muuli_wdr.cpp:1677
+#: src/muuli_wdr.cpp:1686
 msgid "Kad-nodes current"
 msgstr "目前 Kad 節點"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1687
 msgid "Kad-nodes running"
 msgstr "執行中 Kad 節點"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1688
 msgid "Kad-nodes session"
 msgstr "本次 Kad 節點"
 
-#: src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:1692 src/muuli_wdr.cpp:2050
 msgid "Select"
 msgstr "選取"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1696
 msgid "Tree"
 msgstr "樹狀"
 
-#: src/muuli_wdr.cpp:1697
+#: src/muuli_wdr.cpp:1706
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "顯示客戶端版本的數量 ( 0 代表不限制)"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1731
 msgid "!!! WARNING !!!"
 msgstr "!!! 警告 !!!"
 
-#: src/muuli_wdr.cpp:1734
+#: src/muuli_wdr.cpp:1743
 msgid "Max new connections / 5 secs"
 msgstr "5 秒內最大新連線數"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1748
 msgid "File Buffer Size: 240000 bytes"
 msgstr "檔案緩衝區：240.000 KB"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1752
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上傳等候區大小：5000 "
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1756
 msgid "Server connection refresh interval: Disable"
 msgstr "伺服器連線更新間隔時間：停用"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp:1760
 msgid "Disable computer's timed standby mode"
 msgstr "停用電腦的自動進入待命模式功能"
 
-#: src/muuli_wdr.cpp:1770
+#: src/muuli_wdr.cpp:1779
 msgid "Skin to use: "
 msgstr "使用面板："
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1788
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在每個視窗顯示「eD2k 連結快速處理器」。"
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1791
 msgid "Show extended info on categories tabs"
 msgstr "在分類頁中顯示擴充資訊"
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1794
 msgid "Show application version on title"
 msgstr "在標題顯示應用程式版本"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1796
 msgid "Show transfer rates on title"
 msgstr "標題列顯示傳輸速度"
 
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1798
 msgid "Before application name"
 msgstr "在程式名稱前"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1800
 msgid "After application name"
 msgstr "在程式名稱後"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp:1803
 msgid "Show overhead bandwidth"
 msgstr "顯示額外支出頻寬"
 
-#: src/muuli_wdr.cpp:1798
+#: src/muuli_wdr.cpp:1807
 msgid "Vertical toolbar orientation"
 msgstr "垂直顯示工具列"
 
-#: src/muuli_wdr.cpp:1804
+#: src/muuli_wdr.cpp:1813
 msgid "Download Queue Files"
 msgstr "下載等候區檔案"
 
-#: src/muuli_wdr.cpp:1807
+#: src/muuli_wdr.cpp:1816
 msgid "Show progress percentage"
 msgstr "顯示進度百分比"
 
-#: src/muuli_wdr.cpp:1813
+#: src/muuli_wdr.cpp:1822
 msgid "Show progress bar"
 msgstr "顯示進度條"
 
-#: src/muuli_wdr.cpp:1816
+#: src/muuli_wdr.cpp:1825
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:1820
+#: src/muuli_wdr.cpp:1829
 msgid "Round"
 msgstr "圓弧"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1832
 msgid "Auto-sort files (high CPU)"
 msgstr "自動排序檔案 (耗系統資源)"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1834
 msgid "aMule will sort the columns in your download list automatically"
 msgstr "aMule 將自動對下載清單進行排序"
 
-#: src/muuli_wdr.cpp:1842
+#: src/muuli_wdr.cpp:1851
 msgid "External Connection Parameters"
 msgstr "外部連線參數"
 
-#: src/muuli_wdr.cpp:1845
+#: src/muuli_wdr.cpp:1854
 msgid "Accept external connections"
 msgstr "接受外部連線"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1861
 msgid "IP of the listening interface:"
 msgstr "監聽 IP："
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1864
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "輸入要監聽外部連線的的 IP (格式：a.b.c.d)，空白或 0.0.0.0 表示全部。"
 
-#: src/muuli_wdr.cpp:1861 src/muuli_wdr.cpp:1907
+#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:1916
 msgid "TCP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1876
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "外部連線通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:1871 src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2767
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密碼"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1886
 msgid "Web server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1889
 msgid "Run webserver on startup"
 msgstr "啟動時執行網站伺服器"
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1895
 msgid "Web template"
 msgstr "網頁模板"
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1900
 msgid "Full rights password"
 msgstr "絕對權限使用者密碼"
 
-#: src/muuli_wdr.cpp:1895
+#: src/muuli_wdr.cpp:1904
 msgid "Enable Low rights User"
 msgstr "啟用低權限使用者"
 
-#: src/muuli_wdr.cpp:1900
+#: src/muuli_wdr.cpp:1909
 msgid "Low rights password"
 msgstr "低權限使用者密碼"
 
-#: src/muuli_wdr.cpp:1914
+#: src/muuli_wdr.cpp:1923
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "網站伺服器的通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1928
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "網站伺服器的 UPnP TCP 埠 (選用)"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1936
 msgid "Page Refresh Time (in secs)"
 msgstr "頁面更新時間 (秒)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1943
 msgid "Enable Gzip compression"
 msgstr "啟用 Gzip 壓縮"
 
-#: src/muuli_wdr.cpp:1965 src/muuli_wdr.cpp:2048 src/ServerWnd.cpp:233
+#: src/muuli_wdr.cpp:1974 src/muuli_wdr.cpp:2057 src/ServerWnd.cpp:233
 #: src/ServerWnd.cpp:241
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1976
 msgid "Click here to apply any changes made to the preferences."
 msgstr "點選這裏立即套用已變更的偏好設定。"
 
-#: src/muuli_wdr.cpp:1970
+#: src/muuli_wdr.cpp:1979
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有偏好設定變更。"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:2001
 msgid "Title :"
 msgstr "標題："
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2008
 msgid "Comment :"
 msgstr "註解："
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2015
 msgid "Incoming Dir :"
 msgstr "新進檔目錄："
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2024
 msgid "Change priority for new assigned files :"
 msgstr "設定新加入的檔案優先等級為："
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp:2028
 msgid "Don't change"
 msgstr "不要變更"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2040
 msgid "Select color for this Category (currently selected) :"
 msgstr "選取該分類的顏色 (目前選擇)："
 
-#: src/muuli_wdr.cpp:2096 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2105 src/muuli_wdr.cpp:2127
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:136
 msgid "Reset"
 msgstr "清除"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2106 src/muuli_wdr.cpp:2128
 msgid "Click this button to reset the log."
 msgstr "點選這個按鈕來清除記錄。"
 
-#: src/muuli_wdr.cpp:2139
+#: src/muuli_wdr.cpp:2148
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "點選這個按鈕從該網址更新伺服器清單 ..."
 
-#: src/muuli_wdr.cpp:2143
+#: src/muuli_wdr.cpp:2152
 msgid "Server list"
 msgstr "伺服器清單"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2156
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "輸入 server.met 檔案的網址並按下左邊的按鈕以更新已知伺服器清單。"
 
-#: src/muuli_wdr.cpp:2152
+#: src/muuli_wdr.cpp:2161
 msgid "Add server manually: Name"
 msgstr "手動加入伺服器：名稱"
 
-#: src/muuli_wdr.cpp:2155
+#: src/muuli_wdr.cpp:2164
 msgid "Enter the name of the new server here"
 msgstr "輸入新伺服器的名稱"
 
-#: src/muuli_wdr.cpp:2157 src/ServerWnd.cpp:180
+#: src/muuli_wdr.cpp:2166 src/ServerWnd.cpp:180
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2160
+#: src/muuli_wdr.cpp:2169
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "輸入新伺服器的 IP (格式：x.x.x.x)。"
 
-#: src/muuli_wdr.cpp:2166
+#: src/muuli_wdr.cpp:2175
 msgid "Enter the port of the server here."
 msgstr "輸入伺服器的通訊埠。"
 
-#: src/muuli_wdr.cpp:2169
+#: src/muuli_wdr.cpp:2178
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動加入伺服器 (填入左側空格中) ..."
 
-#: src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp:2207
 msgid "aMule Log"
 msgstr "aMule 記錄"
 
-#: src/muuli_wdr.cpp:2202
+#: src/muuli_wdr.cpp:2211
 msgid "Server Info"
 msgstr "伺服器資訊"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2215
 msgid "ED2K Info"
 msgstr "eD2k 資訊"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2219
 msgid "Kad Info"
 msgstr "Kad 資訊"
 
-#: src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:2247
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "點選這個按鈕來從該網址更新節點清單 ..."
 
-#: src/muuli_wdr.cpp:2242
+#: src/muuli_wdr.cpp:2251
 msgid "Nodes (0)"
 msgstr "節點 (0)"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2255
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "輸入 nodes.dat 檔案的網址，並按下左邊的按鈕以更新已知節點清單。"
 
-#: src/muuli_wdr.cpp:2249
+#: src/muuli_wdr.cpp:2258
 msgid "Nodes stats"
 msgstr "節點狀態"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2298
 msgid "Bootstrap"
 msgstr "啓動"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2301
 msgid "New node"
 msgstr "新節點"
 
-#: src/muuli_wdr.cpp:2297
+#: src/muuli_wdr.cpp:2306
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2317
+#: src/muuli_wdr.cpp:2326
 msgid "Port:"
 msgstr "埠："
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp:2337
 msgid "Bootstrap from known clients"
 msgstr "從已知客戶端啓動"
 
-#: src/muuli_wdr.cpp:2331
+#: src/muuli_wdr.cpp:2340
 msgid "Disconnect Kad"
 msgstr "中斷 Kad 連線"
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2374
 msgid "Use Secure User Identification"
 msgstr "啟用使用者安全認證"
 
-#: src/muuli_wdr.cpp:2367
+#: src/muuli_wdr.cpp:2376
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建議啟用此選項。如果使用者安全認證未啟用，將會得不到積分。"
 
-#: src/muuli_wdr.cpp:2369
+#: src/muuli_wdr.cpp:2378
 msgid "Protocol Obfuscation"
 msgstr "模糊協定"
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2381
 msgid "Support Protocol Obfuscation"
 msgstr "支援模糊協定"
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2383
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "啓用模糊協定，可讓 aMule 接受來自其他客戶端的模糊連線。"
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2385
 msgid "Use obfuscation for outgoing connections"
 msgstr "對外的連線使用模糊協定"
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2387
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "使 aMule 在與其他客戶端或伺服器連線時使用模糊協定。"
 
-#: src/muuli_wdr.cpp:2380
+#: src/muuli_wdr.cpp:2389
 msgid "Accept only obfuscated connections"
 msgstr "只接受模糊連線"
 
-#: src/muuli_wdr.cpp:2381
+#: src/muuli_wdr.cpp:2390
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "讓 aMule 只接受模糊協定，檔案來源會比較少，但所有傳輸都將是模糊連線"
 
-#: src/muuli_wdr.cpp:2386
+#: src/muuli_wdr.cpp:2395
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2388
+#: src/muuli_wdr.cpp:2397
 msgid "No one"
 msgstr "無"
 
-#: src/muuli_wdr.cpp:2390
+#: src/muuli_wdr.cpp:2399
 msgid "Who can see my shared files:"
 msgstr "誰可以看我的分享檔案："
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2400
 msgid "Select who can request to view a list of your shared files."
 msgstr "選取可以瀏覽分享檔案清單的使用者。"
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2402
 msgid "IP-Filtering"
 msgstr "IP 過濾"
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2409
 msgid "Filter clients"
 msgstr "過濾客戶端"
 
-#: src/muuli_wdr.cpp:2402
+#: src/muuli_wdr.cpp:2411
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的客戶端 IP"
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2413
 msgid "Filter servers"
 msgstr "過濾伺服器"
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2415
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的伺服器 IP 。"
 
-#: src/muuli_wdr.cpp:2410
+#: src/muuli_wdr.cpp:2419
 msgid "Reload List"
 msgstr "重載入清單"
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2420
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "重新載入 IP 過濾清單 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2426
 msgid "URL:"
 msgstr "網址："
 
-#: src/muuli_wdr.cpp:2421 src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp:2430 src/muuli_wdr.cpp:2623
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2433
 msgid "Auto-update ipfilter at startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2437
 msgid "Filtering Level:"
 msgstr "過濾等級："
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2443
 msgid "Always filter LAN IPs"
 msgstr "永遠過濾區域網路 IP"
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2446
 msgid "Paranoid handling of non-matching IPs"
 msgstr "處理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2439
+#: src/muuli_wdr.cpp:2448
 msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 msgstr "拒絕客戶端 IP 與接收封包中的 IP 不同的封包。(請小心使用)"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2450
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "如果可以則使用系統級的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:2451
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果找不到本機 ipfilter.dat 檔案，則允許使用系統級的 IP 過濾檔。"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2468
 msgid "Enable Online-Signature"
 msgstr "啟用線上簽名識別"
 
-#: src/muuli_wdr.cpp:2461
+#: src/muuli_wdr.cpp:2470
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "啟用寫入到作業系統檔案，以讓外部程式用來建立簽名識別等等。"
 
-#: src/muuli_wdr.cpp:2465
+#: src/muuli_wdr.cpp:2474
 msgid "Update Frequency (Secs):"
 msgstr "更新頻率(秒)："
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2477
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "變更線上簽名識別檔的更新頻率 (單位為 秒)。"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2485
 msgid "Save online signature file in: "
 msgstr "儲存線上簽名識別檔："
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2491
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "點擊選取線上簽識別名檔案所在的目錄。"
 
-#: src/muuli_wdr.cpp:2515
+#: src/muuli_wdr.cpp:2524
 msgid "Show country flags for clients"
 msgstr "顯示客戶端的國旗"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2525
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2521
+#: src/muuli_wdr.cpp:2530
 #, fuzzy
 msgid "Database"
 msgstr "速度："
 
-#: src/muuli_wdr.cpp:2537
+#: src/muuli_wdr.cpp:2546
 #, fuzzy
 msgid "Source:"
 msgstr "來源"
 
-#: src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:2549
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2541
+#: src/muuli_wdr.cpp:2550
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2542
+#: src/muuli_wdr.cpp:2551
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2545
+#: src/muuli_wdr.cpp:2554
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2571
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4275,11 +4294,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2584
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2581
+#: src/muuli_wdr.cpp:2590
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4289,226 +4308,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2596
+#: src/muuli_wdr.cpp:2605
 #, fuzzy
 msgid "Download URL:"
 msgstr "下載："
 
-#: src/muuli_wdr.cpp:2602
+#: src/muuli_wdr.cpp:2611
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2624
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2626
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2618
+#: src/muuli_wdr.cpp:2627
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2641
+#: src/muuli_wdr.cpp:2650
 msgid "Filter incoming messages (except current chat):"
 msgstr "過濾收到的訊息 (不包含目前交談)："
 
-#: src/muuli_wdr.cpp:2643
+#: src/muuli_wdr.cpp:2652
 msgid "Filter all messages"
 msgstr "過濾所有訊息"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2654
 msgid "Filter messages from people not on your friend list"
 msgstr "過濾來自好友以外的訊息"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2656
 msgid "Filter messages from unknown clients"
 msgstr "過濾來自不明客戶端的訊息"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2658
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "過濾含以下內容的訊息 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2652 src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2661 src/muuli_wdr.cpp:2672
 msgid "add here the words amule should filter and block messages including it"
 msgstr "輸入要過濾的詞句"
 
-#: src/muuli_wdr.cpp:2654
+#: src/muuli_wdr.cpp:2663
 msgid "Show received messages in the log"
 msgstr "記錄收到的訊息"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2666
 msgid "Comments"
 msgstr "註解"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2669
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "過濾含以下內容的註解 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2692
 msgid "Enable authentication"
 msgstr "啓用登入驗證"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2693
 msgid "Enable/disable username/password authentication"
 msgstr "啓用/停用 使用者名稱/密碼登入驗證"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2696
 msgid "Username: "
 msgstr "使用者名稱："
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2699
 msgid "The username to use to connect to the proxy"
 msgstr "登入代理伺服器的使用者名稱"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2701
 msgid "Password:"
 msgstr "密碼："
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2704
 msgid "The password to use to connect to the proxy"
 msgstr "登入代理伺服器的密碼"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2706
 msgid "Enable Proxy"
 msgstr "啓用代理伺服器"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2707
 msgid "Enable/disable proxy support"
 msgstr "啓用/停用代理伺服器支援"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2710
 msgid "Proxy type:"
 msgstr "類型："
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2721
 msgid "Proxy host:"
 msgstr "主機："
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2724
 msgid "The proxy host name"
 msgstr "代理伺服器主機名稱"
 
-#: src/muuli_wdr.cpp:2717
+#: src/muuli_wdr.cpp:2726
 msgid "Proxy port:"
 msgstr "連接埠："
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2729
 msgid "The proxy port"
 msgstr "代理伺服器連接埠"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp:2748
 msgid "Connect to:"
 msgstr "連線到："
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2757
 msgid "Login to remote amule"
 msgstr "登入遠端 amule"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2762
 msgid "User name"
 msgstr "使用者名稱"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2773
 msgid "Remember those settings"
 msgstr "記住這些設定"
 
-#: src/muuli_wdr.cpp:2767
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "使用 gzip 壓縮"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2800
 msgid "Enable Verbose Debug-Logging."
 msgstr "啓用記錄詳細除錯訊息。"
 
-#: src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "開啟檔案(&O)"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2804
 msgid "Message Categories:"
 msgstr "訊息分類："
 
-#: src/muuli_wdr.cpp:2819 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:2828 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等候中..."
 
-#: src/muuli_wdr.cpp:2839
+#: src/muuli_wdr.cpp:2848
 msgid "Add imports"
 msgstr "加入"
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2851
 msgid "Retry selected"
 msgstr "重試"
 
-#: src/muuli_wdr.cpp:2844
+#: src/muuli_wdr.cpp:2853
 msgid "Remove selected"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:2907
+#: src/muuli_wdr.cpp:2916
 msgid "Event Types"
 msgstr "事件種類"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2935
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "已選取的檔案的統計資料與等候區客戶端數：本次 / 總計"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2959
 msgid "Active Uploads"
 msgstr "目前上傳數"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2973
 msgid "Percent of total files"
 msgstr "% (所有檔案中)"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3012
 msgid "All files"
 msgstr "所有檔案"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3013
 msgid "Selected files"
 msgstr "選取的檔案"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3014
 msgid "Active uploads only"
 msgstr "僅限目前上傳中"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3016
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:3018
 msgid "Reload:"
 msgstr "重新載入："
 
-#: src/muuli_wdr.cpp:3013
+#: src/muuli_wdr.cpp:3022
 msgid "Reload your shared files"
 msgstr "重新載入分享的檔案"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3084
 msgid "Send"
 msgstr "傳送"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3085
 msgid "Sends the specified message."
 msgstr "傳送訊息。"
 
-#: src/muuli_wdr.cpp:3080
+#: src/muuli_wdr.cpp:3089
 msgid "Close this chat-session."
 msgstr "結束本次交談。"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3112
 msgid "Connect to any server and/or Kad"
 msgstr "連線到任何伺服器 和/或 Kad 網路"
 
-#: src/muuli_wdr.cpp:3109 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
+#: src/muuli_wdr.cpp:3118 src/SharedFilesCtrl.cpp:129 src/Statistics.cpp:927
 msgid "Shared Files"
 msgstr "分享檔案"
 
@@ -4583,7 +4602,7 @@ msgstr "其它"
 msgid "Incomplete"
 msgstr "不完整"
 
-#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4319 src/TransferWnd.cpp:349
+#: src/OtherFunctions.cpp:701 src/PartFile.cpp:4351 src/TransferWnd.cpp:349
 msgid "Stopped"
 msgstr "已停止"
 
@@ -4772,340 +4791,340 @@ msgstr "已儲存 %i 個來源種子給暫存檔 %s (%s)"
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "讀取暫存檔的種子檔案 (%s - %s) 時出錯：%s"
 
-#: src/PartFile.cpp:1232 src/PartFile.cpp:1256
+#: src/PartFile.cpp:1238 src/PartFile.cpp:1262
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "找到損壞 (%d) 的 %d 個暫存檔 %s - 檔案結果 hash 值 |%s| 檔案 hash 值 |%s|"
 
-#: src/PartFile.cpp:1269
+#: src/PartFile.cpp:1287
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "找到已完成的暫存檔 %i 在 %s"
 
-#: src/PartFile.cpp:1298
+#: src/PartFile.cpp:1316
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "已重新計算完成 %s 的 hash 值"
 
-#: src/PartFile.cpp:2288
+#: src/PartFile.cpp:2320
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "計算 %s 時發生意外的錯誤，暫停檔案處理"
 
-#: src/PartFile.cpp:2325
+#: src/PartFile.cpp:2357
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "下載完成：%s"
 
-#: src/PartFile.cpp:2330
+#: src/PartFile.cpp:2362
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "下載完成：%s"
 
-#: src/PartFile.cpp:2389
+#: src/PartFile.cpp:2421
 #, c-format
 msgid "Deleting file: %s"
 msgstr "正刪除檔案：%s "
 
-#: src/PartFile.cpp:2468
+#: src/PartFile.cpp:2500
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "警告：無法計算已下載部份的 hash 值 - %s 的 hash 值組不完整"
 
-#: src/PartFile.cpp:2473
+#: src/PartFile.cpp:2505
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "錯誤：無法計算已下載部分的 hash 值 - %s 的 hash 值組不完整，這個狀況不該發生"
 
-#: src/PartFile.cpp:2496
+#: src/PartFile.cpp:2528
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2508 src/PartFile.cpp:2515
+#: src/PartFile.cpp:2540 src/PartFile.cpp:2547
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "計算下載部份 %u (長度 %u / 最大 %u) - 暫存檔 %s (長度 %u) 的 hash 值時出現檔案結束碼：%s"
 
-#: src/PartFile.cpp:3274
+#: src/PartFile.cpp:3306
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "警告：磁碟可用空間不足！暫停檔案：%s "
 
-#: src/PartFile.cpp:3608
+#: src/PartFile.cpp:3640
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "已下載的部份 %i 已損壞 (檔案：%s)"
 
-#: src/PartFile.cpp:3656
+#: src/PartFile.cpp:3688
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH：已修復損壞的部份 %i (%s) -> 救回 %s"
 
-#: src/PartFile.cpp:4292
+#: src/PartFile.cpp:4324
 msgid "Allocating"
 msgstr "正在分配"
 
-#: src/PartFile.cpp:4308
+#: src/PartFile.cpp:4340
 msgid "Insufficient disk space"
 msgstr "磁碟空間不足"
 
-#: src/PartFile.cpp:4357 src/SearchListCtrl.cpp:1078
+#: src/PartFile.cpp:4389 src/SearchListCtrl.cpp:1078
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "已下載"
 
-#: src/PartFile.cpp:4617
+#: src/PartFile.cpp:4649
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "錯誤：無法開啟暫存檔 %s"
 
-#: src/Preferences.cpp:609
+#: src/Preferences.cpp:610
 msgid "System default"
 msgstr "系統預設"
 
-#: src/Preferences.cpp:610
+#: src/Preferences.cpp:611
 msgid "Albanian"
 msgstr "阿爾巴尼亞語"
 
-#: src/Preferences.cpp:611
+#: src/Preferences.cpp:612
 msgid "Arabic"
 msgstr "阿拉伯語"
 
-#: src/Preferences.cpp:612
+#: src/Preferences.cpp:613
 msgid "Asturian"
 msgstr "奧地利語"
 
-#: src/Preferences.cpp:613
+#: src/Preferences.cpp:614
 msgid "Basque"
 msgstr "巴斯克語"
 
-#: src/Preferences.cpp:614
+#: src/Preferences.cpp:615
 msgid "Bulgarian"
 msgstr "保加利亞語"
 
-#: src/Preferences.cpp:615
+#: src/Preferences.cpp:616
 msgid "Catalan"
 msgstr "加泰隆尼亞語"
 
-#: src/Preferences.cpp:616
+#: src/Preferences.cpp:617
 msgid "Chinese (Simplified)"
 msgstr "簡體中文"
 
-#: src/Preferences.cpp:617
+#: src/Preferences.cpp:618
 msgid "Chinese (Traditional)"
 msgstr "正體中文"
 
-#: src/Preferences.cpp:618
+#: src/Preferences.cpp:619
 msgid "Croatian"
 msgstr "克羅埃西亞語"
 
-#: src/Preferences.cpp:619
+#: src/Preferences.cpp:620
 msgid "Czech"
 msgstr "捷克語"
 
-#: src/Preferences.cpp:620
+#: src/Preferences.cpp:621
 msgid "Danish"
 msgstr "丹麥語"
 
-#: src/Preferences.cpp:621
+#: src/Preferences.cpp:622
 msgid "Dutch"
 msgstr "荷蘭語"
 
-#: src/Preferences.cpp:622
+#: src/Preferences.cpp:623
 msgid "English (U.K.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:623
+#: src/Preferences.cpp:624
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:624
+#: src/Preferences.cpp:625
 msgid "Estonian"
 msgstr "愛沙尼亞語"
 
-#: src/Preferences.cpp:625
+#: src/Preferences.cpp:626
 msgid "Finnish"
 msgstr "芬蘭語"
 
-#: src/Preferences.cpp:626
+#: src/Preferences.cpp:627
 msgid "French"
 msgstr "法語"
 
-#: src/Preferences.cpp:627
+#: src/Preferences.cpp:628
 msgid "Galician"
 msgstr "加利西亞語"
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:629
 msgid "German"
 msgstr "德語"
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:630
 msgid "Greek"
 msgstr "希臘語"
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:631
 msgid "Hebrew"
 msgstr "希伯來語"
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:632
 msgid "Hungarian"
 msgstr "匈牙利語"
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:633
 msgid "Italian"
 msgstr "義大利語"
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:634
 msgid "Italian (Swiss)"
 msgstr "意大利語 (瑞士)"
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:635
 msgid "Japanese"
 msgstr "日語"
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:636
 msgid "Korean"
 msgstr "韓語"
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:637
 msgid "Lithuanian"
 msgstr "立陶宛語"
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:638
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威語"
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:639
 msgid "Polish"
 msgstr "波蘭語"
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:640
 msgid "Portuguese"
 msgstr "葡萄牙語"
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:641
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙語 (巴西)"
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:642
 msgid "Romanian"
 msgstr "羅馬尼亞語"
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:643
 msgid "Russian"
 msgstr "俄語"
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:644
 msgid "Slovenian"
 msgstr "斯洛維尼亞語"
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:645
 msgid "Spanish"
 msgstr "西班牙語"
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:646
 msgid "Swedish"
 msgstr "瑞典語"
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:647
 msgid "Turkish"
 msgstr "土耳其語"
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:648
 msgid "Ukrainian"
 msgstr "烏克蘭語"
 
-#: src/Preferences.cpp:750
+#: src/Preferences.cpp:751
 msgid "Change Language"
 msgstr "變更語言"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "There are no translations installed for aMule"
 msgstr "沒有已安裝的 aMule 翻譯"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:816
 msgid "No languages available"
 msgstr "沒有可用的語言"
 
-#: src/Preferences.cpp:946
+#: src/Preferences.cpp:947
 msgid "no options available"
 msgstr "沒有選項"
 
-#: src/Preferences.cpp:1902
+#: src/Preferences.cpp:1905
 msgid "Invalid category found, skipping"
 msgstr "找到無效的分類，略過"
 
-#: src/Preferences.cpp:2071
+#: src/Preferences.cpp:2074
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP 埠不可大於 65532，因爲伺服器 UDP 連接端點值爲 TCP 埠值+3"
 
-#: src/Preferences.cpp:2072
+#: src/Preferences.cpp:2075
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "使用預設通訊埠 (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:190 src/Statistics.cpp:859
+#: src/PrefsUnifiedDlg.cpp:257 src/Statistics.cpp:859
 msgid "Connection"
 msgstr "連線"
 
-#: src/PrefsUnifiedDlg.cpp:191 src/SearchListCtrl.cpp:107
+#: src/PrefsUnifiedDlg.cpp:258 src/SearchListCtrl.cpp:107
 msgid "Directories"
 msgstr "目錄"
 
-#: src/PrefsUnifiedDlg.cpp:192 src/Statistics.cpp:904
+#: src/PrefsUnifiedDlg.cpp:259 src/Statistics.cpp:904
 msgid "Servers"
 msgstr "伺服器"
 
-#: src/PrefsUnifiedDlg.cpp:193 src/ServerListCtrl.cpp:94
+#: src/PrefsUnifiedDlg.cpp:260 src/ServerListCtrl.cpp:94
 msgid "Files"
 msgstr "檔案"
 
-#: src/PrefsUnifiedDlg.cpp:194
+#: src/PrefsUnifiedDlg.cpp:261
 msgid "Security"
 msgstr "安全"
 
-#: src/PrefsUnifiedDlg.cpp:195
+#: src/PrefsUnifiedDlg.cpp:262
 msgid "Interface"
 msgstr "介面"
 
-#: src/PrefsUnifiedDlg.cpp:202
+#: src/PrefsUnifiedDlg.cpp:269
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:205
+#: src/PrefsUnifiedDlg.cpp:272
 msgid "Proxy"
 msgstr "代理伺服器"
 
-#: src/PrefsUnifiedDlg.cpp:206
+#: src/PrefsUnifiedDlg.cpp:273
 msgid "Filters"
 msgstr "過濾"
 
-#: src/PrefsUnifiedDlg.cpp:207
+#: src/PrefsUnifiedDlg.cpp:274
 msgid "Remote Controls"
 msgstr "遠端控制"
 
-#: src/PrefsUnifiedDlg.cpp:208
+#: src/PrefsUnifiedDlg.cpp:275
 msgid "Online Signature"
 msgstr "線上簽名識別"
 
-#: src/PrefsUnifiedDlg.cpp:209
+#: src/PrefsUnifiedDlg.cpp:276
 msgid "Advanced"
 msgstr "進階"
 
-#: src/PrefsUnifiedDlg.cpp:210
+#: src/PrefsUnifiedDlg.cpp:277
 msgid "Events"
 msgstr "事件"
 
-#: src/PrefsUnifiedDlg.cpp:213
+#: src/PrefsUnifiedDlg.cpp:280
 msgid "Debugging"
 msgstr "除錯"
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:398
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5115,15 +5134,15 @@ msgstr ""
 "    %PARTFILE - 檔案的完整路徑\n"
 "    %PARTNAME - 只有檔案名稱"
 
-#: src/PrefsUnifiedDlg.cpp:345
+#: src/PrefsUnifiedDlg.cpp:419
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:361
+#: src/PrefsUnifiedDlg.cpp:435
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:402
+#: src/PrefsUnifiedDlg.cpp:476
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5138,26 +5157,26 @@ msgstr ""
 "\n"
 "即使不變更這些設定，aMule 一樣可以正常運作。"
 
-#: src/PrefsUnifiedDlg.cpp:465
+#: src/PrefsUnifiedDlg.cpp:546
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將 Cfg 與 widget 相連"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp:594
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將資料 Cfg 與 widget 連線"
 
-#: src/PrefsUnifiedDlg.cpp:566
+#: src/PrefsUnifiedDlg.cpp:647
 msgid "The type of proxy you are connecting to"
 msgstr "正在連線的代理伺服器類型"
 
-#: src/PrefsUnifiedDlg.cpp:740
+#: src/PrefsUnifiedDlg.cpp:823
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 從 Cfg 傳輸資料到 Widget"
 
-#: src/PrefsUnifiedDlg.cpp:814
+#: src/PrefsUnifiedDlg.cpp:897
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5165,32 +5184,37 @@ msgstr ""
 "請重新啟動 aMule，變更的設定才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:821
+#: src/PrefsUnifiedDlg.cpp:904
 msgid "- TCP port changed.\n"
 msgstr "- TCP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:826
+#: src/PrefsUnifiedDlg.cpp:909
 msgid "- UDP port changed.\n"
 msgstr "- UDP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:831
+#: src/PrefsUnifiedDlg.cpp:914
+#, fuzzy
+msgid "- Network interface binding changed.\n"
+msgstr "- 已變更外部連線介面設定。\n"
+
+#: src/PrefsUnifiedDlg.cpp:919
 msgid "- External connect port changed.\n"
 msgstr "- 已變更外部連線埠設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:835
+#: src/PrefsUnifiedDlg.cpp:923
 msgid "- External connect acceptance changed.\n"
 msgstr "- 已變更外部連線設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:839
+#: src/PrefsUnifiedDlg.cpp:927
 msgid "- External connect interface changed.\n"
 msgstr "- 已變更外部連線介面設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:843
+#: src/PrefsUnifiedDlg.cpp:931
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "模糊協定"
 
-#: src/PrefsUnifiedDlg.cpp:852
+#: src/PrefsUnifiedDlg.cpp:940
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5198,7 +5222,7 @@ msgstr ""
 "您的自動更新伺服器清單是空的。\n"
 "「啟動時自動更新伺服器清單」功能將被停用。"
 
-#: src/PrefsUnifiedDlg.cpp:863
+#: src/PrefsUnifiedDlg.cpp:951
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5206,19 +5230,19 @@ msgstr ""
 "您已經設定啓用外部連線但還沒有輸入密碼，\n"
 "輸入有效密碼之後，外部連線才能開始使用。"
 
-#: src/PrefsUnifiedDlg.cpp:876
+#: src/PrefsUnifiedDlg.cpp:964
 msgid "- Language changed.\n"
 msgstr "- 語言已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:881
+#: src/PrefsUnifiedDlg.cpp:969
 msgid "- Temp folder changed.\n"
 msgstr "- 暫存資料夾已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:886
+#: src/PrefsUnifiedDlg.cpp:974
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K 網路已啟用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:975
+#: src/PrefsUnifiedDlg.cpp:1063
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5226,7 +5250,7 @@ msgstr ""
 "eD2k 與 Kad 網路都已停用。\n"
 "請至少啟用一種，否則您將無法連線。"
 
-#: src/PrefsUnifiedDlg.cpp:980
+#: src/PrefsUnifiedDlg.cpp:1068
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5234,7 +5258,7 @@ msgstr ""
 "如果您停用 UDP 埠，Kad 將無法啓動。\n"
 "請啟用 UDP 埠或停用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1033
+#: src/PrefsUnifiedDlg.cpp:1121
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5244,20 +5268,20 @@ msgstr ""
 "您必須立即重新啟動 aMule，\n"
 "如果現在不重啟動，可能會發生不可預期的問題。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1182
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1096
+#: src/PrefsUnifiedDlg.cpp:1184
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1097
+#: src/PrefsUnifiedDlg.cpp:1185
 #, fuzzy
 msgid "Autostart"
 msgstr "已開始自動更新顯示"
 
-#: src/PrefsUnifiedDlg.cpp:1164
+#: src/PrefsUnifiedDlg.cpp:1252
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5267,41 +5291,41 @@ msgstr ""
 "請至少輸入一個能取得有效 server.met 檔案的網址。\n"
 "請點選旁邊的「清單」按鈕後輸入。"
 
-#: src/PrefsUnifiedDlg.cpp:1305
+#: src/PrefsUnifiedDlg.cpp:1393
 msgid "Temporary files"
 msgstr "暫存檔"
 
-#: src/PrefsUnifiedDlg.cpp:1310
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid "Incoming files"
 msgstr "新進檔案"
 
-#: src/PrefsUnifiedDlg.cpp:1315
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid "Online Signatures"
 msgstr "線上簽名識別"
 
-#: src/PrefsUnifiedDlg.cpp:1328
+#: src/PrefsUnifiedDlg.cpp:1416
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "爲 %s 選擇資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:1344
+#: src/PrefsUnifiedDlg.cpp:1432
 msgid "Browse for videoplayer"
 msgstr "瀏覽尋找影片播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1348
+#: src/PrefsUnifiedDlg.cpp:1436
 msgid "Select browser"
 msgstr "設定瀏覽器"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp:1442
 #, c-format
 msgid "Executable%s"
 msgstr "可執行%s"
 
-#: src/PrefsUnifiedDlg.cpp:1374
+#: src/PrefsUnifiedDlg.cpp:1462
 msgid "Edit server list"
 msgstr "編輯伺服器清單"
 
-#: src/PrefsUnifiedDlg.cpp:1375
+#: src/PrefsUnifiedDlg.cpp:1463
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5309,146 +5333,146 @@ msgstr ""
 "加入可下載 server.met 檔案的網址。\n"
 "每一行一個網址。"
 
-#: src/PrefsUnifiedDlg.cpp:1423
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1552
+#: src/PrefsUnifiedDlg.cpp:1640
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1554
+#: src/PrefsUnifiedDlg.cpp:1642
 #, fuzzy
 msgid "Custom source"
 msgstr "完整來源"
 
-#: src/PrefsUnifiedDlg.cpp:1556
+#: src/PrefsUnifiedDlg.cpp:1644
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1576
+#: src/PrefsUnifiedDlg.cpp:1664
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:1578
+#: src/PrefsUnifiedDlg.cpp:1666
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:1582
+#: src/PrefsUnifiedDlg.cpp:1670
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1584
+#: src/PrefsUnifiedDlg.cpp:1672
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626 src/PrefsUnifiedDlg.cpp:1650
+#: src/PrefsUnifiedDlg.cpp:1714 src/PrefsUnifiedDlg.cpp:1738
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延遲時間：%d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:1634
+#: src/PrefsUnifiedDlg.cpp:1722
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值圖表顯示時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:1643
+#: src/PrefsUnifiedDlg.cpp:1731
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "網路連線圖表比例：%d"
 
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/PrefsUnifiedDlg.cpp:1746
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "檔案緩衝區大小：%d B"
 
-#: src/PrefsUnifiedDlg.cpp:1668
+#: src/PrefsUnifiedDlg.cpp:1756
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上傳等候區大小：%d "
 
-#: src/PrefsUnifiedDlg.cpp:1678
+#: src/PrefsUnifiedDlg.cpp:1766
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "伺服器連線更新間隔時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:1683
+#: src/PrefsUnifiedDlg.cpp:1771
 msgid "Server connection refresh interval: Disabled"
 msgstr "伺服器連線更新間隔時間：已停用"
 
-#: src/PrefsUnifiedDlg.cpp:1727
+#: src/PrefsUnifiedDlg.cpp:1815
 msgid "disabled"
 msgstr "已停用"
 
-#: src/PrefsUnifiedDlg.cpp:1753
+#: src/PrefsUnifiedDlg.cpp:1841
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "發生 %s 事件時執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:1760
+#: src/PrefsUnifiedDlg.cpp:1848
 msgid "Enable command execution on core"
 msgstr "啓用在主程式端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:1772
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Core command:"
 msgstr "主程式端指令："
 
-#: src/PrefsUnifiedDlg.cpp:1788
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Enable command execution on GUI"
 msgstr "啓用在圖形界面端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:1800
+#: src/PrefsUnifiedDlg.cpp:1888
 msgid "GUI command:"
 msgstr "圖形界面端指令："
 
-#: src/PrefsUnifiedDlg.cpp:1816
+#: src/PrefsUnifiedDlg.cpp:1904
 msgid "The following variables will be replaced:"
 msgstr ""
 "使用以下變數：\n"
 " "
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp:2063
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1980
+#: src/PrefsUnifiedDlg.cpp:2068
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp:2071
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 #, fuzzy
 msgid "Reloading shared files…"
 msgstr "重新載入分享的檔案"
 
-#: src/PrefsUnifiedDlg.cpp:2012
+#: src/PrefsUnifiedDlg.cpp:2100
 msgid "Scanning for subdirectories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2013
+#: src/PrefsUnifiedDlg.cpp:2101
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2040
+#: src/PrefsUnifiedDlg.cpp:2128
 #, c-format
 msgid "Scanned %u directories…"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2090
+#: src/PrefsUnifiedDlg.cpp:2178
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "重新載入分享檔案清單。"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 12:27+0200\n"
+"POT-Creation-Date: 2026-07-03 14:52+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -203,8 +203,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1029 src/amule.cpp:1143
-#: src/amule.cpp:1445 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
+#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -249,27 +249,37 @@ msgstr "已關閉 aMule 。"
 msgid "Memory debug results for aMule exit:"
 msgstr "離開 aMule 時記憶體除錯結果："
 
-#: src/amule.cpp:571
+#: src/amule.cpp:572
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:573
+#: src/amule.cpp:575
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:633
+#: src/amule.cpp:581
+#, c-format
+msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
+msgstr ""
+
+#: src/amule.cpp:589
+#, c-format
+msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
+msgstr ""
+
+#: src/amule.cpp:648
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "對不起，由於版本變更，您的地區設定已經被變更爲系統預設值。"
 
-#: src/amule.cpp:635 src/amule.cpp:1433 src/CatDialog.cpp:129
+#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "資訊"
 
-#: src/amule.cpp:642
+#: src/amule.cpp:657
 msgid ""
 "\n"
 "EC configuration"
@@ -277,56 +287,56 @@ msgstr ""
 "\n"
 "外部連線設定"
 
-#: src/amule.cpp:645
+#: src/amule.cpp:660
 msgid "Password set and external connections enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/amule.cpp:655 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:904
+#: src/amule.cpp:919
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "網路"
 
-#: src/amule.cpp:909
+#: src/amule.cpp:924
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:918
+#: src/amule.cpp:933
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "在 server.met 中找到 %i 個伺服器"
 
-#: src/amule.cpp:925
+#: src/amule.cpp:940
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1011
+#: src/amule.cpp:1026
 #, c-format
 msgid "web server running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:1024
+#: src/amule.cpp:1039
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1111
+#: src/amule.cpp:1126
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "無法選定使用此位址的通訊埠：%s"
 
-#: src/amule.cpp:1135
+#: src/amule.cpp:1150
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "通訊埠 %u 已被佔用。您會變成 LOWID。\n"
 
-#: src/amule.cpp:1140
+#: src/amule.cpp:1155
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -341,48 +351,48 @@ msgstr ""
 "\n"
 "請檢查網路設定以確保通訊埠可正常使用。"
 
-#: src/amule.cpp:1237
+#: src/amule.cpp:1252
 msgid "Failed to create OnlineSig File"
 msgstr "無法建立線上簽名識別檔"
 
-#: src/amule.cpp:1245
+#: src/amule.cpp:1260
 msgid "Failed to create aMule OnlineSig File"
 msgstr "無法建立 aMule 線上簽名識別檔"
 
-#: src/amule.cpp:1408
+#: src/amule.cpp:1423
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "在您的電腦上似乎沒有安裝您所選取的地區設定。 (但仍會採用您所選擇的設定)"
 
-#: src/amule.cpp:1418
+#: src/amule.cpp:1433
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "這是您第一次執行 aMule %s"
 
-#: src/amule.cpp:1421
+#: src/amule.cpp:1436
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "這個版本是測試版，每日有更新，\n"
 
-#: src/amule.cpp:1422
+#: src/amule.cpp:1437
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "但我們無法擔保它不會造成任何損害、燒掉您的房子、\n"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1438
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或害死您的狗。但一般來講它「應該」是安全的。\n"
 
-#: src/amule.cpp:1428
+#: src/amule.cpp:1443
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "在我們的網頁可找到更多資訊、使用者支援以及程式最新版本：\n"
 
-#: src/amule.cpp:1429
+#: src/amule.cpp:1444
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或我們在 irc.libera.chat 的 IRC 頻道 #aMule。\n"
 
-#: src/amule.cpp:1431
+#: src/amule.cpp:1446
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "歡迎您到 https://github.com/amule-org/amule/issues 提出錯誤報告"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1458
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -390,137 +400,137 @@ msgstr ""
 "您選擇的線上簽名識別檔案所在資料夾無效！\n"
 " 在您變更偏好設定之前，線上簽名識別功能將被停用。"
 
-#: src/amule.cpp:1506
+#: src/amule.cpp:1521
 msgid "Server hostname notified"
 msgstr "已通伺服器主機名稱"
 
-#: src/amule.cpp:1815
+#: src/amule.cpp:1830
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "無法為檔案 %s 預先分配磁碟空間：%s"
 
-#: src/amule.cpp:1944
+#: src/amule.cpp:1959
 msgid "ERROR: can't open logfile"
 msgstr "錯誤：無法開啟記錄檔"
 
-#: src/amule.cpp:1948
+#: src/amule.cpp:1963
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：沒有記錄檔，肯定有什麽地方出錯了。"
 
-#: src/amule.cpp:1965
+#: src/amule.cpp:1980
 msgid "Log has been reset"
 msgstr "記錄已被清除"
 
-#: src/amule.cpp:1989
+#: src/amule.cpp:2004
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "伺服器訊息：%s"
 
-#: src/amule.cpp:2032 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "略過不下載 %s ，因為並不是新近檔案。"
 
-#: src/amule.cpp:2035
+#: src/amule.cpp:2050
 msgid "Failed to download the nodes list."
 msgstr "無法下載節點清單。"
 
-#: src/amule.cpp:2056
+#: src/amule.cpp:2071
 msgid "Failed to open the downloaded version check file"
 msgstr "無法開啟下載的版本檢查檔"
 
-#: src/amule.cpp:2059 src/amule.cpp:2078 src/amule.cpp:2109 src/amule.cpp:2131
+#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
 msgid "Corrupted version check file"
 msgstr "損壞的版本檢查檔"
 
-#: src/amule.cpp:2142
+#: src/amule.cpp:2157
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是過期的 aMule 版本！"
 
-#: src/amule.cpp:2144
+#: src/amule.cpp:2159
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2148
+#: src/amule.cpp:2163
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2151
+#: src/amule.cpp:2166
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本已經過期：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2172
 msgid "Your copy of aMule is up to date."
 msgstr "您的 aMule 是最新版本。"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2179
 msgid "Failed to download the version check file"
 msgstr "無法下載版本檢查檔"
 
-#: src/amule.cpp:2333 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "使用者：%s | 檔案：%s"
 
-#: src/amule.cpp:2334 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "使用者：E:%s K:%s | 檔案：E:%s K:%s"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "未選取網路"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:855
+#: src/amule.cpp:2431 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "有 LowID"
 
-#: src/amule.cpp:2416 src/TextClient.cpp:856
+#: src/amule.cpp:2431 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "有 HighID"
 
-#: src/amule.cpp:2418
+#: src/amule.cpp:2433
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已連線到 %s %s"
 
-#: src/amule.cpp:2422
+#: src/amule.cpp:2437
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在連線到 %s"
 
-#: src/amule.cpp:2424
+#: src/amule.cpp:2439
 msgid "Disconnected from eD2k"
 msgstr "已中斷 eD2k 網路連線"
 
-#: src/amule.cpp:2432
+#: src/amule.cpp:2447
 msgid "Kad started."
 msgstr "Kad 已啓動。"
 
-#: src/amule.cpp:2434
+#: src/amule.cpp:2449
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2442
+#: src/amule.cpp:2457
 msgid "Connected to Kad (ok)"
 msgstr "已連線到 Kad"
 
-#: src/amule.cpp:2444
+#: src/amule.cpp:2459
 msgid "Connected to Kad (firewalled)"
 msgstr "已連線到 Kad 網路 (防火牆內)"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2462
 msgid "Disconnected from Kad"
 msgstr "已中斷 Kad 網路連線"
 
-#: src/amule.cpp:2478
+#: src/amule.cpp:2493
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 網路未啟動：如果在偏好設定中停用了 UDP 埠，Kad 網路將不能使用。"
 
-#: src/amule.cpp:2482
+#: src/amule.cpp:2497
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 網路在偏好設定中被停用了，沒有連線。"
 
@@ -2577,7 +2587,7 @@ msgstr "外部連線：拒絕存取，原因： "
 msgid "External Connection: Handshake failed."
 msgstr "外部連線：訊號交換失敗"
 
-#: src/LibSocketAsio.cpp:1742
+#: src/LibSocketAsio.cpp:1821
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "已開始 HTTP 下載執行緒"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-03 14:52+0200\n"
+"POT-Creation-Date: 2026-07-03 16:31+0200\n"
 "PO-Revision-Date: 2026-06-25 11:15+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -203,8 +203,8 @@ msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural "Could not add %u links from ED2KLinks file (see log for details)."
 msgstr[0] ""
 
-#: src/amuleAppCommon.cpp:178 src/amule.cpp:1044 src/amule.cpp:1158
-#: src/amule.cpp:1460 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
+#: src/amuleAppCommon.cpp:178 src/amule.cpp:1053 src/amule.cpp:1167
+#: src/amule.cpp:1469 src/amule-remote-gui.cpp:463 src/amule-remote-gui.cpp:516
 #: src/amule-remote-gui.cpp:530 src/amule-remote-gui.cpp:549
 #: src/amule-remote-gui.cpp:911 src/amule-remote-gui.cpp:938
 #: src/DownloadQueue.cpp:1472
@@ -249,37 +249,42 @@ msgstr "已關閉 aMule 。"
 msgid "Memory debug results for aMule exit:"
 msgstr "離開 aMule 時記憶體除錯結果："
 
-#: src/amule.cpp:572
+#: src/amule.cpp:576
+#, c-format
+msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
+msgstr ""
+
+#: src/amule.cpp:580
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:575
+#: src/amule.cpp:584
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:590
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:589
+#: src/amule.cpp:598
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:648
+#: src/amule.cpp:657
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "對不起，由於版本變更，您的地區設定已經被變更爲系統預設值。"
 
-#: src/amule.cpp:650 src/amule.cpp:1448 src/CatDialog.cpp:129
+#: src/amule.cpp:659 src/amule.cpp:1457 src/CatDialog.cpp:129
 #: src/CatDialog.cpp:137 src/CatDialog.cpp:150 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:150
 msgid "Info"
 msgstr "資訊"
 
-#: src/amule.cpp:657
+#: src/amule.cpp:666
 msgid ""
 "\n"
 "EC configuration"
@@ -287,56 +292,56 @@ msgstr ""
 "\n"
 "外部連線設定"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:669
 msgid "Password set and external connections enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/amule.cpp:670 src/KadDlg.cpp:174 src/KadDlg.cpp:183
+#: src/amule.cpp:679 src/KadDlg.cpp:174 src/KadDlg.cpp:183
 #: src/PrefsUnifiedDlg.cpp:1123 src/SharedFilesCtrl.cpp:321
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:919
+#: src/amule.cpp:928
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "網路"
 
-#: src/amule.cpp:924
+#: src/amule.cpp:933
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:933
+#: src/amule.cpp:942
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "在 server.met 中找到 %i 個伺服器"
 
-#: src/amule.cpp:940
+#: src/amule.cpp:949
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1026
+#: src/amule.cpp:1035
 #, c-format
 msgid "web server running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:1039
+#: src/amule.cpp:1048
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1126
+#: src/amule.cpp:1135
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "無法選定使用此位址的通訊埠：%s"
 
-#: src/amule.cpp:1150
+#: src/amule.cpp:1159
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "通訊埠 %u 已被佔用。您會變成 LOWID。\n"
 
-#: src/amule.cpp:1155
+#: src/amule.cpp:1164
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -351,48 +356,48 @@ msgstr ""
 "\n"
 "請檢查網路設定以確保通訊埠可正常使用。"
 
-#: src/amule.cpp:1252
+#: src/amule.cpp:1261
 msgid "Failed to create OnlineSig File"
 msgstr "無法建立線上簽名識別檔"
 
-#: src/amule.cpp:1260
+#: src/amule.cpp:1269
 msgid "Failed to create aMule OnlineSig File"
 msgstr "無法建立 aMule 線上簽名識別檔"
 
-#: src/amule.cpp:1423
+#: src/amule.cpp:1432
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "在您的電腦上似乎沒有安裝您所選取的地區設定。 (但仍會採用您所選擇的設定)"
 
-#: src/amule.cpp:1433
+#: src/amule.cpp:1442
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "這是您第一次執行 aMule %s"
 
-#: src/amule.cpp:1436
+#: src/amule.cpp:1445
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "這個版本是測試版，每日有更新，\n"
 
-#: src/amule.cpp:1437
+#: src/amule.cpp:1446
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "但我們無法擔保它不會造成任何損害、燒掉您的房子、\n"
 
-#: src/amule.cpp:1438
+#: src/amule.cpp:1447
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或害死您的狗。但一般來講它「應該」是安全的。\n"
 
-#: src/amule.cpp:1443
+#: src/amule.cpp:1452
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "在我們的網頁可找到更多資訊、使用者支援以及程式最新版本：\n"
 
-#: src/amule.cpp:1444
+#: src/amule.cpp:1453
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或我們在 irc.libera.chat 的 IRC 頻道 #aMule。\n"
 
-#: src/amule.cpp:1446
+#: src/amule.cpp:1455
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "歡迎您到 https://github.com/amule-org/amule/issues 提出錯誤報告"
 
-#: src/amule.cpp:1458
+#: src/amule.cpp:1467
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -400,137 +405,137 @@ msgstr ""
 "您選擇的線上簽名識別檔案所在資料夾無效！\n"
 " 在您變更偏好設定之前，線上簽名識別功能將被停用。"
 
-#: src/amule.cpp:1521
+#: src/amule.cpp:1530
 msgid "Server hostname notified"
 msgstr "已通伺服器主機名稱"
 
-#: src/amule.cpp:1830
+#: src/amule.cpp:1839
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "無法為檔案 %s 預先分配磁碟空間：%s"
 
-#: src/amule.cpp:1959
+#: src/amule.cpp:1968
 msgid "ERROR: can't open logfile"
 msgstr "錯誤：無法開啟記錄檔"
 
-#: src/amule.cpp:1963
+#: src/amule.cpp:1972
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：沒有記錄檔，肯定有什麽地方出錯了。"
 
-#: src/amule.cpp:1980
+#: src/amule.cpp:1989
 msgid "Log has been reset"
 msgstr "記錄已被清除"
 
-#: src/amule.cpp:2004
+#: src/amule.cpp:2013
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "伺服器訊息：%s"
 
-#: src/amule.cpp:2047 src/IP2Country.cpp:233 src/IPFilter.cpp:506
+#: src/amule.cpp:2056 src/IP2Country.cpp:233 src/IPFilter.cpp:506
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "略過不下載 %s ，因為並不是新近檔案。"
 
-#: src/amule.cpp:2050
+#: src/amule.cpp:2059
 msgid "Failed to download the nodes list."
 msgstr "無法下載節點清單。"
 
-#: src/amule.cpp:2071
+#: src/amule.cpp:2080
 msgid "Failed to open the downloaded version check file"
 msgstr "無法開啟下載的版本檢查檔"
 
-#: src/amule.cpp:2074 src/amule.cpp:2093 src/amule.cpp:2124 src/amule.cpp:2146
+#: src/amule.cpp:2083 src/amule.cpp:2102 src/amule.cpp:2133 src/amule.cpp:2155
 msgid "Corrupted version check file"
 msgstr "損壞的版本檢查檔"
 
-#: src/amule.cpp:2157
+#: src/amule.cpp:2166
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是過期的 aMule 版本！"
 
-#: src/amule.cpp:2159
+#: src/amule.cpp:2168
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2163
+#: src/amule.cpp:2172
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2166
+#: src/amule.cpp:2175
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本已經過期：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2181
 msgid "Your copy of aMule is up to date."
 msgstr "您的 aMule 是最新版本。"
 
-#: src/amule.cpp:2179
+#: src/amule.cpp:2188
 msgid "Failed to download the version check file"
 msgstr "無法下載版本檢查檔"
 
-#: src/amule.cpp:2348 src/amule-remote-gui.cpp:793
+#: src/amule.cpp:2357 src/amule-remote-gui.cpp:793
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "使用者：%s | 檔案：%s"
 
-#: src/amule.cpp:2349 src/amule-remote-gui.cpp:794
+#: src/amule.cpp:2358 src/amule-remote-gui.cpp:794
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "使用者：E:%s K:%s | 檔案：E:%s K:%s"
 
-#: src/amule.cpp:2363 src/amule-remote-gui.cpp:807
+#: src/amule.cpp:2372 src/amule-remote-gui.cpp:807
 msgid "No networks selected"
 msgstr "未選取網路"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:855
+#: src/amule.cpp:2440 src/TextClient.cpp:855
 msgid "with LowID"
 msgstr "有 LowID"
 
-#: src/amule.cpp:2431 src/TextClient.cpp:856
+#: src/amule.cpp:2440 src/TextClient.cpp:856
 msgid "with HighID"
 msgstr "有 HighID"
 
-#: src/amule.cpp:2433
+#: src/amule.cpp:2442
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已連線到 %s %s"
 
-#: src/amule.cpp:2437
+#: src/amule.cpp:2446
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在連線到 %s"
 
-#: src/amule.cpp:2439
+#: src/amule.cpp:2448
 msgid "Disconnected from eD2k"
 msgstr "已中斷 eD2k 網路連線"
 
-#: src/amule.cpp:2447
+#: src/amule.cpp:2456
 msgid "Kad started."
 msgstr "Kad 已啓動。"
 
-#: src/amule.cpp:2449
+#: src/amule.cpp:2458
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2457
+#: src/amule.cpp:2466
 msgid "Connected to Kad (ok)"
 msgstr "已連線到 Kad"
 
-#: src/amule.cpp:2459
+#: src/amule.cpp:2468
 msgid "Connected to Kad (firewalled)"
 msgstr "已連線到 Kad 網路 (防火牆內)"
 
-#: src/amule.cpp:2462
+#: src/amule.cpp:2471
 msgid "Disconnected from Kad"
 msgstr "已中斷 Kad 網路連線"
 
-#: src/amule.cpp:2493
+#: src/amule.cpp:2502
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 網路未啟動：如果在偏好設定中停用了 UDP 埠，Kad 網路將不能使用。"
 
-#: src/amule.cpp:2497
+#: src/amule.cpp:2506
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 網路在偏好設定中被停用了，沒有連線。"
 
@@ -891,7 +896,7 @@ msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
 #: src/DownloadListCtrl.cpp:1094 src/ExternalConn.cpp:539
 #: src/FileDetailDialog.cpp:186 src/GenericClientListCtrl.cpp:1136
 #: src/GenericClientListCtrl.cpp:1147 src/GenericClientListCtrl.cpp:1157
-#: src/HTTPDownload.cpp:88 src/KnownFile.cpp:958 src/KnownFile.cpp:964
+#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:958 src/KnownFile.cpp:964
 #: src/MuleTrayIcon.cpp:409 src/MuleTrayIcon.cpp:835 src/PartFile.cpp:2802
 #: src/PartFile.cpp:2808 src/Server.cpp:134 src/Server.cpp:210
 #: src/Statistics.cpp:1094
@@ -2249,49 +2254,49 @@ msgstr "否"
 msgid "Yes"
 msgstr "是"
 
-#: src/HTTPDownload.cpp:58
+#: src/HTTPDownload.cpp:59
 msgid "Downloading..."
 msgstr "正在下載..."
 
-#: src/HTTPDownload.cpp:125
+#: src/HTTPDownload.cpp:126
 msgid "HTTP download cancelled"
 msgstr "已取消 HTTP 下載"
 
-#: src/HTTPDownload.cpp:241
+#: src/HTTPDownload.cpp:323
 msgid "The URL to download can't be empty"
 msgstr "要下載的網址不可空白"
 
-#: src/HTTPDownload.cpp:250
+#: src/HTTPDownload.cpp:334
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "無法從使用者 %s 取得分享檔案清單"
 
-#: src/HTTPDownload.cpp:344
+#: src/HTTPDownload.cpp:413
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:356
+#: src/HTTPDownload.cpp:425
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "暫存資料夾"
 
-#: src/HTTPDownload.cpp:360
+#: src/HTTPDownload.cpp:429
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "已下載 %d B"
 
-#: src/HTTPDownload.cpp:365
+#: src/HTTPDownload.cpp:434
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "網址 %s 傳回：%i - 錯誤 (%i)！"
 
-#: src/HTTPDownload.cpp:373
+#: src/HTTPDownload.cpp:442
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "已取消 HTTP 下載"
 
-#: src/HTTPDownload.cpp:387
+#: src/HTTPDownload.cpp:456
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
@@ -2587,7 +2592,7 @@ msgstr "外部連線：拒絕存取，原因： "
 msgid "External Connection: Handshake failed."
 msgstr "外部連線：訊號交換失敗"
 
-#: src/LibSocketAsio.cpp:1821
+#: src/LibSocketAsio.cpp:1832
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "已開始 HTTP 下載執行緒"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -789,7 +789,10 @@ IF (NEED_LIB_MULESOCKET)
 	if (WIN32)
 		# GetAdaptersAddresses() in LibSocketAsio.cpp resolves a Windows
 		# adapter FriendlyName to its interface index for bind-to-interface.
-		target_link_libraries (mulesocket PRIVATE iphlpapi)
+		# PUBLIC (not PRIVATE): mulesocket is a static lib, so the dependency
+		# must propagate to every consumer that links it (including the
+		# NetworkFunctionsTest unit-test exe), not just to mulesocket itself.
+		target_link_libraries (mulesocket PUBLIC iphlpapi)
 	endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -786,6 +786,11 @@ IF (NEED_LIB_MULESOCKET)
 		PRIVATE ${Boost_LIBRARIES}
 		PUBLIC wxWidgets::BASE
 	)
+	if (WIN32)
+		# GetAdaptersAddresses() in LibSocketAsio.cpp resolves a Windows
+		# adapter FriendlyName to its interface index for bind-to-interface.
+		target_link_libraries (mulesocket PRIVATE iphlpapi)
+	endif()
 endif()
 
 # On MinGW-built Windows targets, bundle the MSYS2 MinGW64 runtime DLLs

--- a/src/HTTPDownload.cpp
+++ b/src/HTTPDownload.cpp
@@ -197,15 +197,26 @@ static void ApplyProxyToSession(wxWebSession &session)
 #endif
 }
 
-// aMule standardises on libcurl for all HTTP (version check, IP2Country,
-// server.met) so the bind-to-interface hook below works uniformly on every
-// platform. Linux and macOS already default to the curl backend; on Windows
-// the default may be WinHTTP, so request curl explicitly. Falls back to the
-// platform default if curl isn't available at runtime — HTTP still works, it
-// just can't be pinned to an interface (the core warns about that separately).
+// HTTP-on-curl is what lets us bind egress to an interface (via the sockopt
+// hook below). We select it on Linux and macOS but deliberately NOT on Windows:
+//
+//   Linux  : curl is already the default backend — use it.
+//   macOS  : the default is the native URLSession backend (whose handle isn't a
+//            CURL*), so request curl explicitly to get a bindable handle.
+//   Windows: the wxMSW libcurl backend is broken — a forced curl request never
+//            progresses and hangs (verified with a standalone wxWebRequest, not
+//            just amuled). WinHTTP (the default) works but has no interface-bind
+//            API, so on Windows HTTP simply stays on WinHTTP and is not bound.
+//
+// P2P traffic is bound on all platforms regardless; only the Windows HTTP
+// side-channels (version check, IP2Country, server.met) are left unbound.
+#if wxUSE_WEBREQUEST_CURL && !defined(__WINDOWS__)
+#define AMULE_HTTP_CURL_BIND 1
+#endif
+
 static wxWebSession &GetAmuleWebSession()
 {
-#if wxUSE_WEBREQUEST_CURL
+#ifdef AMULE_HTTP_CURL_BIND
 	if (wxWebSession::IsBackendAvailable(wxWebSessionBackendCURL)) {
 		static wxWebSession curlSession = wxWebSession::New(wxWebSessionBackendCURL);
 		if (curlSession.IsOpened()) {
@@ -216,11 +227,11 @@ static wxWebSession &GetAmuleWebSession()
 	return wxWebSession::GetDefault();
 }
 
-#if defined(AMULE_HAVE_LIBCURL) && wxUSE_WEBREQUEST_CURL
+#if defined(AMULE_HAVE_LIBCURL) && defined(AMULE_HTTP_CURL_BIND)
 // libcurl invokes this on the freshly-created socket, before connect(). Bind
 // it to the configured interface using aMule's own per-platform logic (the
-// same SO_BINDTODEVICE / IP_BOUND_IF / IP_UNICAST_IF path the P2P sockets use),
-// so HTTP can't leak past a bound interface. See amule-org/amule#173.
+// same SO_BINDTODEVICE / IP_BOUND_IF path the P2P sockets use), so HTTP can't
+// leak past a bound interface. See amule-org/amule#173.
 extern "C" int amuleHttpSockoptCallback(void *, curl_socket_t curlfd, curlsocktype)
 {
 	const wxString &iface = thePrefs::GetNetworkInterface();
@@ -235,11 +246,11 @@ extern "C" int amuleHttpSockoptCallback(void *, curl_socket_t curlfd, curlsockty
 // synchronous-resolver fallback doesn't raise SIGALRM in this multi-threaded
 // process, CURLOPT_CONNECTTIMEOUT_MS so the connect phase (incl. DNS) gives up
 // after 30 s instead of the full OS resolver timeout, and — when an interface
-// is configured — CURLOPT_SOCKOPTFUNCTION to bind egress to it. No-op when the
-// request isn't backed by libcurl.
+// is configured — CURLOPT_SOCKOPTFUNCTION to bind egress to it. Only runs where
+// curl is the selected backend (Linux / macOS); a no-op on Windows (WinHTTP).
 static void CustomizeCurlRequest(wxWebRequest &request)
 {
-#if defined(AMULE_HAVE_LIBCURL) && wxUSE_WEBREQUEST_CURL
+#if defined(AMULE_HAVE_LIBCURL) && defined(AMULE_HTTP_CURL_BIND)
 	if (CURL *curl = static_cast<CURL *>(request.GetNativeHandle())) {
 		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 30000L);

--- a/src/HTTPDownload.cpp
+++ b/src/HTTPDownload.cpp
@@ -217,7 +217,14 @@ static void ApplyProxyToSession(wxWebSession &session)
 static wxWebSession &GetAmuleWebSession()
 {
 #ifdef AMULE_HTTP_CURL_BIND
-	if (wxWebSession::IsBackendAvailable(wxWebSessionBackendCURL)) {
+	// Switch to the curl backend only when an interface is actually bound —
+	// curl is just the means to make HTTP bindable. Forcing it otherwise would
+	// needlessly change the HTTP stack for users who don't use this feature (on
+	// macOS the default is the native URLSession backend, with its own TLS /
+	// proxy handling). No behavioural change on Linux, where the default is
+	// already curl.
+	if (!thePrefs::GetNetworkInterface().IsEmpty() &&
+		wxWebSession::IsBackendAvailable(wxWebSessionBackendCURL)) {
 		static wxWebSession curlSession = wxWebSession::New(wxWebSessionBackendCURL);
 		if (curlSession.IsOpened()) {
 			return curlSession;

--- a/src/HTTPDownload.cpp
+++ b/src/HTTPDownload.cpp
@@ -38,6 +38,7 @@
 #include "InternalEvents.h"         // Needed for CMuleInternalEvent
 #include "Preferences.h"
 #include "Proxy.h"
+#include "LibSocket.h" // BindRawSocketToInterface for the curl bind hook
 
 #ifndef AMULE_DAEMON
 #include "inetdownload.h" // Needed for inetDownload
@@ -156,7 +157,7 @@ wxDEFINE_EVENT(wxEVT_HTTP_PROGRESS, wxEvent);
 wxDEFINE_EVENT(wxEVT_HTTP_SHUTDOWN, wxEvent);
 #endif
 
-// Apply the current proxy prefs to the shared wxWebSession.
+// Apply the current proxy prefs to the given wxWebSession.
 //
 // wxWebProxy / wxWebSession::SetProxy are wx 3.3+ only. On wx 3.2 there is
 // no programmatic way to set a proxy on wxWebRequest, so we rely on the
@@ -169,10 +170,9 @@ wxDEFINE_EVENT(wxEVT_HTTP_SHUTDOWN, wxEvent);
 // SOCKS proxies are intentionally skipped even when SetProxy is available:
 // wx 3.3's wxWebProxy is HTTP-only. A libcurl backend would be required if
 // SOCKS support mattered — that is out of scope for this fix.
-static void ApplyProxyToDefaultSession()
+static void ApplyProxyToSession(wxWebSession &session)
 {
 #if wxCHECK_VERSION(3, 3, 0)
-	wxWebSession &session = wxWebSession::GetDefault();
 	const CProxyData *pd = thePrefs::GetProxyData();
 	if (!pd || !pd->m_proxyEnable || pd->m_proxyType == PROXY_NONE) {
 		session.SetProxy(wxWebProxy::FromURL(wxString())); // clear
@@ -192,7 +192,78 @@ static void ApplyProxyToDefaultSession()
 		url = CFormat("http://%s:%u") % pd->m_proxyHostName % pd->m_proxyPort;
 	}
 	session.SetProxy(wxWebProxy::FromURL(url));
+#else
+	(void)session;
 #endif
+}
+
+// aMule standardises on libcurl for all HTTP (version check, IP2Country,
+// server.met) so the bind-to-interface hook below works uniformly on every
+// platform. Linux and macOS already default to the curl backend; on Windows
+// the default may be WinHTTP, so request curl explicitly. Falls back to the
+// platform default if curl isn't available at runtime — HTTP still works, it
+// just can't be pinned to an interface (the core warns about that separately).
+static wxWebSession &GetAmuleWebSession()
+{
+#if wxUSE_WEBREQUEST_CURL
+	if (wxWebSession::IsBackendAvailable(wxWebSessionBackendCURL)) {
+		static wxWebSession curlSession = wxWebSession::New(wxWebSessionBackendCURL);
+		if (curlSession.IsOpened()) {
+			return curlSession;
+		}
+	}
+#endif
+	return wxWebSession::GetDefault();
+}
+
+#if defined(AMULE_HAVE_LIBCURL) && wxUSE_WEBREQUEST_CURL
+// libcurl invokes this on the freshly-created socket, before connect(). Bind
+// it to the configured interface using aMule's own per-platform logic (the
+// same SO_BINDTODEVICE / IP_BOUND_IF / IP_UNICAST_IF path the P2P sockets use),
+// so HTTP can't leak past a bound interface. See amule-org/amule#173.
+extern "C" int amuleHttpSockoptCallback(void *, curl_socket_t curlfd, curlsocktype)
+{
+	const wxString &iface = thePrefs::GetNetworkInterface();
+	if (!iface.IsEmpty()) {
+		BindRawSocketToInterface(static_cast<uintptr_t>(curlfd), iface);
+	}
+	return CURL_SOCKOPT_OK;
+}
+#endif
+
+// Tune the libcurl handle backing an HTTP request: CURLOPT_NOSIGNAL so the
+// synchronous-resolver fallback doesn't raise SIGALRM in this multi-threaded
+// process, CURLOPT_CONNECTTIMEOUT_MS so the connect phase (incl. DNS) gives up
+// after 30 s instead of the full OS resolver timeout, and — when an interface
+// is configured — CURLOPT_SOCKOPTFUNCTION to bind egress to it. No-op when the
+// request isn't backed by libcurl.
+static void CustomizeCurlRequest(wxWebRequest &request)
+{
+#if defined(AMULE_HAVE_LIBCURL) && wxUSE_WEBREQUEST_CURL
+	if (CURL *curl = static_cast<CURL *>(request.GetNativeHandle())) {
+		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 30000L);
+		if (!thePrefs::GetNetworkInterface().IsEmpty()) {
+			curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, amuleHttpSockoptCallback);
+		}
+	}
+#else
+	(void)request;
+#endif
+}
+
+// Single entry point for all aMule HTTP: curl-backed session + proxy +
+// interface bind, so every HTTP channel is consistent and honours the
+// bind-to-interface preference.
+wxWebRequest CreateAmuleWebRequest(wxEvtHandler *handler, const wxString &url)
+{
+	wxWebSession &session = GetAmuleWebSession();
+	ApplyProxyToSession(session);
+	wxWebRequest request = session.CreateRequest(handler, url);
+	if (request.IsOk()) {
+		CustomizeCurlRequest(request);
+	}
+	return request;
 }
 
 CHTTPDownloadThread::CHTTPDownloadThread(const wxString &url,
@@ -243,29 +314,16 @@ CHTTPDownloadThread::CHTTPDownloadThread(const wxString &url,
 		return;
 	}
 
-	ApplyProxyToDefaultSession();
-
-	m_request = wxWebSession::GetDefault().CreateRequest(this, m_url);
+	// Curl-backed session + proxy + interface bind, all in one place (shared
+	// with the version check). The threaded-resolver caveat still applies: the
+	// CONNECTTIMEOUT set inside bounds the visible delay before Failed fires,
+	// but not the cleanup-time pthread_join on libcurl's threaded resolver.
+	m_request = CreateAmuleWebRequest(this, m_url);
 	if (!m_request.IsOk()) {
 		AddLogLineC(CFormat(_("Failed to create HTTP request for %s")) % m_url);
 		FinishAndDestroy(HTTP_Error);
 		return;
 	}
-
-#if defined(AMULE_HAVE_LIBCURL) && wxUSE_WEBREQUEST_CURL
-	// When wx was built with the libcurl backend AND we found <curl/curl.h>
-	// at configure time, set CURLOPT_NOSIGNAL so the synchronous-resolver
-	// fallback doesn't raise SIGALRM in this multi-threaded process, and
-	// CURLOPT_CONNECTTIMEOUT_MS so the connect phase (incl. DNS) gives up
-	// after 30 s instead of waiting the full OS resolver timeout (~5 min).
-	// This does NOT close the cleanup-time pthread_join hang on libcurl's
-	// threaded resolver — that's bounded by the OS DNS timeout regardless
-	// — but it bounds the visible delay before the Failed event fires.
-	if (CURL *curl = static_cast<CURL *>(m_request.GetNativeHandle())) {
-		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
-		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 30000L);
-	}
-#endif
 
 	// Storage_File: wx streams the response body to an internal temp file
 	// and hands us the path on completion. We then rename it to the

--- a/src/HTTPDownload.h
+++ b/src/HTTPDownload.h
@@ -35,6 +35,13 @@
 
 class wxWebRequestEvent;
 
+// Create an HTTP request through aMule's shared path: a curl-backed
+// wxWebSession (uniform across platforms), the current proxy pref applied, and
+// egress bound to the configured network interface when one is set. Used by
+// every HTTP channel (this downloader + the version check) so they behave
+// consistently and honour bind-to-interface (amule-org/amule#173).
+wxWebRequest CreateAmuleWebRequest(wxEvtHandler *handler, const wxString &url);
+
 enum HTTPDownloadResult
 {
 	HTTP_Success = 0,

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -247,4 +247,10 @@ private:
 	class CAsioServiceThread *m_threads;
 };
 
+// Set the network interface every socket binds its egress to (empty = system
+// default). Pushed in by the core from thePrefs::GetNetworkInterface() so this
+// socket library stays independent of CPreferences. Takes effect for sockets
+// opened after the call.
+void SetSocketBindInterface(const wxString &iface);
+
 #endif /* __LIBSOCKET_H__ */

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -253,9 +253,20 @@ private:
 // opened after the call.
 void SetSocketBindInterface(const wxString &iface);
 
-// Resolve a bind-interface value (POSIX name, Windows adapter friendly name, or
-// numeric index) to an interface index; 0 if empty or not resolvable. Lets the
-// core validate the preference and warn the user before any socket is opened.
-unsigned int ResolveBindInterfaceIndex(const wxString &iface);
+// Outcome of validating the configured bind interface, so the core can report
+// it once at startup instead of discovering it silently per socket.
+enum BindInterfaceStatus
+{
+	BindIface_Empty,      // no interface configured (default)
+	BindIface_OK,         // resolves and binds
+	BindIface_NotFound,   // name/index does not match any interface
+	BindIface_Denied,     // bind needs a privilege we don't have (Linux CAP_NET_RAW)
+	BindIface_Unsupported // platform can't bind, or another error
+};
+
+// Validate the configured bind interface on a throwaway socket. Lets the core
+// warn the user (not found / permission denied) before any real socket opens,
+// rather than leaving traffic silently unbound.
+BindInterfaceStatus TestSocketBindInterface(const wxString &iface);
 
 #endif /* __LIBSOCKET_H__ */

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -253,4 +253,9 @@ private:
 // opened after the call.
 void SetSocketBindInterface(const wxString &iface);
 
+// Resolve a bind-interface value (POSIX name, Windows adapter friendly name, or
+// numeric index) to an interface index; 0 if empty or not resolvable. Lets the
+// core validate the preference and warn the user before any socket is opened.
+unsigned int ResolveBindInterfaceIndex(const wxString &iface);
+
 #endif /* __LIBSOCKET_H__ */

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -269,4 +269,11 @@ enum BindInterfaceStatus
 // rather than leaving traffic silently unbound.
 BindInterfaceStatus TestSocketBindInterface(const wxString &iface);
 
+// Bind an already-open raw socket to the given interface, reusing the exact
+// same per-platform logic as aMule's own sockets. For non-asio sockets such as
+// libcurl's HTTP socket (via CURLOPT_SOCKOPTFUNCTION). The fd is passed as
+// uintptr_t so a Windows SOCKET survives without truncation. Returns true if
+// bound (or nothing to do), false if the bind failed.
+bool BindRawSocketToInterface(uintptr_t fd, const wxString &iface);
+
 #endif /* __LIBSOCKET_H__ */

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -42,6 +42,7 @@
 #include <algorithm> // Needed for std::min - Boost up to 1.54 fails to compile with MSVC 2013 otherwise
 #include <atomic>
 #include <chrono>
+#include <vector> // GetAdaptersAddresses buffer (Windows interface resolution)
 
 // Trip the compile if we accidentally pull a deprecated Asio API back in.
 #define BOOST_ASIO_NO_DEPRECATED
@@ -76,6 +77,7 @@
 // SIO_KEEPALIVE_VALS + struct tcp_keepalive for SetTcpKeepalive.
 // winsock2.h is already brought in transitively by boost::asio.
 #include <mstcpip.h>
+#include <iphlpapi.h> // GetAdaptersAddresses (friendly-name -> interface index)
 // IP_UNICAST_IF / IPV6_UNICAST_IF are Vista+; define them if the SDK target
 // (see _WIN32_WINNT above) predates their headers. Values are ABI-stable.
 #ifndef IP_UNICAST_IF
@@ -167,6 +169,37 @@ static inline void SetTcpKeepalive(Handle native, int idleSec, int intervalSec, 
 #endif
 }
 
+#ifdef __WINDOWS__
+// Map a Windows adapter FriendlyName (what the prefs dropdown shows, e.g.
+// "Ethernet", "Wi-Fi") to its interface index. if_nametoindex() can't do this
+// on Windows — it expects the adapter's GUID-style name, not the friendly one,
+// so the enumerated dropdown value is resolved here instead. Returns 0 if not
+// found (the caller then tries a bare numeric index).
+static unsigned int ResolveWindowsInterfaceIndex(const wxString &friendlyName)
+{
+	ULONG size = 15000;
+	std::vector<uint8_t> buf(size);
+	const ULONG flags = GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
+			    GAA_FLAG_SKIP_DNS_SERVER;
+	PIP_ADAPTER_ADDRESSES aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
+	ULONG ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, NULL, aa, &size);
+	if (ret == ERROR_BUFFER_OVERFLOW) {
+		buf.resize(size);
+		aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
+		ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, NULL, aa, &size);
+	}
+	if (ret != NO_ERROR) {
+		return 0;
+	}
+	for (PIP_ADAPTER_ADDRESSES p = aa; p != NULL; p = p->Next) {
+		if (p->FriendlyName != NULL && friendlyName == wxString(p->FriendlyName)) {
+			return p->IfIndex ? p->IfIndex : p->Ipv6IfIndex;
+		}
+	}
+	return 0;
+}
+#endif // __WINDOWS__
+
 // Pin a socket's egress to a named network interface, *without* requiring
 // elevated privileges. SO_BINDTODEVICE would do this on Linux but needs
 // CAP_NET_RAW (root); the options below do not:
@@ -176,12 +209,12 @@ static inline void SetTcpKeepalive(Handle native, int idleSec, int intervalSec, 
 //
 // Unlike binding to a local IP (SetLocal), this pins the *route*, so traffic
 // can't leak out via the default-route interface — the VPN-leak case behind
-// amule-org/amule#173. The interface is named (e.g. "tun0", "eth0", "en0")
-// and resolved to an index via if_nametoindex(); a bare numeric index is also
-// accepted, which is the practical input on Windows where interfaces aren't
-// named the POSIX way. No-op (with a debug log) when the name is empty,
-// unresolvable, or the platform lacks the option. aMule sockets are IPv4, so
-// callers pass isV6 == false; the v6 branch is kept for completeness.
+// amule-org/amule#173. The interface value is what the prefs dropdown stores:
+// a POSIX name ("tun0", "eth0", "en0") resolved via if_nametoindex(), a Windows
+// adapter FriendlyName resolved via GetAdaptersAddresses(), or a bare numeric
+// index. No-op (with a debug log) when the value is empty, unresolvable, or the
+// platform lacks the option. aMule sockets are IPv4, so callers pass
+// isV6 == false; the v6 branch is kept for completeness.
 template <typename Handle> static void SetBoundInterface(Handle native, const wxString &ifname, bool isV6)
 {
 	if (ifname.IsEmpty()) {
@@ -189,11 +222,13 @@ template <typename Handle> static void SetBoundInterface(Handle native, const wx
 	}
 
 	unsigned int idx = 0;
-#ifndef __WINDOWS__
+#ifdef __WINDOWS__
+	idx = ResolveWindowsInterfaceIndex(ifname);
+#else
 	idx = if_nametoindex(static_cast<const char *>(ifname.utf8_str()));
 #endif
 	if (idx == 0) {
-		// Fall back to a bare interface index (the usual input on Windows).
+		// Fall back to a bare interface index (also the manual Windows path).
 		unsigned long n = 0;
 		if (ifname.ToULong(&n) && n > 0 && n <= 0xFFFFFFFFul) {
 			idx = static_cast<unsigned int>(n);

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -69,16 +69,28 @@
 #include "MuleUDPSocket.h"
 #include "OtherFunctions.h" // DeleteContents
 #include "ScopedPtr.h"
+#include "Preferences.h" // thePrefs::GetNetworkInterface() for bind-to-interface
 #include <common/Macros.h>
 
 #ifdef __WINDOWS__
 // SIO_KEEPALIVE_VALS + struct tcp_keepalive for SetTcpKeepalive.
 // winsock2.h is already brought in transitively by boost::asio.
 #include <mstcpip.h>
+// IP_UNICAST_IF / IPV6_UNICAST_IF are Vista+; define them if the SDK target
+// (see _WIN32_WINNT above) predates their headers. Values are ABI-stable.
+#ifndef IP_UNICAST_IF
+#define IP_UNICAST_IF 31
+#endif
+#ifndef IPV6_UNICAST_IF
+#define IPV6_UNICAST_IF 31
+#endif
 #else
 #include <fcntl.h>       // FD_CLOEXEC
 #include <netinet/tcp.h> // TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT
 #include <sys/socket.h>  // SO_KEEPALIVE
+#include <netinet/in.h>  // IP_UNICAST_IF / IP_BOUND_IF / IPPROTO_*
+#include <net/if.h>      // if_nametoindex
+#include <arpa/inet.h>   // htonl
 #endif
 
 using namespace boost::asio;
@@ -153,6 +165,81 @@ static inline void SetTcpKeepalive(Handle native, int idleSec, int intervalSec, 
 	(void)count;
 #endif
 #endif
+}
+
+// Pin a socket's egress to a named network interface, *without* requiring
+// elevated privileges. SO_BINDTODEVICE would do this on Linux but needs
+// CAP_NET_RAW (root); the options below do not:
+//
+//   Linux / Windows : IP_UNICAST_IF  / IPV6_UNICAST_IF
+//   macOS / *BSD    : IP_BOUND_IF    / IPV6_BOUND_IF
+//
+// Unlike binding to a local IP (SetLocal), this pins the *route*, so traffic
+// can't leak out via the default-route interface — the VPN-leak case behind
+// amule-org/amule#173. The interface is named (e.g. "tun0", "eth0", "en0")
+// and resolved to an index via if_nametoindex(); a bare numeric index is also
+// accepted, which is the practical input on Windows where interfaces aren't
+// named the POSIX way. No-op (with a debug log) when the name is empty,
+// unresolvable, or the platform lacks the option. aMule sockets are IPv4, so
+// callers pass isV6 == false; the v6 branch is kept for completeness.
+template <typename Handle> static void SetBoundInterface(Handle native, const wxString &ifname, bool isV6)
+{
+	if (ifname.IsEmpty()) {
+		return;
+	}
+
+	unsigned int idx = 0;
+#ifndef __WINDOWS__
+	idx = if_nametoindex(static_cast<const char *>(ifname.utf8_str()));
+#endif
+	if (idx == 0) {
+		// Fall back to a bare interface index (the usual input on Windows).
+		unsigned long n = 0;
+		if (ifname.ToULong(&n) && n > 0 && n <= 0xFFFFFFFFul) {
+			idx = static_cast<unsigned int>(n);
+		}
+	}
+	if (idx == 0) {
+		AddDebugLogLineC(logAsio, CFormat("Bind-to-interface: no interface named '%s'") % ifname);
+		return;
+	}
+
+	int err = 0;
+#ifdef __WINDOWS__
+	if (!isV6) {
+		DWORD v = htonl(idx); // IPv4 IP_UNICAST_IF wants the index in network byte order
+		err = ::setsockopt(
+			native, IPPROTO_IP, IP_UNICAST_IF, reinterpret_cast<const char *>(&v), sizeof(v));
+	} else {
+		DWORD v = idx; // IPv6 wants host byte order
+		err = ::setsockopt(
+			native, IPPROTO_IPV6, IPV6_UNICAST_IF, reinterpret_cast<const char *>(&v), sizeof(v));
+	}
+#elif defined(IP_BOUND_IF)   // macOS / *BSD — index in host byte order
+	int v = static_cast<int>(idx);
+	err = ::setsockopt(
+		native, isV6 ? IPPROTO_IPV6 : IPPROTO_IP, isV6 ? IPV6_BOUND_IF : IP_BOUND_IF, &v, sizeof(v));
+#elif defined(IP_UNICAST_IF) // Linux
+	if (!isV6) {
+		uint32_t v = htonl(idx); // IPv4 IP_UNICAST_IF wants network byte order
+		err = ::setsockopt(native, IPPROTO_IP, IP_UNICAST_IF, &v, sizeof(v));
+	} else {
+		uint32_t v = idx; // IPv6 wants host byte order
+		err = ::setsockopt(native, IPPROTO_IPV6, IPV6_UNICAST_IF, &v, sizeof(v));
+	}
+#else
+	(void)native;
+	(void)isV6;
+	AddDebugLogLineC(logAsio, wxT("Bind-to-interface not supported on this platform"));
+	return;
+#endif
+	if (err != 0) {
+		AddDebugLogLineC(logAsio,
+			CFormat("Bind-to-interface: failed to pin socket to '%s' (index %u)") % ifname % idx);
+	} else {
+		AddDebugLogLineF(logAsio,
+			CFormat("Bind-to-interface: pinned socket to '%s' (index %u)") % ifname % idx);
+	}
 }
 
 // Number of threads in the Asio thread pool
@@ -259,6 +346,21 @@ public:
 		m_OK = false;
 		m_sync = !m_notify; // set this once for the whole lifetime of the socket
 		AddDebugLogLineF(logAsio, CFormat("Connect %s %p") % m_IP % this);
+
+		// Pin outbound traffic to the configured network interface (VPN-leak
+		// fix, #173). This must apply even when no local IP is bound (no
+		// SetLocal call), so open the socket here to set the option before
+		// connect; asio's connect happily reuses an already-open socket.
+		if (!thePrefs::GetNetworkInterface().IsEmpty()) {
+			error_code openEc;
+			if (!m_socket->is_open()) {
+				m_socket->open(ip::tcp::v4(), openEc);
+			}
+			if (!openEc) {
+				SetBoundInterface(
+					m_socket->native_handle(), thePrefs::GetNetworkInterface(), false);
+			}
+		}
 
 		if (wait || m_sync) {
 			error_code ec;
@@ -988,6 +1090,7 @@ public:
 		try {
 			open(m_address.GetEndpoint().protocol());
 			SetCloexecOnSocket(native_handle());
+			SetBoundInterface(native_handle(), thePrefs::GetNetworkInterface(), false);
 			set_option(ip::tcp::acceptor::reuse_address(true));
 			bind(m_address.GetEndpoint());
 			listen();
@@ -1441,6 +1544,9 @@ private:
 			// until the user restarts amule — see #103.
 			m_socket->set_option(socket_base::reuse_address(true));
 			SetCloexecOnSocket(m_socket->native_handle());
+			// Pin this UDP socket (ed2k client/server + Kad all funnel
+			// through here) to the configured interface (#173).
+			SetBoundInterface(m_socket->native_handle(), thePrefs::GetNetworkInterface(), false);
 			m_socket->bind(endpoint);
 			AddDebugLogLineN(logAsio,
 				CFormat("Created UDP socket %s %d") % m_address.IPAddress() %

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -70,7 +70,6 @@
 #include "MuleUDPSocket.h"
 #include "OtherFunctions.h" // DeleteContents
 #include "ScopedPtr.h"
-#include "Preferences.h" // thePrefs::GetNetworkInterface() for bind-to-interface
 #include <common/Macros.h>
 
 #ifdef __WINDOWS__
@@ -98,6 +97,17 @@
 using namespace boost::asio;
 using namespace boost::system; // for error_code
 static io_context s_io_service;
+
+// The network interface to bind every socket to (empty = system default).
+// Pushed in by the core via SetSocketBindInterface() rather than read from
+// thePrefs directly: mulesocket must not depend on CPreferences, since EC-only
+// tools (amulecmd, amuleweb) link this library but not the full preferences.
+static wxString s_bindToInterface;
+
+void SetSocketBindInterface(const wxString &iface)
+{
+	s_bindToInterface = iface;
+}
 
 //
 // Mark a freshly-created socket close-on-exec so subprocesses launched
@@ -386,14 +396,13 @@ public:
 		// fix, #173). This must apply even when no local IP is bound (no
 		// SetLocal call), so open the socket here to set the option before
 		// connect; asio's connect happily reuses an already-open socket.
-		if (!thePrefs::GetNetworkInterface().IsEmpty()) {
+		if (!s_bindToInterface.IsEmpty()) {
 			error_code openEc;
 			if (!m_socket->is_open()) {
 				m_socket->open(ip::tcp::v4(), openEc);
 			}
 			if (!openEc) {
-				SetBoundInterface(
-					m_socket->native_handle(), thePrefs::GetNetworkInterface(), false);
+				SetBoundInterface(m_socket->native_handle(), s_bindToInterface, false);
 			}
 		}
 
@@ -1125,7 +1134,7 @@ public:
 		try {
 			open(m_address.GetEndpoint().protocol());
 			SetCloexecOnSocket(native_handle());
-			SetBoundInterface(native_handle(), thePrefs::GetNetworkInterface(), false);
+			SetBoundInterface(native_handle(), s_bindToInterface, false);
 			set_option(ip::tcp::acceptor::reuse_address(true));
 			bind(m_address.GetEndpoint());
 			listen();
@@ -1581,7 +1590,7 @@ private:
 			SetCloexecOnSocket(m_socket->native_handle());
 			// Pin this UDP socket (ed2k client/server + Kad all funnel
 			// through here) to the configured interface (#173).
-			SetBoundInterface(m_socket->native_handle(), thePrefs::GetNetworkInterface(), false);
+			SetBoundInterface(m_socket->native_handle(), s_bindToInterface, false);
 			m_socket->bind(endpoint);
 			AddDebugLogLineN(logAsio,
 				CFormat("Created UDP socket %s %d") % m_address.IPAddress() %

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -88,10 +88,13 @@
 #else
 #include <fcntl.h>       // FD_CLOEXEC
 #include <netinet/tcp.h> // TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT
-#include <sys/socket.h>  // SO_KEEPALIVE
-#include <netinet/in.h>  // IP_UNICAST_IF / IP_BOUND_IF / IPPROTO_*
-#include <net/if.h>      // if_nametoindex
+#include <sys/socket.h>  // SO_KEEPALIVE / SO_BINDTODEVICE
+#include <netinet/in.h>  // IP_BOUND_IF / IPPROTO_*
+#include <net/if.h>      // if_nametoindex / if_indextoname / IF_NAMESIZE
 #include <arpa/inet.h>   // htonl
+#include <unistd.h>      // close() for the startup bind probe
+#include <cstring>       // strlen() for SO_BINDTODEVICE
+#include <cerrno>        // errno / EPERM
 #endif
 
 using namespace boost::asio;
@@ -210,12 +213,16 @@ static unsigned int ResolveWindowsInterfaceIndex(const wxString &friendlyName)
 }
 #endif // __WINDOWS__
 
+#ifdef __WINDOWS__
+typedef SOCKET NativeSocketHandle;
+#else
+typedef int NativeSocketHandle;
+#endif
+
 // Resolve a bind-interface value to an interface index (0 if empty or not
 // resolvable): a POSIX name via if_nametoindex(), a Windows adapter
-// FriendlyName via GetAdaptersAddresses(), or a bare numeric index. Exported so
-// the core can validate the preference once at startup and warn the user before
-// any socket is opened, rather than failing silently per socket.
-unsigned int ResolveBindInterfaceIndex(const wxString &ifname)
+// FriendlyName via GetAdaptersAddresses(), or a bare numeric index.
+static unsigned int ResolveBindInterfaceIndex(const wxString &ifname)
 {
 	if (ifname.IsEmpty()) {
 		return 0;
@@ -236,72 +243,144 @@ unsigned int ResolveBindInterfaceIndex(const wxString &ifname)
 	return idx;
 }
 
-// Pin a socket's egress to a named network interface, *without* requiring
-// elevated privileges. SO_BINDTODEVICE would do this on Linux but needs
-// CAP_NET_RAW (root); the options below do not:
+// Bind a raw socket's egress to a network interface. Unlike binding to a local
+// IP (SetLocal), this pins the *route*, so traffic can't leak out via the
+// default-route interface — the VPN-leak case behind amule-org/amule#173.
 //
-//   Linux / Windows : IP_UNICAST_IF  / IPV6_UNICAST_IF
-//   macOS / *BSD    : IP_BOUND_IF    / IPV6_BOUND_IF
+// Each platform needs the option that is a real egress *constraint*:
+//   Linux         : SO_BINDTODEVICE. IP_UNICAST_IF is only a routing preference
+//                   here (verified: it silently falls back to the default
+//                   route), so it can't prevent leaks. SO_BINDTODEVICE may
+//                   require CAP_NET_RAW on some kernels — the caller surfaces
+//                   that instead of pretending traffic is contained.
+//   macOS / Darwin: IP_BOUND_IF / IPV6_BOUND_IF (Darwin's SO_BINDTODEVICE
+//                   equivalent; a true constraint, no privileges needed).
+//   Windows       : IP_UNICAST_IF / IPV6_UNICAST_IF (a real constraint on
+//                   Windows, unlike Linux).
 //
-// Unlike binding to a local IP (SetLocal), this pins the *route*, so traffic
-// can't leak out via the default-route interface — the VPN-leak case behind
-// amule-org/amule#173. The interface value is what the prefs dropdown stores:
-// a POSIX name ("tun0", "eth0", "en0") resolved via if_nametoindex(), a Windows
-// adapter FriendlyName resolved via GetAdaptersAddresses(), or a bare numeric
-// index. No-op (with a debug log) when the value is empty, unresolvable, or the
-// platform lacks the option. aMule sockets are IPv4, so callers pass
-// isV6 == false; the v6 branch is kept for completeness.
+// Returns 0 on success or an errno-style code on failure; sets *notFound when
+// the interface can't be resolved (distinct from a permission error). aMule
+// sockets are IPv4, so callers pass isV6 == false; the v6 path is kept for
+// completeness.
+static int ApplyBindToInterface(NativeSocketHandle native, const wxString &ifname, bool isV6, bool *notFound)
+{
+	*notFound = false;
+	unsigned int idx = ResolveBindInterfaceIndex(ifname);
+	if (idx == 0) {
+		*notFound = true;
+		return -1;
+	}
+#ifdef __WINDOWS__
+	if (!isV6) {
+		DWORD v = htonl(idx); // IPv4 IP_UNICAST_IF wants the index in network byte order
+		if (::setsockopt(native,
+			    IPPROTO_IP,
+			    IP_UNICAST_IF,
+			    reinterpret_cast<const char *>(&v),
+			    sizeof(v)) != 0) {
+			return ::WSAGetLastError();
+		}
+	} else {
+		DWORD v = idx; // IPv6 wants host byte order
+		if (::setsockopt(native,
+			    IPPROTO_IPV6,
+			    IPV6_UNICAST_IF,
+			    reinterpret_cast<const char *>(&v),
+			    sizeof(v)) != 0) {
+			return ::WSAGetLastError();
+		}
+	}
+	return 0;
+#elif defined(__linux__)
+	// SO_BINDTODEVICE takes the interface *name*; derive the canonical name
+	// from the resolved index (also normalises a numeric-index entry).
+	(void)isV6; // family-agnostic
+	char devName[IF_NAMESIZE] = { 0 };
+	if (if_indextoname(idx, devName) == NULL) {
+		*notFound = true;
+		return -1;
+	}
+	if (::setsockopt(native, SOL_SOCKET, SO_BINDTODEVICE, devName, strlen(devName)) != 0) {
+		return errno;
+	}
+	return 0;
+#elif defined(IP_BOUND_IF) // macOS / Darwin — index in host byte order
+	int v = static_cast<int>(idx);
+	if (::setsockopt(native,
+		    isV6 ? IPPROTO_IPV6 : IPPROTO_IP,
+		    isV6 ? IPV6_BOUND_IF : IP_BOUND_IF,
+		    &v,
+		    sizeof(v)) != 0) {
+		return errno;
+	}
+	return 0;
+#else
+	(void)native;
+	(void)isV6;
+	return ENOTSUP;
+#endif
+}
+
+// Per-socket egress bind (reads the interface pushed in by the core). Kept on
+// the debug channel to avoid spamming the normal log on every connect — the
+// core reports the overall outcome once at startup via TestSocketBindInterface.
 template <typename Handle> static void SetBoundInterface(Handle native, const wxString &ifname, bool isV6)
 {
 	if (ifname.IsEmpty()) {
 		return;
 	}
-
-	unsigned int idx = ResolveBindInterfaceIndex(ifname);
-	if (idx == 0) {
-		// Unresolvable — the core already warned the user loudly at startup
-		// (see SetSocketBindInterface caller); keep the per-socket note on the
-		// debug channel to avoid spamming the normal log on every connect.
-		AddDebugLogLineC(logAsio, CFormat("Bind-to-interface: no interface named '%s'") % ifname);
-		return;
+	bool notFound = false;
+	int err = ApplyBindToInterface(static_cast<NativeSocketHandle>(native), ifname, isV6, &notFound);
+	if (err == 0) {
+		AddDebugLogLineF(logAsio, CFormat("Bind-to-interface: bound socket to '%s'") % ifname);
+	} else {
+		AddDebugLogLineC(logAsio,
+			CFormat("Bind-to-interface: could not bind socket to '%s' (%s)") % ifname %
+				(notFound ? "no such interface" : "error"));
 	}
+}
 
-	int err = 0;
+// Validate the configured interface once, on a throwaway socket, so the core
+// can report the real outcome at startup (found / not-found / permission
+// denied) rather than discovering it silently per socket.
+BindInterfaceStatus TestSocketBindInterface(const wxString &ifname)
+{
+	if (ifname.IsEmpty()) {
+		return BindIface_Empty;
+	}
+	if (ResolveBindInterfaceIndex(ifname) == 0) {
+		return BindIface_NotFound;
+	}
 #ifdef __WINDOWS__
-	if (!isV6) {
-		DWORD v = htonl(idx); // IPv4 IP_UNICAST_IF wants the index in network byte order
-		err = ::setsockopt(
-			native, IPPROTO_IP, IP_UNICAST_IF, reinterpret_cast<const char *>(&v), sizeof(v));
-	} else {
-		DWORD v = idx; // IPv6 wants host byte order
-		err = ::setsockopt(
-			native, IPPROTO_IPV6, IPV6_UNICAST_IF, reinterpret_cast<const char *>(&v), sizeof(v));
-	}
-#elif defined(IP_BOUND_IF)   // macOS / *BSD — index in host byte order
-	int v = static_cast<int>(idx);
-	err = ::setsockopt(
-		native, isV6 ? IPPROTO_IPV6 : IPPROTO_IP, isV6 ? IPV6_BOUND_IF : IP_BOUND_IF, &v, sizeof(v));
-#elif defined(IP_UNICAST_IF) // Linux
-	if (!isV6) {
-		uint32_t v = htonl(idx); // IPv4 IP_UNICAST_IF wants network byte order
-		err = ::setsockopt(native, IPPROTO_IP, IP_UNICAST_IF, &v, sizeof(v));
-	} else {
-		uint32_t v = idx; // IPv6 wants host byte order
-		err = ::setsockopt(native, IPPROTO_IPV6, IPV6_UNICAST_IF, &v, sizeof(v));
+	SOCKET fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd == INVALID_SOCKET) {
+		return BindIface_OK; // resolved; can't probe, assume ok
 	}
 #else
-	(void)native;
-	(void)isV6;
-	AddDebugLogLineC(logAsio, wxT("Bind-to-interface not supported on this platform"));
-	return;
-#endif
-	if (err != 0) {
-		AddDebugLogLineC(logAsio,
-			CFormat("Bind-to-interface: failed to pin socket to '%s' (index %u)") % ifname % idx);
-	} else {
-		AddDebugLogLineF(logAsio,
-			CFormat("Bind-to-interface: pinned socket to '%s' (index %u)") % ifname % idx);
+	int fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd < 0) {
+		return BindIface_OK;
 	}
+#endif
+	bool notFound = false;
+	int err = ApplyBindToInterface(fd, ifname, false, &notFound);
+#ifdef __WINDOWS__
+	::closesocket(fd);
+#else
+	::close(fd);
+#endif
+	if (err == 0) {
+		return BindIface_OK;
+	}
+	if (notFound) {
+		return BindIface_NotFound;
+	}
+#ifndef __WINDOWS__
+	if (err == EPERM || err == EACCES) {
+		return BindIface_Denied;
+	}
+#endif
+	return BindIface_Unsupported;
 }
 
 // Number of threads in the Asio thread pool

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -340,6 +340,17 @@ template <typename Handle> static void SetBoundInterface(Handle native, const wx
 	}
 }
 
+// Bind an already-open raw socket (e.g. libcurl's HTTP socket) to the
+// configured interface, reusing the exact same logic as aMule's own sockets.
+bool BindRawSocketToInterface(uintptr_t fd, const wxString &iface)
+{
+	if (iface.IsEmpty()) {
+		return true;
+	}
+	bool notFound = false;
+	return ApplyBindToInterface(static_cast<NativeSocketHandle>(fd), iface, false, &notFound) == 0;
+}
+
 // Validate the configured interface once, on a throwaway socket, so the core
 // can report the real outcome at startup (found / not-found / permission
 // denied) rather than discovering it silently per socket.

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -210,6 +210,32 @@ static unsigned int ResolveWindowsInterfaceIndex(const wxString &friendlyName)
 }
 #endif // __WINDOWS__
 
+// Resolve a bind-interface value to an interface index (0 if empty or not
+// resolvable): a POSIX name via if_nametoindex(), a Windows adapter
+// FriendlyName via GetAdaptersAddresses(), or a bare numeric index. Exported so
+// the core can validate the preference once at startup and warn the user before
+// any socket is opened, rather than failing silently per socket.
+unsigned int ResolveBindInterfaceIndex(const wxString &ifname)
+{
+	if (ifname.IsEmpty()) {
+		return 0;
+	}
+	unsigned int idx = 0;
+#ifdef __WINDOWS__
+	idx = ResolveWindowsInterfaceIndex(ifname);
+#else
+	idx = if_nametoindex(static_cast<const char *>(ifname.utf8_str()));
+#endif
+	if (idx == 0) {
+		// Fall back to a bare interface index (also the manual Windows path).
+		unsigned long n = 0;
+		if (ifname.ToULong(&n) && n > 0 && n <= 0xFFFFFFFFul) {
+			idx = static_cast<unsigned int>(n);
+		}
+	}
+	return idx;
+}
+
 // Pin a socket's egress to a named network interface, *without* requiring
 // elevated privileges. SO_BINDTODEVICE would do this on Linux but needs
 // CAP_NET_RAW (root); the options below do not:
@@ -231,20 +257,11 @@ template <typename Handle> static void SetBoundInterface(Handle native, const wx
 		return;
 	}
 
-	unsigned int idx = 0;
-#ifdef __WINDOWS__
-	idx = ResolveWindowsInterfaceIndex(ifname);
-#else
-	idx = if_nametoindex(static_cast<const char *>(ifname.utf8_str()));
-#endif
+	unsigned int idx = ResolveBindInterfaceIndex(ifname);
 	if (idx == 0) {
-		// Fall back to a bare interface index (also the manual Windows path).
-		unsigned long n = 0;
-		if (ifname.ToULong(&n) && n > 0 && n <= 0xFFFFFFFFul) {
-			idx = static_cast<unsigned int>(n);
-		}
-	}
-	if (idx == 0) {
+		// Unresolvable — the core already warned the user loudly at startup
+		// (see SetSocketBindInterface caller); keep the per-socket note on the
+		// debug channel to avoid spamming the normal log on every connect.
 		AddDebugLogLineC(logAsio, CFormat("Bind-to-interface: no interface named '%s'") % ifname);
 		return;
 	}

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -93,6 +93,7 @@ uint32 CPreferences::s_maxupload;
 uint32 CPreferences::s_maxdownload;
 uint32 CPreferences::s_slotallocation;
 wxString CPreferences::s_Addr;
+wxString CPreferences::s_NetworkInterface;
 uint16 CPreferences::s_port;
 uint16 CPreferences::s_udpport;
 bool CPreferences::s_UDPEnable;
@@ -1134,6 +1135,7 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	NewCfgItem(IDC_UDPPORT, (MkCfg_Int("/eMule/UDPPort", s_udpport, DEFAULT_UDP_PORT)));
 	NewCfgItem(IDC_UDPENABLE, (new Cfg_Bool("/eMule/UDPEnable", s_UDPEnable, true)));
 	NewCfgItem(IDC_ADDRESS, (new Cfg_Str("/eMule/Address", s_Addr, "")));
+	NewCfgItem(IDC_INTERFACE, (new Cfg_Str("/eMule/NetworkInterface", s_NetworkInterface, "")));
 	NewCfgItem(IDC_AUTOCONNECT, (new Cfg_Bool("/eMule/Autoconnect", s_autoconnect, true)));
 	NewCfgItem(IDC_MAXSOURCEPERFILE, (MkCfg_Int("/eMule/MaxSourcesPerFile", s_maxsourceperfile, 300)));
 	NewCfgItem(IDC_MAXCON,

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -245,6 +245,7 @@ public:
 	static Cfg_Lang_Base *GetCfgLang() { return s_cfgLang; }
 
 	static const wxString &GetAddress() { return s_Addr; }
+	static const wxString &GetNetworkInterface() { return s_NetworkInterface; }
 	static uint16 GetPort() { return s_port; }
 	static void SetPort(uint16 val);
 	static uint16 GetUDPPort() { return s_udpport; }
@@ -766,6 +767,7 @@ protected:
 	static uint32 s_maxdownload;
 	static uint32 s_slotallocation;
 	static wxString s_Addr;
+	static wxString s_NetworkInterface;
 	static uint16 s_port;
 	static uint16 s_udpport;
 	static bool s_UDPEnable;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -29,10 +29,23 @@
 #include <common/Macros.h> // Needed for itemsof()
 
 #include <wx/colordlg.h>
+#include <wx/combobox.h> // network-interface drop-down (bind-to-interface)
 #include <wx/progdlg.h>
 #include <wx/stdpaths.h>
 #include <wx/tooltip.h>
 #include <wx/utils.h> // wxGetUserHome
+
+// Network-interface enumeration for the "Bind to interface" drop-down.
+#ifdef __WINDOWS__
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <iphlpapi.h>
+#include <vector>
+#else
+#include <sys/types.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#endif
 
 #include "amule.h" // Needed for theApp
 #include "amuleDlg.h"
@@ -61,6 +74,60 @@
 #include "Statistics.h"
 #include "UserEvents.h"
 #include "PlatformSpecific.h" // Needed for PLATFORMSPECIFIC_CAN_PREVENT_SLEEP_MODE
+
+namespace
+{
+// Enumerate this machine's usable network interfaces for the "Bind to
+// interface" drop-down. The strings returned are exactly what gets stored in
+// the preference and later resolved to an index in LibSocketAsio.cpp: POSIX
+// interface names (en0, eth0, tun0) and, on Windows, adapter friendly names
+// (Ethernet, Wi-Fi). Loopback is skipped. The control stays editable, so an
+// interface that is down right now (a VPN tunnel) can still be typed in.
+wxArrayString DetectNetworkInterfaces()
+{
+	wxArrayString result;
+#ifdef __WINDOWS__
+	ULONG size = 15000;
+	std::vector<uint8_t> buf(size);
+	const ULONG flags = GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
+			    GAA_FLAG_SKIP_DNS_SERVER;
+	PIP_ADAPTER_ADDRESSES aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
+	ULONG ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, NULL, aa, &size);
+	if (ret == ERROR_BUFFER_OVERFLOW) {
+		buf.resize(size);
+		aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
+		ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, NULL, aa, &size);
+	}
+	if (ret == NO_ERROR) {
+		for (PIP_ADAPTER_ADDRESSES p = aa; p != NULL; p = p->Next) {
+			if (p->IfType == IF_TYPE_SOFTWARE_LOOPBACK || p->FriendlyName == NULL) {
+				continue;
+			}
+			wxString name(p->FriendlyName);
+			if (result.Index(name) == wxNOT_FOUND) {
+				result.Add(name);
+			}
+		}
+	}
+#else
+	struct ifaddrs *ifaces = NULL;
+	if (getifaddrs(&ifaces) == 0) {
+		for (struct ifaddrs *p = ifaces; p != NULL; p = p->ifa_next) {
+			if (p->ifa_name == NULL || (p->ifa_flags & IFF_LOOPBACK)) {
+				continue;
+			}
+			// getifaddrs lists one node per address family, so names repeat.
+			wxString name = wxString::FromUTF8(p->ifa_name);
+			if (result.Index(name) == wxNOT_FOUND) {
+				result.Add(name);
+			}
+		}
+		freeifaddrs(ifaces);
+	}
+#endif
+	return result;
+}
+} // namespace
 
 wxBEGIN_EVENT_TABLE(PrefsUnifiedDlg, wxDialog)
 // Events
@@ -463,6 +530,13 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	m_ShareSelector = CastChild(IDC_SHARESELECTOR, CDirectoryTreeCtrl);
 	m_buttonColor = CastChild(IDC_COLOR_BUTTON, wxButton);
 	m_choiceColor = CastChild(IDC_COLORSELECTOR, wxChoice);
+
+	// Fill the "Bind to interface" drop-down with the detected interfaces.
+	// Done before the Cfg->widget transfer below so the stored value (which
+	// may be an interface that is currently down) is preserved as typed text.
+	if (wxComboBox *ifaceBox = CastChild(IDC_INTERFACE, wxComboBox)) {
+		ifaceBox->Append(DetectNetworkInterfaces());
+	}
 
 	// Connect the Cfgs with their widgets
 	thePrefs::CFGMap::iterator it = thePrefs::s_CfgList.begin();

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -909,6 +909,11 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 		restart_needed_msg += _("- UDP port changed.\n");
 	}
 
+	if (CfgChanged(IDC_INTERFACE)) {
+		restart_needed = true;
+		restart_needed_msg += _("- Network interface binding changed.\n");
+	}
+
 	if (CfgChanged(IDC_EXT_CONN_TCP_PORT)) {
 		restart_needed = true;
 		restart_needed_msg += _("- External connect port changed.\n");

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -643,6 +643,8 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	const int amuledOnlyPrefs[] = {
 		IDC_ADDRESS,
 		IDC_ADDRESSTEXT,
+		IDC_INTERFACE,
+		IDC_INTERFACETEXT,
 		IDC_UPNP_ENABLED,
 		IDC_UPNPTCPPORT,
 		IDC_UPNPTCPPORTTEXT,

--- a/src/VersionCheck.cpp
+++ b/src/VersionCheck.cpp
@@ -31,6 +31,7 @@
 #include <common/ClientVersion.h> // VERSION_MJR / VERSION_MIN / VERSION_UPDATE
 #include "OtherFunctions.h"       // make_full_ed2k_version
 #include "Logger.h"               // AddDebugLogLineN / logGeneral
+#include "HTTPDownload.h"         // CreateAmuleWebRequest (shared curl session + interface bind)
 
 #include <wx/regex.h>
 #include <wx/tokenzr.h>
@@ -66,7 +67,10 @@ void CVersionCheck::Start(wxEvtHandler *notify, int notifyId)
 	m_status = Checking;
 	m_latest.Clear();
 
-	m_request = wxWebSession::GetDefault().CreateRequest(this, VERSION_CHECK_URL);
+	// Shared aMule HTTP path: curl-backed session, proxy, and egress bound to
+	// the configured network interface when one is set (so the check doesn't
+	// leak past a bound interface).
+	m_request = CreateAmuleWebRequest(this, VERSION_CHECK_URL);
 	if (!m_request.IsOk()) {
 		Finish(Failed);
 		return;

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -569,7 +569,16 @@ bool CamuleApp::OnInit()
 	case BindIface_Empty:
 		break; // no interface configured — nothing to report
 	case BindIface_OK:
+#ifdef __WINDOWS__
+		// On Windows only the ed2k/Kad sockets are bound; aMule's HTTP
+		// (version check, IP2Country, server.met) uses the WinHTTP backend,
+		// which has no interface-bind API — so say so rather than overclaim.
+		AddLogLineN(CFormat(_("Binding aMule's peer-to-peer traffic to interface: %s "
+				      "(HTTP updates use the default route)")) %
+			    bindInterface);
+#else
 		AddLogLineN(CFormat(_("Binding all network traffic to interface: %s")) % bindInterface);
+#endif
 		break;
 	case BindIface_NotFound:
 		AddLogLineC(CFormat(_("WARNING: configured network interface '%s' was not found - "

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -560,21 +560,36 @@ bool CamuleApp::OnInit()
 	// Push the bind-to-interface preference into the socket library before any
 	// socket is opened (mulesocket can't read CPreferences itself). It's a
 	// security-relevant choice (VPN-leak prevention), so make the outcome
-	// visible: confirm the bind when the interface resolves, and warn loudly
-	// when it does not — otherwise a typo would silently leave traffic on the
-	// default route while the user believes it is contained.
+	// visible: confirm the bind when it applies, and warn loudly when it does
+	// not (bad name, or missing privilege on Linux) — otherwise traffic would
+	// silently stay on the default route while the user believes it is contained.
 	const wxString &bindInterface = thePrefs::GetNetworkInterface();
 	SetSocketBindInterface(bindInterface);
-	if (!bindInterface.IsEmpty()) {
-		if (ResolveBindInterfaceIndex(bindInterface) != 0) {
-			AddLogLineN(
-				CFormat(_("Binding all network traffic to interface: %s")) % bindInterface);
-		} else {
-			AddLogLineC(CFormat(_("WARNING: configured network interface '%s' was not found - "
-					      "traffic is NOT bound to it and may leave via the default "
-					      "route. Check the interface name in Preferences.")) %
-				    bindInterface);
-		}
+	switch (TestSocketBindInterface(bindInterface)) {
+	case BindIface_Empty:
+		break; // no interface configured — nothing to report
+	case BindIface_OK:
+		AddLogLineN(CFormat(_("Binding all network traffic to interface: %s")) % bindInterface);
+		break;
+	case BindIface_NotFound:
+		AddLogLineC(CFormat(_("WARNING: configured network interface '%s' was not found - "
+				      "traffic is NOT bound to it and may leave via the default "
+				      "route. Check the interface name in Preferences.")) %
+			    bindInterface);
+		break;
+	case BindIface_Denied:
+		AddLogLineC(CFormat(_("WARNING: binding to network interface '%s' requires elevated "
+				      "privileges and was NOT applied - traffic may leave via the "
+				      "default route. Grant the capability (e.g. 'sudo setcap "
+				      "cap_net_raw+ep' on the aMule binary) or run with sufficient "
+				      "privileges.")) %
+			    bindInterface);
+		break;
+	default:
+		AddLogLineC(CFormat(_("WARNING: could not bind to network interface '%s' - traffic "
+				      "may leave via the default route.")) %
+			    bindInterface);
+		break;
 	}
 
 	// The temp / incoming directories are validated and created further

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -558,8 +558,14 @@ bool CamuleApp::OnInit()
 	glob_prefs = new CPreferences();
 
 	// Push the bind-to-interface preference into the socket library before any
-	// socket is opened (mulesocket can't read CPreferences itself).
+	// socket is opened (mulesocket can't read CPreferences itself). Log it at
+	// normal level when set: it's a security-relevant choice (VPN-leak
+	// prevention) the user should see confirmed, like the listen sockets below.
 	SetSocketBindInterface(thePrefs::GetNetworkInterface());
+	if (!thePrefs::GetNetworkInterface().IsEmpty()) {
+		AddLogLineN(CFormat(_("Binding all network traffic to interface: %s")) %
+			    thePrefs::GetNetworkInterface());
+	}
 
 	// The temp / incoming directories are validated and created further
 	// down, after the first-run wizard has had a chance to point them

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -74,6 +74,7 @@
 #include "InternalEvents.h"       // Needed for CMuleInternalEvent
 #include "IPFilter.h"             // Needed for CIPFilter
 #include "KnownFileList.h"        // Needed for CKnownFileList
+#include "LibSocket.h"            // Needed for SetSocketBindInterface
 #include "ListenSocket.h"         // Needed for CListenSocket
 #include "Logger.h"               // Needed for CLogger // Do_not_auto_remove
 #include "MagnetURI.h"            // Needed for CMagnetURI
@@ -555,6 +556,10 @@ bool CamuleApp::OnInit()
 	}
 
 	glob_prefs = new CPreferences();
+
+	// Push the bind-to-interface preference into the socket library before any
+	// socket is opened (mulesocket can't read CPreferences itself).
+	SetSocketBindInterface(thePrefs::GetNetworkInterface());
 
 	// The temp / incoming directories are validated and created further
 	// down, after the first-run wizard has had a chance to point them

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -558,13 +558,23 @@ bool CamuleApp::OnInit()
 	glob_prefs = new CPreferences();
 
 	// Push the bind-to-interface preference into the socket library before any
-	// socket is opened (mulesocket can't read CPreferences itself). Log it at
-	// normal level when set: it's a security-relevant choice (VPN-leak
-	// prevention) the user should see confirmed, like the listen sockets below.
-	SetSocketBindInterface(thePrefs::GetNetworkInterface());
-	if (!thePrefs::GetNetworkInterface().IsEmpty()) {
-		AddLogLineN(CFormat(_("Binding all network traffic to interface: %s")) %
-			    thePrefs::GetNetworkInterface());
+	// socket is opened (mulesocket can't read CPreferences itself). It's a
+	// security-relevant choice (VPN-leak prevention), so make the outcome
+	// visible: confirm the bind when the interface resolves, and warn loudly
+	// when it does not — otherwise a typo would silently leave traffic on the
+	// default route while the user believes it is contained.
+	const wxString &bindInterface = thePrefs::GetNetworkInterface();
+	SetSocketBindInterface(bindInterface);
+	if (!bindInterface.IsEmpty()) {
+		if (ResolveBindInterfaceIndex(bindInterface) != 0) {
+			AddLogLineN(
+				CFormat(_("Binding all network traffic to interface: %s")) % bindInterface);
+		} else {
+			AddLogLineC(CFormat(_("WARNING: configured network interface '%s' was not found - "
+					      "traffic is NOT bound to it and may leave via the default "
+					      "route. Check the interface name in Preferences.")) %
+				    bindInterface);
+		}
 	}
 
 	// The temp / incoming directories are validated and created further

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1385,6 +1385,12 @@ wxSizer *PreferencesConnectionTab( wxWindow *parent, bool call_fit, bool set_siz
     wxTextCtrl *item27 = new wxTextCtrl( parent, IDC_ADDRESS, "", wxDefaultPosition, wxSize(80,-1), 0 );
     item27->SetToolTip( _("Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound.") );
     item25->Add( item27, wxSizerFlags().Expand().CenterHorizontal() );
+
+    wxStaticText *item26b = new wxStaticText( parent, IDC_INTERFACETEXT, _("Bind to network interface (empty for any):"), wxDefaultPosition, wxDefaultSize, 0 );
+    item25->Add( item26b, wxSizerFlags().CenterVertical().Border(wxRIGHT, 5) );
+    wxTextCtrl *item27b = new wxTextCtrl( parent, IDC_INTERFACE, "", wxDefaultPosition, wxSize(80,-1), 0 );
+    item27b->SetToolTip( _("Advanced users only: pin all of aMule's traffic to one network interface by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges. On Windows, enter the interface index.") );
+    item25->Add( item27b, wxSizerFlags().Expand().CenterHorizontal() );
     item0->Add( item25, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 0) );
     wxFlexGridSizer *item28 = new wxFlexGridSizer( 2, 0, 0 );
     item28->AddGrowableCol( 0 );

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1388,8 +1388,11 @@ wxSizer *PreferencesConnectionTab( wxWindow *parent, bool call_fit, bool set_siz
 
     wxStaticText *item26b = new wxStaticText( parent, IDC_INTERFACETEXT, _("Bind to network interface (empty for any):"), wxDefaultPosition, wxDefaultSize, 0 );
     item25->Add( item26b, wxSizerFlags().CenterVertical().Border(wxRIGHT, 5) );
-    wxTextCtrl *item27b = new wxTextCtrl( parent, IDC_INTERFACE, "", wxDefaultPosition, wxSize(80,-1), 0 );
-    item27b->SetToolTip( _("Advanced users only: pin all of aMule's traffic to one network interface by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges. On Windows, enter the interface index.") );
+    // Editable combo: the drop-down is filled at runtime with the machine's
+    // interfaces (PrefsUnifiedDlg), but it stays editable so an interface that
+    // is down when the dialog opens (e.g. a VPN tunnel) can still be typed in.
+    wxComboBox *item27b = new wxComboBox( parent, IDC_INTERFACE, "", wxDefaultPosition, wxSize(120,-1), 0, NULL, wxCB_DROPDOWN );
+    item27b->SetToolTip( _("Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges.") );
     item25->Add( item27b, wxSizerFlags().Expand().CenterHorizontal() );
     item0->Add( item25, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 0) );
     wxFlexGridSizer *item28 = new wxFlexGridSizer( 2, 0, 0 );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -235,6 +235,10 @@ wxSizer *PreferencesGeneralTab(wxWindow *parent, bool call_fit = TRUE, bool set_
 #define IDC_UPNPTCPPORTTEXT 10137
 #define IDC_UPNPTCPPORT 10138
 #define IDC_ADDRESS 10139
+// 10410: bind-to-interface text control (functional, next free above the top
+// of the current range). Its label IDC_INTERFACETEXT lives in the 10355+
+// orphan-label band below.
+#define IDC_INTERFACE 10410
 #define ID_TEXT 10140
 #define IDC_MAXSOURCEPERFILE 10141
 #define IDC_MAXCON 10142
@@ -286,6 +290,7 @@ wxSizer *PreferencesFilesTab(wxWindow *parent, bool call_fit = TRUE, bool set_si
 // IDs below name orphan labels / static boxes so amulegui can hide
 // them via PrefsUnifiedDlg's amuledOnlyPrefs[].
 #define IDC_ADDRESSTEXT 10355
+#define IDC_INTERFACETEXT 10362
 #define IDC_EXT_CONN_PARAMS_BOX 10356
 #define IDC_EXT_CONN_IPTEXT 10357
 #define IDC_EXT_CONN_TCPPORTTEXT 10358

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -144,6 +144,12 @@ target_link_libraries (NetworkFunctionsTest
 	wxWidgets::NET
 )
 
+if (WIN32)
+	# This test compiles LibSocket.cpp directly (not via the mulesocket
+	# library), so it needs iphlpapi for GetAdaptersAddresses() itself.
+	target_link_libraries (NetworkFunctionsTest iphlpapi)
+endif()
+
 add_executable (PathTest
 	PathTest.cpp
 	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp


### PR DESCRIPTION
Closes #173.

The existing `Address=` setting binds to a local IP, which on Linux does not override the kernel's routing decision — outbound traffic can still leak via the default-route interface even when the bind IP belongs to a VPN tunnel. This adds a proper interface bind that pins the egress interface itself, closing that leak.

It uses `IP_UNICAST_IF` / `IPV6_UNICAST_IF` on Linux and Windows, and `IP_BOUND_IF` / `IPV6_BOUND_IF` on macOS/BSD. These require no elevated privileges, unlike `SO_BINDTODEVICE` which needs `CAP_NET_RAW` — aMule keeps running as a normal user.

The bind is applied to every socket aMule opens: the TCP listen socket, outbound TCP (client and server connections), and the UDP socket shared by the ed2k client, ed2k server and Kad.

The Connection preferences page gets a "Bind to network interface" control next to "Bind local address to". It is an editable drop-down populated with the machine's interfaces (`getifaddrs` on POSIX, `GetAdaptersAddresses` on Windows, loopback filtered out), but stays editable so an interface that is down when the dialog opens — a VPN tunnel — can still be typed in. The stored value is a POSIX interface name (`en0`, `eth0`, `tun0`), a Windows adapter friendly name (`Ethernet`, `Wi-Fi`), or a bare numeric index; empty means "any" (unchanged default). Like the address bind, it is a daemon-side setting stored as `/eMule/NetworkInterface` and hidden in the remote GUI. Changing it is flagged restart-needed, consistent with the TCP/UDP port settings.

Because it is a leak-prevention setting, the outcome is made visible: on startup a valid interface is confirmed in the log (`Binding all network traffic to interface: <name>`), and an unresolvable one produces a loud `WARNING` that traffic is not bound and may leave via the default route — so a typo can't silently defeat the protection. All resolution lives in one place in the socket layer, which the core reuses to validate the preference before any socket opens.

Tested: builds clean on macOS, Linux and Windows (monolithic, daemon, remote GUI, amulecmd, amuleweb and the unit tests). The interface-bind syscall was verified returning success as an unprivileged user on all three platforms.
