### PR TITLE
fix(amuled): force UTF-8 file-name conversion on macOS

### DIFF
--- a/src/amuled.cpp
+++ b/src/amuled.cpp
@@ -312,6 +312,17 @@ bool CamuleDaemonApp::Initialize(int &argc_, wxChar **argv_)
 		encName = "UTF-8";
 	}
 
+#ifdef __WXOSX__
+	// macOS reports "Mac OS Roman" from GetSystemEncodingName() regardless
+	// of the user's locale, but HFS+/APFS file names are always UTF-8.
+	// Encoding with Mac Roman turns e.g. U+00AA into the single byte 0xAA,
+	// which the kernel rejects as invalid UTF-8 (EILSEQ) when the completed
+	// file is opened, leaving non-ASCII downloads stuck in PS_ERROR. The GUI
+	// is unaffected because it keeps wx's default (UTF-8) file-name
+	// converter; force UTF-8 here to match it.
+	encName = "UTF-8";
+#endif
+
 	static wxConvBrokenFileNames fileconv(encName);
 	wxConvFileName = &fileconv;
 #endif // __UNIX__


### PR DESCRIPTION
## Symptom

On macOS, headless `amuled` leaves any finished download whose name contains a non-ASCII character (e.g. `ª`, `ñ`, `é`) stuck in **`PS_ERROR`** — it never moves from `Temp/` to `Incoming/`. ASCII-named downloads complete fine, and the **monolithic GUI is unaffected**. The log shows:

```
CFile: Error when opening file (…/Incoming/…2ª….mkv): Illegal byte sequence
Unexpected error while completing … File paused
```

"Illegal byte sequence" is `EILSEQ` from `open()`.

## Root cause

`amuled` installs its own `wxConvFileName` at startup, derived from `wxLocale::GetSystemEncodingName()`:

```cpp
encName = wxLocale::GetSystemEncodingName().Upper();
...
static wxConvBrokenFileNames fileconv(encName);
wxConvFileName = &fileconv;
```

On macOS that function returns **`"WESTERN (MAC OS ROMAN)"` regardless of the user's locale** (verified under `C`, `C.UTF-8`, and `en_US.UTF-8`). The resulting converter encodes `ª` (U+00AA) as the **single byte `0xAA`** instead of UTF-8 `0xC2 0xAA`. Since HFS+/APFS require UTF-8 file names, `open()` rejects the lone `0xAA` with `EILSEQ`, and completion aborts into `PS_ERROR`.

The block was written for Linux, where `GetSystemEncodingName()` returns the locale charset (normally UTF-8), so it's correct there. It has been wrong on macOS since it was added in 2016, and `3.0.1` behaves identically — **this is a long-standing bug, not a regression**. `LC_CTYPE` is irrelevant (the converter uses an explicit charset name, not the locale).

The GUI escapes because it never overrides `wxConvFileName`, keeping wx's default macOS UTF-8 converter (which produces the correct `0xC2 0xAA`).

## Fix

macOS file systems are always UTF-8, so force `encName = "UTF-8"` under `__WXOSX__`. This makes the daemon match the GUI.

## Scope / risk

- **macOS:** fixes it; no downside — there is no valid Mac-Roman-on-APFS case.
- **Linux:** `__WXOSX__` undefined → block unchanged → no effect.
- **Windows:** the entire `__UNIX__` block is already compiled out → no effect.

`amulecmd`/`amuleweb` don't override `wxConvFileName`, so they already use the correct default on macOS.

## Verification

macOS Debug+Release builds via CI. Local runtime repro (complete a non-ASCII-named download under `amuled`, confirm it lands in `Incoming/`) pending — will update before marking ready.
