### PR TITLE
fix(gui): scale main-toolbar icons on hi-DPI displays

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -1480,7 +1480,7 @@ void CamuleDlg::Add_Skin_Icon(const wxString &iconName, const wxBitmap &stdIcon,
 				wxBitmap(img.Scale(
 					img.GetWidth() * 2, img.GetHeight() * 2, wxIMAGE_QUALITY_HIGH))));
 		} else {
-			m_tblist.push_back(wxBitmapBundle(bmp));
+			m_tblist.emplace_back(bmp);
 		}
 	}
 }

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -188,7 +188,7 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 , m_nActiveDialog(DT_NETWORKS_WND)
 , m_is_safe_state(false)
 , m_BlinkMessages(false)
-, m_CurrentBlinkBitmap(24)
+, m_CurrentBlinkBitmap(Toolbar_Messages)
 , m_last_iconizing(0)
 , m_skinFileName()
 , m_clientSkinNames(CLIENT_SKIN_SIZE)
@@ -887,24 +887,24 @@ void CamuleDlg::ShowConnectionState(bool skinChanged)
 
 		wxToolBarToolBase *toolbarTool = m_wndToolbar->FindById(ID_BUTTONCONNECT);
 
-		int bitmapIdx = 0;
+		int bitmapIdx = Toolbar_Connect;
 		switch (currentState) {
 		case ECS_Connecting:
 			toolbarTool->SetLabel(_("Cancel"));
 			toolbarTool->SetShortHelp(_("Stop the current connection attempts"));
-			bitmapIdx = 2;
+			bitmapIdx = Toolbar_Connecting;
 			break;
 
 		case ECS_Connected:
 			toolbarTool->SetLabel(_("Disconnect"));
 			toolbarTool->SetShortHelp(_("Disconnect from the currently connected networks"));
-			bitmapIdx = 1;
+			bitmapIdx = Toolbar_Disconnect;
 			break;
 
 		default:
 			toolbarTool->SetLabel(_("Connect"));
 			toolbarTool->SetShortHelp(_("Connect to the currently enabled networks"));
-			bitmapIdx = 0;
+			bitmapIdx = Toolbar_Connect;
 		}
 
 		// wxToolBarToolBase::SetNormalBitmap only updates the C++ tool
@@ -915,14 +915,8 @@ void CamuleDlg::ShowConnectionState(bool skinChanged)
 		// connect-state transition paints atomically with the new
 		// bitmap on the next redraw — without forcing a re-layout that
 		// would disrupt a vertical toolbar's orientation measurement.
-		// Same pattern as SetMessagesTool() just below. wxCocoa keeps
-		// the tool path because SetToolNormalBitmap isn't fully wired
-		// on the OS X NSToolbar backend. (#800)
-#ifdef __WXCOCOA__
-		toolbarTool->SetNormalBitmap(m_tblist[bitmapIdx]);
-#else
+		// Same pattern as SetMessagesTool() just below. (#800)
 		m_wndToolbar->SetToolNormalBitmap(ID_BUTTONCONNECT, m_tblist[bitmapIdx]);
-#endif
 
 		m_wndToolbar->EnableTool(ID_BUTTONCONNECT,
 			(thePrefs::GetNetworkED2K() || thePrefs::GetNetworkKademlia()) &&
@@ -1345,12 +1339,12 @@ void CamuleDlg::OnGUITimer(wxTimerEvent &WXUNUSED(evt))
 
 	if (msCur - msPrev1 > 1000) { // every second
 		msPrev1 = msCur;
-		if (m_CurrentBlinkBitmap == 12) {
-			m_CurrentBlinkBitmap = 7;
+		if (m_CurrentBlinkBitmap == Toolbar_Blink) {
+			m_CurrentBlinkBitmap = Toolbar_Messages;
 			SetMessagesTool();
 		} else {
 			if (m_BlinkMessages) {
-				m_CurrentBlinkBitmap = 12;
+				m_CurrentBlinkBitmap = Toolbar_Blink;
 				SetMessagesTool();
 			}
 		}
@@ -1359,20 +1353,8 @@ void CamuleDlg::OnGUITimer(wxTimerEvent &WXUNUSED(evt))
 
 void CamuleDlg::SetMessagesTool()
 {
-	// m_CurrentBlinkBitmap starts out as a stale sentinel (24) and only
-	// becomes a valid index (7 or 12) once the blink timer runs; unlike
-	// the old wxImageList::GetBitmap, vector indexing must not go out of
-	// bounds.
-	if (m_CurrentBlinkBitmap < 0 || static_cast<size_t>(m_CurrentBlinkBitmap) >= m_tblist.size()) {
-		return;
-	}
-
 	wxWindowUpdateLocker freezer(m_wndToolbar);
-#ifdef __WXCOCOA__
-	m_wndToolbar->FindById(ID_BUTTONMESSAGES)->SetNormalBitmap(m_tblist[m_CurrentBlinkBitmap]);
-#else
 	m_wndToolbar->SetToolNormalBitmap(ID_BUTTONMESSAGES, m_tblist[m_CurrentBlinkBitmap]);
-#endif
 }
 
 void CamuleDlg::LaunchUrl(const wxString &url)
@@ -1494,11 +1476,9 @@ void CamuleDlg::Add_Skin_Icon(const wxString &iconName, const wxBitmap &stdIcon,
 			if (!img.HasAlpha()) {
 				img.InitAlpha();
 			}
-			wxVector<wxBitmap> sizes;
-			sizes.push_back(bmp);
-			sizes.push_back(wxBitmap(
-				img.Scale(img.GetWidth() * 2, img.GetHeight() * 2, wxIMAGE_QUALITY_HIGH)));
-			m_tblist.push_back(wxBitmapBundle::FromBitmaps(sizes));
+			m_tblist.push_back(wxBitmapBundle::FromBitmaps(bmp,
+				wxBitmap(img.Scale(
+					img.GetWidth() * 2, img.GetHeight() * 2, wxIMAGE_QUALITY_HIGH))));
 		} else {
 			m_tblist.push_back(wxBitmapBundle(bmp));
 		}
@@ -1525,7 +1505,7 @@ void CamuleDlg::Apply_Toolbar_Skin(wxToolBar *wndToolbar)
 	// Clear the toolbar image list
 	m_tblist.clear();
 
-	// Add the images to the image list
+	// Add the images to the image list, in ToolbarSkinEnum order
 	Add_Skin_Icon("Toolbar_Connect", connButImg(0), useSkins);
 	Add_Skin_Icon("Toolbar_Disconnect", connButImg(1), useSkins);
 	Add_Skin_Icon("Toolbar_Connecting", connButImg(2), useSkins);
@@ -1544,61 +1524,62 @@ void CamuleDlg::Apply_Toolbar_Skin(wxToolBar *wndToolbar)
 	wndToolbar->SetMargins(0, 0);
 
 	// Placeholder. Gets updated by ShowConnectionState
-	wndToolbar->AddTool(ID_BUTTONCONNECT, "...", m_tblist[0]);
+	wndToolbar->AddTool(ID_BUTTONCONNECT, "...", m_tblist[Toolbar_Connect]);
 
 	wndToolbar->AddSeparator();
 	wndToolbar->AddTool(ID_BUTTONNETWORKS,
 		_("Networks"),
-		m_tblist[3],
+		m_tblist[Toolbar_Network],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Networks Window"));
 	wndToolbar->AddTool(ID_BUTTONSEARCH,
 		_("Searches"),
-		m_tblist[5],
+		m_tblist[Toolbar_Search],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Searches Window"));
 	wndToolbar->AddTool(ID_BUTTONDOWNLOADS,
 		_("Downloads"),
-		m_tblist[4],
+		m_tblist[Toolbar_Transfers],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Downloads Window"));
 	wndToolbar->AddTool(ID_BUTTONSHARED,
 		_("Shared files"),
-		m_tblist[6],
+		m_tblist[Toolbar_Shared],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Shared Files Window"));
 	wndToolbar->AddTool(ID_BUTTONMESSAGES,
 		_("Messages"),
-		m_tblist[7],
+		m_tblist[Toolbar_Messages],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Messages Window"));
 	wndToolbar->AddTool(ID_BUTTONSTATISTICS,
 		_("Statistics"),
-		m_tblist[8],
+		m_tblist[Toolbar_Stats],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Statistics Graph Window"));
 	wndToolbar->AddSeparator();
 	wndToolbar->AddTool(ID_BUTTONNEWPREFERENCES,
 		_("Preferences"),
-		m_tblist[9],
+		m_tblist[Toolbar_Prefs],
 		wxNullBitmap,
 		wxITEM_NORMAL,
 		_("Preferences Settings Window"));
 #ifndef CLIENT_GUI
 	wndToolbar->AddTool(ID_BUTTONIMPORT,
 		_("Import"),
-		m_tblist[10],
+		m_tblist[Toolbar_Import],
 		wxNullBitmap,
 		wxITEM_NORMAL,
 		_("The partfile importer tool"));
 #endif
-	wndToolbar->AddTool(ID_ABOUT, _("About"), m_tblist[11], wxNullBitmap, wxITEM_NORMAL, _("About/Help"));
+	wndToolbar->AddTool(
+		ID_ABOUT, _("About"), m_tblist[Toolbar_About], wxNullBitmap, wxITEM_NORMAL, _("About/Help"));
 
 	wndToolbar->ToggleTool(ID_BUTTONDOWNLOADS, true);
 

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -182,7 +182,6 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 , m_lastShownMaximized(false)
 , m_lastShownValid(false)
 , m_imagelist(16, 16)
-, m_tblist(32, 32)
 , m_prefsVisible(false)
 , m_wndToolbar(NULL)
 , m_wndTaskbarNotifier(NULL)
@@ -920,9 +919,9 @@ void CamuleDlg::ShowConnectionState(bool skinChanged)
 		// the tool path because SetToolNormalBitmap isn't fully wired
 		// on the OS X NSToolbar backend. (#800)
 #ifdef __WXCOCOA__
-		toolbarTool->SetNormalBitmap(m_tblist.GetBitmap(bitmapIdx));
+		toolbarTool->SetNormalBitmap(m_tblist[bitmapIdx]);
 #else
-		m_wndToolbar->SetToolNormalBitmap(ID_BUTTONCONNECT, m_tblist.GetBitmap(bitmapIdx));
+		m_wndToolbar->SetToolNormalBitmap(ID_BUTTONCONNECT, m_tblist[bitmapIdx]);
 #endif
 
 		m_wndToolbar->EnableTool(ID_BUTTONCONNECT,
@@ -1360,11 +1359,19 @@ void CamuleDlg::OnGUITimer(wxTimerEvent &WXUNUSED(evt))
 
 void CamuleDlg::SetMessagesTool()
 {
+	// m_CurrentBlinkBitmap starts out as a stale sentinel (24) and only
+	// becomes a valid index (7 or 12) once the blink timer runs; unlike
+	// the old wxImageList::GetBitmap, vector indexing must not go out of
+	// bounds.
+	if (m_CurrentBlinkBitmap < 0 || static_cast<size_t>(m_CurrentBlinkBitmap) >= m_tblist.size()) {
+		return;
+	}
+
 	wxWindowUpdateLocker freezer(m_wndToolbar);
 #ifdef __WXCOCOA__
-	m_wndToolbar->FindById(ID_BUTTONMESSAGES)->SetNormalBitmap(m_tblist.GetBitmap(m_CurrentBlinkBitmap));
+	m_wndToolbar->FindById(ID_BUTTONMESSAGES)->SetNormalBitmap(m_tblist[m_CurrentBlinkBitmap]);
 #else
-	m_wndToolbar->SetToolNormalBitmap(ID_BUTTONMESSAGES, m_tblist.GetBitmap(m_CurrentBlinkBitmap));
+	m_wndToolbar->SetToolNormalBitmap(ID_BUTTONMESSAGES, m_tblist[m_CurrentBlinkBitmap]);
 #endif
 }
 
@@ -1476,7 +1483,25 @@ void CamuleDlg::Add_Skin_Icon(const wxString &iconName, const wxBitmap &stdIcon,
 	if (iconName.StartsWith("Client_")) {
 		m_imagelist.Add(bmp);
 	} else if (iconName.StartsWith("Toolbar_")) {
-		m_tblist.Add(bmp);
+		// The toolbar art only exists at one (32x32) size. Store it as a
+		// wxBitmapBundle with a smooth 2x upscale so DPI-aware toolbars
+		// pick a correctly sized bitmap on hi-DPI screens instead of
+		// drawing the 1x art at a tiny physical size. The mask is turned
+		// into an alpha channel first, because high-quality scaling of a
+		// masked image smears the mask colour into the icon edges.
+		wxImage img = bmp.ConvertToImage();
+		if (img.IsOk()) {
+			if (!img.HasAlpha()) {
+				img.InitAlpha();
+			}
+			wxVector<wxBitmap> sizes;
+			sizes.push_back(bmp);
+			sizes.push_back(wxBitmap(
+				img.Scale(img.GetWidth() * 2, img.GetHeight() * 2, wxIMAGE_QUALITY_HIGH)));
+			m_tblist.push_back(wxBitmapBundle::FromBitmaps(sizes));
+		} else {
+			m_tblist.push_back(wxBitmapBundle(bmp));
+		}
 	}
 }
 
@@ -1498,7 +1523,7 @@ void CamuleDlg::Apply_Toolbar_Skin(wxToolBar *wndToolbar)
 	bool useSkins = Check_and_Init_Skin();
 
 	// Clear the toolbar image list
-	m_tblist.RemoveAll();
+	m_tblist.clear();
 
 	// Add the images to the image list
 	Add_Skin_Icon("Toolbar_Connect", connButImg(0), useSkins);
@@ -1519,62 +1544,61 @@ void CamuleDlg::Apply_Toolbar_Skin(wxToolBar *wndToolbar)
 	wndToolbar->SetMargins(0, 0);
 
 	// Placeholder. Gets updated by ShowConnectionState
-	wndToolbar->AddTool(ID_BUTTONCONNECT, "...", m_tblist.GetBitmap(0));
+	wndToolbar->AddTool(ID_BUTTONCONNECT, "...", m_tblist[0]);
 
 	wndToolbar->AddSeparator();
 	wndToolbar->AddTool(ID_BUTTONNETWORKS,
 		_("Networks"),
-		m_tblist.GetBitmap(3),
+		m_tblist[3],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Networks Window"));
 	wndToolbar->AddTool(ID_BUTTONSEARCH,
 		_("Searches"),
-		m_tblist.GetBitmap(5),
+		m_tblist[5],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Searches Window"));
 	wndToolbar->AddTool(ID_BUTTONDOWNLOADS,
 		_("Downloads"),
-		m_tblist.GetBitmap(4),
+		m_tblist[4],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Downloads Window"));
 	wndToolbar->AddTool(ID_BUTTONSHARED,
 		_("Shared files"),
-		m_tblist.GetBitmap(6),
+		m_tblist[6],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Shared Files Window"));
 	wndToolbar->AddTool(ID_BUTTONMESSAGES,
 		_("Messages"),
-		m_tblist.GetBitmap(7),
+		m_tblist[7],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Messages Window"));
 	wndToolbar->AddTool(ID_BUTTONSTATISTICS,
 		_("Statistics"),
-		m_tblist.GetBitmap(8),
+		m_tblist[8],
 		wxNullBitmap,
 		wxITEM_CHECK,
 		_("Statistics Graph Window"));
 	wndToolbar->AddSeparator();
 	wndToolbar->AddTool(ID_BUTTONNEWPREFERENCES,
 		_("Preferences"),
-		m_tblist.GetBitmap(9),
+		m_tblist[9],
 		wxNullBitmap,
 		wxITEM_NORMAL,
 		_("Preferences Settings Window"));
 #ifndef CLIENT_GUI
 	wndToolbar->AddTool(ID_BUTTONIMPORT,
 		_("Import"),
-		m_tblist.GetBitmap(10),
+		m_tblist[10],
 		wxNullBitmap,
 		wxITEM_NORMAL,
 		_("The partfile importer tool"));
 #endif
-	wndToolbar->AddTool(
-		ID_ABOUT, _("About"), m_tblist.GetBitmap(11), wxNullBitmap, wxITEM_NORMAL, _("About/Help"));
+	wndToolbar->AddTool(ID_ABOUT, _("About"), m_tblist[11], wxNullBitmap, wxITEM_NORMAL, _("About/Help"));
 
 	wndToolbar->ToggleTool(ID_BUTTONDOWNLOADS, true);
 
@@ -1610,7 +1634,10 @@ void CamuleDlg::Create_Toolbar(bool orientation)
 			CreateToolBar((orientation ? wxTB_VERTICAL : wxTB_HORIZONTAL) | int(wxNO_BORDER) |
 				      wxTB_TEXT | wxTB_FLAT | wxCLIP_CHILDREN | wxTB_NODIVIDER);
 
-		m_wndToolbar->SetToolBitmapSize(wxSize(32, 32));
+		// No SetToolBitmapSize() here: the tools are wxBitmapBundles, so
+		// the toolbar derives the bitmap size from the bundles' default
+		// (32 DIP) size and scales it with the monitor's DPI. Forcing a
+		// fixed size would pin the icons at 32 physical pixels again.
 	}
 
 	Apply_Toolbar_Skin(m_wndToolbar);

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -29,12 +29,15 @@
 #include "config.h" // for ENABLE_VERSION_CHECK (gates the startup version-check members)
 
 #include <wx/archive.h>
+#include <wx/bmpbndl.h>
 #include <wx/filename.h>
 #include <wx/frame.h> // Needed for wxFrame
 #include <wx/imaglist.h>
 #include <wx/timer.h>
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
+
+#include <vector>
 
 #include "Types.h" // Needed for uint32
 #include "StatisticsDlg.h"
@@ -198,7 +201,11 @@ public:
 	bool m_lastShownValid;
 
 	wxImageList m_imagelist;
-	wxImageList m_tblist;
+	// Toolbar icons as resolution-aware bundles (the 32x32 art plus a
+	// smooth 2x upscale). The executable is per-monitor-DPI aware, so a
+	// plain 32px wxBitmap would be drawn at 32 *physical* pixels — tiny
+	// and blurry on hi-DPI screens.
+	std::vector<wxBitmapBundle> m_tblist;
 
 protected:
 	void OnToolBarButton(wxCommandEvent &ev);

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -104,6 +104,27 @@ enum ClientSkinEnum
 	CLIENT_SKIN_SIZE
 };
 
+// Indexes into CamuleDlg::m_tblist. Must match the order of the
+// Add_Skin_Icon("Toolbar_...") calls in Apply_Toolbar_Skin.
+enum ToolbarSkinEnum
+{
+	Toolbar_Connect = 0,
+	Toolbar_Disconnect,
+	Toolbar_Connecting,
+	Toolbar_Network,
+	Toolbar_Transfers,
+	Toolbar_Search,
+	Toolbar_Shared,
+	Toolbar_Messages,
+	Toolbar_Stats,
+	Toolbar_Prefs,
+	Toolbar_Import,
+	Toolbar_About,
+	Toolbar_Blink,
+	// Add items here.
+	TOOLBAR_SKIN_SIZE
+};
+
 // CamuleDlg Dialogfeld
 class CamuleDlg : public wxFrame
 {


### PR DESCRIPTION
## Summary

The main-toolbar icons (Downloads, Shared Files, Networks, etc.) render tiny and blurry on hi-DPI screens (e.g. 4K at 150–200% scaling). They are stored in a fixed 32x32 `wxImageList` and handed to `wxToolBar` as plain `wxBitmap`s, and since the executable declares PerMonitorV2 DPI awareness (#780) they get drawn at 32 *physical* pixels while the rest of the UI scales.

This PR stores each toolbar icon as a `wxBitmapBundle` (available since wx 3.2, the project minimum):

- `m_tblist` becomes a `std::vector<wxBitmapBundle>`; `AddTool` / `SetToolNormalBitmap` receive bundles, so the toolbar picks a correctly sized bitmap per monitor DPI.
- Each bundle is built from the original 32px art plus a `wxIMAGE_QUALITY_HIGH` 2x upscale. The transparency mask is converted to an alpha channel before scaling, otherwise the smooth scaler smears the mask colour into the icon edges (halos). Works for both built-in art and skin PNGs.
- The hard-coded `SetToolBitmapSize(32, 32)` is dropped so the toolbar derives the logical size from the bundles and scales it with the monitor's DPI.
- `SetMessagesTool` gains a bounds guard: `m_CurrentBlinkBitmap` starts as a stale sentinel (24) that the old `wxImageList::GetBitmap` tolerated (returned `wxNullBitmap`) but vector indexing must not reach.

Since the source art only exists at 32px, the result is a correctly sized, smoothly scaled icon rather than a pixel-perfect one — redrawing the icons as SVG (`wxBitmapBundle::FromSVG`) can layer on top of this later, as can the same treatment for the client-status / tab / flag image lists.

## Test plan

- `clang-format` 18 passes on both touched files (matches the CI gate).
- Code verified against the wx 3.2 API (`AddTool`, `SetToolNormalBitmap` and `wxToolBarToolBase::SetNormalBitmap` all take `wxBitmapBundle` since 3.2).
- No local wxWidgets toolchain was available to build; relying on CI builds for compile verification. Visual check on a scaled display (toolbar icons sized correctly at 150/200%, connect-state and message-blink icon swaps still working) would be appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)