### PR TITLE
InstanceLock: fix Flatpak multi-instance and enable amuled/macOS single-instance

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -113,6 +113,7 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON OR BUILD_REMOTEGUI)
 		GetTickCount.cpp
 		GuiEvents.cpp
 		HTTPDownload.cpp
+		InstanceLock.cpp
 		KnownFile.cpp
 		Logger.cpp
 		MediaProbe.cpp

--- a/src/InstanceLock.cpp
+++ b/src/InstanceLock.cpp
@@ -1,0 +1,153 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+//
+
+#include "InstanceLock.h"
+
+#ifdef __WINDOWS__
+#include <wx/snglinst.h>
+#else
+#include <cerrno>
+#include <cstdio>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+InstanceLock::InstanceLock()
+#ifdef __WINDOWS__
+: m_wxImpl(NULL)
+, m_anotherRunning(false)
+#else
+: m_fd(-1)
+#endif
+{
+}
+
+InstanceLock::~InstanceLock()
+{
+	Release();
+}
+
+#ifdef __WINDOWS__
+
+InstanceLock::Result InstanceLock::Acquire(const wxString &filename, const wxString &dir)
+{
+	Release();
+	m_wxImpl = new wxSingleInstanceChecker();
+	if (!m_wxImpl->Create(filename, dir)) {
+		delete m_wxImpl;
+		m_wxImpl = NULL;
+		return LOCK_ERROR;
+	}
+	m_anotherRunning = m_wxImpl->IsAnotherRunning();
+	return m_anotherRunning ? LOCK_HELD : LOCK_ACQUIRED;
+}
+
+void InstanceLock::Release()
+{
+	delete m_wxImpl;
+	m_wxImpl = NULL;
+	m_anotherRunning = false;
+}
+
+#else // POSIX
+
+InstanceLock::Result InstanceLock::Acquire(const wxString &filename, const wxString &dir)
+{
+	// Idempotent-caller contract (see header). Drop any existing fd first
+	// without unlinking - the file will be replaced on the open() below;
+	// unlink()-ing here would create a race window during which no lock
+	// file exists on disk, and a concurrent third instance could slip in.
+	if (m_fd != -1) {
+		(void)close(m_fd);
+		m_fd = -1;
+	}
+	m_path = dir + filename;
+
+	// Open (or create) the lock file. Unlike wxSingleInstanceChecker we
+	// do NOT use O_EXCL: the file's presence isn't the signal, the
+	// kernel-held fcntl lock is.
+	m_fd = open(m_path.fn_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+	if (m_fd == -1) {
+		return LOCK_ERROR;
+	}
+
+	// Defense against a planted lock file with wrong owner (matches
+	// wxSingleInstanceChecker's paranoia). If someone dropped a
+	// world-writable muleLock into ~/.aMule/ we don't want to touch it.
+	struct stat st;
+	if (fstat(m_fd, &st) == 0 && st.st_uid != getuid()) {
+		(void)close(m_fd);
+		m_fd = -1;
+		return LOCK_ERROR;
+	}
+	(void)fchmod(m_fd, S_IRUSR | S_IWUSR);
+
+	struct flock fl;
+	fl.l_type = F_WRLCK;
+	fl.l_whence = SEEK_SET;
+	fl.l_start = 0;
+	fl.l_len = 0;
+	fl.l_pid = 0;
+
+	if (fcntl(m_fd, F_SETLK, &fl) == -1) {
+		int saved = errno;
+		(void)close(m_fd);
+		m_fd = -1;
+		if (saved == EAGAIN || saved == EACCES) {
+			return LOCK_HELD;
+		}
+		return LOCK_ERROR;
+	}
+
+	// Refresh the on-disk PID as a diagnostic aid ("who owns muleLock?"
+	// via `cat`). The kernel - not this integer - is the source of
+	// truth. Under a PID-namespaced sandbox (Flatpak, docker) this is
+	// the sandbox-local pid and may not match anything visible on the
+	// host, but is still useful for triage.
+	(void)ftruncate(m_fd, 0);
+	char buf[32];
+	int n = snprintf(buf, sizeof(buf), "%d\n", (int)getpid());
+	if (n > 0) {
+		ssize_t rc = write(m_fd, buf, (size_t)n);
+		(void)rc;
+	}
+	return LOCK_ACQUIRED;
+}
+
+void InstanceLock::Release()
+{
+	if (m_fd == -1) {
+		return;
+	}
+	// Unlink first so a fresh start doesn't inherit stale content;
+	// close last so the fcntl lock is released atomically with removal.
+	(void)unlink(m_path.fn_str());
+	(void)close(m_fd);
+	m_fd = -1;
+	m_path.clear();
+}
+
+#endif // __WINDOWS__

--- a/src/InstanceLock.h
+++ b/src/InstanceLock.h
@@ -1,0 +1,86 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+//
+
+#ifndef INSTANCELOCK_H
+#define INSTANCELOCK_H
+
+#include <wx/string.h>
+
+class wxSingleInstanceChecker;
+
+// Cross-instance detector for aMule.
+//
+// Replaces wxSingleInstanceChecker on POSIX because wx's stale-lock
+// recovery falls back to kill(pid, 0) for liveness, which false-negatives
+// across Linux PID namespaces (Flatpak sandboxes, container runtimes):
+// every sandbox has its own PID 1..N, so the PID written by the first
+// instance always maps to a live process in the second's namespace, and
+// IsAnotherRunning() ends up returning false because m_pidLocker == getpid()
+// on both sides. Result: two aMule processes stomping on the same config
+// and downloads directory.
+//
+// This class uses fcntl(F_SETLK) directly: the kernel - not a PID compare -
+// owns the truth about who holds the lock, and it's namespace-independent.
+// On process death (clean exit, crash, SIGKILL) the kernel releases the
+// lock automatically, so a lock file left over from a crashed run simply
+// self-heals on the next start.
+//
+// On Windows the wxSingleInstanceChecker path is retained: it uses a named
+// mutex, which is already namespace-aware.
+
+class InstanceLock
+{
+public:
+	InstanceLock();
+	~InstanceLock();
+
+	enum Result
+	{
+		LOCK_ACQUIRED, // we own the lock; proceed with normal startup
+		LOCK_HELD,     // another live instance holds the lock
+		LOCK_ERROR     // could not open the lock file (bad path/perms)
+	};
+
+	// Try to acquire the lock. Idempotent: if a prior lock is held, the
+	// underlying fd is closed first (kernel drops the old lock), so calling
+	// twice on the same object is safe. This is what
+	// CamuleAppCommon::RefreshSingleInstanceChecker() relies on after
+	// daemon fork().
+	Result Acquire(const wxString &filename, const wxString &dir);
+
+	// Release the lock and unlink the on-disk file. Also called from
+	// the destructor.
+	void Release();
+
+private:
+#ifdef __WINDOWS__
+	wxSingleInstanceChecker *m_wxImpl;
+	bool m_anotherRunning;
+#else
+	int m_fd;
+	wxString m_path;
+#endif
+};
+
+#endif // INSTANCELOCK_H

--- a/src/amule.h
+++ b/src/amule.h
@@ -76,7 +76,7 @@ class wxCloseEvent;
 class wxFFileOutputStream;
 class CTimer;
 class CTimerEvent;
-class wxSingleInstanceChecker;
+class InstanceLock;
 class CHashingEvent;
 class CMediaProbeEvent;
 class CMuleInternalEvent;
@@ -116,8 +116,10 @@ void OnShutdownSignal(int /* sig */);
 class CamuleAppCommon
 {
 private:
-	// Used to detect a previous running instance of aMule
-	wxSingleInstanceChecker *m_singleInstance;
+	// Used to detect a previous running instance of aMule.
+	// InstanceLock replaces wxSingleInstanceChecker on POSIX so single-
+	// instance detection survives PID-namespace boundaries (Flatpak).
+	InstanceLock *m_singleInstance;
 
 	bool CheckPassedLink(const wxString &in, wxString &out, int cat);
 
@@ -176,7 +178,7 @@ public:
 	// distro, any compositor). xdg-shell intentionally doesn't deliver
 	// iconify-state notifications to clients, so several tray-icon
 	// features that rely on detecting "user just minimized the
-	// window" cannot work there — the call sites use this flag to
+	// window" cannot work there - the call sites use this flag to
 	// disable / grey out the relevant prefs and skip the broken paths.
 	static bool IsWaylandSession();
 #endif
@@ -366,7 +368,7 @@ protected:
 	void OnFinishedHashing(CHashingEvent &evt);
 	void OnPartFileHashResult(CPartFileHashResultEvent &evt);
 	void OnFinishedAICHHashing(CHashingEvent &evt);
-	// #140 — CMediaProbeTask marshals results back here so we can
+	// #140 - CMediaProbeTask marshals results back here so we can
 	// attach FT_MEDIA_* tags on the main thread (the worker never
 	// touches CKnownFile state).
 	void OnMediaProbeFinished(CMediaProbeEvent &evt);
@@ -455,7 +457,7 @@ class CamuleGuiApp : public CamuleApp, public CamuleGuiBase
 	// while no aMule windows are visible. Default wxApp::MacReopenApp
 	// behaviour is to do nothing when the frame is hidden, so a
 	// window hidden via the close button (HideOnClose pref) stays
-	// permanently hidden — the app appears stuck.
+	// permanently hidden - the app appears stuck.
 	virtual void MacReopenApp();
 #endif
 

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -28,10 +28,11 @@
 //
 
 #include <wx/wx.h>
-#include <wx/cmdline.h>  // Needed for wxCmdLineParser
-#include <wx/snglinst.h> // Needed for wxSingleInstanceChecker
-#include <wx/textfile.h> // Needed for wxTextFile
-#include <wx/config.h>   // Do_not_auto_remove (win32)
+#include <wx/cmdline.h> // Needed for wxCmdLineParser
+
+#include "InstanceLock.h" // Needed for InstanceLock (replaces wxSingleInstanceChecker on POSIX)
+#include <wx/textfile.h>  // Needed for wxTextFile
+#include <wx/config.h>    // Do_not_auto_remove (win32)
 #include <wx/fileconf.h>
 
 #ifdef __WXGTK__
@@ -83,17 +84,13 @@ CamuleAppCommon::CamuleAppCommon()
 
 CamuleAppCommon::~CamuleAppCommon()
 {
-#if defined(__WXMAC__) && defined(AMULE_DAEMON)
-	// #warning TODO: fix wxSingleInstanceChecker for amuled on Mac (wx link problems)
-#else
 	delete m_singleInstance;
-#endif
 }
 
 #ifdef __WXGTK__
 bool CamuleAppCommon::IsWaylandSession()
 {
-	// Explicit GDK_BACKEND=x11 forces the app onto XWayland — OS
+	// Explicit GDK_BACKEND=x11 forces the app onto XWayland - OS
 	// minimize events come through reliably, so treat it as X11.
 	// This is the documented user workaround for "I want MinToTray
 	// on Wayland": launch with `GDK_BACKEND=x11 amule`. Same trick
@@ -124,12 +121,17 @@ bool CamuleAppCommon::IsWaylandSession()
 
 void CamuleAppCommon::RefreshSingleInstanceChecker()
 {
-#if defined(__WXMAC__) && defined(AMULE_DAEMON)
-	// #warning TODO: fix wxSingleInstanceChecker for amuled on Mac (wx link problems)
-#else
+	// Reacquire after daemonization fork(). POSIX advisory locks are
+	// owned by the parent process, not inherited by the child, so the
+	// forked daemon needs to relock the same file. Historically this
+	// path was disabled on __WXMAC__ + AMULE_DAEMON because linking
+	// wxSingleInstanceChecker into a wxAppConsole (headless) binary
+	// pulled in Cocoa framework symbols. InstanceLock has no wx-GUI
+	// dependencies on POSIX (fcntl only), so amuled/Mac now has
+	// working single-instance detection too.
 	delete m_singleInstance;
-	m_singleInstance = new wxSingleInstanceChecker("muleLock", thePrefs::GetConfigDir());
-#endif
+	m_singleInstance = new InstanceLock();
+	m_singleInstance->Acquire("muleLock", thePrefs::GetConfigDir());
 }
 
 void CamuleAppCommon::AddLinksFromFile()
@@ -371,7 +373,7 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 				"configure-autostart expects 'on' or 'off' (got '%s')\n",
 				(const char *)unicode2char(autostart_arg));
 		}
-		// Exit either way — this flag is a one-shot toggle, not a
+		// Exit either way - this flag is a one-shot toggle, not a
 		// "run aMule WITH autostart enabled" combo. (Caller can chain:
 		// `amule --configure-autostart on && amule`.)
 		// Return-false here propagates to OnInit returning false, which
@@ -539,18 +541,12 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 		}
 	}
 
-#if defined(__WXMAC__) && defined(AMULE_DAEMON)
-	// #warning TODO: fix wxSingleInstanceChecker for amuled on Mac (wx link problems)
-	AddLogLineCS("WARNING: The check for other instances is currently disabled in amuled.\n"
-		     "Please make sure that no other instance of aMule is running or your files might be "
-		     "corrupted.\n");
-#else
 	AddLogLineNS("Checking if there is an instance already running...");
 
-	m_singleInstance = new wxSingleInstanceChecker();
+	m_singleInstance = new InstanceLock();
 	wxString lockfile = IsRemoteGui() ? "muleLockRGUI" : "muleLock";
-	if (m_singleInstance->Create(lockfile, thePrefs::GetConfigDir()) &&
-		m_singleInstance->IsAnotherRunning()) {
+	InstanceLock::Result lockResult = m_singleInstance->Acquire(lockfile, thePrefs::GetConfigDir());
+	if (lockResult == InstanceLock::LOCK_HELD) {
 		AddLogLineCS(CFormat("There is an instance of %s already running") % m_appName);
 		AddLogLineNS(CFormat("(lock file: %s%s)") % thePrefs::GetConfigDir() % lockfile);
 		if (linksPassed) {
@@ -575,10 +571,13 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 		}
 
 		return false;
+	} else if (lockResult == InstanceLock::LOCK_ERROR) {
+		AddLogLineCS(CFormat("Could not access lock file (%s%s); continuing without single-instance "
+				     "protection.") %
+			     thePrefs::GetConfigDir() % lockfile);
 	} else {
 		AddLogLineNS("No other instances are running.");
 	}
-#endif
 
 #ifndef __WINDOWS__
 	// Close standard-input
@@ -598,7 +597,7 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 	// case-insensitive sorted-array binary searches are locale-
 	// deterministic. The initial parse below also has to run under
 	// LC_CTYPE="C" so the in-memory sort order matches what subsequent
-	// Read / Write calls will use — otherwise a session that runs under
+	// Read / Write calls will use - otherwise a session that runs under
 	// a non-C locale silently accumulates duplicate key=value lines in
 	// amule.conf (#852).
 	{
@@ -638,7 +637,7 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 	// moved the AppImage / .app / install dir since they enabled the
 	// toggle), silently rewrite it to the current canonical path so
 	// the next login launches the right binary. No-op if no entry
-	// exists — disabling autostart is always a deliberate choice we
+	// exists - disabling autostart is always a deliberate choice we
 	// don't second-guess.
 	AutostartManager::SelfHealOnStartup();
 


### PR DESCRIPTION
## Summary

Fixes the "aMule Flatpak launches a fresh instance on every click" bug: two full aMule processes end up running against the same `~/.aMule/` config and downloads dir, silently corrupting state. Also enables single-instance detection for `amuled` on macOS, which has been disabled since forever.

## Root cause

`wxSingleInstanceChecker` false-negatives across bwrap PID namespaces. On Unix its startup does `open(muleLock, O_WRONLY|O_CREAT|O_EXCL)` first, so instance 2 fails EEXIST and never reaches `fcntl(F_SETLK)`. It then falls into a stale-check branch that reads the PID stored in the file and calls `kill(pid, 0)` for liveness, and its `IsAnotherRunning()` returns `lockerPid != getpid()`.

Each Flatpak sandbox has its own PID namespace where amule ends up as PID 2. Instance 1 (in sandbox A) writes `"2"` to `muleLock`; instance 2 (in sandbox B) reads `"2"`, calls `kill(2, 0)` in its own namespace and it succeeds (PID 2 is sandbox B's own amule), so `m_pidLocker = 2` and `2 != 2` returns false. wx reports "no other instance" and instance 2 boots up fully.

Verified live in the running org.amule.aMule Flatpak: `/proc/locks` correctly shows instance 1 holding the POSIX WRITE lock on the muleLock inode, and both sandboxes see themselves as PID 2 via `flatpak run --command=sh org.amule.aMule -c 'echo $$'`. The kernel-level lock primitive is not the problem, wx's design assumption that PIDs are globally unique is.

## Fix

Replace with an `InstanceLock` class that uses `fcntl(F_SETLK)` directly, no PID compare. The kernel owns the truth about who holds the lock, and it's namespace-independent. On process death (clean exit, crash, SIGKILL) the kernel releases the lock automatically, so a lock file left over from a crashed run self-heals on the next start with no PID heuristic needed.

Windows keeps `wxSingleInstanceChecker` unchanged: it uses a named mutex, which is already namespace-safe. `InstanceLock` delegates to it via `#ifdef __WINDOWS__`.

## amuled/macOS

The old code had `#if defined(__WXMAC__) && defined(AMULE_DAEMON)` blocks in three places disabling the check entirely and printing "The check for other instances is currently disabled in amuled". Comment said "wx link problems". `wxSingleInstanceChecker` on macOS pulls in Cocoa framework symbols that don't link into a `wxAppConsole` binary. `InstanceLock` has no wx-GUI dependencies on POSIX (just `fcntl` + `wxBase`'s `wxString`), so amuled/Mac links fine and gets working single-instance detection for the first time.

## Test plan

- [x] Build clean on macOS aarch64 (amule + amuled + amulegui)
- [x] Build clean on Ubuntu 26.04 aarch64 (amule + amuled + amulegui + amulecmd + amuleweb + ed2k)
- [x] Build clean under Flatpak SDK 50 aarch64
- [x] Flatpak-vs-Flatpak: instance 2 detects instance 1, prints "There is an instance of aMule already running", writes RAISE_DIALOG to ED2KLinks, exits
- [x] Manual smoke test on macOS: amule + amuled both refuse to start twice
- [x] Windows: unchanged code path (wxSingleInstanceChecker via `#ifdef __WINDOWS__`), CI will validate