### PR TITLE
feat(webui): replace language toggle with scalable dropdown

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -229,6 +229,12 @@ b { font-weight: 600; }
 .btn-sm { padding: 4px 8px; font-size: 13px; }
 .btn-sm .icon { width: 15px; height: 15px; }
 
+/* Language picker: globe icon + native <select>, blended into the ghost toolbar. */
+.lang-select { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; }
+.lang-select select {
+  border: none; background: transparent; padding: 2px 4px; cursor: pointer;
+}
+
 .input, select, textarea {
   padding: 7px 9px;
   border: 1px solid var(--border);
@@ -522,7 +528,8 @@ table.data td.name { white-space: normal; word-break: break-word; min-width: 220
   }
   .nav .tool-label { font-size: 14px; }
   .nav > .conn-btn { display: flex; }
-  .nav-tools .lang-code { display: none; } /* the drawer row shows "Language" instead */
+  .nav-tools .lang-select { min-height: 44px; width: 100%; border-color: transparent; }
+  .nav-tools .lang-select select { flex: 1 1 auto; }
   .nav-backdrop {
     position: fixed; inset: var(--toolbar-h) 0 0 0;
     background: rgba(0, 0, 0, .35); z-index: 79;

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -12,7 +12,7 @@ import { data } from "./events.js";
 import { html, render, useState, useEffect, useStore } from "./dom.js";
 import { toast, Placeholder, confirmDialog } from "./components.js";
 import { formatSpeed, formatInt } from "./format.js";
-import { t, terr, getLang, cycleLang } from "./i18n.js";
+import { t, terr, getLang, setLang, LANGS, langName } from "./i18n.js";
 import { Icon } from "./icons.js";
 import { getTheme, cycleTheme } from "./theme.js";
 import { Login } from "./views/login.js";
@@ -127,7 +127,7 @@ function Toolbar({ route, onLogout }) {
             <span class="tool-label">${r.label}</span>
           </a>`)}
         <div class="nav-tools">
-          <${LangButton} />
+          <${LangSelect} />
           <${ThemeButton} />
           <button class="btn btn-ghost" title=${t("app_logout")} onClick=${doLogout}>
             <${Icon} name="logout" /><span class="sr-only">${t("app_logout")}</span>
@@ -141,7 +141,7 @@ function Toolbar({ route, onLogout }) {
                  onInput=${(e) => setLink(e.target.value)} />
           <button class="btn admin-only" type="submit">${t("app_add")}</button>
         </form>
-        <${LangButton} />
+        <${LangSelect} />
         <${ThemeButton} />
         <button class="btn btn-ghost" title=${t("app_logout")} onClick=${doLogout}>
           <${Icon} name="logout" /><span class="sr-only">${t("app_logout")}</span>
@@ -187,16 +187,20 @@ function ConnectButton({ status }) {
     </button>`;
 }
 
-// Cycles en -> es; the page reloads so module-level t() calls re-resolve.
-function LangButton() {
+// Dropdown of every language in LANGS; selecting one reloads the page so
+// module-level t() calls re-resolve. Native <select> scales to any language
+// count and gives the platform picker on mobile for free.
+function LangSelect() {
   const lang = getLang();
   return html`
-    <button class="btn btn-ghost" title=${t("app_language") + ": " + lang.toUpperCase()}
-            onClick=${cycleLang}>
+    <label class="lang-select btn btn-ghost" title=${t("app_language")}>
       <${Icon} name="language" />
-      <span class="lang-code">${lang.toUpperCase()}</span>
-      <span class="sr-only">${t("app_language")}</span>
-    </button>`;
+      <select aria-label=${t("app_language")}
+              onChange=${(e) => setLang(e.target.value)}>
+        ${LANGS.map((c) => html`
+          <option value=${c} selected=${c === lang}>${langName(c)}</option>`)}
+      </select>
+    </label>`;
 }
 
 // Cycles system -> light -> dark and shows the matching icon.

--- a/src/webapi/static/js/i18n.js
+++ b/src/webapi/static/js/i18n.js
@@ -81,7 +81,10 @@ export function setLang(code) {
   location.reload();
 }
 
-// en -> es -> en
-export function cycleLang() {
-  setLang(LANGS[(LANGS.indexOf(lang) + 1) % LANGS.length]);
+// Language autonym ("English", "español"...), capitalized. Native, no data.
+export function langName(code) {
+  try {
+    const n = new Intl.DisplayNames([code], { type: "language" }).of(code);
+    return n ? n[0].toUpperCase() + n.slice(1) : code.toUpperCase();
+  } catch (_) { return code.toUpperCase(); }
 }


### PR DESCRIPTION
The navbar language selector was a cycle button that stepped through languages one click at a time. This does not scale beyond a couple of locales, so replace it with a native <select> dropdown that lists every language and works identically on desktop and mobile.

- app.js: LangButton (cycle button) -> LangSelect, a native <select>
  populated from LANGS; selecting an option calls setLang() which
  persists and reloads. Rendered in both the desktop tools and the
  mobile drawer.
- i18n.js: drop the now-obsolete cycleLang(); add langName() to show each language as its own autonym via Intl.DisplayNames (no data to maintain).
- app.css: style .lang-select to blend into the ghost toolbar; make it a full-width 44px row in the mobile drawer and hide its redundant text label there (icon + select are self-explanatory).