### PR TITLE
fix: silence deprecation warnings on macOS and Windows (cryptopp + vendored wx pragma-wraps)

### DIFF
--- a/src/CryptoPP_Inc.h
+++ b/src/CryptoPP_Inc.h
@@ -35,6 +35,25 @@
 
 #define CRYPTO_HEADER(hdr) <CRYPTOPP_INCLUDE_PREFIX/hdr>
 
+// cryptopp's headers are heavy on C++03 patterns: virtual dtors that
+// bring in the deprecated implicit copy ctor (P0806 rule), and
+// throw(...) dynamic exception specs that were formally removed in
+// C++17. On Homebrew macOS the cryptopp include directory reaches
+// consumers via CPATH (an `-I` alias), not as `-isystem`, so a strict
+// deprecation-warning audit build (`-Wdeprecated-declarations
+// -Wdeprecated-copy -Wdeprecated`) surfaces ~200 warnings from
+// cryptopp headers alone. GCC's -Wdeprecated-copy doesn't decompose
+// into the -with-user-provided-dtor sub-case, so this only bites
+// Clang builds today; the pragma is scoped to Clang-known sub-flags
+// only for that reason. Local to cryptopp includes; nothing else on
+// the translation unit is affected.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
+
 #include CRYPTO_HEADER(config.h)
 #include CRYPTO_HEADER(md4.h)
 #include CRYPTO_HEADER(md5.h)
@@ -45,5 +64,9 @@
 #include CRYPTO_HEADER(files.h)
 #include CRYPTO_HEADER(sha.h)
 #include CRYPTO_HEADER(des.h)
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif /* CRYPTOPP_INC_H */

--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -233,7 +233,22 @@ private:
 //  wxListLineData (internal)
 //-----------------------------------------------------------------------------
 
+// WX_DECLARE_LIST expands to a class with a user-provided dtor and an
+// implicit copy ctor; that's the deprecated combination P0806 targets.
+// Clang emits it as -Wdeprecated-copy-with-user-provided-dtor at the
+// macro invocation site (fires under the strict deprecation audit),
+// GCC's -Wdeprecated-copy doesn't decompose into that sub-case so it's
+// silent there. Suppress only at this site to keep the audit-strict
+// build clean; the macro comes from vendored wx and we don't want to
+// rewrite it.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#endif
 WX_DECLARE_LIST(wxListItemData, wxListItemDataList);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #include <wx/listimpl.cpp>
 WX_DEFINE_LIST(wxListItemDataList)
 

--- a/src/libwebcommon/Etag.cpp
+++ b/src/libwebcommon/Etag.cpp
@@ -24,7 +24,17 @@
 
 #include "Etag.h"
 
+// See CryptoPP_Inc.h for pragma rationale.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
 #include <cryptopp/sha.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 namespace webcommon
 {

--- a/src/libwebcommon/Jwt.cpp
+++ b/src/libwebcommon/Jwt.cpp
@@ -29,9 +29,20 @@
 #define PICOJSON_USE_INT64
 #include "picojson.h"
 
+// cryptopp headers pull in deprecated implicit copy ctors + throw()
+// specs (P0806 + C++17). See CryptoPP_Inc.h for the full rationale.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
 #include <cryptopp/hmac.h>
 #include <cryptopp/osrng.h>
 #include <cryptopp/sha.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #include <cstdio>
 #include <cstdint>

--- a/src/libwebcommon/Jwt.h
+++ b/src/libwebcommon/Jwt.h
@@ -29,7 +29,17 @@
 #include <string>
 #include <vector>
 
+// See CryptoPP_Inc.h for pragma rationale.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
 #include <cryptopp/secblock.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #include "Role.h"
 

--- a/src/webapi/AmuleApiConfig.cpp
+++ b/src/webapi/AmuleApiConfig.cpp
@@ -33,7 +33,17 @@
 #include <wx/utils.h>
 #include <wx/wfstream.h>
 
+// See CryptoPP_Inc.h for pragma rationale.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
 #include <cryptopp/osrng.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #include <cctype>
 #include <cerrno>

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -28,7 +28,18 @@
 #include <wx/math.h> // Needed for cos, M_PI
 #include <string>    // Do_not_auto_remove (g++-4.0.1)
 
-#include <cryptopp/osrng.h> // CryptoPP::AutoSeededRandomPool, for the session-token CSPRNG
+// CryptoPP::AutoSeededRandomPool, for the session-token CSPRNG. See
+// CryptoPP_Inc.h for pragma rationale.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
+#include <cryptopp/osrng.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #include <wx/datetime.h>
 


### PR DESCRIPTION
## Summary

Second and final PR in the deprecation-warning cleanup series. Follows #339 (Ubuntu). After this the audit build (`-Wdeprecated-declarations -Wdeprecated-copy -Wdeprecated`) reports zero deprecation warnings on macOS, Ubuntu, and Windows, which unblocks `-Werror=deprecated-*` promotion in CI.

## Why this PR needs to exist

Two structural causes of the remaining warnings:

**1. cryptopp headers reach consumers as `-I`, not `-isystem`.** cmake/cryptopp.cmake discovers cryptopp via `check_include_file_cxx` which only verifies the header can be found (through CPATH, CMAKE_PREFIX_PATH, or the compiler default). It doesn't populate `CRYPTOPP_INCLUDE_DIR`, so the `INTERFACE_INCLUDE_DIRECTORIES`/`INTERFACE_SYSTEM_INCLUDE_DIRECTORIES` block below never fires and consumers see cryptopp through `-I` semantics only. On Homebrew macOS (Apple Clang) that surfaces ~200 warnings from cryptopp's C++03 patterns: virtual dtors + implicit copy ctors (P0806) and `throw(...)` dynamic exception specs (removed in C++17). Ubuntu (GCC) doesn't emit these because `-Wdeprecated-copy` on GCC doesn't decompose into the `-with-user-provided-dtor` sub-case that Clang has. Windows (Clang under MSYS2) hits a subset.

**2. Vendored wx `WX_DECLARE_LIST` macro.** `src/extern/wxWidgets/listctrl.cpp:236` invokes `WX_DECLARE_LIST(wxListItemData, wxListItemDataList)`. The macro expands to a class with a user-provided dtor and an implicit copy ctor. Clang flags this at the macro invocation site (in our code), GCC's coverage skips it.

## Fix approach: targeted pragmas

Considered but rejected: `find_path` in cmake/cryptopp.cmake to populate `CRYPTOPP_INCLUDE_DIR`, then wire `INTERFACE_SYSTEM_INCLUDE_DIRECTORIES` on the `CRYPTOPP::CRYPTOPP` target and change `PRIVATE`->`PUBLIC` on `muleappcore`'s cryptopp link plus add cryptopp linkage to `mulecommon`, `muleappcommon`, `amuleweb`. Multiple `target_link_libraries` visibility changes across 3 CMakeLists - real regression risk on Windows/Ubuntu builds. Not worth it for a warning-suppression goal.

Also considered: `include_directories(SYSTEM ${CRYPTOPP_INCLUDE_DIR})` project-wide. Rejected because `CRYPTOPP_INCLUDE_DIR` resolves to `/opt/homebrew/include` on Mac and `/clangarm64/include` on Windows/MSYS2 - broad directories with many unrelated headers. Turning them into `-isystem` would mask warnings from wx / boost / glib code we do want to see.

Landed on: 6 targeted pragma-wraps in the files that actually pull cryptopp in, plus 1 site pragma for the vendored wx macro.

## Files touched

**Cryptopp pragmas (5 files + 1 header):**
- `src/CryptoPP_Inc.h` - the internal wrapper header that most aMule code goes through
- `src/libwebcommon/Jwt.h`, `src/libwebcommon/Jwt.cpp`, `src/libwebcommon/Etag.cpp` - direct `<cryptopp/*>` includes (webcommon lib)
- `src/webserver/src/WebServer.cpp` - direct `<cryptopp/osrng.h>` include (session-token CSPRNG)
- `src/webapi/AmuleApiConfig.cpp` - direct `<cryptopp/osrng.h>` include

Each site gets a 5-line `#pragma clang diagnostic push/ignored/pop` gated on `#if defined(__clang__)` - silences only the three Clang-specific sub-flags (`-Wdeprecated-copy-with-user-provided-dtor`, `-Wdeprecated-copy-with-user-provided-copy`, `-Wdeprecated-dynamic-exception-spec`). GCC never emits these categories on the codebase so its diagnostics stay untouched.

**Vendored wx pragma (1 file):**
- `src/extern/wxWidgets/listctrl.cpp:236` - pragma-wrap around the `WX_DECLARE_LIST` macro invocation

## Verification

macOS Debug audit (Apple Clang, `-Wdeprecated-declarations -Wdeprecated-copy -Wdeprecated`):
- Before: 707 lines, 232 tagged deprecation warnings
- After: 0 tagged deprecation warnings (the remaining 437 are `-Wc++17-extensions` from cryptopp's own `static_assert()` - different category, not blocking `-Werror=deprecated-*`)

## Test plan

- [x] macOS aarch64: `amule` + `amuled` + `amulegui` link clean under audit flags, 0 deprecation warnings
- [x] Ubuntu aarch64: CI (should be no-op since pragmas are Clang-gated)
- [x] mingw-w64: CI validates the listctrl.cpp fix silences the last Windows deprecation warning