### PR TITLE
feat(AppImage): amulegui launcher + shell shortcuts, fix em-dashes

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,53 +111,56 @@ msgstr ""
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -166,15 +169,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:16+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -114,53 +114,56 @@ msgstr ""
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -169,15 +172,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:16+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -123,55 +123,58 @@ msgstr "Información"
 msgid "The specified userhash is not valid!"
 msgstr "¡El hash d'usuariu especificáu nun ye válidu!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Dempués del nome de l'aplicación"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Conexón fallida"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -180,15 +183,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:16+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -115,53 +115,56 @@ msgstr ""
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -170,15 +173,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -110,53 +110,56 @@ msgstr ""
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -165,15 +168,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:17+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -125,55 +125,58 @@ msgstr "Informació"
 msgid "The specified userhash is not valid!"
 msgstr "El resum d'usuari especificat no és vàlid!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Després del nom de l'aplicació"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "La connexió ha fallat "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -182,15 +185,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:17+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -123,55 +123,58 @@ msgstr "Informace"
 msgid "The specified userhash is not valid!"
 msgstr "Zadaný userhash je neplatný!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Za názvem programu"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Připojení selhalo "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -180,15 +183,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:18+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -115,53 +115,56 @@ msgstr ""
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -170,15 +173,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:18+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -125,9 +125,12 @@ msgstr "Information"
 msgid "The specified userhash is not valid!"
 msgstr "Die angegebene Benutzerprüfsumme ist nicht gültig!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -135,46 +138,47 @@ msgstr ""
 "\n"
 "Desktop-Integration jetzt installieren?"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "aMule zum Anwendungsmenü hinzufügen?"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Installieren"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "Nicht jetzt"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "Nicht erneut fragen"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Desktop-Integration konnte nicht installiert werden: die Umgebungsvariable APPDIR ist nicht gesetzt. Dies bedeutet in der Regel, dass das AppImage auf eine nicht standardmäßige Weise gestartet wurde."
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "aMule-Integration fehlgeschlagen"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Desktop-Integration konnte nicht installiert werden: Erstellen von %s fehlgeschlagen. Prüfen Sie, ob Ihr persönliches Verzeichnis schreibbar ist."
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Desktop-Integration konnte nicht installiert werden: Schreiben von %s fehlgeschlagen. Prüfen Sie, ob Ihr persönliches Verzeichnis schreibbar ist."
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "AppImage-Integration: aMule wurde zu Ihrem Anwendungsmenü hinzugefügt."
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -188,15 +192,15 @@ msgstr ""
 "\n"
 "aMule jetzt neu starten?"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule installiert"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Jetzt neu starten"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Später"
 

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:18+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -122,55 +122,58 @@ msgstr "Πληροφορίες"
 msgid "The specified userhash is not valid!"
 msgstr "Ο προσδιορισμένος κατακερματισμός χρήστη δεν είναι έγκυρος!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Μετά το όνομα της εφαρμογής"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Αποτυχία σύνδεσης"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -179,15 +182,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -111,53 +111,56 @@ msgstr ""
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -166,15 +169,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:19+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -129,9 +129,12 @@ msgstr "Información"
 msgid "The specified userhash is not valid!"
 msgstr "¡El hash de usuario especificado no es válido!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -139,46 +142,47 @@ msgstr ""
 "\n"
 "¿Instalar la integración de escritorio ahora?"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "¿Añadir aMule al menú de aplicaciones?"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Instalar"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "Ahora no"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "No volver a preguntar"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "No se puede instalar la integración de escritorio: la variable de entorno APPDIR no está definida. Esto generalmente significa que el AppImage no se inició de forma normal."
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "La integración de aMule ha fallado"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "No se puede instalar la integración de escritorio: error al crear %s. Compruebe que su directorio personal tenga permisos de escritura."
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "No se puede instalar la integración de escritorio: error al escribir %s. Compruebe que su directorio personal tenga permisos de escritura."
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Integración de AppImage: aMule se ha añadido al menú de aplicaciones."
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -192,15 +196,15 @@ msgstr ""
 "\n"
 "¿Reiniciar aMule ahora?"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule instalado"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Reiniciar ahora"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Más tarde"
 

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -123,55 +123,58 @@ msgstr "Informatsioon"
 msgid "The specified userhash is not valid!"
 msgstr "Määratud kasutaja kontrollsumma pole kehtiv!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Järgneva rakenduse nimi"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Ühendus ebaõnnestus "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -180,15 +183,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:20+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -124,55 +124,58 @@ msgstr "Argibideak"
 msgid "The specified userhash is not valid!"
 msgstr "Emandako erabiltzaile egiaztapena ez da baliozkoa!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Aplikazio izenaren ondoren"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Konexioak huts egin du "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -181,15 +184,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:20+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -124,55 +124,58 @@ msgstr "Tietoa"
 msgid "The specified userhash is not valid!"
 msgstr "Annettu käyttäjätarkiste ei ole kelvollinen!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Sovelluksen nimen perässä"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Yhdistäminen epäonnistui "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -181,15 +184,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:21+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -127,9 +127,12 @@ msgstr "Information"
 msgid "The specified userhash is not valid!"
 msgstr "Le hachage utilisateur spécifié est invalide !"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -137,46 +140,47 @@ msgstr ""
 "\n"
 "Installer l'intégration de bureau maintenant ?"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "Ajouter aMule à votre menu d'applications ?"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Installer"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "Pas maintenant"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "Ne plus me demander"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Impossible d'installer l'intégration de bureau : la variable d'environnement APPDIR n'est pas définie. Cela signifie généralement que l'AppImage a été lancée d'une manière non standard."
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "Échec de l'intégration d'aMule"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Impossible d'installer l'intégration de bureau : échec de la création de %s. Vérifiez que votre répertoire personnel est accessible en écriture."
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Impossible d'installer l'intégration de bureau : échec de l'écriture de %s. Vérifiez que votre répertoire personnel est accessible en écriture."
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Intégration AppImage : aMule a été ajouté à votre menu d'applications."
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -190,15 +194,15 @@ msgstr ""
 "\n"
 "Redémarrer aMule maintenant ?"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule installé"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Redémarrer maintenant"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Plus tard"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:21+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -137,9 +137,12 @@ msgstr "Información"
 msgid "The specified userhash is not valid!"
 msgstr "O hash de usuario especificado non é válido!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -147,46 +150,47 @@ msgstr ""
 "\r\n"
 "Quere instalar os atallos?"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "Engadir aMule ao menú de aplicacións?"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Continuar"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "Agora non"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "Non preguntar de novo"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Non se puido integrar co escritorio: a variable APPDIR está baleira. Isto pode pasar ao executar a AppImage dun xeito raro."
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "Non se puido integrar aMule"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Non se puido integrar co escritorio: non se puido crear %s. Comprobe os permisos de escritura do cartafol persoal."
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Non se puido integrar co escritorio: non se puido modificar %s. Comprobe os permisos de escritura do cartafol persoal."
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Integración de AppImage: Engadiuse aMule no menú de aplicacións."
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -200,15 +204,15 @@ msgstr ""
 "\n"
 "Reiniciar agora aMule?"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "Instalouse aMule"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Reiniciar agora"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Máis tarde"
 

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:22+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -119,54 +119,57 @@ msgstr "מידע"
 msgid "The specified userhash is not valid!"
 msgstr "גיבוב-המשתמש הספציפי אינו תקף!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "התחברות נכשלה "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -175,15 +178,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:22+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -117,54 +117,57 @@ msgstr "Informacije"
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Neuspjelo povezivanje"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -173,15 +176,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:22+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -120,9 +120,12 @@ msgstr "Információ"
 msgid "The specified userhash is not valid!"
 msgstr "A megadott felhasználói azonosító (userhash) érvénytelen!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -130,46 +133,47 @@ msgstr ""
 "\n"
 "Installálásra kerüljön az asztal integráció?"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "aMule hozzáadása az alkalmazások menüjéhez?"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Telepítés"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "Most nem"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "Ne kérdezze újra"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Asztal integráció nem telepíthető: az APPDIR környezeti változónak nincs értéke. Ez általában azt jelenti, hogy az AppImage egy szokatlan módon került indításra."
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "aMule integráció sikertelen"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Az asztal integráció telepítése sikertelen: %s létrehozása nem sikerült. Elleőrizze hogy a home könyvtár írható."
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Az asztal integráció telepítése sikertelen: %s írása nem sikerült. Elleőrizze hogy a home könyvtár írható."
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "AppImage integráció: aMule hozzá lett adva az alkalmazások menüjéhez."
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -183,15 +187,15 @@ msgstr ""
 "\n"
 "aMule újraindítása most?"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule telepítve"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Újraindítás most"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Később"
 

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-06 14:35+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -127,9 +127,12 @@ msgstr "Informazione"
 msgid "The specified userhash is not valid!"
 msgstr "L'hash utente specificato non è valido!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -137,46 +140,47 @@ msgstr ""
 "\n"
 "Installare ora l'integrazione con il desktop?"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "Aggiungere aMule al menu delle applicazioni?"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Installa"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "Non ora"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "Non chiedere più"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Impossibile installare l'integrazione con il desktop: la variabile di ambiente APPDIR non è impostata. Di solito significa che l'AppImage è stata avviata in modo non standard."
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "Integrazione di aMule non riuscita"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Impossibile installare l'integrazione con il desktop: errore nella creazione di %s. Verificare che la home directory sia scrivibile."
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Impossibile installare l'integrazione con il desktop: errore nella scrittura di %s. Verificare che la home directory sia scrivibile."
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Integrazione AppImage: aMule è stato aggiunto al menu delle applicazioni."
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -190,15 +194,15 @@ msgstr ""
 "\n"
 "Riavviare aMule ora?"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule installato"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Riavvia ora"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Più tardi"
 

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:23+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -127,9 +127,12 @@ msgstr "Informazione"
 msgid "The specified userhash is not valid!"
 msgstr "L'hash utente specificato non è valido!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -137,46 +140,47 @@ msgstr ""
 "\n"
 "Installare l'integrazione desktop ora?"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "Aggiungere aMule al menu delle applicazioni?"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Installa"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "Non ora"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "Non chiedere più"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Impossibile installare l'integrazione desktop: la variabile d'ambiente APPDIR non è impostata. Di solito ciò significa che l'AppImage è stato avviato in modo non standard."
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "Integrazione di aMule non riuscita"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Impossibile installare l'integrazione desktop: creazione di %s non riuscita. Verifica che la tua home directory sia scrivibile."
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Impossibile installare l'integrazione desktop: scrittura di %s non riuscita. Verifica che la tua home directory sia scrivibile."
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Integrazione AppImage: aMule aggiunto al menu delle applicazioni."
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -190,15 +194,15 @@ msgstr ""
 "\n"
 "Riavviare aMule ora?"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule installato"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Riavvia ora"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Più tardi"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:24+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -120,54 +120,57 @@ msgstr "情報"
 msgid "The specified userhash is not valid!"
 msgstr "指定されたユーザハッシュは不正です！"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "接続に失敗しました "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -176,15 +179,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:24+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -119,54 +119,57 @@ msgstr "정보"
 msgid "The specified userhash is not valid!"
 msgstr "설정된 사용자 해시가 옳바르지 않습니다!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "연결 실패"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -175,15 +178,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:25+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -121,54 +121,57 @@ msgstr "Informacija"
 msgid "The specified userhash is not valid!"
 msgstr "Nurodyta naudotojo maišos f-ja klaidinga!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Prisijungti nepavyko "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -177,15 +180,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-06 14:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -116,53 +116,56 @@ msgstr "Informācija"
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Uzstādīt"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -171,15 +174,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule uzstādīta"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Palaist no jauna tagad"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Vēlāk"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:25+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -125,55 +125,58 @@ msgstr "Informatie"
 msgid "The specified userhash is not valid!"
 msgstr "De aangegeven gebruikers-hash is niet geldig!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Na applicatienaam"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Verbinding mislukt "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -182,15 +185,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:25+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -121,54 +121,57 @@ msgstr "Informasjon"
 msgid "The specified userhash is not valid!"
 msgstr "Den innskrivne brukarhashen er ikkje gyldig!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Oppkopling mislukka "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -177,15 +180,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:26+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -125,55 +125,58 @@ msgstr "Informacje"
 msgid "The specified userhash is not valid!"
 msgstr "Wybrany skrót użytkownika jest niepoprawny!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Za nazwą aplikacji"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Nieudane połączenie "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -182,15 +185,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:27+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -124,9 +124,12 @@ msgstr "Informação"
 msgid "The specified userhash is not valid!"
 msgstr "A Hash do usuário especificado é inválida!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -134,46 +137,47 @@ msgstr ""
 "\n"
 "Deseja instalar agora a integração com o desktop?"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "Adicionar o aMule ao seu menu de aplicativos?"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Instalar"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "Agora não"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "Não perguntar novamente"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Não foi possível instalar a integração com o desktop: a variável de ambienteAPPDIR não está setada. Normalmente isto significa que a AppImage foi lançada de uma forma não padrão."
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "A integração do aMule falhou"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Não foi possível instalar a integração com o desktop: falha ao criar %s. Confira se seu diretório de usuário tem permissão de escrita."
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Não foi possível instalar a integração com o desktop: falha escrevendo %s. Confira se seu diretório de usuário tem permissão de escrita."
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Integração do AppImage: aMule foi adicionado ao seu menu de aplicativos."
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -187,15 +191,15 @@ msgstr ""
 "\n"
 "Reiniciar agora o aMule?"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule instalado"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Reiniciar agora"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Mais tarde"
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:27+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -130,55 +130,58 @@ msgstr "Informação"
 msgid "The specified userhash is not valid!"
 msgstr "A chave de utilizador especificada não é válida!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Depois do nome da aplicação"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "A ligação falhou "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -187,15 +190,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:27+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -122,55 +122,58 @@ msgstr "Informații"
 msgid "The specified userhash is not valid!"
 msgstr "Indexul utilizator specificat nu este valid!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "După numele aplicației"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Conectare eșuată"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -179,15 +182,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:28+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -129,55 +129,58 @@ msgstr "Информация"
 msgid "The specified userhash is not valid!"
 msgstr "Указанный хеш пользователя недопустим."
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "После имени приложения"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Попытка подключиться не удалась "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -186,15 +189,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:28+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -124,55 +124,58 @@ msgstr "Podatki"
 msgid "The specified userhash is not valid!"
 msgstr "Navedena koda uporabnika ni veljavna."
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Za imenom programa"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Povezovanje ni uspelo "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -181,15 +184,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:29+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -120,54 +120,57 @@ msgstr "Informacion"
 msgid "The specified userhash is not valid!"
 msgstr "Userhash-i i specifikuar nuk eshte i vlefshem!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Lidhja deshtoi "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -176,15 +179,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:29+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -122,55 +122,58 @@ msgstr "Information"
 msgid "The specified userhash is not valid!"
 msgstr "Angiven userhash är inte giltig!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Efter programnamn"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Anslutningen misslyckades "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -179,15 +182,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:32+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -110,53 +110,56 @@ msgstr "தகவல்"
 msgid "The specified userhash is not valid!"
 msgstr "குறிப்பிட்ட பயனர்கொத்து தவறானது!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -165,15 +168,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -121,9 +121,12 @@ msgstr "Bilgi"
 msgid "The specified userhash is not valid!"
 msgstr "Belirlenen kullanıcı adreslemesi geçersiz!"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -131,46 +134,47 @@ msgstr ""
 "\n"
 "Masaüstü birleşimi şimdi kurulsun mu?"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "aMule uygulama menünüze eklensin mi?"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "Kur"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "Şimdi değil"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "Tekrar sorma"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Masaüstü birleşimi kurulamaz: APPDIR ortam değişkeni tanımlı değil. Bu, genelde AppImage başlatılmasının standart olmayan bir yolla yapıldığı manasına gelir."
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "aMule birleşimi başarısız"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Masaüstü birleşimi kurulamaz: %s oluşturulması başarısız oldu. Ev dizininizin yazılabilir olduğundan emin olun."
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Masaüstü birleşimi kurulamaz: %s yazması başarısız oldu. Ev dizininizin yazılabilir olduğundan emin olun."
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "AppImage birleşimi: aMule uygulama menünüze ilave edildi."
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -184,15 +188,15 @@ msgstr ""
 "\n"
 "aMule şimdi tekrar başlatılsın mı?"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule kuruldu"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "Şimdi tekrar başlat"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "Daha sonra"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:30+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -122,55 +122,58 @@ msgstr "Інформація"
 msgid "The specified userhash is not valid!"
 msgstr "Визначений хеш користувача невірний"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Після назви програми"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "З'єднання невдале "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -179,15 +182,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:31+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -121,9 +121,12 @@ msgstr "信息"
 msgid "The specified userhash is not valid!"
 msgstr "指定的用户哈希无效！"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
+#, fuzzy
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
@@ -131,46 +134,47 @@ msgstr ""
 "\n"
 "现在立即安装桌面集成吗？"
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 msgid "Add aMule to your application menu?"
 msgstr "添加 aMule 到程序菜单吗？"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr "安装"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr "不是现在"
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr "不要再提醒我"
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "无法安装桌面集成：APPDIR 环境变量未设置。这通常表明 AppImage 以非标准的形式启动。"
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 msgid "aMule integration failed"
 msgstr "aMule 集成失败"
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "无法安装桌面集成：创建 %s 失败。请检查主目录是可写入的。"
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "无法安装桌面集成。写入 %s 失败。请检查主目录是可写入的。"
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, fuzzy, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "AppImage 集成：aMule 已添加到你的应用程序菜单。"
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -184,15 +188,15 @@ msgstr ""
 "\n"
 "现在立即重启 aMule 吗？"
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr "aMule 已安装"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr "立即重启"
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr "稍后重启"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-06 22:14+0200\n"
+"POT-Creation-Date: 2026-07-06 22:41+0200\n"
 "PO-Revision-Date: 2026-07-05 16:31+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -128,55 +128,58 @@ msgstr "資訊"
 msgid "The specified userhash is not valid!"
 msgstr "這個使用者 hash 值無效！"
 
-#: src/AppImageIntegration.cpp:220
+#: src/AppImageIntegration.cpp:296
 msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it appears in your application menu like a regularly installed app. This is reversible — the files live under ~/.local/share/applications and ~/.local/share/icons and can be removed at any time.\n"
+"aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
+"\n"
+"This is reversible - the files live under ~/.local/share/applications, ~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n"
 "\n"
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:225
+#: src/AppImageIntegration.cpp:302
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "在程式名稱後"
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:227
+#: src/AppImageIntegration.cpp:304
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:228
+#: src/AppImageIntegration.cpp:305
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:248
+#: src/AppImageIntegration.cpp:325
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:251 src/AppImageIntegration.cpp:264
-#: src/AppImageIntegration.cpp:276
+#: src/AppImageIntegration.cpp:328 src/AppImageIntegration.cpp:341
+#: src/AppImageIntegration.cpp:362
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "無法連線 "
 
-#: src/AppImageIntegration.cpp:260
+#: src/AppImageIntegration.cpp:337
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:272
+#: src/AppImageIntegration.cpp:358
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:283
-msgid "AppImage integration: aMule added to your application menu."
+#: src/AppImageIntegration.cpp:388
+#, c-format
+msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:286
+#: src/AppImageIntegration.cpp:393
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -185,15 +188,15 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:292
+#: src/AppImageIntegration.cpp:399
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:294
+#: src/AppImageIntegration.cpp:401
 msgid "Later"
 msgstr ""
 

--- a/src/AppImageIntegration.cpp
+++ b/src/AppImageIntegration.cpp
@@ -41,6 +41,7 @@
 #include <wx/utils.h>
 
 #include <cstdlib>
+#include <sys/stat.h>
 #include <unistd.h>
 
 namespace
@@ -184,6 +185,81 @@ bool DesktopFileAlreadyInstalled()
 	return wxFileExists(GetUserApplicationsDir() + wxT("/org.amule.aMule.desktop"));
 }
 
+wxString GetUserBinDir()
+{
+	return wxGetUserHome() + wxT("/.local/bin");
+}
+
+// True if `path` names an existing symlink (broken or intact). Distinct
+// from wxFileExists which returns true for a symlink pointing at a
+// non-existent target BUT ALSO returns true for a regular file — we
+// need to know the difference before deciding whether it's safe to
+// replace with our own symlink.
+bool IsSymlink(const wxString &path)
+{
+	struct stat st;
+	return lstat((const char *)path.mb_str(wxConvUTF8), &st) == 0 && S_ISLNK(st.st_mode);
+}
+
+// The names AppRun's argv[0]-dispatch case knows about. Any name that
+// AppRun doesn't recognize falls back to `amule`, so a stale symlink
+// to a since-removed binary still launches the monolithic GUI —
+// never a hard failure. Order matches the AppRun case statement.
+const wxString kAppRunNames[] = {
+	wxT("amule"),
+	wxT("amuled"),
+	wxT("amulegui"),
+	wxT("amulecmd"),
+	wxT("amuleweb"),
+	wxT("amuleapi"),
+	wxT("ed2k"),
+	wxT("cas"),
+	wxT("wxcas"),
+	wxT("alc"),
+	wxT("alcc"),
+};
+
+// Create ~/.local/bin/<name> symlinks for each AppRun-dispatched
+// binary that this AppImage actually bundles. Returns the count
+// created. Refuses to clobber a pre-existing regular file at any of
+// these paths (protects e.g. a user's distro-packaged amule binary if
+// it somehow lives under ~/.local/bin); existing symlinks ARE replaced
+// so a re-install of a new AppImage refreshes the targets.
+int InstallCommandSymlinks(const wxString &appdir, const wxString &appimagePath)
+{
+	const wxString binDir = GetUserBinDir();
+	if (!wxDirExists(binDir) && !wxFileName::Mkdir(binDir, 0755, wxPATH_MKDIR_FULL)) {
+		AddDebugLogLineC(logGeneral, wxT("AppImageIntegration: failed to create ") + binDir);
+		return 0;
+	}
+
+	int created = 0;
+	for (const wxString &name : kAppRunNames) {
+		// Only if this AppImage actually bundles the binary.
+		const wxString bundled = appdir + wxT("/usr/bin/") + name;
+		if (!wxFileExists(bundled)) {
+			continue;
+		}
+		const wxString linkPath = binDir + wxT("/") + name;
+		if (wxFileExists(linkPath) && !IsSymlink(linkPath)) {
+			AddDebugLogLineC(logGeneral,
+				wxT("AppImageIntegration: not clobbering existing non-symlink ") + linkPath);
+			continue;
+		}
+		if (IsSymlink(linkPath)) {
+			wxRemoveFile(linkPath);
+		}
+		if (symlink((const char *)appimagePath.mb_str(wxConvUTF8),
+			    (const char *)linkPath.mb_str(wxConvUTF8)) == 0) {
+			++created;
+		} else {
+			AddDebugLogLineC(
+				logGeneral, wxT("AppImageIntegration: symlink failed for ") + linkPath);
+		}
+	}
+	return created;
+}
+
 } // anonymous namespace
 
 namespace AppImageIntegration
@@ -217,10 +293,11 @@ void PromptAndInstall(wxWindow *parent)
 	}
 
 	wxRichMessageDialog dlg(parent,
-		_("aMule can install a desktop launcher and icon into your home directory "
-		  "so it appears in your application menu like a regularly installed app. "
-		  "This is reversible — the files live under ~/.local/share/applications "
-		  "and ~/.local/share/icons and can be removed at any time.\n\n"
+		_("aMule can install desktop launchers, icons, and shell command "
+		  "shortcuts into your home directory so it appears in your application "
+		  "menu like a regularly installed app.\n\n"
+		  "This is reversible - the files live under ~/.local/share/applications, "
+		  "~/.local/share/icons, and ~/.local/bin, and can be removed at any time.\n\n"
 		  "Install desktop integration now?"),
 		_("Add aMule to your application menu?"),
 		wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
@@ -265,22 +342,52 @@ void PromptAndInstall(wxWindow *parent)
 		return;
 	}
 
-	const wxString sourceDesktop = appdir + wxT("/usr/share/applications/org.amule.aMule.desktop");
-	const wxString destDesktop = userAppsDir + wxT("/org.amule.aMule.desktop");
+	// Shell-command shortcuts first: the amulegui .desktop file
+	// installed below points at ~/.local/bin/amulegui to route
+	// clicks to the correct AppRun dispatch. If that symlink doesn't
+	// materialise the .gui .desktop's Exec= still resolves via PATH
+	// lookup, but a fresh installation with an untouched
+	// ~/.local/bin/ path is the happy case we design for here.
+	const int symlinkCount = InstallCommandSymlinks(appdir, appimagePath);
 
-	if (!InstallDesktopFile(appimagePath, sourceDesktop, destDesktop)) {
+	// Install org.amule.aMule.desktop (monolithic amule). Exec= points
+	// straight at the AppImage - default AppRun dispatch is amule.
+	const wxString sourceAmuleDesktop = appdir + wxT("/usr/share/applications/org.amule.aMule.desktop");
+	const wxString destAmuleDesktop = userAppsDir + wxT("/org.amule.aMule.desktop");
+	if (!InstallDesktopFile(appimagePath, sourceAmuleDesktop, destAmuleDesktop)) {
 		const wxString msg = wxString::Format(_("Cannot install desktop integration: failed to write "
 							"%s. Check that your home directory is writable."),
-			destDesktop);
+			destAmuleDesktop);
 		AddLogLineC(msg);
 		wxMessageBox(msg, _("aMule integration failed"), wxOK | wxICON_ERROR, parent);
 		return;
 	}
 
+	// Install org.amule.aMule.gui.desktop (remote-GUI amulegui). Exec=
+	// points at the ~/.local/bin/amulegui symlink so AppRun's basename
+	// dispatch picks amulegui rather than the default amule. Only
+	// attempt if the AppImage actually bundles amulegui AND the
+	// symlink was created; otherwise silently skip (a
+	// TESTING=OFF-only build has no amulegui).
+	const wxString guiSource = appdir + wxT("/usr/share/applications/org.amule.aMule.gui.desktop");
+	const wxString guiSymlink = GetUserBinDir() + wxT("/amulegui");
+	if (wxFileExists(guiSource) && wxFileExists(guiSymlink)) {
+		const wxString destGuiDesktop = userAppsDir + wxT("/org.amule.aMule.gui.desktop");
+		if (!InstallDesktopFile(guiSymlink, guiSource, destGuiDesktop)) {
+			AddDebugLogLineC(logGeneral,
+				wxT("AppImageIntegration: failed to install amulegui .desktop; "
+				    "amulegui menu entry and scheme-handler association will not "
+				    "work until re-integrated"));
+		}
+	}
+
 	InstallIcons(appdir, userIconsDir);
 	RefreshSystemCaches(userAppsDir, userIconsDir);
 
-	AddLogLineN(_("AppImage integration: aMule added to your application menu."));
+	AddLogLineN(wxString::Format(
+		_("AppImage integration: aMule added to your application menu (%d shell shortcuts under "
+		  "~/.local/bin)."),
+		symlinkCount));
 
 	wxMessageDialog success(parent,
 		_("aMule has been added to your application menu. You can now launch it from your "

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -339,7 +339,7 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 	const bool no_pass = m_apiConfig.AdminPasswordMd5().empty() && m_apiConfig.GuestPasswordMd5().empty();
 	if (non_loopback && no_pass) {
 		Show(CFormat(_("amuleapi: refusing to start with BindAddress=%s and no "
-			       "admin/guest password configured — this would expose the "
+			       "admin/guest password configured - this would expose the "
 			       "REST surface to anyone reachable on that interface. "
 			       "Either bind to 127.0.0.1, or run "
 			       "`amuleapi --set-admin-pass=<plain>` first.\n")) %


### PR DESCRIPTION
Three related fixes bundled into one small PR while touching the AppImage first-run integration path:

## 1. amulegui as a first-class integrated launcher

Currently `AppImageIntegration::PromptAndInstall` writes only `org.amule.aMule.desktop`. Users can invoke amulegui by manually symlinking the AppImage under a `amulegui`-named path (AppRun's `argv[0]`-basename dispatch handles it), but the menu entry, dock icon, and MimeType handler association for amulegui are all missing.

Extended to also install `org.amule.aMule.gui.desktop` with `Exec=` pointing at `~/.local/bin/amulegui` (see point 2), so a user picking amulegui as the ed2k:// scheme handler in Preferences (via #324) actually gets amulegui - previously `xdg-open` couldn't find the .gui `.desktop` and silently fell back to launching amule.

## 2. Shell command shortcuts

New `InstallCommandSymlinks()` iterates the AppRun-recognized names (`amule`, `amuled`, `amulegui`, `amulecmd`, `amuleweb`, `amuleapi`, `ed2k`, `cas`, `wxcas`, `alc`, `alcc`) and creates `~/.local/bin/<name>` symlinks for each name the AppImage actually bundles. Users can now type `amulecmd`, `amuled`, etc. from any terminal without knowing the AppImage path - matches distro-package expectations.

Safety:

- Refuses to clobber a pre-existing regular file at any of these paths (protects a distro-installed binary if one happens to live under `~/.local/bin`).
- Existing symlinks ARE replaced so a re-integration with a newer AppImage refreshes the target.
- If `~/.local/bin` isn't in `PATH`, the shortcuts still exist but only fire when the user types the full path - no worse than today's zero shortcuts.

## 3. Fix two user-visible em-dashes that mojibake on Windows

Same class of bug as #326 (already merged). My earlier regex-based sweep missed these because both em-dashes sit on multi-line C-string continuations, not the first line after `_(`:

- `src/AppImageIntegration.cpp:222` - the integration-prompt body
- `src/webapi/App.cpp:342` - amuleapi startup error when bound to a non-loopback address with no admin/guest password set

Both replaced with plain ASCII hyphens - identical rendering on Linux and macOS, no cp1252 decode mojibake on Windows.

## Commits

1. `feat(AppImage): install amulegui launcher + shell shortcuts, fix em-dashes` - the actual change (118 insertions across 2 files).
2. `po: regenerate catalogs after AppImageIntegration text changes` - required by the App-catalogs-in-sync CI check.

## Related

- #324 (URL scheme handler PR) - the scheme-handler → amulegui-launcher gap surfaced there is what motivated this PR.
- #326 (em-dash mojibake fix, already merged) - same class of bug; my earlier sweep didn't catch multi-line concatenations.