### PR TITLE
build: enable -Werror=deprecated-* for aMule source targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,32 @@ set (INCLUDE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set (SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set (EC_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/libs/ec/cpp")
 
+# Promote deprecation warnings to errors for our own source targets.
+# Applied here (not via CMAKE_CXX_FLAGS) so config-phase
+# check_include_file_cxx / find_package probes aren't affected: those
+# probes compile stubs against third-party headers (cryptopp, wx,
+# boost) that legitimately emit deprecation warnings; -Werror on
+# those would make cryptopp discovery fail at configure time.
+#
+# GCC and Clang are covered:
+#   -Wdeprecated-declarations  -> users of a [[deprecated]] API
+#   -Wdeprecated-copy          -> P0806 implicit copy special member
+#                                 when the class provides another one
+#   -Wdeprecated               -> broad umbrella (C++17 constexpr
+#                                 static-member redecl, throw() spec)
+#
+# The pragma-wraps landed in #341 keep cryptopp and vendored wx quiet
+# under -isystem-less discovery; without those wraps this gate would
+# fire on ~230 cryptopp header hits on macOS.
+add_compile_options (
+	-Wdeprecated
+	-Wdeprecated-declarations
+	-Wdeprecated-copy
+	-Werror=deprecated
+	-Werror=deprecated-declarations
+	-Werror=deprecated-copy
+)
+
 # Embed every PNG under src/icons/ as a static byte-array table in a
 # generated C TU (see src/icons/embed_icons.py for the format).
 # CamuleArtProvider then exposes the entries to wxArtProvider at

--- a/src/webapi/EventBus.cpp
+++ b/src/webapi/EventBus.cpp
@@ -29,10 +29,15 @@ namespace webapi
 
 // C++14 requires an out-of-class definition for static constexpr
 // members used by reference (test code may bind them through a
-// const auto& parameter). C++17 inlined that, but the project is
-// pinned to C++14.
+// const auto& parameter). C++17 made static constexpr members
+// implicitly inline, so the same lines emit -Wdeprecated on
+// GCC in C++17 mode ("redundant redeclaration of constexpr static
+// data member"). Guard so it compiles clean under both language
+// levels.
+#if __cplusplus < 201703L
 constexpr std::size_t CEventBus::kDefaultCapacity;
 constexpr std::size_t CEventBus::kMinCapacity;
+#endif
 
 CEventBus::CEventBus(std::size_t capacity)
 : m_capacity(capacity < kMinCapacity ? kMinCapacity : capacity)


### PR DESCRIPTION
## Summary

Third and final PR in the deprecation-warning cleanup series. After #339 (Ubuntu wx-enum-OR + ayatana + IPV4 copy-assign) and #341 (macOS + Windows cryptopp + vendored wx pragma-wraps), the strict deprecation audit is clean on all three platforms. This PR flips the gate on so future deprecations get caught at CI rather than accreting silently.

## Two-part change

### 1. `src/CMakeLists.txt` -- add_compile_options with -Werror=deprecated-*

Applied at the src/ level (not via `CMAKE_CXX_FLAGS` globally) so config-phase probes -- `check_include_file_cxx(cryptopp/cryptlib.h)`, `find_package(Boost ...)`, `pkg_check_modules(...)` -- keep compiling their stubs against third-party headers without -Werror. Those probes legitimately emit deprecation warnings from cryptopp / wx / boost internals; making them fatal would break the initial dependency discovery (verified: putting the flag in `CMAKE_CXX_FLAGS` makes cryptopp detection fail at configure time with `cryptlib.h not found`).

Flags gated:
- `-Wdeprecated-declarations` -- users of `[[deprecated]]` APIs
- `-Wdeprecated-copy` -- P0806 implicit copy special member deprecated when the class provides another one
- `-Wdeprecated` -- broad umbrella (C++17 constexpr static-member redecl, `throw()` specs, other future churn)

Each is enabled (`-W...`) and promoted to error (`-Werror=...`).

### 2. `src/webapi/EventBus.cpp` -- guard C++14-era constexpr redecl

The two out-of-class definitions were added for C++14 ODR-use compatibility (`kDefaultCapacity` and `kMinCapacity` bound by reference in tests). C++17 made static constexpr members implicitly inline, and GCC's `-Wdeprecated` (broad category) flags the now-redundant redeclarations at that language level. Guarded behind `#if __cplusplus < 201703L` so the code compiles clean under both C++14 and C++17+.

## Coverage

Gate fires on every executable and library target declared under `src/` -- amule, amuled, amulegui, amulecmd, amuleweb, amuleapi, ed2k plus the mule* / webcommon static libs. Third-party headers (cryptopp, boost, wx, glib, ayatana) stay untouched because the pragma-wraps landed in #341 silence the specific hits they emit under strict deprecation flags.

## Verification via fork CI

Ran on `got3nks/amule/ci/enable-werror-deprecated` against a matrix identical to upstream CI. All 6 build jobs (Ubuntu Debug/Release, macOS Debug/Release, mingw-w64 Debug/Release) and clang-tidy Tier-2 pass. Tier-1 was still running at push time.

## Test plan

- [x] Fork CI: Ubuntu Debug/Release build clean
- [x] Fork CI: macOS Debug/Release build clean
- [x] Fork CI: mingw-w64 Debug/Release build clean
- [x] Fork CI: clang-tidy Tier-2 pass
- [ ] Upstream CI: same matrix + Tier-1 green on PR