### PR TITLE
fix(listctrl): delegate scroll to base; HandleOnScroll private since wx 3.3.3

### DIFF
--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -4579,15 +4579,12 @@ void wxListMainWindow::SortItems(MuleListCtrlCompare fn, wxIntPtr data)
 
 void wxListMainWindow::OnScroll(wxScrollWinEvent &event)
 {
-	// wxScrolledWindows::OnScroll is deprecated in wx 3.0.0 and it does not exist anymore in 3.1.0.
-	// Please also notice that call to
-	// - wxScrolledWindow::OnScroll
-	// - HandleOnScroll
-	// have been removed in code present in
-	// src/generic/listctrl.cpp, wxListMainWindow::OnScroll
-	// of wxWidgets 3.0
-	// FIXME
-	HandleOnScroll(event);
+	// Let the base wxScrolledWindow perform the actual scroll. Older wx let
+	// us drive it directly via HandleOnScroll(), but 3.3.3 made that a
+	// private member, so we hand the event back with Skip() instead: the
+	// base class then does the scroll through its own (private) handler.
+	// This works unchanged across every supported version (min wx 3.2.0).
+	event.Skip();
 
 	// update our idea of which lines are shown when we redraw the window the
 	// next time


### PR DESCRIPTION
## Problem

wxWidgets 3.3.3 made `wxScrollHelperBase::HandleOnScroll` a **private** member. The vendored `src/extern/wxWidgets/listctrl.cpp` calls it from `wxListMainWindow::OnScroll`, so that file no longer compiles once the toolchain ships wx 3.3.3 — which currently breaks the **macOS CI** builds (the GitHub runner's Homebrew wx moved 3.3.2 → 3.3.3). The call already carried a `FIXME`.

## Fix

`wxListMainWindow` derives from `wxScrolledWindow` and binds `EVT_SCROLLWIN(OnScroll)`, so its `OnScroll` *overrides* the base scroll handling and has to drive the scroll itself. Rather than call the now-private `HandleOnScroll()`, it hands the event back to the base with `event.Skip()` — `wxScrolledWindow` then performs the scroll through its own handler, while we keep the list-specific bookkeeping (recompute the visible-line range, refresh the header on horizontal scroll).

`event.Skip()` is public API on every supported version (min wx 3.2.0), so this needs no `#ifdef` version guards and does not change behaviour.

## Testing

Built and run on macOS against **wx 3.3.3** — a clean build of the whole app (GUI, remote GUI, daemon, amulecmd, webserver), not just this file, compiles with zero errors, so `listctrl` was the only 3.3.3 break. Scrolling verified across the transfer, shared-files (including horizontal), search, server and preferences lists with no regression. Also builds clean on wx 3.3.2.
