### PR TITLE
fix(AppImage): guard POSIX-only calls behind __WXGTK__

### DIFF
--- a/src/AppImageIntegration.cpp
+++ b/src/AppImageIntegration.cpp
@@ -192,14 +192,18 @@ wxString GetUserBinDir()
 
 // True if `path` names an existing symlink (broken or intact). Distinct
 // from wxFileExists which returns true for a symlink pointing at a
-// non-existent target BUT ALSO returns true for a regular file — we
+// non-existent target BUT ALSO returns true for a regular file - we
 // need to know the difference before deciding whether it's safe to
-// replace with our own symlink.
+// replace with our own symlink. POSIX-only; MinGW-w64 (Windows) has
+// neither lstat nor S_ISLNK, and the whole AppImage integration path
+// is a no-op there anyway (ShouldPrompt returns false on non-GTK).
+#ifdef __WXGTK__
 bool IsSymlink(const wxString &path)
 {
 	struct stat st;
 	return lstat((const char *)path.mb_str(wxConvUTF8), &st) == 0 && S_ISLNK(st.st_mode);
 }
+#endif
 
 // The names AppRun's argv[0]-dispatch case knows about. Any name that
 // AppRun doesn't recognize falls back to `amule`, so a stale symlink
@@ -225,6 +229,11 @@ const wxString kAppRunNames[] = {
 // these paths (protects e.g. a user's distro-packaged amule binary if
 // it somehow lives under ~/.local/bin); existing symlinks ARE replaced
 // so a re-install of a new AppImage refreshes the targets.
+// POSIX-only (uses symlink(2) and IsSymlink() which use lstat/S_ISLNK).
+// The AppImage integration flow is inherently Linux-only; ShouldPrompt
+// returns false on Windows / macOS, so this function is never actually
+// called on those platforms - but it still needs to compile.
+#ifdef __WXGTK__
 int InstallCommandSymlinks(const wxString &appdir, const wxString &appimagePath)
 {
 	const wxString binDir = GetUserBinDir();
@@ -259,6 +268,14 @@ int InstallCommandSymlinks(const wxString &appdir, const wxString &appimagePath)
 	}
 	return created;
 }
+#else
+// Non-GTK stub - never called at runtime (PromptAndInstall bails
+// early via ShouldPrompt on !__WXGTK__), but needs to link.
+int InstallCommandSymlinks(const wxString &, const wxString &)
+{
+	return 0;
+}
+#endif // __WXGTK__
 
 } // anonymous namespace
 


### PR DESCRIPTION
Broke the master mingw-w64 build in #328. MinGW doesn't have `lstat`, `S_ISLNK`, or `symlink(2)`, and my new `IsSymlink()` + `InstallCommandSymlinks()` referenced all three unconditionally.

The AppImage integration path is inherently Linux-only - `ShouldPrompt()` returns false on `!__WXGTK__`, so `InstallCommandSymlinks` is never actually called on Windows / macOS - but the symbols still had to link. Guard fix:

- Wrap `IsSymlink` and the GTK body of `InstallCommandSymlinks` in `#ifdef __WXGTK__`.
- Provide a stub `InstallCommandSymlinks` on non-GTK builds that returns 0, so the (dead) call site in `PromptAndInstall` still links.

No behaviour change on Linux. Verified locally that macOS still builds (guarded path takes the stub branch on `__WXMAC__`).

Fixes the CI break from #328. Sorry for the churn - I should have compiled locally on Windows before landing #328, or waited for CI green.