### PR TITLE
feat(webapi): add pagination, sorting and count metadata to list endpoints

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -9,7 +9,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Cross-cutting concerns**
 - [Base URL and transport](#base-url-and-transport)
 - [Authentication](#authentication) — [Login response shape](#login-response-shape), [Role model](#role-model), [Rate limiting](#rate-limiting), [JWT structure](#jwt-structure)
-- [Response model](#response-model) — [Success envelope](#success-envelope), [Error envelope](#error-envelope), [ETag and conditional GET](#etag-and-conditional-get), [CORS](#cors), [Path validation](#path-validation), [Request size limits](#request-size-limits)
+- [Response model](#response-model) — [Success envelope](#success-envelope), [List pagination and sorting](#list-pagination-and-sorting), [Error envelope](#error-envelope), [ETag and conditional GET](#etag-and-conditional-get), [CORS](#cors), [Path validation](#path-validation), [Request size limits](#request-size-limits)
 - [Error code catalog](#error-code-catalog)
 - [Backward compatibility](#backward-compatibility)
 
@@ -131,6 +131,39 @@ Header: `{"alg":"HS256","typ":"JWT"}`. Payload: `{"role":"admin"|"guest","iat":<
 ### Success envelope
 
 Each endpoint documents its own response shape under the endpoint section. List endpoints wrap their array under the resource plural name (`{"downloads": [...]}`, `{"shared": [...]}`) so clients can extend the envelope with sibling metadata without breaking JSON-parser pipelines.
+
+### List pagination and sorting
+
+The list endpoints — `GET /downloads`, `/clients`, `/shared`, `/servers`, and `/search/results` — accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
+
+| Param    | Default          | Notes |
+|----------|------------------|-------|
+| `limit`  | *(all items)*    | Maximum items to return, capped at `500`. Omitted → the full set (pre-pagination behaviour). Non-integer or negative → `400 bad_request`. |
+| `offset` | `0`              | Items to skip before the window. Non-integer or negative → `400 bad_request`. |
+| `sort`   | *(native order)* | Field to sort by; endpoint-specific (table below). Unknown field → `400 bad_request`. |
+| `order`  | `asc`            | `asc` or `desc`; anything else → `400 bad_request`. |
+
+Sorting is applied to the full filtered set **before** slicing, so pagination is stable across requests (a stable sort — equal keys keep native order). The response adds three sibling keys to the array:
+
+```json
+{ "shared": [ ... ], "total": 8431, "offset": 100, "limit": 50 }
+```
+
+- `total` — item count after any endpoint-specific filter (e.g. `/clients?filter=`), before slicing.
+- `offset` — the offset applied.
+- `limit` — the effective page size (equals the number of items returned when `limit` was omitted).
+
+Omitting all four parameters preserves the previous response exactly, plus the additive `total` / `offset` / `limit` keys.
+
+**Sortable fields per endpoint:**
+
+| Endpoint              | `sort` values |
+|-----------------------|---------------|
+| `GET /downloads`      | `name`, `size`, `progress`, `speed`, `status` |
+| `GET /clients`        | `name`, `software` |
+| `GET /shared`         | `name`, `size` |
+| `GET /servers`        | `name`, `users`, `ping`, `files` |
+| `GET /search/results` | `name`, `size`, `sources`, `rating` |
 
 ### Localization and number formatting
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1678,17 +1678,158 @@ void WriteSharedObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.EndObject();
 }
 
-// Helper for every list endpoint's envelope: snapshot_at +
-// snapshot_at_unix + the list under its named key. ec_unavailable +
-// 503 is also emitted here so each handler doesn't repeat the check.
+// --- List pagination + sorting (issue #357) ---------------------------
+// Server-side window shared by every list endpoint. `limit` (capped at
+// 500), `offset`, `sort` (an endpoint-defined field) and `order`
+// (asc|desc). Omitting `limit` returns the full set, preserving the
+// pre-#357 behaviour; `total`, `offset` and `limit` metadata are always
+// emitted so a paging consumer can size its requests.
+struct ListParams
+{
+	bool has_limit = false;
+	std::size_t limit = 0;
+	std::size_t offset = 0;
+	std::string sort; // empty = unsorted (native snapshot order)
+	bool desc = false;
+};
+
+// Endpoint-specific sortable fields: field name -> ascending comparator.
+// A vector (not a map) so the definition site reads as an ordered list
+// and an unknown `sort` value is simply a lookup miss -> 400.
+template <class T>
+using ListComparators = std::vector<std::pair<std::string, std::function<bool(const T &, const T &)>>>;
+
+std::unique_ptr<CHttpServer::Response> BadRequestPtr(const char *message)
+{
+	return std::unique_ptr<CHttpServer::Response>(
+		new CHttpServer::Response(ErrorResponse(400, "bad_request", message)));
+}
+
+// Parse ?limit/&offset/&sort/&order from a raw query string. `limit` is
+// clamped to 500; a non-numeric/oversized limit or offset, and a bad
+// `order`, are 400s. `sort` is validated later against the endpoint's
+// comparator table (BuildListWindow).
+std::unique_ptr<CHttpServer::Response> ParseListParams(const std::string &query, ListParams &out)
+{
+	const auto qmap = web_api_path::ParseQuery(query);
+	auto parseCount = [](const std::string &s, std::size_t &v) -> bool {
+		if (s.empty() || s.size() > 9) // > ~1e9 is nonsense for these lists
+			return false;
+		std::size_t val = 0;
+		for (char c : s) {
+			if (c < '0' || c > '9')
+				return false;
+			val = val * 10 + static_cast<std::size_t>(c - '0');
+		}
+		v = val;
+		return true;
+	};
+	const auto limit_it = qmap.find("limit");
+	if (limit_it != qmap.end()) {
+		std::size_t v = 0;
+		if (!parseCount(limit_it->second, v))
+			return BadRequestPtr("`limit` must be a non-negative integer");
+		out.has_limit = true;
+		out.limit = std::min<std::size_t>(v, 500);
+	}
+	const auto offset_it = qmap.find("offset");
+	if (offset_it != qmap.end()) {
+		std::size_t v = 0;
+		if (!parseCount(offset_it->second, v))
+			return BadRequestPtr("`offset` must be a non-negative integer");
+		out.offset = v;
+	}
+	const auto order_it = qmap.find("order");
+	if (order_it != qmap.end()) {
+		if (order_it->second == "asc")
+			out.desc = false;
+		else if (order_it->second == "desc")
+			out.desc = true;
+		else
+			return BadRequestPtr("`order` must be \"asc\" or \"desc\"");
+	}
+	const auto sort_it = qmap.find("sort");
+	if (sort_it != qmap.end())
+		out.sort = sort_it->second;
+	return nullptr;
+}
+
+// Stable-sort the full set (if `params.sort` is set) then slice to the
+// requested window. `out_window` is filled with pointers into `items`
+// (no element copies) and `out_total` with the pre-slice count. Returns
+// a 400 when `params.sort` is set but absent from `comparators`.
+template <class T>
+std::unique_ptr<CHttpServer::Response> BuildListWindow(const std::vector<T> &items,
+	const ListParams &params,
+	const ListComparators<T> &comparators,
+	std::vector<const T *> &out_window,
+	std::size_t &out_total)
+{
+	out_total = items.size();
+	std::vector<const T *> ptrs;
+	ptrs.reserve(items.size());
+	for (const auto &it : items)
+		ptrs.push_back(&it);
+
+	if (!params.sort.empty()) {
+		auto c = std::find_if(comparators.begin(), comparators.end(), [&](const auto &p) {
+			return p.first == params.sort;
+		});
+		if (c == comparators.end())
+			return BadRequestPtr("unknown `sort` field for this endpoint");
+		const auto &cmp = c->second;
+		std::stable_sort(ptrs.begin(), ptrs.end(), [&](const T *a, const T *b) {
+			return params.desc ? cmp(*b, *a) : cmp(*a, *b);
+		});
+	}
+
+	const std::size_t begin = std::min(params.offset, out_total);
+	const std::size_t end = params.has_limit ? std::min(begin + params.limit, out_total) : out_total;
+	out_window.assign(ptrs.begin() + begin, ptrs.begin() + end);
+	return nullptr;
+}
+
+// Emit the `total` / `offset` / `limit` pagination metadata. `limit`
+// echoes the effective page size (the actual number returned when the
+// caller omitted `limit`).
+void WritePageMeta(CJsonWriter &w, std::size_t total, const ListParams &params, std::size_t returned)
+{
+	w.Key("total");
+	w.ValueUInt(total);
+	w.Key("offset");
+	w.ValueUInt(params.offset);
+	w.Key("limit");
+	w.ValueUInt(params.has_limit ? params.limit : returned);
+}
+
+// Extract the raw query string from a request target ("/x?a=1" -> "a=1").
+std::string QueryOf(const CHttpServer::Request &req)
+{
+	std::string path, query;
+	SplitPathAndQuery(req.target, path, query);
+	return query;
+}
+
+// Helper for every list endpoint's envelope: the list under its named
+// key plus #357 pagination metadata. ec_unavailable + 503 is emitted here
+// so each handler doesn't repeat the check.
 template <class T, class WriterFn>
-CHttpServer::Response ListResponse(
-	const webapi::CState &state, const char *plural_key, const std::vector<T> &items, WriterFn write_item)
+CHttpServer::Response ListResponse(const webapi::CState &state,
+	const char *plural_key,
+	const std::vector<T> &items,
+	WriterFn write_item,
+	const ListParams &params = ListParams(),
+	const ListComparators<T> &comparators = ListComparators<T>())
 {
 	if (!state.HasFirstSnapshot()) {
 		return ErrorResponse(
 			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
 	}
+	std::vector<const T *> window;
+	std::size_t total = 0;
+	if (auto err = BuildListWindow(items, params, comparators, window, total))
+		return *err;
+
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "application/json";
@@ -1700,9 +1841,10 @@ CHttpServer::Response ListResponse(
 	w.BeginObject();
 	w.Key(plural_key);
 	w.BeginArray();
-	for (const auto &item : items)
-		write_item(w, item);
+	for (const T *item : window)
+		write_item(w, *item);
 	w.EndArray();
+	WritePageMeta(w, total, params, window.size());
 	w.EndObject();
 	FinalizeJsonBody(w, r);
 	return r;
@@ -1872,13 +2014,43 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 			downloads.end());
 	}
 
+	ListParams params;
+	if (auto err = ParseListParams(QueryOf(req), params))
+		return *err;
+	static const ListComparators<webapi::FileSnapshot> kComps = {
+		{ "name",
+			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
+				return a.name < b.name;
+			} },
+		{ "size",
+			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
+				return a.size < b.size;
+			} },
+		{ "progress",
+			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
+				return a.download.percent < b.download.percent;
+			} },
+		{ "speed",
+			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
+				return a.download.speed_bps < b.download.speed_bps;
+			} },
+		{ "status",
+			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
+				return a.download.status < b.download.status;
+			} },
+	};
 	return ListResponse(
-		m_state, "downloads", downloads, [](CJsonWriter &w, const webapi::FileSnapshot &d) {
+		m_state,
+		"downloads",
+		downloads,
+		[](CJsonWriter &w, const webapi::FileSnapshot &d) {
 			// List mode — omit `progress.parts` (Q2 + the per-list
 			// shape: omitting parts keeps the list response compact,
 			// detail endpoint is where parts ship).
 			WriteDownloadObject(w, d, /*include_parts=*/false);
-		});
+		},
+		params,
+		kComps);
 }
 
 CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &req)
@@ -1931,7 +2103,20 @@ CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &
 			clients.end());
 	}
 
-	return ListResponse(m_state, "clients", clients, WriteClientObject);
+	ListParams params;
+	if (auto err = ParseListParams(QueryOf(req), params))
+		return *err;
+	static const ListComparators<webapi::ClientSnapshot> kComps = {
+		{ "name",
+			[](const webapi::ClientSnapshot &a, const webapi::ClientSnapshot &b) {
+				return a.client_name < b.client_name;
+			} },
+		{ "software",
+			[](const webapi::ClientSnapshot &a, const webapi::ClientSnapshot &b) {
+				return a.software < b.software;
+			} },
+	};
+	return ListResponse(m_state, "clients", clients, WriteClientObject, params, kComps);
 }
 
 CHttpServer::Response CApiDispatcher::HandleSharedList(const CHttpServer::Request &req)
@@ -1940,7 +2125,21 @@ CHttpServer::Response CApiDispatcher::HandleSharedList(const CHttpServer::Reques
 		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
 	if (!a.ok)
 		return a.rejection;
-	return ListResponse(m_state, "shared", m_state.Shared(), WriteSharedObject);
+
+	ListParams params;
+	if (auto err = ParseListParams(QueryOf(req), params))
+		return *err;
+	static const ListComparators<webapi::FileSnapshot> kComps = {
+		{ "name",
+			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
+				return a.name < b.name;
+			} },
+		{ "size",
+			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
+				return a.size < b.size;
+			} },
+	};
+	return ListResponse(m_state, "shared", m_state.Shared(), WriteSharedObject, params, kComps);
 }
 
 CHttpServer::Response CApiDispatcher::HandleDownloadDetail(
@@ -2628,7 +2827,29 @@ CHttpServer::Response CApiDispatcher::HandleServers(const CHttpServer::Request &
 		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
 	if (!a.ok)
 		return a.rejection;
-	return ListResponse(m_state, "servers", m_state.Servers(), WriteServerObject);
+
+	ListParams params;
+	if (auto err = ParseListParams(QueryOf(req), params))
+		return *err;
+	static const ListComparators<webapi::ServerSnapshot> kComps = {
+		{ "name",
+			[](const webapi::ServerSnapshot &a, const webapi::ServerSnapshot &b) {
+				return a.name < b.name;
+			} },
+		{ "users",
+			[](const webapi::ServerSnapshot &a, const webapi::ServerSnapshot &b) {
+				return a.users < b.users;
+			} },
+		{ "ping",
+			[](const webapi::ServerSnapshot &a, const webapi::ServerSnapshot &b) {
+				return a.ping_ms < b.ping_ms;
+			} },
+		{ "files",
+			[](const webapi::ServerSnapshot &a, const webapi::ServerSnapshot &b) {
+				return a.files < b.files;
+			} },
+	};
+	return ListResponse(m_state, "servers", m_state.Servers(), WriteServerObject, params, kComps);
 }
 
 namespace
@@ -3482,6 +3703,35 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 	const std::vector<webapi::SearchResult> results_vec = m_state.Search();
 	const webapi::SearchProgressSnapshot progress = m_state.SearchProgress();
 
+	// #357 pagination/sort. This endpoint keeps its own envelope (the
+	// `progress` object rides alongside `results`), so it can't call
+	// ListResponse, but it shares the window + page-meta helpers.
+	ListParams params;
+	if (auto err = ParseListParams(QueryOf(req), params))
+		return *err;
+	static const ListComparators<webapi::SearchResult> kComps = {
+		{ "name",
+			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
+				return a.name < b.name;
+			} },
+		{ "size",
+			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
+				return a.size < b.size;
+			} },
+		{ "sources",
+			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
+				return a.source_count < b.source_count;
+			} },
+		{ "rating",
+			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
+				return a.rating < b.rating;
+			} },
+	};
+	std::vector<const webapi::SearchResult *> window;
+	std::size_t total = 0;
+	if (auto err = BuildListWindow(results_vec, params, kComps, window, total))
+		return *err;
+
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "application/json";
@@ -3489,9 +3739,10 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 	w.BeginObject();
 	w.Key("results");
 	w.BeginArray();
-	for (const auto &item : results_vec)
-		WriteSearchObject(w, item);
+	for (const webapi::SearchResult *item : window)
+		WriteSearchObject(w, *item);
 	w.EndArray();
+	WritePageMeta(w, total, params, window.size());
 	// Mirrors the `search_progress` SSE event field-for-field. `state`
 	// is canonical and encodes the full lifecycle (running / finished /
 	// idle), so we don't also emit redundant `active` / `complete`

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1701,8 +1701,7 @@ using ListComparators = std::vector<std::pair<std::string, std::function<bool(co
 
 std::unique_ptr<CHttpServer::Response> BadRequestPtr(const char *message)
 {
-	return std::unique_ptr<CHttpServer::Response>(
-		new CHttpServer::Response(ErrorResponse(400, "bad_request", message)));
+	return std::make_unique<CHttpServer::Response>(ErrorResponse(400, "bad_request", message));
 }
 
 // Parse ?limit/&offset/&sort/&order from a raw query string. `limit` is

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# amuleapi list pagination + sorting (issue #357). Exercises the shared
+# ?limit/&offset/&sort/&order machinery across every list endpoint:
+# /downloads, /shared, /servers, /clients and /search/results.
+#
+# Data-tolerant like the other read smokes — it asserts the pagination
+# metadata (`total`/`offset`/`limit`), that `limit` bounds the array
+# length, that omitting params preserves the array, and that malformed
+# params are rejected with 400. Ordering correctness needs >= 2 items to
+# observe and is left to the live test / unit layer; here `sort` is only
+# asserted to be accepted (valid field) or rejected (unknown field).
+#
+# Bring-up convention (see run-all.sh / 04-read-downloads-shared.sh):
+#   amuleapi --config-dir=/tmp/... --host=127.0.0.1 --port=4712 \
+#            --password=amule --set-admin-pass=adminpass
+#   amuleapi --config-dir=/tmp/... --host=127.0.0.1 --port=4712 \
+#            --password=amule &
+#   ./28-list-pagination-sort.sh
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+
+CURL_BODY_FILE=$(mktemp -t amuleapi_28_list_pagination_body.XXXXXX)
+trap 'rm -f "$CURL_BODY_FILE"' EXIT
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 10 \
+		-o "$CURL_BODY_FILE" -w '%{http_code}' "$@") \
+		|| _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat "$CURL_BODY_FILE")
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS" \
+			"body head: $(printf '%s' "$CURL_BODY" | head -c 200)"
+	fi
+}
+
+_assert_json_eq() {
+	local expr=$1 expected=$2 label=$3
+	local actual
+	actual=$(printf '%s' "$CURL_BODY" | jq -r "$expr" 2>/dev/null) \
+		|| _fail "$label" "body was not valid JSON" "body: $CURL_BODY"
+	if [ "$actual" = "$expected" ]; then
+		_pass "$label"
+	else
+		_fail "$label" "expected $expected, got $actual" "body: $CURL_BODY"
+	fi
+}
+
+# jq expr must evaluate to a number; assert it is <= bound.
+_assert_json_le() {
+	local expr=$1 bound=$2 label=$3
+	local actual
+	actual=$(printf '%s' "$CURL_BODY" | jq -r "$expr" 2>/dev/null)
+	if [ -n "$actual" ] && [ "$actual" != "null" ] && [ "$actual" -le "$bound" ] 2>/dev/null; then
+		_pass "$label ($actual <= $bound)"
+	else
+		_fail "$label" "expected <= $bound, got $actual" "body: $CURL_BODY"
+	fi
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+	_die "jq is required. brew install jq."
+fi
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
+fi
+
+echo "amuleapi 28-list-pagination-sort smoke @ $HOST"
+
+# --- 0. Log in. ----------------------------------------------------
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
+	|| _die "could not log in for pagination tests"
+
+sleep 3 # let the refresher build its caches
+
+AUTH=(-H "Authorization: Bearer $TOKEN")
+
+# endpoint:array-key pairs. search/results wraps under "results".
+ENDPOINTS=(
+	"downloads:downloads"
+	"shared:shared"
+	"servers:servers"
+	"clients:clients"
+	"search/results:results"
+)
+
+for pair in "${ENDPOINTS[@]}"; do
+	ep=${pair%%:*}
+	key=${pair##*:}
+	echo "  --- /$ep (key .$key) ---"
+
+	# 1. Baseline: array + always-present pagination metadata.
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep"
+	_assert_status 200 "GET /$ep → 200"
+	_assert_json_eq ".$key | type"  array  "/$ep .$key is an array"
+	_assert_json_eq ".total | type"  number "/$ep total is a number"
+	_assert_json_eq ".offset | type" number "/$ep offset is a number"
+	_assert_json_eq ".limit | type"  number "/$ep limit is a number"
+	_assert_json_eq ".offset"        0      "/$ep default offset is 0"
+
+	# 2. limit bounds the array length; limit echoes back.
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=1"
+	_assert_status 200 "GET /$ep?limit=1 → 200"
+	_assert_json_le ".$key | length" 1 "/$ep?limit=1 returns <= 1 item"
+	_assert_json_eq ".limit" 1 "/$ep?limit=1 echoes limit=1"
+
+	# 3. limit=0 → empty window, total still reported.
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=0"
+	_assert_status 200 "GET /$ep?limit=0 → 200"
+	_assert_json_eq ".$key | length" 0 "/$ep?limit=0 returns empty array"
+
+	# 4. offset past the end → empty window, no error.
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?offset=100000"
+	_assert_status 200 "GET /$ep?offset=100000 → 200"
+	_assert_json_eq ".$key | length" 0 "/$ep offset past end → empty array"
+
+	# 5. valid sort field is accepted (every list has a `name` field).
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?sort=name&order=desc"
+	_assert_status 200 "GET /$ep?sort=name&order=desc → 200"
+
+	# 6. Malformed params → 400.
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=-1"
+	_assert_status 400 "GET /$ep?limit=-1 → 400"
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=notanumber"
+	_assert_status 400 "GET /$ep?limit=notanumber → 400"
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?offset=-5"
+	_assert_status 400 "GET /$ep?offset=-5 → 400"
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?order=sideways"
+	_assert_status 400 "GET /$ep?order=sideways → 400"
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?sort=nonexistent_field"
+	_assert_status 400 "GET /$ep?sort=nonexistent_field → 400"
+
+	# 7. limit is capped at 500 (echoed limit never exceeds 500).
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=99999"
+	_assert_status 200 "GET /$ep?limit=99999 → 200 (clamped)"
+	_assert_json_le ".limit" 500 "/$ep?limit=99999 echoes limit <= 500"
+done
+
+echo
+echo "28-list-pagination-sort: $((TEST_COUNT-FAIL_COUNT))/$TEST_COUNT passed"
+[ "$FAIL_COUNT" -eq 0 ] || exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -200,6 +200,7 @@ PHASES=(
 	25-cors.sh
 	26-rfc-followup-endpoints.sh
 	27-static-frontend.sh
+	28-list-pagination-sort.sh
 )
 
 # Override list from the command line if given.


### PR DESCRIPTION
Closes #357.

Adds opt-in server-side windowing and ordering to the amuleapi list endpoints — `/downloads`, `/clients`, `/shared`, `/servers`, `/search/results` — with always-present pagination metadata, as requested by @ngosang.

## Query parameters

| Param | Default | Notes |
|-------|---------|-------|
| `limit` | *(all)* | Items to return, capped at 500. Omitted → full set (unchanged behaviour). |
| `offset` | 0 | Items to skip. |
| `sort` | *(native order)* | Endpoint-defined field. |
| `order` | asc | `asc` / `desc`. |

The response gains sibling keys `total` (count after any endpoint filter, before slicing), `offset`, and `limit`:

```json
{ "shared": [ ... ], "total": 8431, "offset": 100, "limit": 50 }
```

## Design decisions (the open questions from the issue)

- **`limit` omitted returns the full set**, not a default cap — this keeps existing clients (including the bundled frontend, which fetches full lists) working unchanged. `limit` only applies when given, then clamped to 500.
- **Bad params are `400`**: non-integer/negative `limit`/`offset`, an invalid `order`, or an unknown `sort` field.
- **Sort is a `stable_sort` over the full filtered set before slicing**, so pagination is stable across requests and equal keys keep native order.
- **Centralized** in the shared `ListResponse` helper via `BuildListWindow` (sorts pointers into the vector — no element copies) + `WritePageMeta`. `/search/results` keeps its own `progress`-bearing envelope but reuses the same two helpers, so all five endpoints behave identically. Per-endpoint sortable fields live in small comparator tables at each handler.

Sortable fields: `/downloads` name/size/progress/speed/status · `/clients` name/software · `/shared` name/size · `/servers` name/users/ping/files · `/search/results` name/size/sources/rating.

## Docs & tests

- `docs/api/REFERENCE.md` — new "List pagination and sorting" section.
- `unittests/curl-tests/amuleapi/28-list-pagination-sort.sh` — 105 assertions across all five endpoints (metadata shape, `limit` bounding + 500 cap, offset, valid/invalid sort, all bad-param 400s), registered in `run-all.sh`. Verified live: 105/105 pass, plus manual checks confirming asc/desc/size ordering and stable offset windows.
