### PR TITLE
fix(webapi): add missing ed2k link input to mobile navigation drawer

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -538,6 +538,9 @@ table.data td.name { white-space: normal; word-break: break-word; min-width: 220
     display: flex; flex-direction: column; gap: 2px;
     margin-top: auto; padding-top: 8px; border-top: 1px solid var(--border);
   }
+  .nav-tools .ed2k-add { padding: 4px 8px; margin-bottom: 4px; border-bottom: 1px solid var(--border); }
+  .nav-tools .ed2k-add .btn { justify-content: center; min-height: 34px; border-color: var(--border); flex: 0 0 auto; padding: 0 12px; }
+  .nav-tools .ed2k-input { flex: 1 1 auto; width: 100%; max-width: none; }
   .nav-tools .btn { justify-content: flex-start; min-height: 44px; border-color: transparent; }
   /* reveal the buttons' sr-only labels as drawer row text */
   .nav-tools .sr-only {

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -127,6 +127,12 @@ function Toolbar({ route, onLogout }) {
             <span class="tool-label">${r.label}</span>
           </a>`)}
         <div class="nav-tools">
+          <form class="ed2k-add admin-only" onSubmit=${(e) => { e.preventDefault(); addEd2k(); }}>
+            <input class="input ed2k-input" type="text" placeholder="ed2k://|file|…"
+                   aria-label=${t("app_add_ed2k_link")} value=${link}
+                   onInput=${(e) => setLink(e.target.value)} />
+            <button class="btn admin-only" type="submit">${t("app_add")}</button>
+          </form>
           <${LangSelect} />
           <${ThemeButton} />
           <button class="btn btn-ghost" title=${t("app_logout")} onClick=${doLogout}>


### PR DESCRIPTION
The ED2K link input form was hidden on mobile screens because `.header-tools` has `display: none`. This PR duplicates the input form inside the `.nav-tools` side drawer and adds the necessary CSS rules so mobile users can add links.
