### PR TITLE
fix(shared): notify GUI when the dir-watcher re-shares a known file

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -560,7 +560,7 @@ unsigned CSharedFileList::AddFilesFromDirectory(const CPath &directory,
 // and the incremental watcher path (NotifyPathAdded below) so the two
 // agree on shareability rules.
 CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
-	const CPath &directory, const CPath &fname, TaskList &hashTasks)
+	const CPath &directory, const CPath &fname, TaskList &hashTasks, bool notifyGuiOnKnownAdd)
 {
 	CPath fullPath = directory.JoinPaths(fname);
 
@@ -597,6 +597,14 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 		toadd->SetFilePath(directory);
 		if (AddFile(toadd)) {
 			AddDebugLogLineN(logKnownFiles, CFormat("Added known file '%s' to shares") % fname);
+			// The bulk-Reload caller repaints the whole view once its
+			// walk finishes; the incremental watcher caller has no such
+			// follow-up, so tell the GUI about this freshly-shared file
+			// directly (otherwise it stays invisible in the shared-files
+			// view despite being in the core share set -- see the header).
+			if (notifyGuiOnKnownAdd) {
+				Notify_SharedFilesShowFile(toadd);
+			}
 		} else {
 			AddDebugLogLineN(logKnownFiles, CFormat("File already shared, skipping: %s") % fname);
 		}
@@ -820,7 +828,7 @@ void CSharedFileList::NotifyPathAdded(const wxString &fullPath)
 	}
 
 	TaskList hashTasks;
-	switch (AddPathToShares(directory, fname, hashTasks)) {
+	switch (AddPathToShares(directory, fname, hashTasks, /*notifyGuiOnKnownAdd=*/true)) {
 	case kAddPathQueued:
 		// Hand the new hashing task to the scheduler. The thread
 		// will call SafeAddKFile() when it finishes, which is

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -180,13 +180,25 @@ private:
 	// a CHashingTask onto hashTasks. Shared between the bulk-Reload
 	// directory walk and the per-event watcher dispatch so the two
 	// paths agree on what counts as shareable.
+	//
+	// notifyGuiOnKnownAdd: the bulk-Reload path repaints the whole
+	// shared-files view with Notify_SharedFilesShowFileList() once the
+	// walk finishes, so it leaves this false. The incremental watcher
+	// path has no such follow-up, so it passes true to get a per-file
+	// Notify_SharedFilesShowFile() when a known file is freshly attached
+	// (otherwise a re-shared file -- e.g. a rename in Incoming to a name
+	// already in known.met -- updates the core share set but never
+	// reaches the GUI view).
 	enum AddPathResult
 	{
 		kAddPathSkipped, // broken link, zero size, stat failed
 		kAddPathKnown,   // matched a CKnownFile, attached (or already attached)
 		kAddPathQueued   // unknown file, CHashingTask pushed
 	};
-	AddPathResult AddPathToShares(const CPath &directory, const CPath &fname, TaskList &hashTasks);
+	AddPathResult AddPathToShares(const CPath &directory,
+		const CPath &fname,
+		TaskList &hashTasks,
+		bool notifyGuiOnKnownAdd = false);
 	// scanned/aborted are in/out: the caller passes a running count
 	// and a flag that the dir walker flips on abort. Lets a single
 	// counter span all paths in one Reload() pass.


### PR DESCRIPTION
### Problem

Renaming a file inside a shared directory (e.g. `Incoming/`) to a name already present in `known.met` makes it **disappear from the GUI shared-files view**, even though it stays shared in the core.

Repro:

```
mv Incoming/foo.mp3 Incoming/bar.mp3   # bar.mp3 already known from a prior session
```

The watcher logs the re-share and `amulecmd "show shared"` still lists `bar.mp3` with its hash — but the shared-files list in the GUI no longer shows it.

### Cause

The incremental shared-dir watcher attaches an already-known file through `AddPathToShares()` → `AddFile()`, which updates the core `m_Files_map` but never calls `Notify_SharedFilesShowFile()` (that notification lives only in `SafeAddKFile()`). The bulk `Reload()` path gets away with the bare `AddFile()` because it repaints the whole view with a single `Notify_SharedFilesShowFileList()` when its directory walk finishes — the watcher has no such follow-up.

So the two halves of a rename are asymmetric: the DELETE half fires `Notify_SharedFilesRemoveFile` (GUI drops the old row), but the ADD half is silent (GUI never gets the new row), and the file vanishes from view.

### Fix

Add a `notifyGuiOnKnownAdd` flag to `AddPathToShares()`. The watcher path (`NotifyPathAdded`) passes `true`, emitting a per-file `Notify_SharedFilesShowFile()` when a known file is freshly attached; the bulk-Reload walk leaves it `false` and keeps its single bulk repaint unchanged. Purely the local GUI view — the daemon/EC share set was already correct.
