### PR TITLE
Make media metadata probing safe: dedicated worker, ffprobe timeout, CTag + codec fixes

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -45,6 +45,7 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		UploadQueue.cpp
 		PartFileWriteThread.cpp
 		PartFileHashThread.cpp
+		MediaProbeThread.cpp
 		ThreadTasks.cpp
 	)
 endif()

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -74,7 +74,8 @@ CDebugCategory g_debugcats[] = { CDebugCategory(logGeneral, "General"),
 	CDebugCategory(logKadEntryTracking, "Kademlia Entry Tracking"),
 	CDebugCategory(logEC, "External Connect"),
 	CDebugCategory(logHTTP, "HTTP"),
-	CDebugCategory(logAsio, "Asio Sockets") };
+	CDebugCategory(logAsio, "Asio Sockets"),
+	CDebugCategory(logMediaProbe, "Media Probe") };
 
 const int categoryCount = itemsof(g_debugcats);
 

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -112,7 +112,9 @@ enum DebugType
 	//! Warnings/Errors related to HTTP traffic
 	logHTTP,
 	//! Warnings/Errors related to Boost Asio networking
-	logAsio
+	logAsio,
+	//! Media-metadata probing (ffprobe) subsystem.
+	logMediaProbe
 	// IMPORTANT NOTE: when you add values to this enum, update the g_debugcats
 	// array in Logger.cpp!
 };

--- a/src/MediaProbe.cpp
+++ b/src/MediaProbe.cpp
@@ -413,17 +413,20 @@ bool Probe(const wxString &ffprobePath,
 		return false;
 	}
 
-	// -show_entries constrains the output to the three fields we care about
-	// (codec of every stream + format-level duration + format-level bit_rate).
-	// -of default=nk=0:nw=1 emits one bare "key=value" per line, no INI
-	// section headers, no line wrapping. -v error silences informational
-	// chatter. Tokens are passed as a real argv (no shell), so the file path
-	// needs no quoting/escaping.
+	// -show_entries constrains the output to what we care about: each stream's
+	// codec_name plus its codec_type (so we can prefer the video track's codec,
+	// then the audio track's, over subtitle / data streams), and the format-
+	// level duration + bit_rate. -of default=nk=0:nw=1 emits one bare
+	// "key=value" per line, no INI section headers, no line wrapping; ffprobe
+	// prints the stream fields in the requested order, so each stream is a
+	// codec_name line immediately followed by its codec_type line. -v error
+	// silences informational chatter. Tokens are passed as a real argv (no
+	// shell), so the file path needs no quoting/escaping.
 	wxArrayString argv;
 	argv.Add(wxT("-v"));
 	argv.Add(wxT("error"));
 	argv.Add(wxT("-show_entries"));
-	argv.Add(wxT("format=duration,bit_rate:stream=codec_name"));
+	argv.Add(wxT("format=duration,bit_rate:stream=codec_name,codec_type"));
 	argv.Add(wxT("-of"));
 	argv.Add(wxT("default=nk=0:nw=1"));
 	argv.Add(file.GetRaw());
@@ -452,7 +455,10 @@ bool Probe(const wxString &ffprobePath,
 
 	MediaInfo info;
 	bool got_duration = false;
-	bool got_codec = false;
+	// Codec selection: the first video track's codec, else the first audio
+	// track's. Subtitle / data streams (e.g. a leading subrip track in an
+	// mkv) never win, so we don't advertise "subrip" as a file's codec.
+	wxString videoCodec, audioCodec, pendingCodec;
 	for (const wxString &line : stdout_lines) {
 		// Split on the first '=' only — codec_name values themselves
 		// don't contain '=' but the parser mustn't assume that.
@@ -466,13 +472,24 @@ bool Probe(const wxString &ffprobePath,
 			got_duration = ParseSeconds(value, info.length_seconds);
 		} else if (key == wxT("bit_rate")) {
 			(void)ParseBitrateKbps(value, info.bitrate_kbps);
-		} else if (key == wxT("codec_name") && !got_codec) {
-			// First stream's codec wins — this is video for
-			// video containers, audio for audio-only files.
-			info.codec = value;
-			got_codec = true;
+		} else if (key == wxT("codec_name")) {
+			// Held until this stream's codec_type line arrives next.
+			pendingCodec = value;
+		} else if (key == wxT("codec_type")) {
+			if (value == wxT("video") && videoCodec.IsEmpty()) {
+				videoCodec = pendingCodec;
+			} else if (value == wxT("audio") && audioCodec.IsEmpty()) {
+				audioCodec = pendingCodec;
+			}
+			pendingCodec.clear();
 		}
 	}
+	if (!videoCodec.IsEmpty()) {
+		info.codec = videoCodec;
+	} else if (!audioCodec.IsEmpty()) {
+		info.codec = audioCodec;
+	}
+	const bool got_codec = !info.codec.IsEmpty();
 
 	// A file with zero streams / zero duration produces an all-blank
 	// MediaInfo which is meaningless to advertise — treat it as a

--- a/src/MediaProbe.cpp
+++ b/src/MediaProbe.cpp
@@ -22,16 +22,42 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 #include <wx/arrstr.h>
+#include <wx/ffile.h>
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
-#include <wx/utils.h>
+#include <wx/stopwatch.h>
+#include <wx/tokenzr.h>
+#include <wx/utils.h> // Needed for wxExecute (AutoDetectPath) / wxMilliSleep
 
 #include <common/Format.h>
 
 #include "Logger.h"
 #include "libs/common/Path.h"
+
+// Native child-process primitives for the bounded, killable probe runner.
+// wxExecute/wxProcess async bookkeeping is bound to the main-thread event
+// loop (its SIGCHLD reaper fires wxProcess::OnTerminate there), so polling
+// it from the probe worker races that loop — a use-after-free. Managing
+// ffprobe with native primitives keeps the whole lifecycle on this thread.
+#ifdef __WXMSW__
+#include <windows.h>
+#else
+#include <csignal>
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#ifdef __APPLE__
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#else
+extern char **environ;
+#endif
+#endif
 
 namespace MediaProbe
 {
@@ -169,34 +195,258 @@ bool ParseBitrateKbps(const wxString &value, uint32 &out)
 
 } // anonymous namespace
 
-bool Probe(const wxString &ffprobePath, const CPath &file, MediaInfo &out)
+namespace
+{
+
+// Return values for RunBoundedFFProbe: a child exit code (>= 0), or one of:
+constexpr int kSpawnFailed = -1; // couldn't launch the binary at all
+constexpr int kKilled = -2;      // overran timeoutMs, or keepRunning went false
+
+// Spawn `exe argv...`, capturing stdout to a temp file, and wait for it with
+// a `timeoutMs` wall-clock bound. The wait loop also polls `keepRunning`; when
+// it flips false (worker shutdown) the child is killed at once so the caller's
+// thread-join can return. Args are passed as a real argv vector — no shell —
+// so paths with spaces / quotes need no escaping. See the include-block note
+// for why this bypasses wxExecute/wxProcess entirely.
+int RunBoundedFFProbe(const wxString &exe,
+	const wxArrayString &argv,
+	unsigned timeoutMs,
+	const std::atomic<bool> &keepRunning,
+	wxArrayString &stdoutLines)
+{
+	const wxString tmpPath = wxFileName::CreateTempFileName(wxT("amule-mediaprobe"));
+	if (tmpPath.IsEmpty()) {
+		return kSpawnFailed;
+	}
+
+	int exitCode = kSpawnFailed;
+
+#ifdef __WXMSW__
+	SECURITY_ATTRIBUTES sa;
+	sa.nLength = sizeof(sa);
+	sa.bInheritHandle = TRUE;
+	sa.lpSecurityDescriptor = nullptr;
+	HANDLE hOut = ::CreateFileW(tmpPath.wc_str(),
+		GENERIC_WRITE,
+		FILE_SHARE_READ,
+		&sa,
+		CREATE_ALWAYS,
+		FILE_ATTRIBUTE_TEMPORARY,
+		nullptr);
+	if (hOut == INVALID_HANDLE_VALUE) {
+		wxRemoveFile(tmpPath);
+		return kSpawnFailed;
+	}
+
+	// Job object with kill-on-close so terminating (or closing) it takes down
+	// the whole process tree — the Windows equivalent of the POSIX
+	// process-group kill. ffprobe.exe forks nothing, but a wrapper-style path
+	// (rare on Windows) would; a plain TerminateProcess would orphan it.
+	HANDLE hJob = ::CreateJobObjectW(nullptr, nullptr);
+	if (hJob != nullptr) {
+		JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli;
+		::ZeroMemory(&jeli, sizeof(jeli));
+		jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+		::SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli));
+	}
+
+	// Quote each token for the single command-line string CreateProcess wants.
+	wxString cmdLine = wxT("\"") + exe + wxT("\"");
+	for (const wxString &a : argv) {
+		cmdLine += wxT(" \"") + a + wxT("\"");
+	}
+	std::vector<wchar_t> cmdBuf(cmdLine.wc_str(), cmdLine.wc_str() + cmdLine.length() + 1);
+
+	STARTUPINFOW si;
+	::ZeroMemory(&si, sizeof(si));
+	si.cb = sizeof(si);
+	si.dwFlags = STARTF_USESTDHANDLES;
+	si.hStdInput = ::GetStdHandle(STD_INPUT_HANDLE);
+	si.hStdOutput = hOut;
+	si.hStdError = hOut;
+
+	PROCESS_INFORMATION pi;
+	::ZeroMemory(&pi, sizeof(pi));
+
+	// Start suspended so the child is in the job before it runs (and thus
+	// before it can spawn a grandchild that escapes the job), then resume.
+	const BOOL ok = ::CreateProcessW(nullptr,
+		cmdBuf.data(),
+		nullptr,
+		nullptr,
+		TRUE,
+		CREATE_NO_WINDOW | CREATE_SUSPENDED,
+		nullptr,
+		nullptr,
+		&si,
+		&pi);
+	::CloseHandle(hOut);
+	if (!ok) {
+		if (hJob != nullptr) {
+			::CloseHandle(hJob);
+		}
+		wxRemoveFile(tmpPath);
+		return kSpawnFailed;
+	}
+	if (hJob != nullptr) {
+		::AssignProcessToJobObject(hJob, pi.hProcess);
+	}
+	::ResumeThread(pi.hThread);
+
+	wxStopWatch sw;
+	for (;;) {
+		if (::WaitForSingleObject(pi.hProcess, 25) == WAIT_OBJECT_0) {
+			DWORD code = 0;
+			::GetExitCodeProcess(pi.hProcess, &code);
+			exitCode = static_cast<int>(code);
+			break;
+		}
+		if (!keepRunning || static_cast<unsigned>(sw.Time()) >= timeoutMs) {
+			// Kill the whole job (wrapper + real ffprobe), mirroring the
+			// POSIX process-group kill; fall back to the bare process if the
+			// job could not be created.
+			if (hJob != nullptr) {
+				::TerminateJobObject(hJob, 1);
+			} else {
+				::TerminateProcess(pi.hProcess, 1);
+			}
+			::WaitForSingleObject(pi.hProcess, INFINITE);
+			exitCode = kKilled;
+			break;
+		}
+	}
+	::CloseHandle(pi.hProcess);
+	::CloseHandle(pi.hThread);
+	if (hJob != nullptr) {
+		::CloseHandle(hJob);
+	}
+#else
+	std::vector<std::string> storage;
+	storage.reserve(argv.GetCount() + 1);
+	storage.emplace_back(exe.fn_str());
+	for (const wxString &a : argv) {
+		storage.emplace_back(a.fn_str());
+	}
+	std::vector<char *> cargv;
+	cargv.reserve(storage.size() + 1);
+	for (std::string &s : storage) {
+		cargv.push_back(const_cast<char *>(s.c_str()));
+	}
+	cargv.push_back(nullptr);
+
+	const std::string tmpNative(tmpPath.fn_str());
+
+	posix_spawn_file_actions_t fa;
+	posix_spawn_file_actions_init(&fa);
+	// stdout -> temp file, stderr -> /dev/null (we parse stdout only).
+	posix_spawn_file_actions_addopen(
+		&fa, STDOUT_FILENO, tmpNative.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	posix_spawn_file_actions_addopen(&fa, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
+
+	// Put the child in its own process group so a kill can take out the
+	// whole tree. ffprobe itself forks nothing, but a wrapper-style path
+	// (snap's /snap/bin/ffprobe, a flatpak-run shim) is a shell that execs
+	// the real binary as a child — killing only the wrapper would orphan
+	// it. setpgroup(0) makes the child a group leader (pgid == pid); the
+	// kill path below signals -pid to hit the group.
+	posix_spawnattr_t attr;
+	posix_spawnattr_init(&attr);
+	posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP);
+	posix_spawnattr_setpgroup(&attr, 0);
+
+	pid_t pid = 0;
+	const int rc = posix_spawnp(&pid, cargv[0], &fa, &attr, cargv.data(), environ);
+	posix_spawnattr_destroy(&attr);
+	posix_spawn_file_actions_destroy(&fa);
+	if (rc != 0) {
+		wxRemoveFile(tmpPath);
+		return kSpawnFailed;
+	}
+
+	wxStopWatch sw;
+	for (;;) {
+		int status = 0;
+		const pid_t r = waitpid(pid, &status, WNOHANG);
+		if (r == pid) {
+			exitCode = WIFEXITED(status) ? WEXITSTATUS(status) : kKilled;
+			break;
+		}
+		if (r == -1) { // vanished / already reaped
+			exitCode = kKilled;
+			break;
+		}
+		if (!keepRunning || static_cast<unsigned>(sw.Time()) >= timeoutMs) {
+			kill(-pid, SIGKILL);      // whole group: wrapper + real ffprobe
+			waitpid(pid, &status, 0); // reap the leader; init reaps the rest
+			exitCode = kKilled;
+			break;
+		}
+		wxMilliSleep(25);
+	}
+#endif
+
+	// Slurp captured stdout. On a kill the file is partial/empty, but the
+	// caller treats kKilled as failure and never reads stdoutLines then.
+	if (exitCode >= 0) {
+		wxFFile f(tmpPath, wxT("rb"));
+		wxString content;
+		if (f.IsOpened() && f.ReadAll(&content, wxConvUTF8)) {
+			wxStringTokenizer tok(content, wxT("\r\n"), wxTOKEN_STRTOK);
+			while (tok.HasMoreTokens()) {
+				stdoutLines.Add(tok.GetNextToken());
+			}
+		}
+	}
+	wxRemoveFile(tmpPath);
+	return exitCode;
+}
+
+} // anonymous namespace
+
+bool Probe(const wxString &ffprobePath,
+	const CPath &file,
+	MediaInfo &out,
+	unsigned timeoutMs,
+	const std::atomic<bool> &keepRunning)
 {
 	if (ffprobePath.IsEmpty()) {
 		return false;
 	}
 
-	// -show_entries constrains the output to the three fields we care
-	// about (codec of every stream + format-level duration + format-
-	// level bit_rate). -of default=nk=0:nw=1 emits one bare "key=value"
-	// per line, no INI section headers, no line wrapping — trivial to
-	// scan. -v error silences the informational lines that would
-	// otherwise fight for stdout.
-	//
-	// The file path is quoted so paths with spaces work on both
-	// POSIX and Windows. wxExecute forwards the string to the shell
-	// as-is; embedded `"` in filenames would corrupt the quoting but
-	// that's a vanishingly rare case on shared media files.
-	const wxString cmd = wxT("\"") + ffprobePath + wxT("\"") + wxT(" -v error") +
-			     wxT(" -show_entries format=duration,bit_rate:stream=codec_name") +
-			     wxT(" -of default=nk=0:nw=1 \"") + file.GetRaw() + wxT("\"");
+	// -show_entries constrains the output to the three fields we care about
+	// (codec of every stream + format-level duration + format-level bit_rate).
+	// -of default=nk=0:nw=1 emits one bare "key=value" per line, no INI
+	// section headers, no line wrapping. -v error silences informational
+	// chatter. Tokens are passed as a real argv (no shell), so the file path
+	// needs no quoting/escaping.
+	wxArrayString argv;
+	argv.Add(wxT("-v"));
+	argv.Add(wxT("error"));
+	argv.Add(wxT("-show_entries"));
+	argv.Add(wxT("format=duration,bit_rate:stream=codec_name"));
+	argv.Add(wxT("-of"));
+	argv.Add(wxT("default=nk=0:nw=1"));
+	argv.Add(file.GetRaw());
 
-	wxArrayString stdout_lines, stderr_lines;
-	const long rc =
-		wxExecute(cmd, stdout_lines, stderr_lines, wxEXEC_SYNC | wxEXEC_NODISABLE | wxEXEC_NOEVENTS);
-	if (rc != 0) {
-		AddDebugLogLineN(logGeneral,
-			CFormat(wxT("MediaProbe: ffprobe failed (rc=%ld) for %s")) % rc %
+	// Traced under the dedicated logMediaProbe category so a subsystem that
+	// silently shells out to ffprobe is diagnosable when the category is on.
+	AddDebugLogLineN(logMediaProbe, CFormat(wxT("MediaProbe: probing %s")) % file.GetPrintable());
+
+	// Bounded + killable: this runs on the dedicated CMediaProbeThread, so a
+	// slow/hung ffprobe can only ever delay other probes — never completions.
+	// The timeout and keepRunning cancel also stop a stuck child from wedging
+	// the worker itself or the shutdown join.
+	wxArrayString stdout_lines;
+	const int rc = RunBoundedFFProbe(ffprobePath, argv, timeoutMs, keepRunning, stdout_lines);
+	if (rc == kKilled) {
+		AddDebugLogLineN(logMediaProbe,
+			CFormat(wxT("MediaProbe: ffprobe timed out / cancelled for %s")) %
 				file.GetPrintable());
+		return false;
+	}
+	if (rc != 0) {
+		AddDebugLogLineN(logMediaProbe,
+			CFormat(wxT("MediaProbe: ffprobe failed (rc=%d) for %s")) % rc % file.GetPrintable());
 		return false;
 	}
 
@@ -228,11 +478,14 @@ bool Probe(const wxString &ffprobePath, const CPath &file, MediaInfo &out)
 	// MediaInfo which is meaningless to advertise — treat it as a
 	// probe failure so the caller doesn't attach empty tags.
 	if (!got_duration && !got_codec) {
-		AddDebugLogLineN(logGeneral,
+		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: no metadata parsed for %s")) % file.GetPrintable());
 		return false;
 	}
 
+	AddDebugLogLineN(logMediaProbe,
+		CFormat(wxT("MediaProbe: extracted %s -> length=%us bitrate=%ukbps codec=%s")) %
+			file.GetPrintable() % info.length_seconds % info.bitrate_kbps % info.codec);
 	out = info;
 	return true;
 }

--- a/src/MediaProbe.h
+++ b/src/MediaProbe.h
@@ -21,6 +21,8 @@
 #ifndef MEDIAPROBE_H
 #define MEDIAPROBE_H
 
+#include <atomic>
+
 #include <wx/string.h>
 
 #include "Types.h"
@@ -72,11 +74,20 @@ wxString AutoDetectPath();
 // (a file the probe can't read still gets shared, just without
 // media tags).
 //
-// The probe forks a subprocess and waits synchronously; expect
-// 30-100 ms per file on typical hardware. Callers MUST run this off
-// the main thread — CSharedFileList threading extends the existing
-// batch-scan path.
-bool Probe(const wxString &ffprobePath, const CPath &file, MediaInfo &out);
+// The probe spawns ffprobe as a child process and waits for it with a
+// `timeoutMs` wall-clock bound: if the child outlives the deadline it is
+// killed and the probe reports failure. `keepRunning` is polled during the
+// wait — when it flips false (worker shutdown) the child is killed
+// immediately so the caller's join can complete. Both bounds mean a
+// slow/hung ffprobe can never wedge the worker or the shutdown path.
+//
+// Callers MUST run this off the main thread — it blocks for the duration
+// of the child (typically 30-100 ms, at most `timeoutMs`).
+bool Probe(const wxString &ffprobePath,
+	const CPath &file,
+	MediaInfo &out,
+	unsigned timeoutMs,
+	const std::atomic<bool> &keepRunning);
 
 } // namespace MediaProbe
 

--- a/src/MediaProbeThread.cpp
+++ b/src/MediaProbeThread.cpp
@@ -1,0 +1,121 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "MediaProbeThread.h"
+
+#include <wx/app.h> // Needed for wxTheApp / wxQueueEvent
+
+#include "Logger.h"
+#include "MediaProbe.h"  // Needed for MediaProbe::Probe / MediaInfo
+#include "ThreadTasks.h" // Needed for CMediaProbeEvent
+
+namespace
+{
+// Wall-clock ceiling for a single ffprobe run. A local media file probes in
+// tens of milliseconds; anything approaching this is a hung/pathological
+// invocation the worker kills rather than blocking on. Also bounds how long
+// a shutdown can wait on an in-flight probe (EndThread flips m_bRun, which
+// Probe polls, so a stuck child is usually killed well before this).
+constexpr unsigned kProbeTimeoutMs = 30000;
+} // namespace
+
+CMediaProbeThread::CMediaProbeThread()
+: wxThread(wxTHREAD_JOINABLE)
+, m_condition(m_mutex)
+{
+	m_bRun = false;
+	m_bWorkPending = false;
+	wxMutexLocker lock(m_mutex);
+	if (Create() == wxTHREAD_NO_ERROR) {
+		Run();
+	}
+}
+
+void CMediaProbeThread::EndThread()
+{
+	{
+		wxMutexLocker lock(m_mutex);
+		m_bRun = false;
+		m_bWorkPending = true;
+		m_condition.Signal();
+	}
+	Wait();
+}
+
+void CMediaProbeThread::QueueProbe(const CMD4Hash &hash, const CPath &fullPath, const wxString &ffprobePath)
+{
+	MediaProbeJob job;
+	job.hash = hash;
+	job.path = fullPath;
+	job.ffprobePath = ffprobePath;
+
+	wxMutexLocker lock(m_mutex);
+	m_jobList.push_back(job);
+	m_bWorkPending = true;
+	m_condition.Signal();
+}
+
+void *CMediaProbeThread::Entry()
+{
+	m_bRun = true;
+	AddDebugLogLineN(logMediaProbe, wxT("Media probe thread: started"));
+
+	for (;;) {
+		std::list<MediaProbeJob> workList;
+		{
+			wxMutexLocker lock(m_mutex);
+			if (m_bRun && !m_bWorkPending) {
+				m_condition.WaitTimeout(500);
+			}
+			m_bWorkPending = false;
+			// On shutdown, drop any queued probes: metadata is
+			// best-effort, and unlike the hash thread there is no
+			// pending-count gate that anything waits on.
+			if (!m_bRun) {
+				break;
+			}
+			workList.swap(m_jobList);
+		}
+
+		for (const MediaProbeJob &job : workList) {
+			// Shut down promptly rather than draining a long backlog.
+			if (!m_bRun) {
+				break;
+			}
+			MediaInfo info;
+			if (MediaProbe::Probe(job.ffprobePath, job.path, info, kProbeTimeoutMs, m_bRun)) {
+				// Marshal the result to the main thread, which
+				// resolves the hash to the CKnownFile and attaches
+				// the FT_MEDIA_* tags (doing that here would race the
+				// publish paths that read m_taglist).
+				CMediaProbeEvent evt(
+					job.hash, info.length_seconds, info.bitrate_kbps, info.codec);
+				wxQueueEvent(wxTheApp, evt.Clone());
+			}
+		}
+	}
+
+	AddDebugLogLineN(logMediaProbe, wxT("Media probe thread: stopped"));
+	return nullptr;
+}

--- a/src/MediaProbeThread.h
+++ b/src/MediaProbeThread.h
@@ -1,0 +1,89 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef MEDIAPROBETHREAD_H
+#define MEDIAPROBETHREAD_H
+
+#include <list>
+#include <atomic>
+#include <wx/thread.h>
+#include <wx/string.h>
+
+#include "MD4Hash.h"     // Needed for CMD4Hash
+#include <common/Path.h> // Needed for CPath (value member of MediaProbeJob)
+
+// One queued ffprobe job. Everything is snapshotted by value at enqueue
+// time so the worker never touches shared CKnownFile / thePrefs state.
+struct MediaProbeJob
+{
+	CMD4Hash hash;        // resolved back to the CKnownFile on the main thread
+	CPath path;           // file to probe
+	wxString ffprobePath; // ffprobe binary
+};
+
+// Dedicated worker for ffprobe media-metadata extraction (#280).
+//
+// Why its own thread: media probing shells out to ffprobe via wxExecute,
+// which can block for a long time (or, on a headless daemon, hang) and
+// must never stall the core. Previously CMediaProbeTask ran on the shared
+// CThreadScheduler alongside CHashingTask / CCompletionTask, so a single
+// hung ffprobe wedged every download completion. Running probes on a
+// dedicated, isolated worker means a slow/hung probe can only ever delay
+// other probes, never completions or hashing. A wall-clock timeout in
+// MediaProbe::Probe bounds each probe so even this thread can't wedge.
+//
+// Mirrors CPartFileHashThread: a single joinable worker draining a job
+// queue and posting a CMediaProbeEvent back to the main thread.
+class CMediaProbeThread : public wxThread
+{
+public:
+	CMediaProbeThread();
+	// EndThread() (which joins the worker) must be called before the
+	// object is destroyed; the destructor itself has nothing to do.
+	~CMediaProbeThread() = default;
+
+	// Signal the worker to stop and join it. Queued (not-yet-started)
+	// probes are dropped — metadata is best-effort. An in-flight probe's
+	// ffprobe child is killed promptly (Probe polls the run flag), so the
+	// join returns without waiting on a slow or hung ffprobe.
+	void EndThread();
+
+	// Enqueue a probe. Thread-safe; returns immediately.
+	void QueueProbe(const CMD4Hash &hash, const CPath &fullPath, const wxString &ffprobePath);
+
+	bool IsRunning() const { return m_bRun; }
+
+private:
+	void *Entry() override;
+
+	std::atomic<bool> m_bRun{ false };
+	bool m_bWorkPending; // sticky wake flag, protected by m_mutex
+
+	wxMutex m_mutex;
+	wxCondition m_condition;
+
+	std::list<MediaProbeJob> m_jobList; // protected by m_mutex
+};
+
+#endif // MEDIAPROBETHREAD_H

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -35,18 +35,19 @@
 
 #include <wx/utils.h>
 
-#include "Packet.h"         // Needed for CPacket
-#include "MemFile.h"        // Needed for CMemFile
-#include "ServerConnect.h"  // Needed for CServerConnect
-#include "KnownFileList.h"  // Needed for CKnownFileList
-#include "ThreadTasks.h"    // Needed for CThreadScheduler and CHasherTask
-#include "OtherFunctions.h" // Needed for GetED2KFileTypeID / ED2KFT_* (MaybeScheduleMediaProbe)
-#include "Preferences.h"    // Needed for thePrefs
-#include "DownloadQueue.h"  // Needed for CDownloadQueue
-#include "amule.h"          // Needed for theApp
-#include "PartFile.h"       // Needed for PartFile
-#include "Server.h"         // Needed for CServer
-#include "Statistics.h"     // Needed for theStats
+#include "Packet.h"           // Needed for CPacket
+#include "MemFile.h"          // Needed for CMemFile
+#include "ServerConnect.h"    // Needed for CServerConnect
+#include "KnownFileList.h"    // Needed for CKnownFileList
+#include "ThreadTasks.h"      // Needed for CThreadScheduler and CHasherTask
+#include "MediaProbeThread.h" // Needed for CMediaProbeThread (media probe queue)
+#include "OtherFunctions.h"   // Needed for GetED2KFileTypeID / ED2KFT_* (MaybeScheduleMediaProbe)
+#include "Preferences.h"      // Needed for thePrefs
+#include "DownloadQueue.h"    // Needed for CDownloadQueue
+#include "amule.h"            // Needed for theApp
+#include "PartFile.h"         // Needed for PartFile
+#include "Server.h"           // Needed for CServer
+#include "Statistics.h"       // Needed for theStats
 #include "Logger.h"
 #include <common/Format.h>
 #include <common/FileFunctions.h>
@@ -676,10 +677,23 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile)
 		return;
 	}
 	if (pFile->GetIntTagValue(FT_MEDIA_LENGTH) > 0) {
+		AddDebugLogLineN(logMediaProbe,
+			CFormat(wxT("MediaProbe: skip (already has metadata) %s")) % pFile->GetFileName());
 		return;
 	}
 	const CPath fullPath = pFile->GetFilePath().JoinPaths(pFile->GetFileName());
-	CThreadScheduler::AddTask(new CMediaProbeTask(pFile->GetFileHash(), fullPath, ffprobePath));
+	// #280: run on the dedicated media-probe worker, NOT the shared
+	// CThreadScheduler — a slow/hung ffprobe there wedges completions.
+	if (theApp->mediaProbeThread) {
+		AddDebugLogLineN(logMediaProbe,
+			CFormat(wxT("MediaProbe: queueing %s (ffprobe=%s)")) % pFile->GetFileName() %
+				ffprobePath);
+		theApp->mediaProbeThread->QueueProbe(pFile->GetFileHash(), fullPath, ffprobePath);
+	} else {
+		AddDebugLogLineN(logMediaProbe,
+			CFormat(wxT("MediaProbe: dropped %s — probe thread not ready")) %
+				pFile->GetFileName());
+	}
 }
 
 void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -201,33 +201,43 @@ CTag::~CTag()
 CTag &CTag::operator=(const CTag &rhs)
 {
 	if (&rhs != this) {
+		// Release whatever THIS currently owns, keyed on its *current*
+		// type — the same dispatch the destructor uses. The union means
+		// the owned pointer only exists for string / hash / blob / bsob
+		// tags; for an int/float tag that union slot holds a scalar, not
+		// a pointer. Freeing based on the RHS type (as this used to) frees
+		// a garbage "pointer" whenever the two tags' types differ — e.g.
+		// assigning a string tag onto a slot that currently holds an int,
+		// which is exactly what std::vector<CTag>::erase does when it
+		// shifts elements. That corrupts the heap (observed as a double
+		// free in a wxString destructor).
+		if (IsStr()) {
+			delete m_pstrVal;
+		} else if (IsHash()) {
+			delete m_hashVal;
+		} else if (IsBlob() || IsBsob()) {
+			delete[] m_pData;
+		}
+
 		m_uType = rhs.m_uType;
 		m_uName = rhs.m_uName;
 		m_Name = rhs.m_Name;
 		m_nSize = 0;
 		if (rhs.IsStr()) {
-			wxString *p = new wxString(rhs.GetStr());
-			delete m_pstrVal;
-			m_pstrVal = p;
+			m_pstrVal = new wxString(rhs.GetStr());
 		} else if (rhs.IsInt()) {
 			m_uVal = rhs.GetInt();
 		} else if (rhs.IsFloat()) {
 			m_fVal = rhs.GetFloat();
 		} else if (rhs.IsHash()) {
-			CMD4Hash *p = new CMD4Hash(rhs.GetHash());
-			delete m_hashVal;
-			m_hashVal = p;
+			m_hashVal = new CMD4Hash(rhs.GetHash());
 		} else if (rhs.IsBlob()) {
 			m_nSize = rhs.GetBlobSize();
-			unsigned char *p = new unsigned char[rhs.GetBlobSize()];
-			delete[] m_pData;
-			m_pData = p;
+			m_pData = new unsigned char[rhs.GetBlobSize()];
 			memcpy(m_pData, rhs.GetBlob(), rhs.GetBlobSize());
 		} else if (rhs.IsBsob()) {
 			m_nSize = rhs.GetBsobSize();
-			unsigned char *p = new unsigned char[rhs.GetBsobSize()];
-			delete[] m_pData;
-			m_pData = p;
+			m_pData = new unsigned char[rhs.GetBsobSize()];
 			memcpy(m_pData, rhs.GetBsob(), rhs.GetBsobSize());
 		} else {
 			wxFAIL;

--- a/src/ThreadTasks.cpp
+++ b/src/ThreadTasks.cpp
@@ -30,7 +30,6 @@
 #include <unordered_set> // CAICHSyncTask orphan-prune liveRoots set
 
 #include "ThreadTasks.h"      // Interface declarations
-#include "MediaProbe.h"       // Needed for CMediaProbeTask
 #include "PartFile.h"         // Needed for CPartFile
 #include "CFile.h"            // Needed for CFile::CloneFile
 #include "Logger.h"           // Needed for Add(Debug)LogLine{C,N}
@@ -254,38 +253,6 @@ void CHashingTask::OnLastTask()
 		// Make sure the AICH-hashes are up to date.
 		CThreadScheduler::AddTask(new CAICHSyncTask());
 	}
-}
-
-////////////////////////////////////////////////////////////
-// CMediaProbeTask
-
-CMediaProbeTask::CMediaProbeTask(const CMD4Hash &hash, const CPath &fullPath, const wxString &ffprobePath)
-// ETP_Low so an in-progress hashing or completion job always wins
-// the CPU. The task-type + desc combine to give the scheduler a
-// dedup key: two concurrent adds of the same hash silently collapse
-// into one probe.
-: CThreadTask("Media Probe", hash.Encode(), ETP_Low)
-, m_hash(hash)
-, m_path(fullPath)
-, m_ffprobePath(ffprobePath)
-{
-}
-
-void CMediaProbeTask::Entry()
-{
-	// Probe is entirely off-main and touches no CKnownFile state.
-	MediaInfo info;
-	if (!MediaProbe::Probe(m_ffprobePath, m_path, info)) {
-		return;
-	}
-	if (TestDestroy()) {
-		return;
-	}
-	// Marshal the result back to the main thread; the handler there
-	// resolves m_hash to the CKnownFile (which may have been
-	// unshared while we were probing) and attaches the tags.
-	CMediaProbeEvent evt(m_hash, info.length_seconds, info.bitrate_kbps, info.codec);
-	wxQueueEvent(wxTheApp, evt.Clone());
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/ThreadTasks.h
+++ b/src/ThreadTasks.h
@@ -120,35 +120,10 @@ private:
 	void SetHashingProgress(uint16 part);
 };
 
-/**
- * Runs MediaProbe against a shared audio / video file so its
- * FT_MEDIA_LENGTH / _BITRATE / _CODEC tags can be published to
- * ed2k + Kad. Scheduled by CSharedFileList::AddFile for eligible
- * files (see issue #140). Posts MULE_EVT_MEDIA_PROBE on success;
- * the main-thread handler attaches the tags via AddTagUnique so
- * subsequent publish paths pick them up automatically.
- */
-class CMediaProbeTask : public CThreadTask
-{
-public:
-	CMediaProbeTask(const CMD4Hash &hash, const CPath &fullPath, const wxString &ffprobePath);
-
-protected:
-	//! @see CThreadTask::Entry
-	virtual void Entry();
-
-	//! Identifies the CKnownFile to attach the tags to when the
-	//! result event fires on the main thread. Resolved via
-	//! CKnownFileList::FindKnownFileByID at that point since the
-	//! file may have been unshared while we were probing.
-	CMD4Hash m_hash;
-	//! Full path to the file. Snapshotted at ctor time so the
-	//! worker thread doesn't touch shared CKnownFile state.
-	CPath m_path;
-	//! ffprobe binary path snapshotted at ctor time so the task
-	//! doesn't need to reach into thePrefs from the worker thread.
-	wxString m_ffprobePath;
-};
+// Media metadata probing (#140/#280) runs on the dedicated
+// CMediaProbeThread, not the shared CThreadScheduler, so a slow/hung
+// ffprobe can't stall completions. Results still arrive via the
+// CMediaProbeEvent below. See MediaProbeThread.h.
 
 /**
  * This task synchronizes the AICH hashlist.

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -94,6 +94,7 @@
 #include "UploadQueue.h"         // Needed for CUploadQueue
 #include "PartFileWriteThread.h" // Needed for CPartFileWriteThread
 #include "PartFileHashThread.h"  // Needed for CPartFileHashThread
+#include "MediaProbeThread.h"    // Needed for CMediaProbeThread
 #include "UploadBandwidthThrottler.h"
 #include "UploadDiskIOThread.h"
 #include "UserEvents.h"
@@ -215,6 +216,7 @@ CamuleApp::CamuleApp()
 #endif
 	core_timer = NULL;
 	partFileHashThread = NULL;
+	mediaProbeThread = nullptr;
 
 	m_localip = 0;
 	m_dwPublicIP = 0;
@@ -341,6 +343,15 @@ int CamuleApp::OnExit()
 
 	delete uploadqueue;
 	uploadqueue = NULL;
+
+	// Stop the media-probe worker: it's independent of the download
+	// pipeline, so tear it down early. Queued probes are dropped; any
+	// in-flight ffprobe is bounded by MediaProbe's timeout.
+	if (mediaProbeThread) {
+		mediaProbeThread->EndThread();
+		delete mediaProbeThread;
+		mediaProbeThread = nullptr;
+	}
 
 	// Stop hash thread first so any in-flight HashSinglePart finishes
 	// and m_pendingHashes drops to 0 before ~CPartFile waits on it.
@@ -834,6 +845,9 @@ bool CamuleApp::OnInit()
 	// PartFileBufferedData queue (#849).
 	partFileWriteThread = new CPartFileWriteThread();
 	partFileHashThread = new CPartFileHashThread();
+	// #280: dedicated worker for ffprobe metadata, isolated from the shared
+	// CThreadScheduler so a slow/hung probe can never stall completions.
+	mediaProbeThread = new CMediaProbeThread();
 
 	m_AsioService = new CAsioService;
 
@@ -1814,6 +1828,11 @@ void CamuleApp::OnMediaProbeFinished(CMediaProbeEvent &evt)
 	if (!evt.GetCodec().IsEmpty()) {
 		file->AddTagUnique(CTagString(FT_MEDIA_CODEC, evt.GetCodec()));
 	}
+	// Traced under logMediaProbe — the "metadata actually landed"
+	// confirmation, logged once per file when tags are attached.
+	AddDebugLogLineN(logMediaProbe,
+		CFormat(wxT("Media metadata: %s -> length=%us bitrate=%ukbps codec=%s")) %
+			file->GetFileName() % evt.GetLengthSeconds() % evt.GetBitrateKbps() % evt.GetCodec());
 	// EC exports the tag list; the remote GUI + web UI need to see
 	// the new values on next refresher tick.
 	file->MarkECChanged();

--- a/src/amule.h
+++ b/src/amule.h
@@ -46,6 +46,7 @@ class CDownloadQueue;
 class CUploadQueue;
 class CPartFileWriteThread;
 class CPartFileHashThread;
+class CMediaProbeThread;
 class CPartFileHashResultEvent;
 class CServerConnect;
 class CSharedFileList;
@@ -283,6 +284,7 @@ public:
 	CUploadQueue *uploadqueue;
 	CPartFileWriteThread *partFileWriteThread;
 	CPartFileHashThread *partFileHashThread;
+	CMediaProbeThread *mediaProbeThread;
 	CServerConnect *serverconnect;
 	CSharedFileList *sharedfiles;
 	CServerList *serverlist;


### PR DESCRIPTION
## Problem

`ffprobe` media-metadata extraction (#280) runs on the shared `CThreadScheduler` — the single worker that also runs hashing and download completion (`CHashingTask` / `CCompletionTask`). `ffprobe` is invoked synchronously via `wxExecute` and can block for a long time, or hang outright on a headless daemon. When it does, it blocks the scheduler, so every finished download stays stuck at `PS_COMPLETING` and shutdown stalls behind it.

## Fix

Move probing onto a dedicated `CMediaProbeThread` (modelled on `CPartFileHashThread`), so a slow or hung probe can only ever delay other probes — never completions or hashing.

Bound and make each probe killable. The `ffprobe` invocation is now a native `posix_spawn` / `CreateProcess` child instead of `wxExecute`: the synchronous `wxExecute` path is uncancellable, and its async path ties termination and pipe draining to the main-thread event loop, which is unsafe to poll from a worker thread (a use-after-free). The child is waited on with a 30s wall-clock timeout plus a cancel flag that `EndThread` flips at shutdown; on either, the child is killed and the join returns promptly. The kill takes the whole process tree — a POSIX process group (`kill(-pid)`) on Unix, a Job Object on Windows — so a wrapper-style `ffprobe` (snap, flatpak) is fully reaped rather than orphaned.

Probe tracing moves to a dedicated `Media Probe` (`logMediaProbe`) debug category.

## Codec selection: prefer the video track (then audio)

The probe reported the first stream's codec, which for a container whose first stream is a subtitle or data track — common in mkv, where a leading `subrip` track advertised "subrip" as the file's codec. It now queries `codec_type` alongside `codec_name` and selects the first video track's codec, falling back to the first audio track's; subtitle / data streams never win.

## Pre-existing `CTag::operator=` double-free

Exercising the re-attach path surfaced a latent heap-corruption bug that predates 3.0.1 and is independent of the media-probe change. `CTag` keeps an owned pointer in a union that is only valid for string / hash / blob tags; `operator=` freed that pointer keyed on the right-hand side's type, so assigning a string tag onto a slot currently holding an int freed a garbage pointer (the int's bits reinterpreted). `std::vector<CTag>::erase` hits this whenever it shifts a string tag over a non-string one — exactly the media tag set `[length, bitrate, codec]` when `AddTagUnique` re-attaches it. Fixed to free by the tag's current type (mirroring the destructor) then copy from the source (mirroring the copy constructor).

## Commits

- `Fix CTag::operator= freeing the wrong union member` — the pre-existing double-free above.
- `Isolate media probing on a dedicated bounded worker thread` — thread isolation, native bounded/killable spawn (timeout + cancel + tree kill), `logMediaProbe` category.
- `Prefer the video track's codec (then audio) in media probing` — codec selection.

## Test plan

Eight deterministic checks, run on each platform:

1. **Probe → extract → attach** — a shared media file yields `MediaProbe: extracted … codec=…` then `Media metadata: … ->` (tags attached), under the `Media Probe` debug category.
2. **Persisted, once-only** — after a restart with `known.met` kept, the file logs `skip (already has metadata)`; the tags survive in `known.met`.
3. **Runtime isolation** — with `FFProbePath` pointed at a program that hangs, a probe blocks but EC round-trips stay responsive and completions proceed.
4. **Timeout** — the hung probe is killed at ~30s with `ffprobe timed out / cancelled`; the daemon stays alive.
5. **Shutdown** — with a probe hung, a graceful shutdown returns promptly (≈1–3s) instead of wedging on the join.
6. **Tree kill** — a wrapper-style hung ffprobe that forks a child is fully reaped on shutdown/timeout, no orphan (POSIX process group / Windows Job Object).
7. **Re-attach** — a file shared under two paths (same hash) re-attaches its media tags without the `CTag` crash.
8. **Codec selection** — a subtitle-first mkv reports the video codec (`h264`), not `subrip`.

| Platform | Build | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|---|---|---|---|---|---|---|---|---|---|
| macOS (ARM64) | Debug | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| Linux (Ubuntu ARM64) | Debug | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| Windows 11 (ARM64) | Debug | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
