### PR TITLE
macOS: keep the system awake during transfers, not the display

### DIFF
--- a/src/PlatformSpecific.cpp
+++ b/src/PlatformSpecific.cpp
@@ -346,8 +346,8 @@ void PlatformSpecific::PreventSleepMode()
 // - http://developer.apple.com/library/mac/#qa/qa1340/_index.html
 // - http://www.cimgf.com/2009/10/14/the-journey-to-disabling-sleep-with-iokit/
 #elif defined(__WXMAC__) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 // 10.6 only
-		CFStringRef reasonForActivity = CFSTR("Prevent Display Sleep");
-		IOReturn success = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep,
+		CFStringRef reasonForActivity = CFSTR("aMule is transferring files");
+		IOReturn success = IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleSystemSleep,
 			kIOPMAssertionLevelOn,
 			reasonForActivity,
 			&assertionID);
@@ -360,7 +360,7 @@ void PlatformSpecific::PreventSleepMode()
 
 #elif defined(__WXMAC__) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1050 // 10.5 only
 		IOReturn success = IOPMAssertionCreate(
-			kIOPMAssertionTypeNoDisplaySleep, kIOPMAssertionLevelOn, &assertionID);
+			kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn, &assertionID);
 		if (success == kIOReturnSuccess) {
 			// Correctly vetoed, flag so we don't do it again.
 			m_preventingSleepMode = true;


### PR DESCRIPTION
On macOS, `PlatformSpecific::PreventSleepMode()` takes an `IOPMAssertion` of type `kIOPMAssertionTypeNoDisplaySleep` (reason string "Prevent Display Sleep"). That forces the *display* to stay on for the entire duration of a transfer. It does keep the Mac awake as a side effect — the system won't idle-sleep while the display is lit — so downloads do survive, but at the cost of needlessly burning the screen.

The Windows path already does the right thing: `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)` is *system*-required, not display-required. macOS was the odd one out.

This switches the modern (10.6+) branch to `kIOPMAssertionTypePreventUserIdleSystemSleep` — keep the system awake, let the screen sleep, which is exactly what `caffeinate -s` does and what "keep transferring in the background" should mean. The legacy pre-10.7 branch moves from `kIOPMAssertionTypeNoDisplaySleep` to `kIOPMAssertionTypeNoIdleSleep`, the correct older analog (the `PreventUserIdle…` constant doesn't exist before 10.7). The reason string is updated to "aMule is transferring files" so it reads sensibly in `pmset -g assertions`.

`AllowSleepMode()` is unchanged — it releases the shared `assertionID` and is type-agnostic.

Verified the modern branch compiles and links against IOKit/CoreFoundation on a current SDK. The legacy branch is unreachable on modern SDKs (the `>= 1060` arm wins the `#elif` chain first), so its pre-existing `IOPMAssertionCreate` deprecation doesn't reach the `-Werror=deprecated-*` gate.
