### PR TITLE
fix(ec): drop stale per-ECID CValueMap on encoder re-create

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -143,7 +143,12 @@ class CFileEncoderMap : public std::map<uint32, CKnownFile_Encoder *>
 
 public:
 	~CFileEncoderMap();
-	void UpdateEncoders();
+	// If freshEcids is non-null, receives the ECIDs whose encoder was
+	// (re-)created this call. Freshly-created encoders signal that the
+	// caller's per-ECID EC caches (CObjTagMap valuemap, sent-with-detail
+	// set) are stale w.r.t. the client's local view and must be dropped
+	// so INC_UPDATE emissions re-send identifying fields.
+	void UpdateEncoders(IDSet *freshEcids = nullptr);
 };
 
 CFileEncoderMap::~CFileEncoderMap()
@@ -156,7 +161,7 @@ CFileEncoderMap::~CFileEncoderMap()
 
 // Check if encoder contains files that are no longer used
 // or if we have new files without encoder yet.
-void CFileEncoderMap::UpdateEncoders()
+void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 {
 	IDSet curr_files, dead_files;
 	// Downloads
@@ -167,6 +172,9 @@ void CFileEncoderMap::UpdateEncoders()
 		curr_files.insert(id);
 		if (!count(id)) {
 			(*this)[id] = new CPartFile_Encoder(downloads[i]);
+			if (freshEcids) {
+				freshEcids->insert(id);
+			}
 		}
 	}
 	// Shares
@@ -183,6 +191,9 @@ void CFileEncoderMap::UpdateEncoders()
 		curr_files.insert(id);
 		if (!count(id)) {
 			(*this)[id] = new CKnownFile_Encoder(shares[i]);
+			if (freshEcids) {
+				freshEcids->insert(id);
+			}
 		}
 	}
 	// Check for removed files, and store them in a set for deletion.
@@ -910,7 +921,20 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 	const uint64 ec_snapshot = CKnownFile::GetGlobalECGen();
 	const uint64 ec_threshold = io_lastEcGenSeen;
 
-	encoders.UpdateEncoders();
+	// Freshly-created encoders this cycle. Every entry is an ECID whose
+	// prior encoder was either destroyed (file dropped from m_Files_map /
+	// downloadqueue) or never existed. In both cases the peer's mirrored
+	// state for that ECID is empty, so any INC_UPDATE the ctor would
+	// suppress against a cached value in `tagmap.GetValueMap(ecid)` or a
+	// membership in `io_sentWithDetailIds` produces a hash-less tag that
+	// the client rejects (`amule-remote-gui.cpp` #808 guard). Drop both
+	// caches so the file re-appears in full detail on this response.
+	std::set<uint32> freshEcids;
+	encoders.UpdateEncoders(&freshEcids);
+	for (uint32 ecid : freshEcids) {
+		tagmap.EraseValueMap(ecid);
+		io_sentWithDetailIds.erase(ecid);
+	}
 
 	// Snapshot the IDs of all files currently alive on the server. Used
 	// by the partial-update path below to diff against the previous cycle

--- a/src/ExternalConn.h
+++ b/src/ExternalConn.h
@@ -65,6 +65,12 @@ class CObjTagMap
 public:
 	CValueMap &GetValueMap(uint32 ECID) { return m_obj_map[ECID]; }
 
+	// Drop the per-ECID field cache. Called when an encoder for this ECID
+	// is freshly (re-)created so the next EC_DETAIL_INC_UPDATE emits every
+	// identifying field (hash / name / size) instead of suppressing them
+	// against a stale cache the peer no longer holds.
+	void EraseValueMap(uint32 ECID) { m_obj_map.erase(ECID); }
+
 	size_t size() { return m_obj_map.size(); }
 };
 


### PR DESCRIPTION
## Bug

Files moved out of a shared directory and then moved back in are removed from `amulegui`'s view on the mv-out but never reappear on the mv-in — the client has to be restarted to see them again. The daemon detaches and re-adds them correctly (`Added known file 'X' to shares` in the log) so the daemon-side state is right.

Reproducer:

```
$ mv Shared/<some-file> .
$ # amulegui view: file disappears — correct
$ mv <some-file> Shared/
$ # amulegui view: file does NOT reappear until amulegui is restarted
```

## Root cause

Not the shared file list — the per-connection EC delta state.

Under `EC_OP_GET_UPDATE`, the server encodes each file with a per-ECID [`CValueMap`](src/ExternalConn.h#L61) inside [`CObjTagMap`](src/ExternalConn.h#L61) that suppresses tags whose value has not changed since it was last sent. When the file is removed the server emits an explicit `EC_TAG_FILE_REMOVED` for the ECID and the client drops the entry from `m_items_hash`, but the server's `CValueMap` for that ECID is **never cleared**. On re-add:

1. [`CFileEncoderMap::UpdateEncoders()`](src/ExternalConn.cpp#L159) (destroyed on removal) creates a fresh encoder for the ECID.
2. `MarkECChanged()` fires via [`CKnownFile::SetFilePath()`](src/KnownFile.cpp#L539) in `AddPathToShares`, so `m_ecGen > ec_threshold` and the file falls through to the full-detail path.
3. The [`CEC_SharedFile_Tag` ctor](src/ECSpecialCoreTags.cpp#L242-L251) walks its tag list through the stale valuemap and suppresses `EC_TAG_PARTFILE_HASH`, `_NAME`, `_SIZE_FULL` etc. — their cached values are unchanged.
4. amulegui receives an `INC_UPDATE` tag with statistical children but no identifying fields, hits the [`#808` guard](src/amule-remote-gui.cpp#L1517) ("incomplete INC_UPDATE tag (no PARTFILE_HASH) for unknown file ID X; ignoring"), and discards.
5. The server records the ECID in `io_sentWithDetailIds`, so subsequent cycles take the alive-marker / silent-skip shortcut and the file stays invisible until amulegui restarts (fresh empty `CObjTagMap`).

## Fix

Signal fresh-encoder events out of `UpdateEncoders` and, in the one INC_UPDATE handler that uses a valuemap, drop both the per-connection `CValueMap` entry and the `io_sentWithDetailIds` membership for every fresh ECID before encoding. The next INC_UPDATE cycle then re-sends every identifying field.

Uniformly handles the reported scenario (removed-then-added-across-cycles) and the freshly-hashed-first-time path (which was already correct because both caches were empty for that ECID), covering partial-update-capable clients and legacy inference-of-absence clients identically.

The other two INC_UPDATE producers (`Get_EC_Response_GetSharedFiles` and `Get_EC_Response_GetDownloadQueue`, both amuleweb) do not pass a valuemap into the tag ctor and rely on per-encoder byte-level caches that are already reset by encoder destruction, so they need no change.

## Test plan

- [x] amuled + amulegui on Linux: reproduce mv-out / mv-in scenario without the fix and observe the file failing to reappear.
- [x] Same scenario after the fix: file reappears on the next EC poll cycle without amulegui restart.