### PR TITLE
fix: share and detach files when a shared directory is renamed or deleted

### DIFF
--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -425,6 +425,56 @@ void CSharedDirWatcher::RegisterNewSubdirectory(const wxString &path)
 	ScanNewSubdirRace(p);
 }
 
+bool CSharedDirWatcher::IsInSharedSet(const wxString &path) const
+{
+	CPath p(path);
+	if (!p.IsOk()) {
+		return false;
+	}
+	const thePrefs::PathList &shared = theApp->glob_prefs->shareddir_list;
+	for (size_t i = 0; i < shared.size(); ++i) {
+		if (shared[i].IsSameDir(p)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool CSharedDirWatcher::HandleDirRemoved(const wxString &path)
+{
+	// Detach the vanished dir's subtree (NotifyPathRemoved is per-file only).
+	m_parent->NotifyDirRemoved(path);
+
+	// Drop it from the runtime union so scans stop chasing a dead path. Leave
+	// the user's explicit/recursive config alone -- the union is recomputed
+	// from it on reload anyway.
+	bool removed = false;
+	CPath gone(path);
+	if (gone.IsOk()) {
+		thePrefs::PathList &shared = theApp->glob_prefs->shareddir_list;
+		for (size_t i = 0; i < shared.size(); ++i) {
+			if (shared[i].IsSameDir(gone)) {
+				shared.erase(shared.begin() + i);
+				removed = true;
+				AddDebugLogLineN(logKnownFiles,
+					CFormat("Shared-dir watcher: dropped '%s' from shared set "
+						"(directory removed)") %
+						path);
+				break;
+			}
+		}
+	}
+
+#ifndef __WXOSX__
+	// Remove its per-subdir watch (macOS covers the whole tree via FSEvents).
+	if (removed && m_watcher) {
+		m_watcher->Remove(wxFileName::DirName(path));
+	}
+#endif
+
+	return removed;
+}
+
 void CSharedDirWatcher::ScanNewSubdirRace(const CPath &parent)
 {
 	if (!parent.IsOk() || !parent.DirExists()) {
@@ -622,6 +672,22 @@ void CSharedDirWatcher::FlushPendingEvents()
 		// own event slot will handle the add. Treat the rename as
 		// (delete-old) then schedule new-path processing.
 		if (ev.flags & wxFSW_EVENT_RENAME) {
+			// Directory rename: the subtree moved with no per-file events, so
+			// the file pipeline would just log a bogus "does not exist" and
+			// share nothing. Register the new dir (watch + walk contents); it
+			// only re-shares under a recursive ancestor, so an explicitly
+			// picked folder isn't resurrected at its new name.
+			if (!ev.renamedTo.IsEmpty() && wxFileName::DirExists(ev.renamedTo)) {
+				// Tear down the old path only if it's gone (inotify shape).
+				// Backends that report the rename against the still-existing
+				// parent deliver the old subtree via a separate DELETE, so
+				// never touch a path that still exists (that's the parent).
+				if (!wxFileName::DirExists(path) && IsInSharedSet(path)) {
+					HandleDirRemoved(path);
+				}
+				RegisterNewSubdirectory(ev.renamedTo);
+				continue;
+			}
 			m_parent->NotifyPathRemoved(path);
 			if (!ev.renamedTo.IsEmpty()) {
 				m_parent->NotifyPathAdded(ev.renamedTo);
@@ -635,7 +701,20 @@ void CSharedDirWatcher::FlushPendingEvents()
 		// multiple flags because fs-watcher fires DELETE for the
 		// rename's source on some backends.
 		if (ev.flags & wxFSW_EVENT_DELETE) {
-			m_parent->NotifyPathRemoved(path);
+			// A vanished shared *dir* isn't in the file index, so
+			// NotifyPathRemoved would no-op. Detach its subtree only when it is
+			// a shared dir AND genuinely gone from disk -- a spurious/transient
+			// DELETE, or a delete-then-recreate coalesced into this debounce
+			// window, must not unshare a directory that still exists. The
+			// shared-set check also keeps this off the hot path of ordinary
+			// file DELETEs (no O(files) scan per file).
+			if (IsInSharedSet(path) && !wxFileName::DirExists(path)) {
+				if (HandleDirRemoved(path)) {
+					theApp->glob_prefs->SaveSharedFolders();
+				}
+			} else {
+				m_parent->NotifyPathRemoved(path);
+			}
 			continue;
 		}
 

--- a/src/SharedDirWatcher.h
+++ b/src/SharedDirWatcher.h
@@ -113,6 +113,15 @@ private:
 	// "auto-share new subdirs of watched parents" behaviour.
 	void RegisterNewSubdirectory(const wxString &path);
 
+	// Tear down a renamed-away / deleted shared dir: detach its subtree, drop it
+	// from the runtime shared set + its watch. Never touches the user's
+	// explicit/recursive config. Returns true if it removed a set entry.
+	bool HandleDirRemoved(const wxString &path);
+
+	// Is `path` in the runtime shared set? Distinguishes a dir event from a
+	// file event once the path is gone from disk.
+	bool IsInSharedSet(const wxString &path) const;
+
 	// Closes the inotify/kqueue race window inside RegisterNewSubdirectory:
 	// between the kernel mkdir and our wxFileSystemWatcher::Add(), any
 	// files or subdirs created inside the new directory fire on a watch

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -769,6 +769,45 @@ void CSharedFileList::NotifyPathRemoved(const wxString &fullPath)
 	RemoveFile(file);
 }
 
+void CSharedFileList::NotifyDirRemoved(const wxString &dirPath)
+{
+	if (dirPath.IsEmpty()) {
+		return;
+	}
+
+	// Trailing separator so ".../Season 1" does not match sibling ".../Season 10".
+	wxString prefix = dirPath;
+	const wxString sep(wxFileName::GetPathSeparator());
+	if (!prefix.EndsWith(sep)) {
+		prefix += sep;
+	}
+
+	// Collect under the lock, detach outside it: RemoveFile re-locks and erases
+	// from m_pathIndex.
+	std::vector<CKnownFile *> victims;
+	{
+		wxMutexLocker lock(list_mut);
+		for (std::unordered_map<wxString, CKnownFile *>::const_iterator it = m_pathIndex.begin();
+			it != m_pathIndex.end();
+			++it) {
+			if (it->first.StartsWith(prefix)) {
+				victims.push_back(it->second);
+			}
+		}
+	}
+
+	if (victims.empty()) {
+		return;
+	}
+
+	AddDebugLogLineN(logKnownFiles,
+		CFormat("Watcher: detaching %zu shared file(s) under removed dir '%s'") % victims.size() %
+			dirPath);
+	for (std::vector<CKnownFile *>::iterator it = victims.begin(); it != victims.end(); ++it) {
+		RemoveFile(*it);
+	}
+}
+
 void CSharedFileList::NotifyPathModified(const wxString &fullPath)
 {
 	if (fullPath.IsEmpty()) {

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -148,6 +148,11 @@ public:
 	void NotifyPathRemoved(const wxString &fullPath);
 	void NotifyPathModified(const wxString &fullPath);
 
+	// Detach every shared file under `dirPath` (separator-anchored prefix, so
+	// ".../Season 1" does not swallow sibling ".../Season 10"). For a renamed
+	// or deleted dir, whose subtree moves with no per-file events.
+	void NotifyDirRemoved(const wxString &dirPath);
+
 private:
 	typedef std::list<CThreadTask *> TaskList;
 


### PR DESCRIPTION
## Problem

When a shared directory is renamed (or deleted), the incremental shared-dir watcher mishandles it. A rename moves the whole subtree with no per-file filesystem events, but the watcher fed the rename destination into the per-file add path — whose file-exists check fails on a directory and logs a misleading `shared file does not exist (possibly a broken link)`. Result: the files inside the renamed folder are never shared, and no watch is installed on the new path. The old location is left attached to now-dead paths too, because path removal is keyed on individual files, not directories.

## Fix

Route a directory rename through the same path a fresh `mkdir` already uses (`RegisterNewSubdirectory`): install a watch on the new directory and walk its contents. Add `CSharedFileList::NotifyDirRemoved()`, a directory-aware removal that detaches the old subtree by a separator-anchored prefix match (so `.../Season 1` does not swallow the sibling `.../Season 10`), and drop the removed directory from the runtime shared-set union and its watch.

`RegisterNewSubdirectory` only re-shares under a recursive ancestor, so a folder the user explicitly picked is not silently re-shared at its new name — the fix errs toward *less* sharing, never more, and never rewrites the user's explicit/recursive share config.

Handles both watcher event shapes: inotify reports a rename as a single `RENAME` on the old directory; other backends report `DELETE` on the old path plus `RENAME` on the parent. Guarded so the still-existing parent tree is never torn down.
