### PR TITLE
fix(amulecmd): define MULE_EVT_NOTIFY so LTO builds link

### DIFF
--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -1382,6 +1382,16 @@ int CamulecmdApp::OnRun()
 
 // Stub functions needed by the linker in ASIO builds
 #include "GuiEvents.h"
+
+// MULE_EVT_NOTIFY is declared in GuiEvents.h and referenced by the header-inline
+// CMuleGUIEvent (its ctor and Clone()) that this console binary pulls in, but amulecmd
+// links no TU that defines it: GuiEvents.cpp lives in muleappcore and WebInterface.cpp
+// in the webserver, neither of which amulecmd links. Non-LTO builds dead-strip the
+// unused inline copies before the symbol is demanded; LTO keeps the CMuleGUIEvent vtable
+// and the reference survives to the final link, so the definition must live here. Same
+// per-binary event-definition pattern as MULE_EVT_LOGLINE in LoggerConsole.cpp.
+wxDEFINE_EVENT(MULE_EVT_NOTIFY, wxEvent);
+
 namespace MuleNotify
 {
 void HandleNotification(const class CMuleNotiferBase &) {}


### PR DESCRIPTION
`amulecmd` references `MULE_EVT_NOTIFY` through the header-inline `CMuleGUIEvent` (pulled in via `TextClient.cpp`) but links no translation unit that defines it — the definitions live in `GuiEvents.cpp` (muleappcore) and `WebInterface.cpp` (webserver), neither of which `amulecmd` links.

Non-LTO builds dead-strip the unused inline `CMuleGUIEvent` ctor/`Clone()` copies before the symbol is demanded, so the gap stayed latent. Under LTO the vtable is retained and the reference reaches the final link undefined, breaking the `amulecmd` link with `undefined reference to MULE_EVT_NOTIFY`.

The regression dates to `c30cdc42b`, which changed `MULE_EVT_NOTIFY` from a plain `const wxEventType` (an `int`, foldable/strippable) into a `const wxEventTypeTag<wxEvent>` object.

The fix gives `amulecmd` its own definition in its console TU, matching the per-binary event-definition pattern it already uses for `MULE_EVT_LOGLINE` in `LoggerConsole.cpp`.

Reproduced on Arch (GCC 16.1.1, x86_64, `-fcf-protection`, `-flto=auto`) — same error and `.text` offset as reported — and verified the one-line fix links `amulecmd` cleanly.

Refs #367
