### PR TITLE
build(metainfo): generate AppStream <releases> from CHANGELOG.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,29 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      # Gate: the release version must have a docs/CHANGELOG.md entry before we
+      # tag. The AppStream metainfo <releases> is generated from that changelog
+      # at build time, so a missing entry would ship a stale store version (the
+      # 3.0.1-labelled-3.0.0 drift this process fixes). Runs before tagging so a
+      # forgotten changelog blocks the release instead of shipping wrong.
+      - name: Verify CHANGELOG has an entry for this version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          # Throwaway fork-test tags (e.g. 0.0.0-fork-test) won't be in the
+          # changelog; don't block them.
+          case "${VERSION}" in
+            0.0.0*|*fork-test*) echo "Test version ${VERSION}; skipping CHANGELOG gate."; exit 0 ;;
+          esac
+          top="$(grep -m1 -oE '^## Version [^ ]+' docs/CHANGELOG.md | awk '{print $3}')"
+          if [ "${top}" != "${VERSION}" ]; then
+            echo "::error::docs/CHANGELOG.md newest entry is '${top}', but releasing '${VERSION}'."
+            echo "Add a '## Version ${VERSION}' block (date line + summary paragraph) to docs/CHANGELOG.md before releasing -- the AppStream metainfo release list is generated from it."
+            exit 1
+          fi
+          echo "CHANGELOG newest entry matches ${VERSION}."
       - name: Create and push tag if missing
         if: github.event_name == 'workflow_dispatch'
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,9 +436,35 @@ if (BUILD_REMOTEGUI)
 	)
 endif()
 
-install (FILES org.amule.aMule.metainfo.xml
-	DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo"
-)
+# The AppStream metainfo's <releases> list is generated from docs/CHANGELOG.md
+# at build time so the store-visible version can't drift from the shipped one
+# (single source of truth). This runs inside any CMake build -- including
+# flatpak-builder / Flathub building from a tag -- so the tagged source tree is
+# self-sufficient. AppStream metainfo is a freedesktop concept; gate it to Linux
+# (macOS/Windows never consumed the installed copy) so those builds need no
+# python3.
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	find_package (Python3 COMPONENTS Interpreter REQUIRED)
+	set (_amule_metainfo "${CMAKE_CURRENT_BINARY_DIR}/org.amule.aMule.metainfo.xml")
+	add_custom_command (
+		OUTPUT "${_amule_metainfo}"
+		COMMAND "${Python3_EXECUTABLE}"
+			"${CMAKE_CURRENT_SOURCE_DIR}/packaging/gen-metainfo-releases.py"
+			--changelog "${CMAKE_CURRENT_SOURCE_DIR}/docs/CHANGELOG.md"
+			--template "${CMAKE_CURRENT_SOURCE_DIR}/org.amule.aMule.metainfo.xml.in"
+			--output "${_amule_metainfo}"
+		DEPENDS
+			"${CMAKE_CURRENT_SOURCE_DIR}/packaging/gen-metainfo-releases.py"
+			"${CMAKE_CURRENT_SOURCE_DIR}/org.amule.aMule.metainfo.xml.in"
+			"${CMAKE_CURRENT_SOURCE_DIR}/docs/CHANGELOG.md"
+		COMMENT "Generating AppStream metainfo releases from docs/CHANGELOG.md"
+		VERBATIM
+	)
+	add_custom_target (amule_metainfo ALL DEPENDS "${_amule_metainfo}")
+	install (FILES "${_amule_metainfo}"
+		DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo"
+	)
+endif()
 
 install (FILES LICENSE.md
 	DESTINATION "${CMAKE_INSTALL_DOCDIR}"

--- a/org.amule.aMule.metainfo.xml.in
+++ b/org.amule.aMule.metainfo.xml.in
@@ -34,25 +34,11 @@
   <url type="bugtracker">https://github.com/amule-org/amule/issues</url>
   <url type="help">https://amule-org.github.io/docs</url>
 
-  <!-- TODO: Auto generate me from changelog! -->
-  <releases>
-    <release version="3.0.1" date="2026-06-24">
-      <url>https://amule-org.github.io/blog/amule-3-0-1</url>
-      <description>
-        <p>
-          First point release after the 3.0.0 rebirth: a new IP2Country preferences panel, remote-GUI (amulegui) improvements over EC, smarter search with length/bitrate/codec columns, AICH request rate-limiting, a top-to-bottom WebUI / WebServer modernization and security pass, a Weblate-driven translation pipeline, and a one-click release process. No on-disk format or config changes — a drop-in upgrade from 3.0.0.
-        </p>
-      </description>
-    </release>
-    <release version="3.0.0" date="2026-06-08">
-      <url>https://amule-org.github.io/blog/amule-3-0-0</url>
-      <description>
-        <p>
-          First major release in five years. Headline changes are dramatic throughput improvements (peer-to-peer downloads see ~100–380× speedups over 2.3.3 across macOS, Linux, and Windows), a full build-system overhaul (CMake replaces autotools), a modernized dependency stack, native binaries for Linux / macOS / Windows, and a broad legacy-API cleanup.
-        </p>
-      </description>
-    </release>
-  </releases>
+  <!-- Releases are generated from docs/CHANGELOG.md by
+       packaging/gen-metainfo-releases.py at build time (single source of
+       truth so the store-visible version can't drift from the shipped one).
+       Do not edit the release list here; edit docs/CHANGELOG.md. -->
+@RELEASES@
 
   <launchable type="desktop-id">org.amule.aMule.desktop</launchable>
   <screenshots>

--- a/packaging/gen-metainfo-releases.py
+++ b/packaging/gen-metainfo-releases.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# This file is part of the aMule Project.
+#
+# Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+"""Generate the AppStream <releases> block from docs/CHANGELOG.md.
+
+The metainfo template (org.amule.aMule.metainfo.xml.in) carries a single
+`@RELEASES@` marker; this script replaces it with one <release> entry per
+CHANGELOG version that has a prose summary paragraph (the 3.0.0+ format).
+Older contributor-list entries (2.3.3 and earlier) have no summary and are
+skipped. Keeping the changelog as the single source of truth stops the
+store-visible version from drifting from the shipped one.
+
+No third-party dependencies -- runs anywhere python3 is available: dev
+machines, CI, the GNOME SDK build sandbox, and Flathub-at-tag builds.
+"""
+
+import argparse
+import re
+import sys
+from html import escape
+
+# "## Version 3.0.1 — "bugfixes and polish"" -> "3.0.1"
+_HEADER = re.compile(r"^## Version\s+(\S+)\s+—")
+_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _strip_markdown(text):
+    # Inline code `x` -> x and bold **x** -> x; metainfo <p> is plain text.
+    return text.replace("`", "").replace("**", "")
+
+
+def parse_changelog(path):
+    with open(path, encoding="utf-8") as handle:
+        lines = handle.read().split("\n")
+
+    releases = []
+    i, n = 0, len(lines)
+    while i < n:
+        header = _HEADER.match(lines[i])
+        if not header:
+            i += 1
+            continue
+        version = header.group(1)
+        i += 1
+
+        # Date is the next non-empty line.
+        while i < n and not lines[i].strip():
+            i += 1
+        if i >= n or not _DATE.match(lines[i].strip()):
+            continue
+        date = lines[i].strip()
+        i += 1
+
+        # The summary is the next paragraph (up to a blank line).
+        while i < n and not lines[i].strip():
+            i += 1
+        para = []
+        while i < n and lines[i].strip():
+            para.append(lines[i])
+            i += 1
+        if not para:
+            continue
+
+        # Old-format entries open with a tabbed contributor name
+        # ("\talesnav:") or a list/heading -- no prose summary. Skip them.
+        first = para[0]
+        if first.startswith("\t") or first.lstrip()[:1] in ("-", "*", "#"):
+            continue
+
+        summary = _strip_markdown(" ".join(s.strip() for s in para)).strip()
+        releases.append((version, date, summary))
+
+    return releases
+
+
+def render_releases(releases):
+    out = ["  <releases>"]
+    for version, date, summary in releases:
+        url = "https://github.com/amule-org/amule/releases/tag/" + version
+        out += [
+            '    <release version="{0}" date="{1}">'.format(version, date),
+            "      <url>{0}</url>".format(url),
+            "      <description>",
+            "        <p>",
+            "          " + escape(summary, quote=False),
+            "        </p>",
+            "      </description>",
+            "    </release>",
+        ]
+    out.append("  </releases>")
+    return "\n".join(out)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changelog", required=True)
+    parser.add_argument("--template", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    releases = parse_changelog(args.changelog)
+    if not releases:
+        sys.exit("gen-metainfo-releases: no prose releases found in " + args.changelog)
+
+    with open(args.template, encoding="utf-8") as handle:
+        template = handle.read()
+    if "@RELEASES@" not in template:
+        sys.exit("gen-metainfo-releases: @RELEASES@ marker missing in " + args.template)
+
+    result = template.replace("@RELEASES@", render_releases(releases))
+    with open(args.output, "w", encoding="utf-8") as handle:
+        handle.write(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The metainfo `<releases>` list was hand-maintained and drifted — it still advertised **3.0.0** after 3.0.1 shipped, so `flatpak info`, GNOME Software and app stores showed the wrong version (the version comes from the newest `<release>` entry, not the git rev).

## Fix — `docs/CHANGELOG.md` as the single source of truth

- **`packaging/gen-metainfo-releases.py`** parses the changelog and emits one `<release>` per version that has a prose summary paragraph (the 3.0.0+ format; older contributor-list entries are skipped). Dependency-free `python3` — runs on dev machines, CI, the GNOME SDK sandbox, and Flathub.
- **`org.amule.aMule.metainfo.xml` → `.xml.in`** with an `@RELEASES@` marker; the real file is generated at **build time** by a CMake `add_custom_command` and installed. The old static file is removed — the generated copy only ever lives in the build directory.
- **Why CMake, not `build.sh`:** `flatpak-builder` (your flatpak and Flathub) and local builders reach the metainfo through `cmake --install`, never `build.sh`. Hooking generation into the CMake graph means every path — local `cmake --build`, `packaging/build.sh`, flatpak-builder, and **Flathub building from a tag** — regenerates it automatically, so the tagged source tree is self-sufficient with no Flathub-side config.
- Gated to **Linux** (AppStream is freedesktop-only); macOS/Windows no longer install the inert file and need no `python3`.
- **`release.yml` pre-tag gate:** a one-click release now fails if `docs/CHANGELOG.md` has no entry for the version being cut (fork-test tags exempt), so the list can't fall behind again.

## Behavior changes to review

- **Release descriptions** now come from the changelog intro paragraph instead of the previous hand-written metainfo text — the point of single-sourcing.
- **Release `<url>`** points to the GitHub release tag (`…/releases/tag/X`) instead of the blog post — always valid and auto-derivable.

## Verified

- Generator reproduces the 3.0.1 + 3.0.0 entries; `xmllint` well-formed; `appstreamcli validate` passes (only the pre-existing pedantic `cid-contains-uppercase-letter` hint).
- End-to-end on Linux: `cmake` build runs the generator, `cmake --install` ships it, and the installed metainfo validates — the exact flatpak-builder/Flathub path.
