### PR TITLE
fix(webapi): make peer software_version locale-independent

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -577,6 +577,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 `upload_file_hash` / `download_file_hash` are the 32-char MD4 hex hashes of the partfile or shared file the peer is currently transferring with — directly resolvable against [`/api/v0/downloads/{hash}`](#get-apiv0downloadshash) (in-progress) or the corresponding entry in [`/api/v0/shared`](#get-apiv0shared) by `.hash`. Either field can be empty when the peer is queued / idle in that direction. `download_file_name` is the filename the peer advertised in `OP_REQFILENAMEANSWER` and is populated only while we're actively downloading from them.
 
+`software` and `software_version` are locale-independent, per the API's English-only contract. A peer the daemon could not identify reports `"software": "unknown"` and `"software_version": "unknown"` — a lowercase sentinel, never a daemon-localized string (the daemon's own version formatting is gettext-translated and is deliberately not surfaced here). `os_info` is the peer's *own* self-reported OS string (raw external data, not normalized by amuled) and is frequently empty, since most clients don't send it.
+
 **Errors:** `400 bad_request` (unknown filter token), `503 ec_unavailable`.
 
 ---

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -527,14 +527,31 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c,
 		if (c->AssignIfExist(EC_TAG_CLIENT_USER_PORT, v))
 			cs.port = v;
 	}
-	{
-		std::uint32_t v = 0;
-		if (c->AssignIfExist(EC_TAG_CLIENT_SOFTWARE, v))
-			cs.software = ClientSoftwareName(v);
+	std::uint32_t soft_code = static_cast<std::uint32_t>(SO_UNKNOWN);
+	if (c->AssignIfExist(EC_TAG_CLIENT_SOFTWARE, soft_code))
+		cs.software = ClientSoftwareName(soft_code);
+
+	// software_version: the daemon formats this with gettext -- an
+	// unidentified peer yields _("Unknown"), which is "Desconocido" on a
+	// Spanish daemon and would leak the daemon locale into the English-only
+	// API (#359). amuleapi runs in its own process and can't reverse the
+	// translation, so we key off the locale-independent numeric software
+	// code instead of the string: a client the daemon couldn't identify
+	// (SO_UNKNOWN, which is exactly the branch that sets the translated
+	// "Unknown") gets the lowercase "unknown" sentinel, matching the other
+	// enum-like string fields. A known client with an absent/empty version
+	// string falls through to the same sentinel.
+	if (soft_code != static_cast<std::uint32_t>(SO_UNKNOWN)) {
+		if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_SOFT_VER_STR)) {
+			cs.software_version = std::string(t->GetStringData().utf8_str());
+		}
 	}
-	if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_SOFT_VER_STR)) {
-		cs.software_version = std::string(t->GetStringData().utf8_str());
+	if (cs.software_version.empty()) {
+		cs.software_version = "unknown";
 	}
+	// os_info is the peer's own self-reported OS string (raw external data,
+	// not gettext-translated by our daemon), so it carries no locale-leak;
+	// it is frequently empty because most clients don't send it.
 	if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_OS_INFO)) {
 		cs.os_info = std::string(t->GetStringData().utf8_str());
 	}

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -33,6 +33,8 @@
 #include <ec/cpp/ECTag.h>
 #include <ec/cpp/ECCodes.h>
 
+#include "include/protocol/ed2k/ClientSoftware.h" // SO_* client-software enum
+
 #include <cstdint>
 #include <map>
 
@@ -715,4 +717,65 @@ TEST(Refresher, SearchProgressIdleZeroesOutGracefully)
 	ASSERT_TRUE(!s.active);
 	ASSERT_TRUE(!s.complete);
 	ASSERT_EQUALS(static_cast<uint32_t>(0), s.percent);
+}
+
+// --- #359: peer software_version must be locale-independent ----------
+//
+// The daemon formats the version string with gettext, so an unidentified
+// client yields _("Unknown") -- "Desconocido" on a Spanish daemon. amuleapi
+// is a separate process and can't reverse the translation, so the refresher
+// keys off the numeric software code (locale-independent) and emits the
+// lowercase "unknown" sentinel instead of the translated string.
+
+// Build a one-client GET_UPDATE response: an EC_TAG_CLIENT container with a
+// single child client carrying the software code and (optionally) a version
+// string. Mirrors the amuled-side EC_TAG_CLIENT shape.
+static void PutOneClient(CECPacket &resp,
+	std::uint32_t ecid,
+	std::uint32_t soft,
+	const char *ver_str /* nullptr = omit the version tag */)
+{
+	CECTag container(EC_TAG_CLIENT, static_cast<std::uint32_t>(0));
+	CECTag cli(EC_TAG_CLIENT, ecid);
+	cli.AddTag(CECTag(EC_TAG_CLIENT_SOFTWARE, soft));
+	if (ver_str)
+		cli.AddTag(CECTag(EC_TAG_CLIENT_SOFT_VER_STR, wxString::FromUTF8(ver_str)));
+	container.AddTag(cli);
+	resp.AddTag(container);
+}
+
+TEST(Refresher, ClientVersionUnknownYieldsLocaleIndependentSentinel)
+{
+	std::map<std::uint32_t, ClientSnapshot> cache;
+	std::map<std::uint32_t, std::string> no_files;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	// Unidentified client + a translated version string, as a non-English
+	// daemon would ship it. Must NOT leak into the API response.
+	PutOneClient(resp, 7, static_cast<std::uint32_t>(SO_UNKNOWN), "Desconocido");
+	ApplyGetUpdateToClients(&resp, cache, no_files);
+	ASSERT_TRUE(cache.find(7) != cache.end());
+	ASSERT_EQUALS(std::string("unknown"), cache[7].software_version);
+}
+
+TEST(Refresher, ClientVersionKnownStringPassesThrough)
+{
+	std::map<std::uint32_t, ClientSnapshot> cache;
+	std::map<std::uint32_t, std::string> no_files;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	PutOneClient(resp, 8, static_cast<std::uint32_t>(SO_AMULE), "aMule 2.3.3");
+	ApplyGetUpdateToClients(&resp, cache, no_files);
+	ASSERT_TRUE(cache.find(8) != cache.end());
+	ASSERT_EQUALS(std::string("aMule 2.3.3"), cache[8].software_version);
+}
+
+TEST(Refresher, ClientKnownButNoVersionStringFallsBackToSentinel)
+{
+	std::map<std::uint32_t, ClientSnapshot> cache;
+	std::map<std::uint32_t, std::string> no_files;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	// Known software, but the daemon shipped no version string at all.
+	PutOneClient(resp, 9, static_cast<std::uint32_t>(SO_EMULE), nullptr);
+	ApplyGetUpdateToClients(&resp, cache, no_files);
+	ASSERT_TRUE(cache.find(9) != cache.end());
+	ASSERT_EQUALS(std::string("unknown"), cache[9].software_version);
 }


### PR DESCRIPTION
Closes #359.

`/clients[].software_version` was populated from the daemon's gettext-formatted client-version string, so an unidentified peer surfaced the translated `_("Unknown")` — `"Desconocido"` on a Spanish daemon — leaking the daemon locale into the English-only API contract.

## Fix (refresher-only, no amule-core change)

amuleapi runs in its own process and can't reverse the translation, so it keys off the locale-independent **numeric** software code (`EC_TAG_CLIENT_SOFTWARE`, which the refresher already decodes for the `software` field). A client the daemon couldn't identify (`SO_UNKNOWN` — exactly the branch that emits the translated string) now reports the lowercase `"unknown"` sentinel, matching the other enum-like string fields. A known client with an absent/empty version string falls back to the same sentinel.

The field is written once into the `ClientSnapshot`, which feeds **both** the REST `/clients` response and the SSE `client_added`/`client_updated` events, so both surfaces are corrected from one place. A locale-independent value is also strictly better for SSE/ETag stability.

## On `os_info` (the issue's secondary question)

Traced end-to-end: it's the peer's **own** self-reported OS string (`ET_OS_INFO`, parsed in `BaseClient.cpp` only for the aMule/Hydranode-class clients that send it), forwarded verbatim over EC and parsed correctly by the refresher. It's raw external data — not gettext-translated by our daemon — so it carries no locale leak, and it's frequently empty because most clients never transmit it. Left as-is and documented as such.

## Tests & docs

- `RefresherTest`: three cases feeding a crafted `EC_TAG_CLIENT` — `SO_UNKNOWN` + a translated `"Desconocido"` version (→ `"unknown"`), a known version (passthrough), and known-without-version (→ `"unknown"`). The unknown-peer path can't be forced from a live smoke test, so it's covered at the cctest layer.
- `docs/api/REFERENCE.md`: `/clients` field notes for `software_version` and `os_info`. The SSE `client_updated` event is documented as "identical to the REST shape", so it inherits the note.
