### PR TITLE
chore(metainfo): add 3.0.1 release entry

### DIFF
--- a/org.amule.aMule.metainfo.xml
+++ b/org.amule.aMule.metainfo.xml
@@ -36,6 +36,14 @@
 
   <!-- TODO: Auto generate me from changelog! -->
   <releases>
+    <release version="3.0.1" date="2026-06-24">
+      <url>https://amule-org.github.io/blog/amule-3-0-1</url>
+      <description>
+        <p>
+          First point release after the 3.0.0 rebirth: a new IP2Country preferences panel, remote-GUI (amulegui) improvements over EC, smarter search with length/bitrate/codec columns, AICH request rate-limiting, a top-to-bottom WebUI / WebServer modernization and security pass, a Weblate-driven translation pipeline, and a one-click release process. No on-disk format or config changes — a drop-in upgrade from 3.0.0.
+        </p>
+      </description>
+    </release>
     <release version="3.0.0" date="2026-06-08">
       <url>https://amule-org.github.io/blog/amule-3-0-0</url>
       <description>


### PR DESCRIPTION
The AppStream `<releases>` list stopped at 3.0.0, so `flatpak info`, GNOME Software and other app stores advertised **3.0.0** even for the 3.0.1 release and every master build since — the version string is taken from the newest `<release>` entry, not the git rev.

Add the missing `3.0.1` entry (released 2026-06-24) so the store-visible version matches the shipped one. No code change.

Validated with `appstreamcli validate` (passes; the single pedantic `cid-contains-uppercase-letter` hint is pre-existing and about the app-id).

Going forward the `<releases>` list should be bumped as part of the release process (there's already a `TODO: Auto generate me from changelog!` on it).
