### PR TITLE
fix(gui): drop Mac padding from Preferences page icons

### DIFF
--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -300,48 +300,21 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	preferencesDlgTop(this, false);
 
 	m_PrefsIcons = CastChild(ID_PREFSLISTCTRL, wxListCtrl);
-	// Pad the tab icons so they don't sit flush against the cell label
-	// and (on Mac) so they don't drop to the row baseline. wxOSX
-	// NSTableView draws the image with zero native horizontal gap and
-	// vertically centres the bitmap; wxGTK and wxMSW already insert a
-	// few pixels of horizontal padding natively and align top-to-top.
-	//
-	// Two-dimensional padding gated on Mac only:
-	//  * Right pad — visible gap between icon and the cell text.
-	//  * Bottom pad — taller bitmap; with the 16x16 source pinned to
-	//    the bitmap's top, NSTableView's vertical centring then lifts
-	//    the icon up to sit alongside the text baseline instead of
-	//    falling to the bottom of the row.
 	const int kPrefsIconW = 16;
 	const int kPrefsIconH = 16;
-#ifdef __WXOSX__
-	const int kPrefsIconRightPad = 14;
-	const int kPrefsIconBottomPad = 9;
-#else
-	const int kPrefsIconRightPad = 0;
-	const int kPrefsIconBottomPad = 0;
-#endif
-	const int kPrefsImageW = kPrefsIconW + kPrefsIconRightPad;
-	const int kPrefsImageH = kPrefsIconH + kPrefsIconBottomPad;
 
 	// The page art only exists at one (16x16) size. Wrap each icon in a
 	// wxBitmapBundle with a smooth 2x upscale so DPI-aware builds render
 	// it at the correct logical size on hi-DPI screens instead of a tiny
 	// 16-physical-pixel square (same treatment as the main toolbar). The
-	// mask is turned into an alpha channel first, because high-quality
-	// scaling needs it and the padding below must stay transparent. Each
-	// resolution is padded to its own scale of the kPrefsImageW/H canvas,
-	// source pinned to the top-left; the padding is a no-op off Mac.
+	// mask is turned into an alpha channel first because high-quality
+	// scaling needs it.
 	auto makeIcon = [&](const wxBitmap &src) -> wxBitmapBundle {
 		wxImage img = src.ConvertToImage();
 		if (!img.HasAlpha()) {
 			img.InitAlpha();
 		}
 		wxImage img2x = img.Scale(img.GetWidth() * 2, img.GetHeight() * 2, wxIMAGE_QUALITY_HIGH);
-		if (kPrefsIconRightPad != 0 || kPrefsIconBottomPad != 0) {
-			img = img.Size(wxSize(kPrefsImageW, kPrefsImageH), wxPoint(0, 0));
-			img2x = img2x.Size(wxSize(kPrefsImageW * 2, kPrefsImageH * 2), wxPoint(0, 0));
-		}
 		return wxBitmapBundle::FromBitmaps(wxBitmap(img), wxBitmap(img2x));
 	};
 


### PR DESCRIPTION
## Bug

Follow-up to #295. On macOS, the Preferences page selector shows a visible extra horizontal gap between each icon and its label. Not present on Windows or Linux — the gap is Mac-only.

## Root cause

The `#ifdef __WXOSX__` right/bottom pads (14 / 9 px) added earlier were compensating for how `AssignImageList` + NSTableView rendered:

- NSTableView drew the image with zero native horizontal gap → we padded 14 px on the right to insert a visible gap between icon and label.
- NSTableView vertically centred the *whole* bitmap → with a 16x16 icon pinned to the top of a 16x25 canvas, the icon then aligned to the text baseline instead of dropping to the row bottom.

#295 switched to `SetSmallImages(wxVector<wxBitmapBundle>)`. That path uses a different wxOSX render code that already inserts native icon/text spacing and centres just the icon rather than the full bitmap. The old pads are now added on top of that native spacing, producing the extra gap.

## Fix

Drop the Mac-only pad values (0 on Windows/Linux, so this touches only the wxOSX path), and remove the now-dead `img.Size()` pass in the bundle builder. The icon canvas becomes plain 16x16 at 1x and 32x32 at 2x on every backend.

## Test plan

- [x] macOS: Preferences page selector renders with no extra gap; icons sit at the natural offset the wx-native path picks.
- [x] Windows / Linux: no visible change (both pads were already 0).