### PR TITLE
feat(webapi): make frontend API base URL dynamic to support subpath r…

### DIFF
--- a/src/webapi/static/js/api.js
+++ b/src/webapi/static/js/api.js
@@ -4,12 +4,12 @@
 // - Parses the {error:{code,message}} envelope into ApiError.
 // - Caches ETags per GET target and revalidates with If-None-Match so a
 //   304 short-circuits re-downloading/parsing an unchanged body.
-// - Absolute "/api/v0" base: amuleapi serves this frontend on the same origin
-//   as the REST + SSE API, so the fixed root always resolves.
+// - Dynamic base path: derived from window.location.pathname so it works
+//   both at the root (/) and under a reverse proxy subpath (e.g. /amule/).
 
 import { t } from "./i18n.js";
 
-const BASE = "/api/v0";
+const BASE = window.location.pathname.replace(/\/?$/, "/") + "api/v0";
 
 export class ApiError extends Error {
   constructor(status, code, message) {

--- a/src/webapi/static/js/events.js
+++ b/src/webapi/static/js/events.js
@@ -103,7 +103,7 @@ async function refreshStatus() {
 // --- SSE ---------------------------------------------------------------
 function openSse() {
   if (es) return;
-  es = new EventSource("/api/v0/events");
+  es = new EventSource(window.location.pathname.replace(/\/?$/, "/") + "api/v0/events");
 
   es.addEventListener("open", () => {
     sseFails = 0;


### PR DESCRIPTION
Replaced the hardcoded `/api/v0` path in JS with a dynamic one based on `window.location.pathname`. This allows hosting the Web UI behind a reverse proxy using a subfolder (e.g. `https://domain.com/amule/`) without breaking the API and SSE calls.
