### PR TITLE
fix(i18n): lowercase 'days' unit in CastSecondsToHM

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -4550,7 +4550,7 @@ msgid "hours"
 msgstr ""
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr ""
 
 #: src/OtherFunctions.cpp:685

--- a/po/ar.po
+++ b/po/ar.po
@@ -4603,7 +4603,7 @@ msgid "hours"
 msgstr ""
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr ""
 
 #: src/OtherFunctions.cpp:685

--- a/po/ast.po
+++ b/po/ast.po
@@ -4660,8 +4660,8 @@ msgid "hours"
 msgstr "hores"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Díes"
+msgid "days"
+msgstr "díes"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/bg.po
+++ b/po/bg.po
@@ -4589,7 +4589,7 @@ msgid "hours"
 msgstr "часа"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "дни"
 
 #: src/OtherFunctions.cpp:685

--- a/po/bn.po
+++ b/po/bn.po
@@ -4549,7 +4549,7 @@ msgid "hours"
 msgstr ""
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr ""
 
 #: src/OtherFunctions.cpp:685

--- a/po/ca.po
+++ b/po/ca.po
@@ -4638,8 +4638,8 @@ msgid "hours"
 msgstr "hores"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dies"
+msgid "days"
+msgstr "dies"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/cs.po
+++ b/po/cs.po
@@ -4638,7 +4638,7 @@ msgid "hours"
 msgstr "hod."
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "dní"
 
 #: src/OtherFunctions.cpp:685

--- a/po/da.po
+++ b/po/da.po
@@ -4607,7 +4607,7 @@ msgid "hours"
 msgstr ""
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr ""
 
 #: src/OtherFunctions.cpp:685

--- a/po/de.po
+++ b/po/de.po
@@ -4630,8 +4630,8 @@ msgid "hours"
 msgstr "Stunden"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Tage"
+msgid "days"
+msgstr "tage"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/el.po
+++ b/po/el.po
@@ -4672,8 +4672,8 @@ msgid "hours"
 msgstr "ώρες"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Μέρες"
+msgid "days"
+msgstr "μέρες"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4550,7 +4550,7 @@ msgid "hours"
 msgstr ""
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr ""
 
 #: src/OtherFunctions.cpp:685

--- a/po/es.po
+++ b/po/es.po
@@ -4647,8 +4647,8 @@ msgid "hours"
 msgstr "horas"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Días"
+msgid "days"
+msgstr "días"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -4639,7 +4639,7 @@ msgid "hours"
 msgstr "tundi"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "päev(a)"
 
 #: src/OtherFunctions.cpp:685

--- a/po/eu.po
+++ b/po/eu.po
@@ -4639,8 +4639,8 @@ msgid "hours"
 msgstr "ordu"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Egunak"
+msgid "days"
+msgstr "egunak"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/fi.po
+++ b/po/fi.po
@@ -4639,8 +4639,8 @@ msgid "hours"
 msgstr "tuntia"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Päivää"
+msgid "days"
+msgstr "päivää"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/fr.po
+++ b/po/fr.po
@@ -4642,8 +4642,8 @@ msgid "hours"
 msgstr "heures"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Jours"
+msgid "days"
+msgstr "jours"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/gl.po
+++ b/po/gl.po
@@ -4645,8 +4645,8 @@ msgid "hours"
 msgstr "horas"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Días"
+msgid "days"
+msgstr "días"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/he.po
+++ b/po/he.po
@@ -4614,7 +4614,7 @@ msgid "hours"
 msgstr "שעות"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "ימים"
 
 #: src/OtherFunctions.cpp:685

--- a/po/hr.po
+++ b/po/hr.po
@@ -4626,8 +4626,8 @@ msgid "hours"
 msgstr "sati"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dani"
+msgid "days"
+msgstr "dani"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4619,7 +4619,7 @@ msgid "hours"
 msgstr "óra"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "nap"
 
 #: src/OtherFunctions.cpp:685

--- a/po/it.po
+++ b/po/it.po
@@ -4648,8 +4648,8 @@ msgid "hours"
 msgstr "ore"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Giorni"
+msgid "days"
+msgstr "giorni"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -4633,8 +4633,8 @@ msgid "hours"
 msgstr "ore"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Giorni"
+msgid "days"
+msgstr "giorni"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/ja.po
+++ b/po/ja.po
@@ -4644,7 +4644,7 @@ msgid "hours"
 msgstr "時間"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "日"
 
 #: src/OtherFunctions.cpp:685

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -4671,7 +4671,7 @@ msgid "hours"
 msgstr "시"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "일"
 
 #: src/OtherFunctions.cpp:685

--- a/po/lt.po
+++ b/po/lt.po
@@ -4683,7 +4683,7 @@ msgid "hours"
 msgstr "val."
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "dienų"
 
 #: src/OtherFunctions.cpp:685

--- a/po/lv.po
+++ b/po/lv.po
@@ -4560,8 +4560,8 @@ msgid "hours"
 msgstr "stundas"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dienas"
+msgid "days"
+msgstr "dienas"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/nl.po
+++ b/po/nl.po
@@ -4641,8 +4641,8 @@ msgid "hours"
 msgstr "uren"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dagen"
+msgid "days"
+msgstr "dagen"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/nn.po
+++ b/po/nn.po
@@ -4665,8 +4665,8 @@ msgid "hours"
 msgstr "timar"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dagar"
+msgid "days"
+msgstr "dagar"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/pl.po
+++ b/po/pl.po
@@ -4662,8 +4662,8 @@ msgid "hours"
 msgstr "godzin"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dni"
+msgid "days"
+msgstr "dni"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4643,8 +4643,8 @@ msgid "hours"
 msgstr "horas"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dias"
+msgid "days"
+msgstr "dias"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -4646,8 +4646,8 @@ msgid "hours"
 msgstr "horas"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dias"
+msgid "days"
+msgstr "dias"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/ro.po
+++ b/po/ro.po
@@ -4649,8 +4649,8 @@ msgid "hours"
 msgstr "ore"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Zile"
+msgid "days"
+msgstr "zile"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/ru.po
+++ b/po/ru.po
@@ -4682,7 +4682,7 @@ msgid "hours"
 msgstr "ч"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "д"
 
 #: src/OtherFunctions.cpp:685

--- a/po/sl.po
+++ b/po/sl.po
@@ -4674,7 +4674,7 @@ msgid "hours"
 msgstr "ur"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "dni"
 
 #: src/OtherFunctions.cpp:685

--- a/po/sq.po
+++ b/po/sq.po
@@ -4659,8 +4659,8 @@ msgid "hours"
 msgstr "ore"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dite"
+msgid "days"
+msgstr "dite"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/sv.po
+++ b/po/sv.po
@@ -4636,8 +4636,8 @@ msgid "hours"
 msgstr "timmar"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Dagar"
+msgid "days"
+msgstr "dagar"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/ta.po
+++ b/po/ta.po
@@ -4549,7 +4549,7 @@ msgid "hours"
 msgstr ""
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr ""
 
 #: src/OtherFunctions.cpp:685

--- a/po/tr.po
+++ b/po/tr.po
@@ -4635,8 +4635,8 @@ msgid "hours"
 msgstr "saat"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
-msgstr "Gün"
+msgid "days"
+msgstr "gün"
 
 #: src/OtherFunctions.cpp:685
 msgid "all"

--- a/po/uk.po
+++ b/po/uk.po
@@ -4682,7 +4682,7 @@ msgid "hours"
 msgstr "год"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "діб"
 
 #: src/OtherFunctions.cpp:685

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4636,7 +4636,7 @@ msgid "hours"
 msgstr "小时"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "日"
 
 #: src/OtherFunctions.cpp:685

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4626,7 +4626,7 @@ msgid "hours"
 msgstr "時"
 
 #: src/OtherFunctions.cpp:108
-msgid "Days"
+msgid "days"
 msgstr "天"
 
 #: src/OtherFunctions.cpp:685

--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -105,7 +105,7 @@ wxString CastSecondsToHM(uint32 count, uint16 msecs)
 	} else if (count < 86400) {
 		return CFormat("%u:%02u %s") % (count / 3600) % ((count % 3600) / 60) % _("hours");
 	} else {
-		return CFormat("%u %s %02u:%02u %s") % (count / 86400) % _("Days") %
+		return CFormat("%u %s %02u:%02u %s") % (count / 86400) % _("days") %
 		       ((count % 86400) / 3600) % ((count % 3600) / 60) % _("hours");
 	}
 }


### PR DESCRIPTION
The days unit in CastSecondsToHM was capitalized ("Days") while all other time units (secs, mins, hours) are lowercase, producing inconsistent output like "3 Days 04:05 hours".

- src/OtherFunctions.cpp: change _("Days") to _("days").
- po/amule.pot and all 41 po/*.po catalogs: migrate the "Days" msgid to "days" and lowercase the first character of each translation to match, preserving existing translations. Non-cased scripts (ja, zh, ko, he), already-lowercase entries, and empty msgstrs are left unchanged.