### PR TITLE
fix: emit UTF-8 for console/log output on non-Windows (garbled non-ASCII under a C/POSIX locale)

### DIFF
--- a/src/libs/common/StringFunctions.cpp
+++ b/src/libs/common/StringFunctions.cpp
@@ -33,34 +33,52 @@
 // Implementation of the non-inlines
 
 //
-// Conversion of wxString so it can be used by printf() in a console
-// On some platforms (Windows) the console allows only "plain" characters,
-// so try to convert as much as possible and replace the others with '?'.
-// On other platforms (some Linux) wxConvLibc silently converts to UTF8
-// so the console can show even Chinese chars.
+// Conversion of a wxString so it can be used by printf() on a console.
+//
+// On non-Windows we emit UTF-8 directly. *nix terminals and log files are
+// effectively always UTF-8 nowadays, whereas routing through the C-library
+// locale charset (wxConvLibc) mangles non-ASCII text under a C/POSIX locale
+// -- common in minimal Docker images -- and does so inconsistently across
+// libc implementations (glibc fails the conversion outright, macOS libc
+// succeeds with lossy bytes). Going straight to UTF-8 sidesteps all of that;
+// ASCII is unaffected since it is identical in both encodings.
+//
+// On Windows the console is limited to the active code page, so we try the
+// locale charset first and then fall back to a best-effort per-character
+// conversion, replacing each non-representable character with '?'.
 //
 Unicode2CharBuf unicode2char(const wxChar *s)
 {
-	// First try the straight way.
+#ifndef __WXMSW__
+	return wxConvUTF8.cWX2MB(s);
+#else
+	// First try the locale charset (the active code page).
 	Unicode2CharBuf buf1(wxConvLibc.cWX2MB(s));
 	if ((const char *)buf1) {
 		return buf1;
 	}
-	// Failed. Try to convert as much as possible.
+	// Failed. Convert character by character, replacing what we can't.
 	size_t len = wxStrlen(s);
 	size_t maxlen = len * 4;      // Allow for an encoding of up to 4 byte per char.
 	wxCharBuffer buf(maxlen + 1); // This is wasteful, but the string is used temporary anyway.
 	char *data = buf.data();
-	for (size_t i = 0, pos = 0; i < len; i++) {
+	size_t pos = 0;
+	for (size_t i = 0; i < len; i++) {
+		// FromWChar() writes the raw bytes for one character and returns
+		// how many it wrote (no NUL, since we pass an explicit length),
+		// so advance by exactly that -- the previous `- 1` left pos on
+		// the last byte and made every ASCII char overwrite its
+		// predecessor.
 		size_t len_char = wxConvLibc.FromWChar(data + pos, maxlen - pos, s + i, 1);
-		if (len_char != wxCONV_FAILED) {
-			pos += len_char - 1;
+		if (len_char != wxCONV_FAILED && len_char > 0) {
+			pos += len_char;
 		} else if (pos < maxlen) {
 			data[pos++] = '?';
-			data[pos] = 0;
 		}
 	}
+	data[pos] = 0;
 	return buf;
+#endif
 }
 
 static uint8_t base16Chars[17] = "0123456789ABCDEF";


### PR DESCRIPTION
### Problem

`amulecmd` prints garbled, undecodable filenames for search results containing non-ASCII characters when it runs under a `C`/`POSIX` locale — the setup in the Docker image from #279. For example `Супер Video 2024-….mp4` comes out as `?????5`, and the byte stream can't be decoded as UTF-8, Latin-1 or CP1252.

### Root cause

Console/log output goes through the shared helper `unicode2char()`, which converts via the C-library locale charset (`wxConvLibc`). Under a non-UTF-8 locale that converter can't represent non-ASCII characters, so the text is mangled. Two things compound it:

- glibc fails the conversion outright while macOS libc succeeds with lossy bytes, so the behaviour is inconsistent across platforms.
- The per-character fallback had a bug: `pos += len_char - 1`. For a successfully-converted ASCII character `FromWChar()` writes 1 byte and returns 1, so `pos` never advanced and every ASCII byte overwrote its predecessor — which is why a name starting with five Cyrillic letters collapsed to five `?` plus one trailing character (`?????5`).

### Fix

Emit UTF-8 directly on non-Windows. `*nix` terminals and log files are effectively always UTF-8 regardless of `LC_*`, so this removes the locale guesswork entirely, and ASCII is unchanged. Windows keeps the active-code-page path, with the fallback loop's pointer advance corrected.

This mirrors the decision already made for the logger in #40, where the stdout sink was switched from `unicode2char()` to UTF-8 for exactly this reason (`wxConvLibc` "collapses non-ASCII to `?` in the default `C` locale ... common in containerized deployments"), and the on-disk log already uses `wxConvUTF8`. This change aligns the shared helper with that.

### Scope

`unicode2char()` is the shared console/log conversion helper, so this affects all non-Windows binaries — `amuled`, `amule`, `amulecmd`, `amuleweb` and the utilities — for console + log output. It is locale-independent by construction: `wxConvUTF8` never consults the C locale, so `setlocale(LC_ALL,"")` (`aMuleInitLocale`), the temporary `LC_CTYPE="C"` scope used around wxFileConfig lookups, and `wxLocale` init can no longer shape its output the way they could with `wxConvLibc`. Because `aMuleInitLocale()` already does `setlocale(LC_ALL,"")`, a properly-configured UTF-8 host produced UTF-8 from the old path too, so the change is a no-op there and only the broken C-locale case flips to correct.

### Verification

Reproduced against a live global search, capturing `results` under two locales before and after:

| | `LC_ALL=C.UTF-8` | `LC_ALL=C` |
|---|---|---|
| before | `Супер Video 2024-…mp4` | `?????5` |
| after | `Супер Video 2024-…mp4` | `Супер Video 2024-…mp4` |

After the fix the `LC_ALL=C` output is byte-identical to the UTF-8-locale output and fully valid UTF-8. (A few results still show mojibake like `ð¤©` — those names were already double-encoded on the ed2k wire by the uploader and render identically under any locale; that's source data, not this bug.)

Closes #279.
