### PR TITLE
feat(webapi): bulk mutations with a unified per-item results envelope

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -9,7 +9,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Cross-cutting concerns**
 - [Base URL and transport](#base-url-and-transport)
 - [Authentication](#authentication) — [Login response shape](#login-response-shape), [Role model](#role-model), [Rate limiting](#rate-limiting), [JWT structure](#jwt-structure)
-- [Response model](#response-model) — [Success envelope](#success-envelope), [List pagination and sorting](#list-pagination-and-sorting), [Error envelope](#error-envelope), [ETag and conditional GET](#etag-and-conditional-get), [CORS](#cors), [Path validation](#path-validation), [Request size limits](#request-size-limits)
+- [Response model](#response-model) — [Success envelope](#success-envelope), [List pagination and sorting](#list-pagination-and-sorting), [Bulk mutations and the `results` envelope](#bulk-mutations-and-the-results-envelope), [Error envelope](#error-envelope), [ETag and conditional GET](#etag-and-conditional-get), [CORS](#cors), [Path validation](#path-validation), [Request size limits](#request-size-limits)
 - [Error code catalog](#error-code-catalog)
 - [Backward compatibility](#backward-compatibility)
 
@@ -26,6 +26,8 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/downloads`](#get-apiv0downloads) — list active queue
 - [`GET /api/v0/downloads/{hash}`](#get-apiv0downloadshash) — detail view; `{hash}` is the 32-char MD4 hex hash
 - [`POST /api/v0/downloads`](#post-apiv0downloads) — add ed2k link(s)
+- [`PATCH /api/v0/downloads`](#patch-apiv0downloads) — bulk pause / resume / priority / category
+- [`DELETE /api/v0/downloads`](#delete-apiv0downloads) — bulk cancel + remove
 - [`PATCH /api/v0/downloads/{hash}`](#patch-apiv0downloadshash) — pause / resume / priority / category
 - [`DELETE /api/v0/downloads/{hash}`](#delete-apiv0downloadshash) — cancel + remove
 - [`POST /api/v0/downloads/clear_completed`](#post-apiv0downloadsclear_completed) — bulk-clear completed staging buffer
@@ -36,6 +38,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Shared files**
 - [`GET /api/v0/shared`](#get-apiv0shared) — list shared files
 - [`POST /api/v0/shared/reload`](#post-apiv0sharedreload) — re-walk shared directories
+- [`PATCH /api/v0/shared`](#patch-apiv0shared) — bulk change upload priority
 - [`PATCH /api/v0/shared/{hash}`](#patch-apiv0sharedhash) — change upload priority
 
 **Servers**
@@ -164,6 +167,33 @@ Omitting all four parameters preserves the previous response exactly, plus the a
 | `GET /shared`         | `name`, `size` |
 | `GET /servers`        | `name`, `users`, `ping`, `files` |
 | `GET /search/results` | `name`, `size`, `sources`, `rating` |
+
+### Bulk mutations and the `results` envelope
+
+Every mutation that operates on more than one item — `POST /downloads`, `PATCH /downloads`, `DELETE /downloads`, `PATCH /shared` — reports one entry per input item under a unified `results` array, so a client submitting N items learns the fate of each rather than an aggregate counter or a first-error-only summary:
+
+```json
+{
+  "results": [
+    { "id": "8b54a3c2…", "ok": true },
+    { "id": "0011…",     "ok": false, "error": { "code": "not_found", "message": "no download with that hash" } }
+  ]
+}
+```
+
+- `id` — the item key: the MD4 hash for `/downloads` and `/shared`, or the submitted ed2k link for `POST /downloads`.
+- `ok` — whether that single item's mutation succeeded.
+- `error` — present only when `ok` is false; same `{code,message}` shape as the top-level [error envelope](#error-envelope).
+
+Processing is **best-effort per item** — each item is an independent EC roundtrip, so a mid-batch failure does not abort the rest. The **HTTP status aggregates** the batch:
+
+| Status | Meaning |
+|--------|---------|
+| `200 OK` (`202 Accepted` for the async `POST /downloads` add) | every item succeeded |
+| `207 Multi-Status` | a mix — inspect each `results[].ok` |
+| `503 ec_unavailable` | *every* item failed because the daemon was unreachable |
+
+A malformed **request** (missing/empty `hashes`, an invalid patch field) is still a top-level `400 bad_request` and returns the plain error envelope, not `results`. The `hashes` array is capped at 500 entries.
 
 ### Localization and number formatting
 
@@ -467,21 +497,48 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/downloads"
 ```
 
-**Response:** `202 Accepted` (all links accepted), `207 Multi-Status` (partial), or `503 ec_unavailable` (every link rejected by EC).
+**Response:** `202 Accepted` (all links accepted — the add is asynchronous: amuled allocates and hashes the partfile before it surfaces in `GET /downloads`, typically within one refresher tick), `207 Multi-Status` (partial), or `503 ec_unavailable` (every link blocked by an EC disconnect). Per-item outcomes use the shared [bulk `results` envelope](#bulk-mutations-and-the-results-envelope), keyed by the submitted link:
 
 ```json
 {
-  "ok": true,
-  "accepted": 1,
-  "failed": 1,
-  "disconnected": 0,
-  "accepted_links": ["ed2k://|file|a|...|/"],
-  "failed_links":   ["ed2k://|file|b|...|/"],
-  "first_error":    "malformed ed2k link"
+  "results": [
+    { "id": "ed2k://|file|a|...|/", "ok": true },
+    { "id": "ed2k://|file|b|...|/", "ok": false,
+      "error": { "code": "amuled_rejected", "message": "malformed ed2k link" } }
+  ]
 }
 ```
 
-**Errors:** `400 bad_request` (malformed body, both forms used, non-string link), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (malformed body, both forms used, non-string link, link not starting with `ed2k://`), `503 ec_unavailable`.
+
+#### `PATCH /api/v0/downloads`
+
+**Auth:** `ADMIN`
+
+Bulk pause/resume, priority, or category change over multiple downloads — the same patch applied to every listed hash.
+
+**Body:** `{ "hashes": ["<md4>", …], … }` — a non-empty `hashes` array (max 500) plus at least one of the single-item PATCH fields: `status` (`"paused"` | `"resumed"`), `priority` (`low` | `normal` | `high` | `release` | `auto`), `category` (integer 0–255).
+
+```sh
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"hashes":["8b54a3c2…","0a1b2c3d…"],"priority":"high"}' "http://$HOST/api/v0/downloads"
+```
+
+**Response:** the [bulk `results` envelope](#bulk-mutations-and-the-results-envelope) (`200` all ok / `207` partial / `503`), keyed by hash. Per-item `error.code` is `not_found`, `amuled_rejected`, or `ec_unavailable`.
+
+**Errors:** `400 bad_request` (missing/empty `hashes`, no patch field present, invalid field value), `503 ec_unavailable`.
+
+#### `DELETE /api/v0/downloads`
+
+**Auth:** `ADMIN`
+
+Bulk cancel + remove of active downloads (deletes each `.part`/`.met` from disk). A completed entry is rejected per-item with `completed_use_clear_completed` — clear those via `POST /downloads/clear_completed`.
+
+**Body:** `{ "hashes": ["<md4>", …] }` (non-empty, max 500).
+
+**Response:** the [bulk `results` envelope](#bulk-mutations-and-the-results-envelope), keyed by hash. Per-item `error.code` is `not_found`, `completed_use_clear_completed`, `amuled_rejected`, or `ec_unavailable`.
+
+**Errors:** `400 bad_request` (missing/empty `hashes`), `503 ec_unavailable`.
 
 #### `PATCH /api/v0/downloads/{hash}`
 
@@ -673,6 +730,18 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 Returns `202 Accepted`.
 
 **Errors:** `503 ec_unavailable`.
+
+#### `PATCH /api/v0/shared`
+
+**Auth:** `ADMIN`
+
+Bulk upload-priority change over multiple shared files — the same `priority` applied to every listed hash.
+
+**Body:** `{ "hashes": ["<md4>", …], "priority": "<level>" }` — a non-empty `hashes` array (max 500) plus a required `priority` (`very_low` | `low` | `normal` | `high` | `release` | `auto`).
+
+**Response:** the [bulk `results` envelope](#bulk-mutations-and-the-results-envelope) (`200` all ok / `207` partial / `503`), keyed by hash. Per-item `error.code` is `not_found`, `amuled_rejected`, or `ec_unavailable`.
+
+**Errors:** `400 bad_request` (missing/empty `hashes`, missing/invalid `priority`), `503 ec_unavailable`.
 
 #### `PATCH /api/v0/shared/{hash}`
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -698,7 +698,16 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			// add a download by ed2k link.
 			return HandleDownloadAdd(req);
 		}
-		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / POST on /downloads");
+		if (req.method == "PATCH") {
+			// bulk pause/resume/priority/category over {hashes:[...]}.
+			return HandleDownloadsBulkPatch(req);
+		}
+		if (req.method == "DELETE") {
+			// bulk cancel+remove over {hashes:[...]}.
+			return HandleDownloadsBulkDelete(req);
+		}
+		return ErrorResponse(
+			405, "method_not_allowed", "only GET / HEAD / POST / PATCH / DELETE on /downloads");
 	}
 
 	// bulk clear-completed.
@@ -721,10 +730,14 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	}
 
 	if (path == "/api/v0/shared") {
-		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(405, "method_not_allowed", "only GET on /shared");
+		if (req.method == "GET" || req.method == "HEAD") {
+			return HandleSharedList(req);
 		}
-		return HandleSharedList(req);
+		if (req.method == "PATCH") {
+			// bulk upload-priority PATCH over {hashes:[...], priority}.
+			return HandleSharedBulkPatch(req);
+		}
+		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / PATCH on /shared");
 	}
 
 	if (path == "/api/v0/shared/reload") {
@@ -2183,6 +2196,121 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDetail(
 	return r;
 }
 
+namespace
+{
+
+// --- Bulk mutation results (issue #358) -------------------------------
+// Every bulk mutation (POST /downloads, PATCH/DELETE /downloads,
+// PATCH /shared) reports one entry per input item under a unified
+// `results` array, so a client that submits N items learns the fate of
+// each without parallel arrays or a first-error-only summary.
+struct BulkItem
+{
+	std::string id; // the item key: ed2k link or MD4 hash
+	bool ok = false;
+	int http = 200;      // per-item semantic status; used only to aggregate
+	std::string code;    // error code   (when !ok)
+	std::string message; // error message (when !ok)
+};
+
+BulkItem BulkOk(const std::string &id)
+{
+	BulkItem b;
+	b.id = id;
+	b.ok = true;
+	return b;
+}
+
+BulkItem BulkErr(const std::string &id, int http, const char *code, const std::string &message)
+{
+	BulkItem b;
+	b.id = id;
+	b.ok = false;
+	b.http = http;
+	b.code = code;
+	b.message = message;
+	return b;
+}
+
+// Emit `{"results":[{"id","ok"[,"error":{"code","message"}]}]}`. Aggregate
+// status: every item ok -> `all_ok_status`; every item failed because the
+// daemon was unreachable (503) -> 503; any other mix -> 207 Multi-Status.
+CHttpServer::Response BulkResultsResponse(const std::vector<BulkItem> &items, int all_ok_status)
+{
+	bool all_ok = true;
+	bool all_unreachable = !items.empty();
+	for (const auto &it : items) {
+		if (!it.ok) {
+			all_ok = false;
+			if (it.http != 503)
+				all_unreachable = false;
+		} else {
+			all_unreachable = false;
+		}
+	}
+
+	CHttpServer::Response r;
+	r.status = all_ok ? all_ok_status : (all_unreachable ? 503 : 207);
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("results");
+	w.BeginArray();
+	for (const auto &it : items) {
+		w.BeginObject();
+		w.Key("id");
+		w.ValueString(wxString::FromUTF8(it.id.c_str()));
+		w.Key("ok");
+		w.ValueBool(it.ok);
+		if (!it.ok) {
+			w.Key("error");
+			w.BeginObject();
+			w.Key("code");
+			w.ValueString(wxString::FromUTF8(it.code.c_str()));
+			w.Key("message");
+			w.ValueString(wxString::FromUTF8(it.message.c_str()));
+			w.EndObject();
+		}
+		w.EndObject();
+	}
+	w.EndArray();
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+// Extract a non-empty `hashes` string array (max 500) from a parsed body.
+// On any shape problem fills `err` with a 400 and returns false.
+bool ParseBulkHashes(const picojson::object &obj, std::vector<std::string> &out, CHttpServer::Response &err)
+{
+	const auto it = obj.find("hashes");
+	if (it == obj.end() || !it->second.is<picojson::array>()) {
+		err = ErrorResponse(400, "bad_request", "`hashes` must be an array of 32-char hex strings");
+		return false;
+	}
+	const auto &arr = it->second.get<picojson::array>();
+	if (arr.empty()) {
+		err = ErrorResponse(400, "bad_request", "`hashes` must contain at least one entry");
+		return false;
+	}
+	if (arr.size() > 500) {
+		err = ErrorResponse(400, "bad_request", "`hashes` may contain at most 500 entries");
+		return false;
+	}
+	out.clear();
+	out.reserve(arr.size());
+	for (const auto &v : arr) {
+		if (!v.is<std::string>()) {
+			err = ErrorResponse(400, "bad_request", "`hashes` entries must be strings");
+			return false;
+		}
+		out.push_back(v.get<std::string>());
+	}
+	return true;
+}
+
+} // namespace
+
 CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Request &req)
 {
 	auto a = AuthenticateRequestRateLimited(
@@ -2275,10 +2403,12 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 	// the whole picture at the end — never short-circuit on an EC
 	// blip mid-batch (an unconditional 503 would silently throw away
 	// the links amuled already queued from earlier iterations).
-	std::vector<std::string> accepted_links;
-	std::vector<std::string> failed_links;
-	std::vector<std::string> ec_disconnected_links;
-	std::string first_error;
+	// Unified per-item envelope (#358): one `results` entry per submitted
+	// link, keyed by the link itself. amuleapi is not yet shipped, so this
+	// deliberately replaces the previous ok/accepted/failed counter shape
+	// rather than extending it -- there are no released clients to break.
+	std::vector<BulkItem> results;
+	results.reserve(links.size());
 	for (const auto &link : links) {
 		std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_ADD_LINK));
 		CECTag link_tag(EC_TAG_STRING, wxString::FromUTF8(link.c_str()));
@@ -2286,22 +2416,18 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 		ec_req->AddTag(link_tag);
 		const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
 		if (!ec_resp) {
-			ec_disconnected_links.push_back(link);
-			if (first_error.empty()) {
-				first_error = "EC roundtrip failed for ADD_LINK";
-			}
+			results.push_back(
+				BulkErr(link, 503, "ec_unavailable", "EC roundtrip failed for ADD_LINK"));
 			continue;
 		}
 		std::string ec_err_msg;
-		const bool failed = IsEcFailedResponse(ec_resp, ec_err_msg);
-		delete ec_resp;
-		if (failed) {
-			failed_links.push_back(link);
-			if (first_error.empty())
-				first_error = ec_err_msg;
-		} else {
-			accepted_links.push_back(link);
+		if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+			delete ec_resp;
+			results.push_back(BulkErr(link, 400, "amuled_rejected", ec_err_msg));
+			continue;
 		}
+		delete ec_resp;
+		results.push_back(BulkOk(link));
 	}
 
 	// Inline-refresh the cache so the response sees post-mutation
@@ -2313,64 +2439,10 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 	// the new entry.
 	(void)RefresherTick(m_app, m_state);
 
-	CHttpServer::Response r;
-	// 202 (all clean), 207 (any rejection or mid-batch disconnect
-	// with at least one accept), 503 (every link blocked by an EC
-	// disconnect — the operator's amuled is unreachable and nothing
-	// could land at all). 207 is per the partial-success convention
-	// documented in QUICKSTART.
-	const bool all_ok = failed_links.empty() && ec_disconnected_links.empty();
-	const bool none_landed = accepted_links.empty();
-	r.status = all_ok ? 202 : (none_landed && !ec_disconnected_links.empty()) ? 503 : 207;
-	r.content_type = "application/json";
-	CJsonWriter w;
-	w.BeginObject();
-	w.Key("ok");
-	w.ValueBool(all_ok);
-	w.Key("accepted");
-	w.ValueInt(static_cast<int64_t>(accepted_links.size()));
-	w.Key("failed");
-	w.ValueInt(static_cast<int64_t>(failed_links.size()));
-	w.Key("disconnected");
-	w.ValueInt(static_cast<int64_t>(ec_disconnected_links.size()));
-	if (!accepted_links.empty()) {
-		w.Key("accepted_links");
-		w.BeginArray();
-		for (const auto &l : accepted_links) {
-			w.ValueString(wxString::FromUTF8(l.c_str()));
-		}
-		w.EndArray();
-	}
-	if (!failed_links.empty()) {
-		w.Key("failed_links");
-		w.BeginArray();
-		for (const auto &l : failed_links) {
-			w.ValueString(wxString::FromUTF8(l.c_str()));
-		}
-		w.EndArray();
-	}
-	if (!ec_disconnected_links.empty()) {
-		// Distinct from `failed_links` — amuled didn't reject these,
-		// it just wasn't there to receive them. Clients can retry
-		// this subset once /api/v0/status reports ec_connected=true.
-		w.Key("disconnected_links");
-		w.BeginArray();
-		for (const auto &l : ec_disconnected_links) {
-			w.ValueString(wxString::FromUTF8(l.c_str()));
-		}
-		w.EndArray();
-	}
-	if (!first_error.empty()) {
-		w.Key("first_error");
-		w.ValueString(wxString::FromUTF8(first_error.c_str()));
-	}
-	w.Key("message");
-	w.ValueString(wxString::FromUTF8("link(s) accepted; new downloads will appear after amuled has "
-					 "allocated and hashed the partfiles (typically within one "
-					 "refresher tick)"));
-	w.EndObject();
-	FinalizeJsonBody(w, r);
-	return r;
+	// All accepted -> 202 (async: amuled allocates + hashes the partfile
+	// before it surfaces in GET /downloads, typically within one tick); a
+	// mix -> 207; every link blocked by an EC disconnect -> 503.
+	return BulkResultsResponse(results, 202);
 }
 
 CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
@@ -4650,6 +4722,302 @@ CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 	WriteSharedObject(w, s_after);
 	FinalizeJsonBody(w, r);
 	return r;
+}
+
+// --- Bulk mutations (issue #358) -------------------------------------
+// PATCH/DELETE /downloads and PATCH /shared take a `hashes` array and
+// apply the same op to each, reporting per-item outcomes under `results`
+// (see BulkResultsResponse). Best-effort per item -- each hash is an
+// independent EC roundtrip, so a mid-batch failure doesn't abort the
+// rest. One RefresherTick runs after the whole batch. All-ok is 200
+// (the mutations complete synchronously, unlike the async POST /downloads
+// add which is 202); a mix is 207 Multi-Status; an all-unreachable batch
+// collapses to 503.
+
+CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer::Request &req)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err))
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	const auto &obj = root.get<picojson::object>();
+
+	std::vector<std::string> hashes;
+	CHttpServer::Response bad;
+	if (!ParseBulkHashes(obj, hashes, bad))
+		return bad;
+
+	// Validate the patch ONCE -- the same op list applies to every hash, so
+	// a malformed patch is a 400 for the whole request; per-hash problems
+	// (not found, amuled rejection) surface per item. Fixed order
+	// (status, priority, category) keeps the wire effect deterministic.
+	struct PatchOp
+	{
+		ec_opcode_t op;
+		bool has_inner;
+		ec_tagname_t inner_name;
+		std::uint8_t inner_value;
+	};
+	std::vector<PatchOp> ops;
+	{
+		const auto it = obj.find("status");
+		if (it != obj.end()) {
+			if (!it->second.is<std::string>())
+				return ErrorResponse(400,
+					"bad_request",
+					"`status` must be one of \"paused\" or \"resumed\"");
+			const std::string &v = it->second.get<std::string>();
+			if (v == "paused")
+				ops.push_back(
+					{ EC_OP_PARTFILE_PAUSE, false, static_cast<ec_tagname_t>(0), 0 });
+			else if (v == "resumed")
+				ops.push_back(
+					{ EC_OP_PARTFILE_RESUME, false, static_cast<ec_tagname_t>(0), 0 });
+			else
+				return ErrorResponse(400,
+					"bad_request",
+					"`status` must be one of \"paused\" or \"resumed\"");
+		}
+	}
+	{
+		const auto it = obj.find("priority");
+		if (it != obj.end()) {
+			if (!it->second.is<std::string>())
+				return ErrorResponse(
+					400, "bad_request", "`priority` must be a wire-string enum");
+			std::uint8_t code = 0;
+			if (!DownloadPriorityToCode(it->second.get<std::string>(), code))
+				return ErrorResponse(400,
+					"bad_request",
+					"`priority` must be one of low, normal, high, release, auto");
+			ops.push_back({ EC_OP_PARTFILE_PRIO_SET, true, EC_TAG_PARTFILE_PRIO, code });
+		}
+	}
+	{
+		const auto it = obj.find("category");
+		if (it != obj.end()) {
+			if (!it->second.is<double>())
+				return ErrorResponse(
+					400, "bad_request", "`category` must be a non-negative integer");
+			const double v = it->second.get<double>();
+			if (v < 0 || v > 255)
+				return ErrorResponse(400, "bad_request", "`category` must be in [0, 255]");
+			ops.push_back({ EC_OP_PARTFILE_SET_CAT,
+				true,
+				EC_TAG_PARTFILE_CAT,
+				static_cast<std::uint8_t>(v) });
+		}
+	}
+	if (ops.empty())
+		return ErrorResponse(400,
+			"bad_request",
+			"request body must include at least one of `status`, `priority`, or `category`");
+
+	std::vector<BulkItem> results;
+	results.reserve(hashes.size());
+	for (const std::string &raw : hashes) {
+		std::string needle = raw;
+		std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+			return static_cast<char>(std::tolower(c));
+		});
+		webapi::FileSnapshot d;
+		if (!m_state.FindDownload(needle, d)) {
+			results.push_back(BulkErr(raw, 404, "not_found", "no download with that hash"));
+			continue;
+		}
+		CMD4Hash file_hash;
+		if (!HashFromHex(d.hash, file_hash)) {
+			results.push_back(
+				BulkErr(raw, 500, "internal_error", "failed to decode partfile hash"));
+			continue;
+		}
+		bool item_ok = true;
+		for (const PatchOp &pop : ops) {
+			std::unique_ptr<CECPacket> p(new CECPacket(pop.op));
+			CECTag hash_tag(EC_TAG_PARTFILE, file_hash);
+			if (pop.has_inner)
+				hash_tag.AddTag(CECTag(pop.inner_name, pop.inner_value));
+			p->AddTag(hash_tag);
+			const CECPacket *ec_resp = m_app.SendRecvSerialized(p.get());
+			if (!ec_resp) {
+				results.push_back(BulkErr(raw, 503, "ec_unavailable", "EC roundtrip failed"));
+				item_ok = false;
+				break;
+			}
+			std::string ec_err;
+			if (IsEcFailedResponse(ec_resp, ec_err)) {
+				delete ec_resp;
+				results.push_back(BulkErr(raw, 400, "amuled_rejected", ec_err));
+				item_ok = false;
+				break;
+			}
+			delete ec_resp;
+		}
+		if (item_ok)
+			results.push_back(BulkOk(raw));
+	}
+	(void)RefresherTick(m_app, m_state);
+	return BulkResultsResponse(results, 200);
+}
+
+CHttpServer::Response CApiDispatcher::HandleDownloadsBulkDelete(const CHttpServer::Request &req)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err))
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	const auto &obj = root.get<picojson::object>();
+
+	std::vector<std::string> hashes;
+	CHttpServer::Response bad;
+	if (!ParseBulkHashes(obj, hashes, bad))
+		return bad;
+
+	std::vector<BulkItem> results;
+	results.reserve(hashes.size());
+	for (const std::string &raw : hashes) {
+		std::string needle = raw;
+		std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+			return static_cast<char>(std::tolower(c));
+		});
+		webapi::FileSnapshot d;
+		if (!m_state.FindDownload(needle, d)) {
+			results.push_back(BulkErr(raw, 404, "not_found", "no download with that hash"));
+			continue;
+		}
+		// Same guard as the single-item DELETE: completed entries are not
+		// removable here (use POST /downloads/clear_completed).
+		if (d.download.status == "completed") {
+			results.push_back(BulkErr(raw,
+				409,
+				"completed_use_clear_completed",
+				"DELETE only removes active downloads; use POST "
+				"/downloads/clear_completed to clear a completed entry"));
+			continue;
+		}
+		CMD4Hash file_hash;
+		if (!HashFromHex(d.hash, file_hash)) {
+			results.push_back(
+				BulkErr(raw, 500, "internal_error", "failed to decode partfile hash"));
+			continue;
+		}
+		std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_PARTFILE_DELETE));
+		ec_req->AddTag(CECTag(EC_TAG_PARTFILE, file_hash));
+		const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+		if (!ec_resp) {
+			results.push_back(
+				BulkErr(raw, 503, "ec_unavailable", "EC roundtrip failed for DELETE"));
+			continue;
+		}
+		std::string ec_err;
+		if (IsEcFailedResponse(ec_resp, ec_err)) {
+			delete ec_resp;
+			results.push_back(BulkErr(raw, 400, "amuled_rejected", ec_err));
+			continue;
+		}
+		delete ec_resp;
+		results.push_back(BulkOk(raw));
+	}
+	(void)RefresherTick(m_app, m_state);
+	return BulkResultsResponse(results, 200);
+}
+
+CHttpServer::Response CApiDispatcher::HandleSharedBulkPatch(const CHttpServer::Request &req)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err))
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	const auto &obj = root.get<picojson::object>();
+
+	std::vector<std::string> hashes;
+	CHttpServer::Response bad;
+	if (!ParseBulkHashes(obj, hashes, bad))
+		return bad;
+
+	// `priority` required + validated once for the whole batch.
+	const auto pit = obj.find("priority");
+	if (pit == obj.end())
+		return ErrorResponse(400, "bad_request", "request body must include `priority`");
+	if (!pit->second.is<std::string>())
+		return ErrorResponse(400, "bad_request", "`priority` must be a wire-string enum");
+	std::uint8_t code = 0;
+	if (!SharedPriorityToCode(pit->second.get<std::string>(), code))
+		return ErrorResponse(400,
+			"bad_request",
+			"`priority` must be one of very_low, low, normal, high, release, auto");
+
+	std::vector<BulkItem> results;
+	results.reserve(hashes.size());
+	for (const std::string &raw : hashes) {
+		std::string needle = raw;
+		std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+			return static_cast<char>(std::tolower(c));
+		});
+		webapi::FileSnapshot s;
+		if (!m_state.FindShared(needle, s)) {
+			results.push_back(BulkErr(raw, 404, "not_found", "no shared file with that hash"));
+			continue;
+		}
+		CMD4Hash file_hash;
+		if (!HashFromHex(s.hash, file_hash)) {
+			results.push_back(BulkErr(raw, 500, "internal_error", "failed to decode file hash"));
+			continue;
+		}
+		std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SHARED_SET_PRIO));
+		CECTag hash_tag(EC_TAG_PARTFILE, file_hash);
+		hash_tag.AddTag(CECTag(EC_TAG_PARTFILE_PRIO, code));
+		ec_req->AddTag(hash_tag);
+		const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+		if (!ec_resp) {
+			results.push_back(BulkErr(
+				raw, 503, "ec_unavailable", "EC roundtrip failed for SHARED_SET_PRIO"));
+			continue;
+		}
+		std::string ec_err;
+		if (IsEcFailedResponse(ec_resp, ec_err)) {
+			delete ec_resp;
+			results.push_back(BulkErr(raw, 400, "amuled_rejected", ec_err));
+			continue;
+		}
+		delete ec_resp;
+		results.push_back(BulkOk(raw));
+	}
+	(void)RefresherTick(m_app, m_state);
+	return BulkResultsResponse(results, 200);
 }
 
 CHttpServer::Response CApiDispatcher::HandleSharedReload(const CHttpServer::Request &req)

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -108,6 +108,9 @@ private:
 	// clear completed downloads.
 	CHttpServer::Response HandleDownloadDelete(const CHttpServer::Request &, const std::string &key);
 	CHttpServer::Response HandleDownloadsClearCompleted(const CHttpServer::Request &);
+	// bulk mutations over a `hashes` array, per-item `results` envelope (#358).
+	CHttpServer::Response HandleDownloadsBulkPatch(const CHttpServer::Request &);
+	CHttpServer::Response HandleDownloadsBulkDelete(const CHttpServer::Request &);
 	// server lifecycle.
 	CHttpServer::Response HandleServerAdd(const CHttpServer::Request &);
 	CHttpServer::Response HandleServerConnect(const CHttpServer::Request &, const std::string &ecid_str);
@@ -132,6 +135,8 @@ private:
 	CHttpServer::Response HandleKadBootstrap(const CHttpServer::Request &);
 	// shared file priority PATCH. `key` = hash OR ECID.
 	CHttpServer::Response HandleSharedPatch(const CHttpServer::Request &, const std::string &key);
+	// bulk shared-priority PATCH over a `hashes` array (#358).
+	CHttpServer::Response HandleSharedBulkPatch(const CHttpServer::Request &);
 
 	// Static-frontend fallthrough. Resolves `url_path` under
 	// ServerCfg().static_root, returns the file with a content-type

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -177,11 +177,12 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		'/shared[0].priority_auto is boolean'
 fi
 
-# --- 7. Method gate (POST/DELETE not allowed on read-only). -------
-for ep in downloads shared; do
-	_curl -X DELETE -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/$ep"
-	_assert_status 405 "DELETE /api/v0/$ep → 405"
-done
+# --- 7. Method gate. DELETE is method-gated on the /shared collection
+# (no bulk-unshare endpoint); the /downloads collection now accepts a bulk
+# DELETE (issue #358, exercised by 29-bulk-mutations.sh), so it is no
+# longer 405 here.
+_curl -X DELETE -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared"
+_assert_status 405 "DELETE /api/v0/shared → 405"
 
 # --- Summary. -----------------------------------------------------
 echo

--- a/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
+++ b/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
@@ -144,7 +144,10 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"ed2k_link\":\"$TEST_LINK\"}" "$HOST/api/v0/downloads"
 _assert_status 202 "POST /downloads (Ubuntu ISO) → 202"
-_assert_json_eq '.ok' true 'POST /downloads response.ok==true'
+# Unified per-item envelope (#358): one accepted result keyed by the link.
+_assert_json_eq '.results | length' 1 'POST /downloads returns one result'
+_assert_json_eq '.results[0].ok' true 'POST /downloads results[0].ok==true'
+_assert_json_eq ".results[0].id" "$TEST_LINK" 'POST /downloads results[0].id echoes the link'
 
 # Poll until the new partfile surfaces in /downloads (amuled's ADD_LINK
 # is async — allocation + hashing happen post-roundtrip). Bound at

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -221,10 +221,11 @@ if [ "$RC" = "202" ]; then
 else
 	_fail "downloads array status" "expected 202, got $RC: $(cat /tmp/p11_dl.json)"
 fi
-if jq -e '.accepted == 1 and .failed == 0' /tmp/p11_dl.json >/dev/null 2>&1; then
-	_pass "POST /downloads array reports accepted=1, failed=0"
+# Unified per-item envelope (#358): one accepted result, no legacy counters.
+if jq -e '(.results | length) == 1 and .results[0].ok == true' /tmp/p11_dl.json >/dev/null 2>&1; then
+	_pass "POST /downloads array reports one ok result"
 else
-	_fail "downloads array counts" "$(cat /tmp/p11_dl.json)"
+	_fail "downloads array results" "$(cat /tmp/p11_dl.json)"
 fi
 # Mixing both forms → 400
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \

--- a/unittests/curl-tests/amuleapi/29-bulk-mutations.sh
+++ b/unittests/curl-tests/amuleapi/29-bulk-mutations.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# amuleapi bulk mutations (issue #358). Exercises the unified per-item
+# `results` envelope across POST /downloads, PATCH/DELETE /downloads and
+# PATCH /shared, plus the 207 Multi-Status / 400 conventions.
+#
+# Data-tolerant: a nonexistent hash yields a per-item `not_found`, so the
+# full path (routing -> parse -> per-hash loop -> per-item error -> 207
+# aggregation) is exercised without needing real downloads/shares on the
+# daemon. Success-path (ok:true) needs live files and is left to manual /
+# integration testing.
+#
+# Bring-up: see run-all.sh / 04-read-downloads-shared.sh.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+BODY=$(mktemp -t amuleapi_29_bulk_body.XXXXXX)
+trap 'rm -f "$BODY"' EXIT
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() { TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1)); echo "  FAIL  $1"; shift; for a in "$@"; do echo "        $a"; done; }
+
+# _req METHOD PATH JSON  -> sets STATUS + CURL_BODY
+_req() {
+	local method=$1 path=$2 json=${3:-}
+	local args=(-s --max-time 10 -o "$BODY" -w '%{http_code}' -X "$method"
+		-H "Authorization: Bearer $TOKEN")
+	[ -n "$json" ] && args+=(-H "Content-Type: application/json" -d "$json")
+	STATUS=$(curl "${args[@]}" "$HOST$path") || _die "curl failed: $method $path"
+	CURL_BODY=$(cat "$BODY")
+}
+
+_status() { [ "$STATUS" = "$1" ] && _pass "$2 (HTTP $STATUS)" || _fail "$2" "want HTTP $1 got $STATUS" "body: $(printf %s "$CURL_BODY" | head -c 200)"; }
+_jq()     { local a; a=$(printf %s "$CURL_BODY" | jq -r "$1" 2>/dev/null); [ "$a" = "$2" ] && _pass "$3" || _fail "$3" "want '$2' got '$a'" "body: $CURL_BODY"; }
+
+command -v jq >/dev/null 2>&1 || _die "jq required"
+curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" || _die "amuleapi at $HOST not reachable"
+
+echo "amuleapi 29-bulk-mutations @ $HOST"
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" -d "{\"password\":\"$ADMIN_PASS\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
+sleep 2
+
+H0="00000000000000000000000000000000"
+H1="11111111111111111111111111111111"
+
+# --- auth gate --------------------------------------------------------
+S=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH -H "Content-Type: application/json" \
+	-d "{\"hashes\":[\"$H0\"],\"priority\":\"high\"}" "$HOST/api/v0/shared")
+[ "$S" = 401 ] && _pass "PATCH /shared without creds -> 401" || _fail "PATCH /shared no-creds" "want 401 got $S"
+
+# --- per-item not_found => 207 Multi-Status ---------------------------
+echo "  --- 207 per-item not_found ---"
+_req PATCH /api/v0/downloads "{\"hashes\":[\"$H0\"],\"priority\":\"high\"}"
+_status 207 "PATCH /downloads [bogus hash]"
+_jq '.results | length' 1                "  results has 1 entry"
+_jq '.results[0].id'    "$H0"            "  results[0].id echoes the hash"
+_jq '.results[0].ok'    false            "  results[0].ok is false"
+_jq '.results[0].error.code' not_found   "  results[0].error.code is not_found"
+
+_req DELETE /api/v0/downloads "{\"hashes\":[\"$H0\"]}"
+_status 207 "DELETE /downloads [bogus hash]"
+_jq '.results[0].error.code' not_found   "  DELETE results[0] not_found"
+
+_req PATCH /api/v0/shared "{\"hashes\":[\"$H0\"],\"priority\":\"high\"}"
+_status 207 "PATCH /shared [bogus hash]"
+_jq '.results[0].error.code' not_found   "  PATCH /shared results[0] not_found"
+
+# --- multiple items => length matches --------------------------------
+_req PATCH /api/v0/shared "{\"hashes\":[\"$H0\",\"$H1\"],\"priority\":\"low\"}"
+_status 207 "PATCH /shared [2 bogus hashes]"
+_jq '.results | length' 2                "  results has 2 entries"
+_jq '[.results[].ok] | any'  false       "  no item succeeded"
+
+# --- bad requests => 400 ---------------------------------------------
+echo "  --- 400 validation ---"
+_req PATCH /api/v0/downloads "{\"priority\":\"high\"}";            _status 400 "PATCH /downloads missing hashes"
+_req PATCH /api/v0/downloads "{\"hashes\":[]}";                    _status 400 "PATCH /downloads empty hashes"
+_req PATCH /api/v0/downloads "{\"hashes\":[\"$H0\"]}";            _status 400 "PATCH /downloads no patch fields"
+_req PATCH /api/v0/downloads "{\"hashes\":[\"$H0\"],\"priority\":\"bogus\"}"; _status 400 "PATCH /downloads bad priority"
+_req DELETE /api/v0/downloads "{}";                               _status 400 "DELETE /downloads missing hashes"
+_req PATCH /api/v0/shared "{\"hashes\":[\"$H0\"]}";              _status 400 "PATCH /shared missing priority"
+_req PATCH /api/v0/shared "{\"hashes\":[\"$H0\"],\"priority\":\"nope\"}";     _status 400 "PATCH /shared bad priority"
+
+# --- method routing ---------------------------------------------------
+_req PUT /api/v0/downloads "{}";  _status 405 "PUT /downloads -> 405"
+_req PUT /api/v0/shared "{}";     _status 405 "PUT /shared -> 405"
+
+# --- POST /downloads unified shape (no legacy counters) --------------
+echo "  --- POST /downloads unified results shape ---"
+LINK="ed2k://|file|bulk-test.bin|1024|0123456789ABCDEF0123456789ABCDEF|/"
+_req POST /api/v0/downloads "{\"links\":[\"$LINK\"]}"
+_jq '.results | type' array              "POST /downloads has results[] array"
+_jq '.results | length' 1                "  one result entry"
+_jq '.results[0].id' "$LINK"             "  result id echoes the link"
+_jq '.accepted // "absent"' absent       "  legacy 'accepted' counter removed"
+_jq '.ok // "absent"' absent             "  legacy 'ok' bool removed"
+
+echo
+echo "29-bulk-mutations: $((TEST_COUNT-FAIL_COUNT))/$TEST_COUNT passed"
+[ "$FAIL_COUNT" -eq 0 ] || exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -201,6 +201,7 @@ PHASES=(
 	26-rfc-followup-endpoints.sh
 	27-static-frontend.sh
 	28-list-pagination-sort.sh
+	29-bulk-mutations.sh
 )
 
 # Override list from the command line if given.


### PR DESCRIPTION
Closes #358.

Adds collection-level bulk mutations and standardizes every multi-item mutation on a single per-item `results` array, so a client submitting N items learns the fate of each — no aggregate counters, no first-error-only summary.

## ⚠️ Breaking change (intentional, no shim)

`POST /api/v0/downloads` **drops** its old `{ ok, accepted, failed, accepted_links, failed_links, first_error }` counter shape and now returns the unified `results` envelope. amuleapi is **not yet released**, so there is deliberately **no back-compatibility shim** — clients must read `results`. Flagging explicitly since it changes an existing endpoint's contract.

## New endpoints

All admin, body `{"hashes": ["<md4>", …], …}` (non-empty, capped at 500):

- **`PATCH /downloads`** — bulk pause/resume/priority/category
- **`DELETE /downloads`** — bulk cancel + remove (a completed entry is rejected per-item with `completed_use_clear_completed`)
- **`PATCH /shared`** — bulk upload-priority

## Unified envelope

```json
{ "results": [
  { "id": "8b54a3c2…", "ok": true },
  { "id": "0011…", "ok": false, "error": { "code": "not_found", "message": "…" } }
] }
```

`id` = hash (or the ed2k link for `POST /downloads`). Best-effort per item (each is an independent EC roundtrip; one refresher tick after the batch). HTTP status aggregates: **200** all-ok (**202** for the async `POST /downloads` add) / **207 Multi-Status** / **503** when *every* item failed unreachable. A malformed *request* (missing/empty `hashes`, bad patch field) stays a top-level **400**.

Centralized in `BulkResultsResponse` + `BulkItem` + `ParseBulkHashes`; the single-item PATCH/DELETE handlers are untouched.

## Docs & tests

- `docs/api/REFERENCE.md` — new "Bulk mutations and the `results` envelope" section, three new endpoint entries, rewritten `POST /downloads`.
- `29-bulk-mutations.sh` (27 assertions: 207 per-item `not_found`, multi-item, 400 validation, method routing, unified `POST` shape) + `12-downloads-add-patch.sh` updated for the new shape. Verified green via `run-all.sh` (29 + 12/13/17 — no single-item regressions).
