### PR TITLE
fix(amulegui): persist list-control settings on every macOS quit path

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -122,6 +122,11 @@ void CEConnectDlg::OnOK(wxCommandEvent &evt)
 wxDEFINE_EVENT(wxEVT_EC_INIT_DONE, wxEvent);
 
 wxBEGIN_EVENT_TABLE(CamuleRemoteGuiApp, wxApp)
+	// macOS Dock right-click -> Quit ends the session without going through
+	// the red-X / Cmd+Q paths; catch it so ShutDown + OnExit cleanup still runs.
+	EVT_QUERY_END_SESSION(CamuleRemoteGuiApp::OnQueryEndSession)
+	EVT_END_SESSION(CamuleRemoteGuiApp::OnEndSession)
+
 	// Core timer
 	EVT_TIMER(ID_CORE_TIMER_EVENT, CamuleRemoteGuiApp::OnPollTimer)
 	// Watchdog on the initial EC connect attempt
@@ -146,6 +151,17 @@ int CamuleRemoteGuiApp::OnExit()
 
 	wxSocketBase::Shutdown(); // needed because we also called Initialize() manually
 
+	// Mirror CamuleApp::OnExit (#141): CMuleListCtrl::SaveSettings runs from
+	// the frame's lazily-scheduled destructor, so drain the pending-delete
+	// queue (where CamuleDlg::OnClose -> ShutDown parked amuledlg->Destroy())
+	// and then tear down wxConfig to flush it. Otherwise the red-X + confirm
+	// path reaches here with the destroy still queued and the column widths /
+	// sort orders it would have written are lost (CMD+Q happens to drain
+	// naturally). The _Exit(0) below skips wx's own cleanup that normally does
+	// both, so we do it by hand here.
+	DeletePendingObjects();
+	delete wxConfigBase::Set(nullptr);
+
 	// Skip wx's static-destructor / module cleanup, exactly as the monolithic
 	// app does in CamuleGuiApp::OnExit (amule.cpp). wx's WebRequestModule
 	// teardown destroys the platform wxWebSession, whose dtor dereferences
@@ -157,6 +173,27 @@ int CamuleRemoteGuiApp::OnExit()
 	std::_Exit(0);
 
 	return wxApp::OnExit();
+}
+
+void CamuleRemoteGuiApp::OnQueryEndSession(wxCloseEvent &evt)
+{
+	// Flag the quit so CamuleDlg::OnClose skips its HideOnClose-veto branch
+	// and actually quits on a Dock right-click -> Quit (as for Cmd+Q).
+	SetQuitting();
+	evt.Skip();
+}
+
+void CamuleRemoteGuiApp::OnEndSession(wxCloseEvent &evt)
+{
+	// The Dock-Quit path can bypass OnExit, so run ShutDown (unless OnClose
+	// already did -- it nulls amuledlg) and then OnExit explicitly, so the
+	// list-control destructors + wxConfig flush run and column widths / sort
+	// orders persist. Mirrors CamuleGuiApp::OnEndSession (amule-gui.cpp).
+	if (amuledlg) {
+		ShutDown(evt);
+	}
+	OnExit();
+	evt.Skip();
 }
 
 #if wxUSE_ON_FATAL_EXCEPTION

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -752,6 +752,12 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 
 	int OnExit();
 
+	// Catch alternate quit paths (macOS Dock right-click -> Quit) so the
+	// ShutDown + OnExit cleanup (list-control SaveSettings, wxConfig flush)
+	// runs even when wx skips OnExit. Mirrors CamuleGuiApp (amule-gui.cpp).
+	void OnEndSession(wxCloseEvent &evt);
+	void OnQueryEndSession(wxCloseEvent &evt);
+
 #if wxUSE_ON_FATAL_EXCEPTION
 	// Print a libbfd/addr2line-resolved backtrace on fatal signal.
 	// Mirrors CamuleApp::OnFatalException so amulegui crashes (#692)


### PR DESCRIPTION
## Problem

On macOS, resizing the peers-table (or any list-control) columns in amulegui only persisted when quitting with **Cmd+Q**. Exiting with the **red X → confirm** dialog, or **Dock right-click → Quit → confirm**, silently discarded the changes.

`CMuleListCtrl::SaveSettings` runs from the frame's destructor, which `CamuleDlg::OnClose → CamuleRemoteGuiApp::ShutDown` only *schedules* (`amuledlg->Destroy()` is lazy). `CamuleRemoteGuiApp::OnExit` then `std::_Exit(0)`s to dodge the wxWebSession dtor crash (#18 / #159), which skips wx's own cleanup — so the queued destroy and the wxConfig flush never run and the freshly-written column widths / sort orders are lost. Cmd+Q happened to drain the pending-delete queue naturally, which is why only that path persisted.

## Fix

Mirrors the monolithic app in two places:

- **`OnExit`** — `DeletePendingObjects()` + tear down wxConfig (which flushes it) before `_Exit(0)`, so the red-X + confirm path runs the list-control destructors against a live config. Same idea as `CamuleApp::OnExit` (#141).
- **`OnQueryEndSession` / `OnEndSession` handlers** — the Dock right-click → Quit path ends the session without going through `OnExit`, so route it through `ShutDown` + `OnExit` explicitly. Mirrors `CamuleGuiApp` (`amule-gui.cpp`).

## Testing

macOS, resized the Transfers/peers columns and verified persistence across relaunch on all three quit paths: **Cmd+Q**, **red X → confirm**, and **Dock → Quit → confirm**. All three now save.
