### PR TITLE
Attach media metadata to downloaded files: probe on completion + inherit preview from search results

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -167,7 +167,21 @@ CPartFile::CPartFile(CSearchFile *searchresult)
 			{
 				uint8 nID;
 				uint8 nType;
-			} _aMetaTags[] = { { FT_FILETYPE, 2 }, { FT_FILEFORMAT, 2 } };
+			} _aMetaTags[] = { { FT_FILETYPE, 2 },
+				{ FT_FILEFORMAT, 2 },
+				// Media metadata (#280) advertised by the source: length /
+				// bitrate (uint32) + codec (string). Inherit it so a download
+				// carries FT_MEDIA_* immediately -- visible while downloading
+				// and persisted on completion -- without needing a local
+				// ffprobe. Source-agnostic: ed2k and Kad use the same tag IDs
+				// (TAG_MEDIA_* == FT_MEDIA_*), and the completion probe still
+				// fills in files whose source advertised nothing (its
+				// FT_MEDIA_LENGTH>0 gate skips the ones handled here).
+				// (type 3 = TAGTYPE_UINT32, type 2 = TAGTYPE_STRING; bare
+				// literals to match the FT_FILETYPE/FT_FILEFORMAT entries above.)
+				{ FT_MEDIA_LENGTH, 3 },
+				{ FT_MEDIA_BITRATE, 3 },
+				{ FT_MEDIA_CODEC, 2 } };
 			for (unsigned int t = 0; t < itemsof(_aMetaTags); ++t) {
 				if (pTag.GetType() == _aMetaTags[t].nType &&
 					pTag.GetNameID() == _aMetaTags[t].nID) {

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -647,7 +647,7 @@ bool CSharedFileList::AddFile(CKnownFile *pFile)
 	return false;
 }
 
-void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile)
+void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, bool bForceReprobe)
 {
 	// Called from AddFile under list_mut so we already know pFile is
 	// live and stable for the duration of this call.
@@ -676,12 +676,30 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile)
 	if (type != ED2KFT_AUDIO && type != ED2KFT_VIDEO) {
 		return;
 	}
-	if (pFile->GetIntTagValue(FT_MEDIA_LENGTH) > 0) {
+	// Never probe an in-progress download. A partfile is shared while
+	// transferring, so this fires from AddFile() during the download; there is
+	// no complete file to read yet (its on-disk name is <hash>.part), and its
+	// metadata is derived exactly once -- on completion, which re-enters here
+	// with bForceReprobe set. Skipping unconditionally (not just when metadata
+	// happened to be inherited from the search result) keeps that guarantee.
+	if (!bForceReprobe && pFile->IsPartFile()) {
+		AddDebugLogLineN(logMediaProbe,
+			CFormat(wxT("MediaProbe: skip (incomplete download) %s")) % pFile->GetFileName());
+		return;
+	}
+	if (!bForceReprobe && pFile->GetIntTagValue(FT_MEDIA_LENGTH) > 0) {
 		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: skip (already has metadata) %s")) % pFile->GetFileName());
 		return;
 	}
 	const CPath fullPath = pFile->GetFilePath().JoinPaths(pFile->GetFileName());
+	// Only probe a file that is actually on disk at this resolved path -- a
+	// stale known.met record can outlive its deleted file, and this is cheap
+	// insurance against handing ffprobe a path that cannot succeed. (In-progress
+	// downloads are already excluded by the partfile guard above.)
+	if (!fullPath.FileExists()) {
+		return;
+	}
 	// #280: run on the dedicated media-probe worker, NOT the shared
 	// CThreadScheduler — a slow/hung ffprobe there wedges completions.
 	if (theApp->mediaProbeThread) {
@@ -749,6 +767,17 @@ void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)
 			// index still points at the stale Temp path and the dir-watcher
 			// can't resolve a DELETE of the completed file. Re-key it.
 			RefreshPathIndex(toadd);
+			// A download just completed. Because the file was shared as a
+			// partfile, its hash was already in the map, so AddFile()'s
+			// insert (which is what normally schedules the media probe) no-op'd
+			// above -- a media download would otherwise only get its FT_MEDIA_*
+			// tags on the next startup rescan. Now that it is complete on disk
+			// at its Incoming path, schedule the probe here. QueueProbe() only
+			// enqueues (it never runs ffprobe inline), so this cannot stall the
+			// completion. Force it (bypassing the already-has-FT_MEDIA gate) so
+			// the authoritative local probe overwrites any metadata inherited
+			// from the search result, which is only a during-download preview.
+			MaybeScheduleMediaProbe(toadd, /*bForceReprobe=*/true);
 		}
 	}
 

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -173,7 +173,12 @@ private:
 	// CMediaProbeTask when the preference is enabled and the file
 	// looks like media (audio / video by ED2K file type) and hasn't
 	// been probed yet. Returns silently if any gate fails.
-	void MaybeScheduleMediaProbe(CKnownFile *pFile);
+	// bForceReprobe bypasses the "already has FT_MEDIA_LENGTH" gate: set on
+	// download completion, where the authoritative local probe must overwrite
+	// any metadata inherited from the search result (which is only a
+	// during-download preview). Left false everywhere else so startup rescans
+	// still probe each file at most once.
+	void MaybeScheduleMediaProbe(CKnownFile *pFile, bool bForceReprobe = false);
 
 	// Per-path attach: stat fname under directory, look it up in
 	// known.met, and either AddFile() the existing CKnownFile or push


### PR DESCRIPTION
## Problem

After #319, media-metadata probing works, but a **downloaded** media file didn't get its `FT_MEDIA_*` tags until the **next daemon restart**. Two gaps:

1. `MaybeScheduleMediaProbe` only runs when a file is first inserted into the shared list. A download is shared as a **partfile** while transferring, so on completion `CompleteFileEnded → SafeAddKFile` re-adds it, `AddFile`'s insert **no-ops** (hash already present — the `alreadyCanonical` branch), and the probe is never scheduled.
2. The search result the download came from **already carried** the file's media metadata (a source running #280 advertises `FT_MEDIA_LENGTH/BITRATE/CODEC`), but `CPartFile(CSearchFile*)` copied only `FT_FILETYPE`/`FT_FILEFORMAT` and dropped it (`ignored tag 0xD3…`), so nothing was shown while downloading either.

## Fix

**Commit 1 — probe on completion** (`SharedFileList.cpp/.h`): schedule the probe from the completion (`alreadyCanonical`) branch, once the file is complete on disk in Incoming. `QueueProbe` only enqueues, so it never stalls completion (rides on #319's isolation). The completion call **forces** the probe (new `bForceReprobe` arg bypasses the already-has-`FT_MEDIA` gate) so the **authoritative local ffprobe is the source of truth** — it always runs on completion and overwrites anything inherited from the network; startup rescans stay probe-once. Two guards on `MaybeScheduleMediaProbe`:
- **Never probe an in-progress download** — a partfile is shared while transferring, so `AddFile` calls this during the download when there is no complete file to read (`<hash>.part`). Skip any non-forced probe of a partfile *unconditionally* (the completion re-enters with the force flag); metadata is derived exactly once, on completion.
- **Skip when the resolved path isn't on disk** — so a stale known.met record that outlived its deleted file never hands ffprobe a path that can't succeed.

**Commit 2 — inherit a preview from search results** (`PartFile.cpp`): add `FT_MEDIA_LENGTH/BITRATE/CODEC` to the tags `CPartFile(CSearchFile*)` inherits, so a download **shows media metadata immediately while transferring**, with no local ffprobe. This is a **preview only** — the authoritative completion probe re-derives and overwrites it. Source-agnostic: ed2k and Kad share the same tag IDs (`TAG_MEDIA_* == FT_MEDIA_* == 0xD3/D4/D5`) and the same `CSearchFile` path, so one change covers both.

**Model:** inherited network tags give an instant, free preview *during* the download; on completion the local ffprobe always runs and replaces them with verified values. A media download ends up authoritatively tagged whether or not its source advertised anything — and the network is never trusted as the final answer.

## Test plan (macOS, Linux, Windows)

1. **Probe on completion** — download a media file; on completion (no restart) the log shows `queueing → extracted → Media metadata`, and known.met gains `FT_MEDIA_*`.
2. **Inherit preview** — download one whose search result carried `0xD3/D4/D5`: the partfile carries the tags *during* download, and on completion the probe still runs (`extracted`, not `skip`) and overwrites with local values.
3. **No stall** — completions flow normally throughout (rides on #319).
4. **Existence guard** — a still-downloading partfile / stale known.met entry is not probed.
