### PR TITLE
fix(shared): re-key path index when a downloaded file completes

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -648,11 +648,16 @@ void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)
 		//      m_pathIndex). Detach the stale entry and install the
 		//      live one so the view mirrors knownfiles.
 		CKnownFile *stale = NULL;
+		bool alreadyCanonical = false;
 		{
 			wxMutexLocker lock(list_mut);
 			CKnownFileMap::iterator it = m_Files_map.find(toadd->GetFileHash());
-			if (it != m_Files_map.end() && it->second != toadd) {
-				stale = it->second;
+			if (it != m_Files_map.end()) {
+				if (it->second != toadd) {
+					stale = it->second;
+				} else {
+					alreadyCanonical = true;
+				}
 			}
 		}
 		if (stale) {
@@ -665,6 +670,15 @@ void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)
 			if (AddFile(toadd)) {
 				Notify_SharedFilesShowFile(toadd);
 			}
+		} else if (alreadyCanonical) {
+			// Same pointer, already the canonical shared entry, but its
+			// path may have moved since it was first shared: a partfile
+			// downloaded this session was keyed under the Temp dir and has
+			// just been re-added from CPartFile::CompleteFileEnded() with
+			// SetFilePath(Incoming). AddFile()'s insert no-ops here, so the
+			// index still points at the stale Temp path and the dir-watcher
+			// can't resolve a DELETE of the completed file. Re-key it.
+			RefreshPathIndex(toadd);
 		}
 	}
 
@@ -672,6 +686,35 @@ void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)
 		// Publishing of files is not anymore handled here.
 		// Instead, the timer does it by itself.
 		m_lastPublishED2KFlag = true;
+	}
+}
+
+void CSharedFileList::RefreshPathIndex(CKnownFile *file)
+{
+	if (!file) {
+		return;
+	}
+	wxMutexLocker lock(list_mut);
+	const wxString key = file->GetFilePath().JoinPaths(file->GetFileName()).GetRaw();
+	// Drop any stale keys pointing at this file (the pre-completion
+	// Temp/<name> entry, or the "" placeholder from a not-yet-pathed
+	// CPartFile) so the index maps only its current on-disk location.
+	// O(shared files), but only runs on the rare re-add of an
+	// already-shared file (download completion / re-share).
+	bool rekeyed = false;
+	for (std::unordered_map<wxString, CKnownFile *>::iterator it = m_pathIndex.begin();
+		it != m_pathIndex.end();) {
+		if (it->second == file && it->first != key) {
+			it = m_pathIndex.erase(it);
+			rekeyed = true;
+		} else {
+			++it;
+		}
+	}
+	m_pathIndex[key] = file;
+	if (rekeyed) {
+		AddDebugLogLineN(
+			logKnownFiles, CFormat("Path index re-keyed to '%s' (file moved/completed)") % key);
 	}
 }
 

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -158,6 +158,17 @@ private:
 
 	bool AddFile(CKnownFile *pFile);
 
+	// Re-key m_pathIndex for an already-shared file whose on-disk path
+	// changed since it was first added. A partfile shared while
+	// downloading is keyed under the Temp dir (or "" before SetFilePath
+	// ran); on completion it moves to Incoming with SetFilePath(), but
+	// AddFile only writes m_pathIndex on a fresh insert, so the re-add
+	// leaves the index pointing at the stale path. Drops any keys
+	// pointing at `file` and installs its current
+	// GetFilePath().JoinPaths(GetFileName()) key, so the dir-watcher can
+	// resolve a later DELETE of the completed file. Takes list_mut.
+	void RefreshPathIndex(CKnownFile *file);
+
 	// #140 — invoked by AddFile once list_mut is held. Kicks off a
 	// CMediaProbeTask when the preference is enabled and the file
 	// looks like media (audio / video by ED2K file type) and hasn't


### PR DESCRIPTION
## Problem

Deleting a file from a shared directory did not remove it from the shared list / GUI **if that file finished downloading during the current session**. Files shared at startup were removed correctly; only files completed mid-session lingered.

The shared-dir watcher resolves a filesystem `DELETE` to its `CKnownFile` through `m_pathIndex`, keyed by the file's full on-disk path. A partfile shared while downloading is keyed under the **Temp** dir (or `""` before `SetFilePath` has run). On completion, `CPartFile::CompleteFileEnded()` moves it to Incoming and calls `SetFilePath()` + `SafeAddKFile()` — but `AddFile()` only writes `m_pathIndex` on a *fresh* insert. The file is already the canonical entry under its hash, so the re-add no-ops and the index keeps pointing at the stale Temp path.

The symptom in the watcher log: the `DELETE` event fires and the debounce flushes, but no `detaching deleted file` line follows, because `NotifyPathRemoved()` looks up the new Incoming path and misses:

```
event 0x2 on '.../Incoming/<completed>.mkv'
applying 1 incremental delta(s) after debounce
(no detach — m_pathIndex miss)
```

## Fix

Add `RefreshPathIndex()`, called from `SafeAddKFile()` when the file is already the canonical shared entry: it drops any stale keys pointing at the file and installs its current `GetFilePath().JoinPaths(GetFileName())` key. This is the "attach the real path via the post-completion path" step the existing `AddFile()` comment already promised. It's `O(shared files)` but only runs on the rare re-add of an already-shared file (completion / re-share), not on the startup insert path.

## Testing

macOS (live node): with the fix, completing a download logs `Path index re-keyed to '.../Incoming/<name>' (file moved/completed)`; a subsequent `rm` of that file then produces the `event 0x2` → debounce flush → `detaching deleted file` chain and the file disappears from the Shared panel. Verified against the exact repro that previously failed. Startup-shared files continue to detach as before.
