### PR TITLE
fix(amulegui): apply the wxWebSession-cleanup _Exit workaround to the remote GUI

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -146,6 +146,16 @@ int CamuleRemoteGuiApp::OnExit()
 
 	wxSocketBase::Shutdown(); // needed because we also called Initialize() manually
 
+	// Skip wx's static-destructor / module cleanup, exactly as the monolithic
+	// app does in CamuleGuiApp::OnExit (amule.cpp). wx's WebRequestModule
+	// teardown destroys the platform wxWebSession, whose dtor dereferences
+	// already-freed state and raise(SIGABRT)s on quit (amule-org/amule#18,
+	// PR #159). amulegui links wxWebRequest too, so it hits the identical
+	// crash. By this point our own cleanup (timer, sockets) has run; _Exit
+	// bypasses atexit + static destructors so the buggy wx dtor never runs.
+	// Remove once the upstream wx fix lands in a release we depend on.
+	std::_Exit(0);
+
 	return wxApp::OnExit();
 }
 


### PR DESCRIPTION
### Problem

amulegui SIGABRTs on quit inside wxWidgets' own module cleanup (macOS, wx 3.3.2):

```
main → wxEntry → wxEntryCleanup → wxModule::CleanUpModules
     → WebRequestModule::OnExit() → wxWebSessionURLSession::~()   ← crash
```

### Root cause

Same wxWebSession teardown bug fixed for the monolithic app in #159 (backtrace in #18): wx's `WebRequestModule::OnExit` destroys the platform `wxWebSession`, whose dtor dereferences already-freed state and raises SIGABRT. The monolithic `amule` dodges it with `std::_Exit(0)` in `CamuleGuiApp::OnExit`, but the remote GUI uses a separate app class (`CamuleRemoteGuiApp`) whose `OnExit` never got the guard. amulegui links `wxWebRequest` too, so it hits the identical path.

### Fix

Apply the same `std::_Exit(0)` in `CamuleRemoteGuiApp::OnExit`, after amulegui's own cleanup (tick timer, sockets) has run — mirroring the monolithic fix.
