### PR TITLE
fix(amulegui): remove shared-file exclusion Preview button from the remote GUI

### DIFF
--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -522,6 +522,19 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 		resetBtn->Show(false);
 	}
 
+#ifdef CLIENT_GUI
+	// The shared-file exclusion preview counts against the core's in-memory
+	// shared list, which the remote GUI has no local access to (its handler
+	// is compiled out too). Remove the button and its info label here; the
+	// pattern/regex fields still work and sync to amuled over EC.
+	if (wxWindow *previewBtn = FindWindow(IDC_EXCLUDE_SHARE_PREVIEW)) {
+		previewBtn->Show(false);
+	}
+	if (wxWindow *previewInfo = FindWindow(IDC_EXCLUDE_SHARE_PREVIEW_INFO)) {
+		previewInfo->Show(false);
+	}
+#endif
+
 	// Select the first item
 	m_PrefsIcons->SetItemState(0, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1686,11 +1686,11 @@ wxSizer *PreferencesDirectoriesTab( wxWindow *parent, bool call_fit, bool set_si
     itemExcludeRegex->SetToolTip(_("When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."));
     item9->Add( itemExcludeRegex, 0, wxALIGN_CENTER_VERTICAL, 0 );
 
-#ifndef CLIENT_GUI
     // Live preview: how many currently-shared files the typed pattern would
-    // exclude. Needs the core's in-memory shared list, so it is omitted in
-    // the remote GUI (amulegui) -- the pattern/regex fields above still work
-    // there and sync to amuled over EC.
+    // exclude. Needs the core's in-memory shared list, which the remote GUI
+    // (amulegui) does not have; this file is built once into muleappgui with
+    // CLIENT_GUI undefined, so PrefsUnifiedDlg removes the button + info at
+    // runtime there (the pattern/regex fields still work and sync over EC).
     wxBoxSizer *itemPreviewRow = new wxBoxSizer( wxHORIZONTAL );
     wxButton *itemPreviewBtn = new wxButton( parent, IDC_EXCLUDE_SHARE_PREVIEW, _("Preview"), wxDefaultPosition, wxDefaultSize, 0 );
     itemPreviewBtn->SetToolTip(_("Show how many shared files the current pattern would exclude."));
@@ -1698,7 +1698,6 @@ wxSizer *PreferencesDirectoriesTab( wxWindow *parent, bool call_fit, bool set_si
     wxStaticText *itemPreviewInfo = new wxStaticText( parent, IDC_EXCLUDE_SHARE_PREVIEW_INFO, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     itemPreviewRow->Add( itemPreviewInfo, wxSizerFlags(1).CenterVertical() );
     item9->Add( itemPreviewRow, wxSizerFlags().Expand().Border(wxTOP, 4) );
-#endif
 
     item0->Add( item9, wxSizerFlags(1).Expand().CenterVertical().Border(wxALL, 0) );
     if (set_sizer)


### PR DESCRIPTION
The shared-file exclusion **Preview** button (Directories preferences page, added in #286/#350) shows in the remote GUI (amulegui), where it does nothing — its click handler and the count logic both need the core's in-memory shared-file list, which amulegui has no local access to.

The existing `#ifndef CLIENT_GUI` guard around the button in `muuli_wdr.cpp` is ineffective: that file is compiled once into the `muleappgui` static library (linked into both amule and amulegui) with `CLIENT_GUI` never defined, so the button is always built in. The handler in `PrefsUnifiedDlg.cpp` is correctly gated (that file is in `GUI_SOURCES`, compiled per-executable), which is why the button appeared but was inert in amulegui.

Fix: drop the dead guard in `muuli_wdr.cpp` and remove the button + its info label at runtime in `PrefsUnifiedDlg.cpp` under `#ifdef CLIENT_GUI` — the same `Show(false)` pattern already used there for the Advanced-page reset button. The pattern/regex fields remain and sync to amuled over EC.

Verified: amule (monolithic) and amulegui both build clean on macOS; the button is present in amule and absent in amulegui.
