### PR TITLE
feat(amuleapi): locale-independent API — typed /stats/tree, English errors

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -2,6 +2,8 @@
 
 This document is the contract for the `/api/v0/events` Server-Sent Events stream. For the REST surface see [REFERENCE.md](REFERENCE.md). For first-run setup see [../QUICKSTART-AMULEAPI.md](../QUICKSTART-AMULEAPI.md).
 
+Event payloads follow the same machine contract as the REST responses: **English text and C-locale numbers**, independent of the `amuleapi`/`amuled` `--locale` (see [Localization and number formatting](REFERENCE.md#localization-and-number-formatting)). The same out-of-scope carve-outs apply (log line content and user/external data are not English-normalized).
+
 ## Why SSE
 
 Polling `/api/v0/downloads` every second for a few thousand transfers is a multi-MB-per-tick conversation that the ETag cache helps with but can't eliminate — even a 304 still costs the round trip. SSE lets the daemon push only the deltas the client hasn't seen: a single `download_updated` per transfer per second, against a JSON envelope of a few hundred bytes.

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -132,6 +132,15 @@ Header: `{"alg":"HS256","typ":"JWT"}`. Payload: `{"role":"admin"|"guest","iat":<
 
 Each endpoint documents its own response shape under the endpoint section. List endpoints wrap their array under the resource plural name (`{"downloads": [...]}`, `{"shared": [...]}`) so clients can extend the envelope with sibling metadata without breaking JSON-parser pipelines.
 
+### Localization and number formatting
+
+The API is a machine contract: **all API text is English and all numbers use the C locale** (a `.` decimal separator, no digit grouping), independent of the `amuleapi`/`amuled` locale or the `--locale` option. Localization is a client concern.
+
+- **Text** — enum-like fields (download status, priorities, upload/connection states) and the `/stats/tree` node label templates cross the wire in English. Strings relayed from amuled (for example `error.message` on an `amuled_rejected` failure, or connect/disconnect `message` fields) are passed through verbatim and are never translated by amuleapi.
+- **Numbers** — every JSON number is C-locale. `/stats/tree` values are raw and typed (seconds, bytes, bytes/second, …) so the client does its own formatting and localization; nothing arrives pre-formatted with a locale's decimal separator.
+
+Explicitly **out of scope** (not English-normalized): `GET /api/v0/logs/amule` content — daemon log lines are gettext-translated at the daemon's locale by nature — and user/external data such as file names, category names and comments, and server names and descriptions.
+
 ### Error envelope
 
 Every non-2xx response carries the same shape:
@@ -977,18 +986,44 @@ The ed2k server-info log buffer. Unlike `/logs/amule`, amuled ships this one as 
 
 A tree mirroring amuled's "Statistics" tree (transfers, connections, clients, servers, downloads). Cached with a 1 s TTL.
 
-The envelope is `{ "nodes": [...] }`. Each node is `{ "label": "<text>", "children": [...] }`; a leaf is a node whose `children` array is empty, with its value baked into the `label` string (e.g. `"Total uploaded: 12.4 GB"`).
+The envelope is `{ "nodes": [...] }`. Each node is `{ "label": "<template>", "values": [...], "children": [...] }`. A leaf is a node whose `children` array is empty.
+
+`label` is the **untranslated English template** (e.g. `"Total uploaded: %s"`), and `values` are the **typed, raw** values that fill its `%s` placeholders in order — the client formats and localizes them. This keeps the response identical regardless of the amuleapi/amuled `--locale` (see [Response model](#response-model)). A container node (one that only groups children) has an empty `values` array.
+
+Each value is `{ "type": "<type>", "value": <raw> }`:
+
+| `type` | `value` JSON | meaning |
+| --- | --- | --- |
+| `integer`, `istring`, `ishort` | number | plain count |
+| `bytes` | number | raw bytes |
+| `speed` | number | raw bytes/second |
+| `time` | number | raw seconds |
+| `double` | number | raw double |
+| `string` | string | opaque English string (e.g. a ratio, or `"Not available"`) |
+
+A value may carry a nested `extra` value of the same shape — the parenthetical "(total …)" some nodes append (e.g. session vs. total transfer).
 
 ```json
 {
   "nodes": [
     {
       "label": "Transfers",
+      "values": [],
       "children": [
         {
           "label": "Uploads",
+          "values": [],
           "children": [
-            { "label": "Total uploaded: 12.4 GB", "children": [] }
+            {
+              "label": "Total uploaded: %s",
+              "values": [ { "type": "bytes", "value": 13314398208 } ],
+              "children": []
+            },
+            {
+              "label": "Session UL:DL Ratio (Total): %s",
+              "values": [ { "type": "string", "value": "1 : 769.34 (1 : 1125.54)" } ],
+              "children": []
+            }
           ]
         }
       ]

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1275,7 +1275,10 @@ static CECPacket *Get_EC_Response_Server_Add(const CECPacket *request)
 		response = new CECPacket(EC_OP_NOOP);
 	} else {
 		response = new CECPacket(EC_OP_FAILED);
-		response->AddTag(CECTag(EC_TAG_STRING, _("Server not added")));
+		// wxTRANSLATE (not _()) so the wire string stays English; the API
+		// contract is English text / C-locale numbers, and webapi relays this
+		// verbatim. Consistent with the other EC_OP_FAILED replies here.
+		response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Server not added")));
 		delete toadd;
 	}
 

--- a/src/StatTree.cpp
+++ b/src/StatTree.cpp
@@ -540,34 +540,34 @@ void CStatTreeItemAverageSpeed::AddECValues(CECTag *tag) const
 
 /* CStatTreeItemRatio */
 
-wxString CStatTreeItemRatio::GetString() const
+wxString CStatTreeItemRatio::GetString(bool cLocale) const
 {
+	// Number formatter: C-locale (period, locale-independent) for the EC/API
+	// wire, or CFormat (honours LC_NUMERIC) for GUI display.
+	const auto num = [cLocale](double d) -> wxString {
+		return cLocale ? wxString::FromCDouble(d, 2) : (CFormat(wxT("%.2f")) % d).GetString();
+	};
+
 	wxString ret;
-	double v1 = m_counter1->GetValue();
-	double v2 = m_counter2->GetValue();
+	double v1 = static_cast<double>(m_counter1->GetValue());
+	double v2 = static_cast<double>(m_counter2->GetValue());
 	if (v1 > 0 && v2 > 0) {
-		if (v2 < v1) {
-			ret = CFormat("%.2f : 1") % (v1 / v2);
-		} else {
-			ret = CFormat("1 : %.2f") % (v2 / v1);
-		}
+		ret = (v2 < v1) ? num(v1 / v2) + wxT(" : 1") : wxT("1 : ") + num(v2 / v1);
 	} else {
-		ret = _("Not available");
+		// English on the wire (client translates); localised for the GUI.
+		ret = cLocale ? wxString(wxTRANSLATE("Not available")) : _("Not available");
 	}
 
 	// show the total ratio
 	if (m_totalfunc1 && m_totalfunc2) {
-		double t1 = m_totalfunc1() + v1;
-		double t2 = m_totalfunc2() + v2;
+		double t1 = static_cast<double>(m_totalfunc1()) + v1;
+		double t2 = static_cast<double>(m_totalfunc2()) + v2;
 		// Guard against fresh-install / zero-history cases. Without
 		// this, t1/t2 or t2/t1 divides by zero and the UI surfaces
 		// "(1 : nan)" or "(1 : inf)".
 		if (t1 > 0 && t2 > 0) {
-			if (t2 < t1) {
-				ret += CFormat(" (%.2f : 1)") % (t1 / t2);
-			} else {
-				ret += CFormat(" (1 : %.2f)") % (t2 / t1);
-			}
+			ret += (t2 < t1) ? wxT(" (") + num(t1 / t2) + wxT(" : 1)")
+					 : wxT(" (1 : ") + num(t2 / t1) + wxT(")");
 		}
 	}
 
@@ -583,7 +583,11 @@ wxString CStatTreeItemRatio::GetDisplayString() const
 
 void CStatTreeItemRatio::AddECValues(CECTag *tag) const
 {
-	CECTag value(EC_TAG_STAT_NODE_VALUE, GetString());
+	// API contract: English text, C-locale numbers. GetString(false) formats via
+	// CFormat (honours LC_NUMERIC) and translates "Not available" at the daemon
+	// locale, so the wire value uses GetString(true) instead. The GUI path
+	// (GetDisplayString -> GetString()) is unaffected.
+	CECTag value(EC_TAG_STAT_NODE_VALUE, GetString(true));
 	value.AddTag(CECTag(EC_TAG_STAT_VALUE_TYPE, (uint8)EC_VALUE_STRING));
 	tag->AddTag(value);
 }

--- a/src/StatTree.h
+++ b/src/StatTree.h
@@ -1032,8 +1032,10 @@ protected:
 	uint64_t (*m_totalfunc2)();
 
 private:
-	//! Formatted String for display or EC
-	wxString GetString() const;
+	//! Formatted "a : b (c : d)" ratio string. cLocale=true renders C-locale
+	//! numbers and an untranslated English "Not available" for the EC/API wire
+	//! (locale-independent); the default renders in the GUI locale for display.
+	wxString GetString(bool cLocale = false) const;
 };
 
 /**

--- a/src/libwebcommon/JsonWriter.cpp
+++ b/src/libwebcommon/JsonWriter.cpp
@@ -24,6 +24,7 @@
 
 #include "JsonWriter.h"
 
+#include <clocale>
 #include <cmath>
 #include <cstdio>
 
@@ -128,6 +129,19 @@ void CJsonWriter::ValueDouble(double v)
 		// already handled those above.
 		char buf[64];
 		std::snprintf(buf, sizeof(buf), "%.17g", v);
+		// JSON numbers are always C-locale (a '.' decimal point), but snprintf
+		// honours LC_NUMERIC, which amuleapi/amuleweb inherit from --locale.
+		// %g never emits digit grouping, so the only possible locale artifact is
+		// the decimal separator; normalise it to '.' so the output is valid JSON
+		// regardless of the process locale.
+		const char decimal_point = *std::localeconv()->decimal_point;
+		if (decimal_point != '.') {
+			for (char *p = buf; *p; ++p) {
+				if (*p == decimal_point) {
+					*p = '.';
+				}
+			}
+		}
 		*m_buf += wxString::FromAscii(buf);
 	}
 	m_needs_comma = true;

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3175,11 +3175,41 @@ std::string TailString(const std::string &text, std::size_t tail_lines)
 namespace
 {
 
+void WriteStatsValue(CJsonWriter &w, const webapi::StatsTreeValue &v)
+{
+	w.BeginObject();
+	w.Key("type");
+	w.ValueString(wxString::FromUTF8(v.type.c_str()));
+	w.Key("value");
+	switch (v.kind) {
+	case webapi::StatsTreeValue::Num:
+		w.ValueUInt(v.num);
+		break;
+	case webapi::StatsTreeValue::Dbl:
+		w.ValueDouble(v.dbl);
+		break;
+	case webapi::StatsTreeValue::Str:
+		w.ValueString(wxString::FromUTF8(v.str.c_str()));
+		break;
+	}
+	// Optional nested sub-value (the parenthetical "(total …)" some nodes carry).
+	if (!v.extra.empty()) {
+		w.Key("extra");
+		WriteStatsValue(w, v.extra.front());
+	}
+	w.EndObject();
+}
+
 void WriteStatsNode(CJsonWriter &w, const webapi::StatsTreeNode &n)
 {
 	w.BeginObject();
 	w.Key("label");
 	w.ValueString(wxString::FromUTF8(n.label.c_str()));
+	w.Key("values");
+	w.BeginArray();
+	for (const auto &v : n.values)
+		WriteStatsValue(w, v);
+	w.EndArray();
 	w.Key("children");
 	w.BeginArray();
 	for (const auto &c : n.children)

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1265,16 +1265,82 @@ void ApplyGetUpdateToServers(const CECPacket *resp, std::map<std::uint32_t, Serv
 namespace
 {
 
+// EC value type -> stable lowercase API string. Mirrors the EC_VALUE_* enum
+// (ECCodes.h); the numeric value is carried raw (seconds, bytes, bytes/s, …)
+// so clients format and localize.
+const char *ECStatValueTypeName(int type)
+{
+	switch (type) {
+	case EC_VALUE_INTEGER:
+		return "integer";
+	case EC_VALUE_ISTRING:
+		return "istring";
+	case EC_VALUE_BYTES:
+		return "bytes";
+	case EC_VALUE_ISHORT:
+		return "ishort";
+	case EC_VALUE_TIME:
+		return "time";
+	case EC_VALUE_SPEED:
+		return "speed";
+	case EC_VALUE_STRING:
+		return "string";
+	case EC_VALUE_DOUBLE:
+		return "double";
+	default:
+		return "integer";
+	}
+}
+
+// Extract one EC_TAG_STAT_NODE_VALUE as a typed value, raw and untranslated
+// (mirrors ECSpecialTags::FormatValue but without wxGetTranslation / unit
+// formatting). Recurses one level for the optional nested "(total …)" value.
+void ExtractStatsValue(const CECTag *v, StatsTreeValue &out)
+{
+	const CECTag *vt = v->GetTagByName(EC_TAG_STAT_VALUE_TYPE);
+	const int type = vt != nullptr ? (int)vt->GetInt() : EC_VALUE_INTEGER;
+	out.type = ECStatValueTypeName(type);
+	switch (type) {
+	case EC_VALUE_STRING:
+		// The wire string is English (daemon uses wxTRANSLATE); the API must
+		// relay it verbatim and never translate -- that is a client concern.
+		out.kind = StatsTreeValue::Str;
+		out.str = std::string(v->GetStringData().utf8_str());
+		break;
+	case EC_VALUE_DOUBLE:
+		out.kind = StatsTreeValue::Dbl;
+		out.dbl = v->GetDoubleData();
+		break;
+	default:
+		out.kind = StatsTreeValue::Num;
+		out.num = v->GetInt();
+		break;
+	}
+	const CECTag *nested = v->GetTagByName(EC_TAG_STAT_NODE_VALUE);
+	if (nested) {
+		StatsTreeValue e;
+		ExtractStatsValue(nested, e);
+		out.extra.push_back(std::move(e));
+	}
+}
+
 void ParseStatsTreeNode(const CECTag *node, StatsTreeNode &out)
 {
 	const CEC_StatTree_Node_Tag *n = static_cast<const CEC_StatTree_Node_Tag *>(node);
-	out.label = std::string(n->GetDisplayString().utf8_str());
+	// Untranslated English label template exactly as EC carries it (e.g.
+	// "Uptime: %s"); NOT GetDisplayString(), which translates and locale-formats
+	// in the amuleapi process and would make output depend on --locale.
+	out.label = std::string(n->GetStringData().utf8_str());
 	for (CECTag::const_iterator it = n->begin(); it != n->end(); ++it) {
-		if (it->GetTagName() != EC_TAG_STATTREE_NODE)
-			continue;
-		StatsTreeNode child;
-		ParseStatsTreeNode(&*it, child);
-		out.children.push_back(std::move(child));
+		if (it->GetTagName() == EC_TAG_STAT_NODE_VALUE) {
+			StatsTreeValue v;
+			ExtractStatsValue(&*it, v);
+			out.values.push_back(std::move(v));
+		} else if (it->GetTagName() == EC_TAG_STATTREE_NODE) {
+			StatsTreeNode child;
+			ParseStatsTreeNode(&*it, child);
+			out.children.push_back(std::move(child));
+		}
 	}
 }
 
@@ -1283,6 +1349,7 @@ void ParseStatsTreeNode(const CECTag *node, StatsTreeNode &out)
 void ParseStatsTreeFromPacket(const CECPacket *resp, StatsTreeNode &out)
 {
 	out.label.clear();
+	out.values.clear();
 	out.children.clear();
 	if (!resp)
 		return;

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -276,15 +276,41 @@ struct CategorySnapshot
 	std::string priority; // human-readable (very_low/low/normal/high/release/auto)
 };
 
+// One typed value carried by a stats-tree node. The EC packet transports
+// the untranslated English label template plus one or more typed values
+// (EC_TAG_STAT_NODE_VALUE), so the API exposes them structurally rather than
+// flattening through GetDisplayString() (which translates and locale-formats
+// in the amuleapi process). `type` is the EC value type as a stable lowercase
+// string; the raw value lands in exactly one of num/dbl/str per `kind`.
+// `extra` holds the optional nested sub-value (the parenthetical "(total …)"
+// some nodes carry) — at most one level deep, matching the EC encoding.
+struct StatsTreeValue
+{
+	enum Kind
+	{
+		Num, // integer/istring/bytes/ishort/time/speed -> num (raw seconds/bytes/…)
+		Dbl, // double -> dbl
+		Str  // string -> str (raw, untranslated English)
+	};
+
+	std::string type;
+	Kind kind = Num;
+	std::uint64_t num = 0;
+	double dbl = 0.0;
+	std::string str;
+	std::vector<StatsTreeValue> extra;
+};
+
 // One node in the recursive stats tree (amuled's "Statistics" panel
 // contents — counters, ratios, uptime, transfer aggregates, etc.).
-// amule emits a flat-label representation: `GetDisplayString()`
-// returns the rendered text (e.g. "Total bytes transferred: 12.3 GiB")
-// rather than a typed value, so we pass it through as a single
-// human-readable string and let clients render the tree verbatim.
+// `label` is the untranslated English template exactly as EC carries it
+// (e.g. "Uptime: %s"); `values` are the typed raw values that fill it, so
+// clients do their own formatting/localization. The API contract is English
+// text + C-locale numbers, independent of the amuleapi/amuled --locale.
 struct StatsTreeNode
 {
 	std::string label;
+	std::vector<StatsTreeValue> values;
 	std::vector<StatsTreeNode> children;
 };
 

--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -89,7 +89,16 @@ _assert_json_eq '.nodes | type'            array  '/stats/tree .nodes is array'
 # entry rather than pinning specific text (locale-dependent).
 _assert_json_eq '.nodes | length > 0'      true   '/stats/tree has at least one top-level node'
 _assert_json_eq '.nodes[0].label | type'   string '/stats/tree first node has a label'
+_assert_json_eq '.nodes[0].values | type'  array  '/stats/tree first node has a values array'
 _assert_json_eq '.nodes[0].children | type' array '/stats/tree first node has a children array'
+# Typed values: labels are English "%s" templates, values carry the raw typed
+# data (integer/bytes/time/…), so the payload is locale-independent. Assert at
+# least one typed value exists and every value type is from the known set.
+_assert_json_eq '[.. | .values? // empty | .[]?] | length > 0' true \
+	'/stats/tree carries at least one typed value'
+_assert_json_eq '([.. | .values? // empty | .[]? | .type] | unique)
+	- ["integer","istring","bytes","ishort","time","speed","string","double"]
+	| length == 0' true '/stats/tree value types are all from the known set'
 
 # --- 3. /stats/graphs/{graph} — all four named graphs. -------------
 for g in download upload connections kad; do


### PR DESCRIPTION
Addresses #291. Enforces the API contract: all API text is English and all numbers are C-locale, independent of the amuleapi/amuled `--locale`.

## `/stats/tree` — typed, structural (Problem 1)

Nodes were built from `GetDisplayString()`, which translates and locale-formats in the amuleapi process and fuses label+value into one opaque string. Now built from the raw EC data:

```json
{ "label": "Uptime: %s", "values": [ { "type": "time", "value": 1803 } ], "children": [] }
```

- `label` — untranslated English template exactly as EC carries it.
- `values` — typed raw values (`integer`/`istring`/`bytes`/`ishort`/`time`/`speed`/`string`/`double`), with an optional nested `extra` for the "(total …)" sub-value. Clients format and localize.
- Verified identical output under `--locale de_DE`.

## Error message (Problem 2)

`_("Server not added")` → `wxTRANSLATE(...)`, so the wire string stays English (consistent with the other `EC_OP_FAILED` replies); webapi relays it verbatim.

## Contract, documented (Problem 3)

REFERENCE.md gains a "Localization and number formatting" section; EVENTS.md points SSE at the same contract; both note the out-of-scope carve-outs (`logs/amule` content, user/external data). No webapi path calls `wxGetTranslation` anymore.

## Two supporting fixes

- **Ratio (daemon):** `CStatTreeItemRatio::AddECValues` formatted via `CFormat` (honours `LC_NUMERIC`) and translated "Not available" at the daemon locale. Now C-locale (`wxString::FromCDouble`) + English. Kept as a C-locale **string**, not the raw `DOUBLE` the issue suggested: the same EC value is rendered by amulecmd/amulegui/amuleweb as the composite `"1 : X (Y : Z)"`, so a bare double would break their display; the string fixes the locale leak for all consumers. GUI `GetString()` untouched.
- **JSON `ValueDouble`:** normalise the decimal separator to `.`, so JSON stays valid even under a comma-locale amuleapi (covers e.g. `download.percent`, not just stats).

## Scope

The web frontend (#220) consumes the old flat-label shape and must be updated to the new one — that's ngosang's, out of scope here. Master has no stats-tree consumer, so this lands safely on its own; #220 is updated to match before it merges.

## Testing

Daemon + amuleapi built on macOS. `/stats/tree` exercised live: English `%s` templates, raw typed values, working nested `extra`, and an English ratio. `07-read-stats-and-search-results.sh` extended to assert the `values` array, at least one typed value, and that all value types are from the known set.

Full curl-test suite (`unittests/curl-tests/amuleapi/run-all.sh`) against a live amuled — **27/27 scripts, 0 failures**:

<details>
<summary>per-script results</summary>

```
01-version-and-errors                  9/9
02-auth                               35/35
03-read-status                        16/16
04-read-downloads-shared              16/16
05-read-servers-kad-categories-prefs  44/44
06-read-logs                          26/26
07-read-stats-and-search-results      45/45   ← new /stats/tree value assertions
08-read-download-parts                 4/4
09-refresher-consolidation            18/18
10-refresher-lazy-ondemand            25/25
11-downloads-default-filter           16/16
12-downloads-add-patch                31/31
13-downloads-delete-clear             27/27
14-servers-mutations                  24/24
15-preferences-patch                  23/23
16-networks-connect                   22/22
17-shared-priority-patch              32/32
18-categories-crud                    24/24
19-search                             40/40
20-etag-conditional-get               30/30
21-sse-heartbeat                      11/11
22-sse-diff-emission                  15/15
23-sse-replay                          7/7
24-sse-resync                          9/9
25-cors                               21/21
26-rfc-followup-endpoints             32/32
27-static-frontend                    12/12
```

</details>
