### PR TITLE
fix(appimage): sanitize child env for external program launches (#334)

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -105,6 +105,7 @@ endif()
 if (BUILD_MONOLITHIC OR BUILD_DAEMON OR BUILD_REMOTEGUI)
 	set (COMMON_SOURCES
 		amuleAppCommon.cpp
+		AppImageEnv.cpp
 		AutostartManager.cpp
 		ProtocolHandlerManager.cpp
 		$<$<BOOL:${APPLE}>:ProtocolHandlerManager_mac.mm>

--- a/packaging/linux/appimage/AppRun
+++ b/packaging/linux/appimage/AppRun
@@ -27,6 +27,12 @@ if [ -d "${HERE}/apprun-hooks" ]; then
     done
 fi
 
+# The AppImage runtime already exports APPDIR when it mounts the image, but set
+# it explicitly so detection also works when AppRun is invoked from an extracted
+# tree (--appimage-extract). aMule reads APPDIR both for desktop integration and
+# to strip these bundle paths back out when it launches external programs like
+# the preview player (#334).
+export APPDIR="${HERE}"
 export PATH="${HERE}/usr/bin:${PATH}"
 export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH:-}"
 

--- a/src/AppImageEnv.cpp
+++ b/src/AppImageEnv.cpp
@@ -1,0 +1,96 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//
+
+#include "AppImageEnv.h"
+
+#include <wx/string.h>
+#include <wx/tokenzr.h>
+#include <wx/utils.h>
+
+#include <cstdlib>
+
+namespace
+{
+
+// The AppImage runtime (and our AppRun) export APPDIR = the squashfs mount
+// point. Its presence is what tells us we're running from inside a bundle.
+wxString GetAppDir()
+{
+	const char *env = getenv("APPDIR");
+	return env ? wxString::FromUTF8(env) : wxString();
+}
+
+} // namespace
+
+namespace AppImageEnv
+{
+
+bool GetSanitizedExecEnv(wxExecuteEnv &env)
+{
+	const wxString appdir = GetAppDir();
+	if (appdir.IsEmpty()) {
+		// Not inside an AppImage: nothing to strip, inherit the environment.
+		return false;
+	}
+
+	wxEnvVariableHashMap current;
+	if (!wxGetEnvMap(&current)) {
+		return false;
+	}
+
+	// A path component belongs to the bundle when it is $APPDIR itself or sits
+	// beneath it. Strip such components from every variable; a variable whose
+	// whole value was bundle-owned is dropped entirely. Deliberately generic
+	// rather than a fixed LD_LIBRARY_PATH/GTK_PATH list, so the module- and
+	// data-path variables the linuxdeploy GTK hooks inject are covered too.
+	const wxString prefix = appdir + wxT("/");
+	for (const auto &var : current) {
+		const wxString &value = var.second;
+		if (!value.Contains(appdir)) {
+			env.env[var.first] = value;
+			continue;
+		}
+		wxString kept;
+		wxStringTokenizer parts(value, wxT(":"), wxTOKEN_RET_EMPTY_ALL);
+		while (parts.HasMoreTokens()) {
+			const wxString part = parts.GetNextToken();
+			if (part == appdir || part.StartsWith(prefix)) {
+				// Bundle-owned entry -- drop it so the child resolves the
+				// host's system copy instead.
+				continue;
+			}
+			if (!kept.IsEmpty()) {
+				kept << wxT(":");
+			}
+			kept << part;
+		}
+		if (!kept.IsEmpty()) {
+			env.env[var.first] = kept;
+		}
+		// else: every component was bundle-owned -> omit the variable.
+	}
+	return true;
+}
+
+} // namespace AppImageEnv

--- a/src/AppImageEnv.h
+++ b/src/AppImageEnv.h
@@ -1,0 +1,51 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//
+
+#ifndef APPIMAGEENV_H
+#define APPIMAGEENV_H
+
+#include <wx/utils.h> // wxExecuteEnv
+
+namespace AppImageEnv
+{
+
+// Fill `env` with a copy of the current environment that is safe for launching
+// an external (non-bundled) program -- the preview player, the configured web
+// browser, a user-event command, etc. When running inside an AppImage, every
+// search-path entry that points into the bundle ($APPDIR) is stripped so the
+// child loads the host's system libraries and modules instead of the older
+// bundled copies; otherwise a GnuTLS-linked host program picks up the bundle's
+// stale libnghttp2 and dies with an undefined-symbol error (#334). Returns true
+// when a sanitized environment was produced (pass &env to wxExecute); false
+// when not inside an AppImage, in which case the child should inherit the
+// environment unchanged.
+//
+// Lives in COMMON so both the daemon and the GUI can share it; it has no GUI
+// dependencies and is a no-op (returns false) on every platform that does not
+// set $APPDIR.
+bool GetSanitizedExecEnv(wxExecuteEnv &env);
+
+} // namespace AppImageEnv
+
+#endif // APPIMAGEENV_H

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -31,6 +31,7 @@
 #include <common/Format.h>    // Needed for CFormat
 #include "amule.h"            // Needed for theApp
 #include "amuleDlg.h"         // Needed for CamuleDlg
+#include "AppImageEnv.h"      // Needed for GetSanitizedExecEnv
 #include "BarShader.h"        // Needed for CBarShader
 #include "CommentDialogLst.h" // Needed for CCommentDialogLst
 #include "DataToText.h"       // Needed for PriorityToStr
@@ -1450,9 +1451,16 @@ void CDownloadListCtrl::PreviewFile(CPartFile *file)
 	command.Replace("%PARTFILE", partFile);
 	command.Replace("%PARTNAME", partName);
 
-	// We can't use wxShell here, it blocks the app
+	// We can't use wxShell here, it blocks the app.
+	// Inside an AppImage, hand the player a sanitized environment: the bundle's
+	// library/module dirs are stripped from the child's search paths so a host
+	// player (e.g. Celluloid) loads system libraries, not the older bundled
+	// ones -- otherwise it dies on an undefined symbol (#334). A no-op copy
+	// outside an AppImage, where we launch with the inherited environment.
 	CTerminationProcess *p = new CTerminationProcess(command);
-	int ret = wxExecute(command, wxEXEC_ASYNC, p);
+	wxExecuteEnv execEnv;
+	const bool sanitized = AppImageEnv::GetSanitizedExecEnv(execEnv);
+	long ret = wxExecute(command, wxEXEC_ASYNC, p, sanitized ? &execEnv : nullptr);
 	bool ok = ret > 0;
 	if (!ok) {
 		delete p;

--- a/src/UserEvents.cpp
+++ b/src/UserEvents.cpp
@@ -25,12 +25,14 @@
 #include "UserEvents.h"
 
 #include <common/Format.h>
+#include "AppImageEnv.h" // Needed for GetSanitizedExecEnv
 #include "Logger.h"
 #include "Preferences.h"
 #include "PartFile.h"
 #include "TerminationProcess.h" // Needed for CTerminationProcess
 
 #include <wx/process.h>
+#include <wx/utils.h> // Needed for wxExecuteEnv
 
 #define USEREVENTS_EVENT(ID, NAME, VARS) { #ID, NAME, false, "", false, "" },
 static struct
@@ -144,8 +146,13 @@ static void ExecuteCommand(enum CUserEvents::EventType event, const void *object
 		   } */
 	}
 	if (!command.empty()) {
+		// Inside an AppImage, run the user command with a sanitized environment
+		// so it loads system libraries rather than the bundled ones (#334); a
+		// no-op copy elsewhere.
 		CTerminationProcess *p = new CTerminationProcess(cmd);
-		if (!wxExecute(command, wxEXEC_ASYNC, p)) {
+		wxExecuteEnv execEnv;
+		const bool sanitized = AppImageEnv::GetSanitizedExecEnv(execEnv);
+		if (!wxExecute(command, wxEXEC_ASYNC, p, sanitized ? &execEnv : nullptr)) {
 			// If wxExecute fails, we need to delete the CTerminationProcess
 			// otherwise it will leak.
 			delete p;

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -48,6 +48,7 @@
 #include <common/Format.h>    // Needed for CFormat
 #include "AboutDialog.h"      // Needed for CAboutDlg
 #include "amule.h"            // Needed for theApp
+#include "AppImageEnv.h"      // Needed for GetSanitizedExecEnv
 #include "ChatWnd.h"          // Needed for CChatWnd
 #include "SourceListCtrl.h"   // Needed for CSourceListCtrl
 #include "DownloadListCtrl.h" // Needed for CDownloadListCtrl
@@ -1372,8 +1373,13 @@ void CamuleDlg::LaunchUrl(const wxString &url)
 			cmd += " " + tmp;
 		}
 
+		// Inside an AppImage, launch the browser with a sanitized environment
+		// so it loads system libraries rather than the bundled ones (#334); a
+		// no-op copy elsewhere.
 		CTerminationProcess *p = new CTerminationProcess(cmd);
-		if (wxExecute(cmd, wxEXEC_ASYNC, p)) {
+		wxExecuteEnv execEnv;
+		const bool sanitized = AppImageEnv::GetSanitizedExecEnv(execEnv);
+		if (wxExecute(cmd, wxEXEC_ASYNC, p, sanitized ? &execEnv : nullptr)) {
 			AddLogLineN(_("Launch Command: ") + cmd);
 			return;
 		} else {


### PR DESCRIPTION
## Summary

Fixes #334. Inside the AppImage, aMule launches external programs — the Preview player, the configured web browser, user-event commands — with a polluted environment, so a GnuTLS-linked program like Celluloid crashes on an undefined `libnghttp2` symbol instead of running.

## Root cause

`AppRun` prepends the bundle's `usr/lib` to `LD_LIBRARY_PATH` (and the linuxdeploy GTK hooks add `GTK_PATH`, `GDK_PIXBUF_MODULE_FILE`, …). aMule's `wxExecute` calls passed that environment straight to the child. The bundle ships the OpenSSL `libcurl.so.4` but **not** the GnuTLS `libcurl-gnutls.so.4`, so a GnuTLS program loads the *system* `libcurl-gnutls.so.4` (built against a newer nghttp2) yet resolves `libnghttp2` from the *older bundled* copy on `LD_LIBRARY_PATH`:

```
symbol lookup error: /lib/x86_64-linux-gnu/libcurl-gnutls.so.4: undefined symbol: nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation
```

The 2.3.3 distro package works with the same player because it has no bundled libs and no `LD_LIBRARY_PATH` mutation.

## Fix

New shared helper `AppImageEnv::GetSanitizedExecEnv` (in `COMMON`, so both `amuled` and the GUI use it). When `$APPDIR` is set it returns a copy of the environment with every search-path component that points into the bundle stripped out (a variable whose whole value was bundle-owned is dropped). The rule is generic — any `$APPDIR`-rooted component in any variable, not a fixed list — so the module and data paths the GTK hooks inject are covered too.

Audit of every process-launch site:

| Site | Launches | Action |
|---|---|---|
| `CDownloadListCtrl::PreviewFile` | external media player | sanitized |
| `CamuleDlg::LaunchUrl` | configured web browser | sanitized |
| `CUserEvents::ExecuteCommand` | user-event command | sanitized |
| `amule.cpp` webserver | **amuleweb** (own binary) | left as-is — needs bundled libs |
| AppImage self-relaunch | re-exec `$APPIMAGE` | left as-is — own binary |
| `CMediaProbe` | system ffprobe | **follow-up** — uses `posix_spawn`/`CreateProcess` with an explicit `envp` |

**Outside an AppImage** (`$APPDIR` unset — distro packages, Flatpak, macOS, Windows, dev builds) the helper returns `false` and children launch with the inherited environment exactly as before. It is a runtime check, not an `#ifdef`. `AppRun` also now exports `APPDIR` explicitly so detection works from an extracted tree.

## Test Plan

- [x] Reproduced the exact crash on Debian trixie (LMDE 7's base) with the official 3.0.1 x64 AppImage, using `git-remote-https` (links the same `libcurl-gnutls.so.4` as Celluloid) as a stand-in — identical error string.
- [x] Confirmed the bundle ships `libnghttp2.so.14` **without** the `rfc9113` symbol while the system copy has it, and ships OpenSSL `libcurl.so.4` but not the GnuTLS variant.
- [x] Verified the fix on the real vulnerable libraries: applying the stripping rule to the leaked `LD_LIBRARY_PATH` turns the crash into a successful call.
- [x] `amule` (GUI) and `amuled` (daemon) both build and link clean — the shared helper resolves from `COMMON` in the daemon.
- [x] Whole-file `clang-format` clean on all changed/new files.
- [x] **Awaiting the original reporter's confirmation** on their LMDE 7 system, with a fork-built AppImage, that Preview now launches Celluloid.

Marking as **draft** until the reporter confirms on real hardware. A follow-up for the `MediaProbe`/ffprobe `posix_spawn` path will reference this PR.
