### PR TITLE
fix(daemon): persist MaxConnectionsPerFiveSeconds bump; silence mimeapps.list probe

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1765,14 +1765,20 @@ void CPreferences::LoadAllItems(wxConfigBase *cfg)
 	SetSlotAllocation(s_slotallocation);
 
 	// One-time bump of the raised MaxConnectionsPerFiveSeconds default (20 ->
-	// 50). Every registered key is written to amule.conf unconditionally, so an
-	// existing config already holds the old default and would never pick up the
-	// new one. The marker makes this run exactly once, and the == 20 guard means
-	// a value the user set (including a deliberate 20 after this upgrade) is left
-	// alone.
+	// 50). An existing config holds the old default and would never pick up
+	// the new one. The marker makes this run exactly once, and the == 20 guard
+	// means a value the user set (including a deliberate 20 after this upgrade)
+	// is left alone.
+	//
+	// The value is written straight into cfg alongside the marker, not just
+	// into the s_MaxConperFive static: amuled never calls Save()/SaveAllItems,
+	// so a static-only bump is lost on exit while the explicitly-written marker
+	// persists -- which on the next boot suppresses the re-run and reverts the
+	// value to the un-bumped 20. Writing both keeps them in lockstep on disk.
 	if (!cfg->HasEntry("/eMule/MaxConPerFiveDefaultBumped")) {
 		if (s_MaxConperFive == 20) {
 			s_MaxConperFive = 50;
+			cfg->Write("/eMule/MaxConnectionsPerFiveSeconds", (long)s_MaxConperFive);
 		}
 		cfg->Write("/eMule/MaxConPerFiveDefaultBumped", true);
 	}

--- a/src/ProtocolHandlerManager.cpp
+++ b/src/ProtocolHandlerManager.cpp
@@ -594,6 +594,12 @@ struct IniLine
 static std::vector<IniLine> ReadIniLines(const wxString &path)
 {
 	std::vector<IniLine> lines;
+	// A missing file is the normal "not configured yet" case (e.g. no
+	// ~/.config/mimeapps.list on a headless daemon). Bail before opening so
+	// wxFile does not log a spurious "can't open file (error 2)" for it.
+	if (!wxFile::Exists(path)) {
+		return lines;
+	}
 	wxFile f(path, wxFile::read);
 	if (!f.IsOpened()) {
 		return lines;


### PR DESCRIPTION
Two small config-robustness fixes for headless `amuled`, both stemming from the fact that the daemon never calls `Save()`/`SaveAllItems()` on its preferences.

## 1. The MaxConnectionsPerFiveSeconds default bump never stuck

The one-time bump of the default from `20` → `50` (added in #308) set the `s_MaxConperFive` static and wrote a marker via `cfg->Write(...)`. But since `amuled` never saves prefs, the static bump was lost on exit while the explicitly-written marker **persisted** (wxFileConfig flushes explicit writes). On the next boot the marker suppressed the re-run, and the value loaded back as the un-bumped `20` from `amule.conf` — permanently stuck at 20.

Concretely, an affected daemon config ends up:

```
MaxConPerFiveDefaultBumped=1
MaxConnectionsPerFiveSeconds=20
```

Fix: write the value into `cfg` alongside the marker, so both persist in lockstep. #308 is post-3.0.1 and unreleased, so no shipped config carries the marker — no migration or second marker is needed.

## 2. Spurious mimeapps.list error on every daemon startup

`ProtocolHandlerManager::ReadIniLines` opened `~/.config/mimeapps.list` (and the other scheme-handler ini paths) unconditionally. On a headless host without that file, `wxFile` logs `Error: can't open file '.../mimeapps.list' (error 2: No such file or directory)` on every startup — before the existing graceful `!IsOpened()` bail. Guard the open with `wxFile::Exists` so a missing optional file is silently the "not configured" case.

## Testing

- Builds clean (monolithic + daemon + remote GUI), no new warnings.
- Fix 1 mechanism verified against a real stuck config: the marker persisting while the value didn't is exactly the observed `amule.conf` state; writing the value via the same `cfg->Write` path that already persists the marker keeps them consistent.
- Fix 2: with no `mimeapps.list` present, the `error 2` line no longer appears at startup.
