### PR TITLE
feat(amuleweb): deprecation notice (startup, man page, docs)

### DIFF
--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -7,6 +7,8 @@ exposes its own HTTP surface on a separate port. amuleapi is the first
 shipping REST API for aMule — there is no prior on-the-wire surface to
 migrate from.
 
+> aMule's older web frontend, **amuleweb**, is **deprecated** — it may be removed in aMule 3.2 or later (it is not being removed yet). amuleapi is its intended replacement.
+
 For the endpoint list see the [What ships](#what-ships) section below. Full per-endpoint contracts (methods, query params, request bodies, response shapes, error codes) live in [`docs/api/REFERENCE.md`](api/REFERENCE.md); the SSE event catalog and Last-Event-ID reconnect semantics live in [`docs/api/EVENTS.md`](api/EVENTS.md). The source of truth for routing is [`src/webapi/Api.cpp`](../src/webapi/Api.cpp).
 
 ## Requirements

--- a/docs/man/amuleweb.1.in
+++ b/docs/man/amuleweb.1.in
@@ -39,6 +39,10 @@ amuleweb \- aMule web server
 .RB [ \-\-amule\-config\-file = \fI<path> ]
 
 .SH DESCRIPTION
+.B DEPRECATED:
+amuleweb is deprecated and may be removed in aMule 3.2 or later.
+It is not being removed yet; consider migrating to amuleapi, the REST/SSE API.
+.PP
 \fBamuleweb\fR manages your access to amule through a web browser.
 You can start amuleweb together with \fBamule\fR(1), or separately, any time later.
 Options can be specified via command-line or via config-file.

--- a/docs/man/po/manpages-de.po
+++ b/docs/man/po/manpages-de.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: manpages-de\n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:29+0000\n"
 "Last-Translator: Balla Marcell <marcell.balla@gmx.at>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -182,14 +182,14 @@ msgstr "Setzt die Kategorie für den übergebenen eD2k Verweis I<E<lt>NumE<gt>>"
 # type: Plain text
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "Zeigt die derzeitige Versionsnummer an."
 
 # type: Plain text
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -238,27 +238,27 @@ msgstr "ein Magnet Verweis."
 
 # type: SH
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "ANMERKUNGEN"
 
 # type: SS
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "Pfade"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Für alle Optionen die ein I<E<lt>PfadE<gt>> Argument erwarten, wenn der I<Pfad> kein Verzeichnis enthält(z.B. nur einen Dateinamen), dann wird angenommen, diese Datei liegt um aMule-Konfigurationsverzeichnis, I<~/.aMule>."
 
 # type: SH
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -273,7 +273,7 @@ msgstr "~/.aMule/*"
 # type: SH
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -284,7 +284,7 @@ msgstr "FEHLER MELDEN"
 # type: Plain text
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -294,7 +294,7 @@ msgstr "Bitte meldet Fehler entweder in unserem Forum (I<https://github.com/amul
 # type: SH
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -305,7 +305,7 @@ msgstr "COPYRIGHT"
 # type: Plain text
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -315,7 +315,7 @@ msgstr "aMule und alle seine zugehörigen Anwendungen werden unter der GNU Gener
 # type: SH
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -326,7 +326,7 @@ msgstr "SIEHE AUCH"
 # type: SH
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -335,7 +335,7 @@ msgid "AUTHOR"
 msgstr "VERFASSER"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -398,83 +398,83 @@ msgstr "B<amulecmd> ist ein Konsolenprogramm zur Steuerung von aMule."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>HostE<gt>>, B<--host>=I<E<lt>HostE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Der Rechner auf dem aMule läuft (Standard: I<127.0.0.1>).  I<E<lt>HostE<gt>> kann eine IP-Adresse oder ein DNS-Name sein."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>PortE<gt>>, B<--port>=I<E<lt>PortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "aMule's Port für Externe Verbindungen, wie in den Optionen unter-E<gt>Fernsteuerung (Standard: I<4712>) eingestellt."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>PasswortE<gt>>, B<--password>=I<E<lt>PasswortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "Passwort für Externe Verbindungen."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>PfadE<gt>>, B<--config-file>=I<E<lt>PfadE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Benutzt die angegebene Konfigurationsdatei. Die Standardkonfigurationsdatei ist I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "Keine Ausgabe auf stdout ausgeben."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "Sei gesprächig - Gebe auch Debuggingausgaben aus"
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>SpracheE<gt>>, B<--locale>=I<E<lt>SpracheE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Setzt die Lokale (Sprache) des Programms.  Siehe Abschnitt B<ANMERKUNGEN> für die Beschreibung des I<E<lt>SpracheE<gt>> Parameters."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "Schreibe die Kommandozeilenoptionen in die Konfigurationsdatei und kehre zur Shell zurück."
 
@@ -493,19 +493,19 @@ msgstr "Führe I<E<lt>BefehlE<gt>> aus, als wäre es auf amulecmd's Eingabeauffo
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>PfadE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Konfigurationsdatei basierend auf I<E<lt>PfadE<gt>>, welche auf eine gültige aMule Konfigurationsdatei verweisen muss, erstellen und danach beenden."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Erzwingt ZLIB Kompression der externen Verbindung, unabhängig von der Lokalität der gewählten IP. Nützlich, wenn der Server über einen VPN Tunnel erreichbar ist, der eine LAN IP ist, und die Heuristik sonst Kompression deaktivieren würde."
 
@@ -856,50 +856,50 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr "Zeigt den Verbindungsstatus, aktuelle Up/Downloadgeschindigkeiten, etc. an."
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "Sprachen"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Der I<E<lt>SpracheE<gt>> Parameter der B<-l> Option hat folgende Form: I<sprache>[B<_>I<SPRACHE>][B<.>I<kodierung>][B<@>I<modifikation>] wobei I<sprache> die eigentliche Sprache, I<SPRACHE> das Gebiet, I<kodierung> den zu nutzenden Zeichensatz und I<modifikation> eine bestimmte Untergruppe in diesem darstellt."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "Zum Besispiel sind die folgenden Zeichenketten gültig:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Alle oben genannten Zeicheketten werden als gültige Sprachdefinitionen akzeptiert, I<KODIERUNG> und I<zusatz> werden zur Zeit nicht genutzt."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Zusätzlich zu den obigen Formaten, kann man komplette englische Sprachbezeichnungen angeben - B<-l german> ist ebenfalls gültig und entspricht B<-l de_DE>."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Wenn keine Sprache definiert wurde, weder in der Kommandozeile noch in der Konfigurationsdatei, wird die Standardsprache des Systems verwendet."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 # type: SH
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "BEISPIEL"
@@ -918,7 +918,7 @@ msgstr "B<amulecmd> B<-h> I<hostname> B<-p> I<EC-Port> B<-P> I<EC-Passwort> B<-w
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "oder"
 
@@ -930,7 +930,7 @@ msgstr "B<amulecmd> B<--create-config-from>=I</home/Benutzer/.aMule/amule.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Dies speichert die Einstellungen in I<$HOME/.aMule/remote.conf>, und später tippst du nur noch:"
 
@@ -1122,186 +1122,191 @@ msgstr "[B<-A> I<E<lt>PasswortE<gt>>] [B<-G> I<E<lt>PasswortE<gt>>]"
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>PfadE<gt>>]"
 
+#. type: Plain text
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> ermöglicht dir den Zugriff auf amule(d) per Webbrowser. Man kann amuleweb zusammen mit B<amule>(1) starten lassen, oder ihn separat später starten. Optionen können auf der Kommandozeile oder in der Konfigurationsdatei angegeben werden. Kommandozeilenoptionen überschreiben die Werte aus der Konfigurationsdatei."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>NameE<gt>>, B<--template>=I<E<lt>NameE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Lädt die mit I<E<lt>NameE<gt>> spezifizierte Vorlage. Siehe auch Abschnitt B<SKIN UNTERSTÜTZUNG> für Details."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>PortE<gt>>, B<--server-port>=I<E<lt>PortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "HTTP Port des Webservers. Der Port der im Browser angegeben werden muss (Standard: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "Aktiviere UPnP."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>PortE<gt>>, B<--upnp-port>=I<E<lt>PortE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "UPnP Port."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Benutzt gzip Kompression für den HTTP Verkehr um Bandbreite zu sparen."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Schalten die gzip Kompression ab (Standard)"
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>PasswortE<gt>>, B<--admin-pass>=I<E<lt>PasswortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "Passwort für vollen Zugriff auf den Webserver"
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>PasswortE<gt>>, B<--guest-pass>=I<E<lt>PasswortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "Gäste Passwort für den Webserver"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "Erlaubt den Zugriff als Gast."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "Verbietet den Zugriff als Gast (Standard)"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Lade/Speichere Einstellungen vom/zum entfernen aMule. Dies bringt amuleweb dazu, die Kommandozeilen- und Konfigurationsdateieinstellungen zu ignorieren, und von aMule zu beziehen. Beim Speichern werden keine Einstellungen in die Konfigurationsdatei geschrieben, sondern zu aMule gesendet. (das funktioniert nur für Einstellungen in aMule's Einstellungen-E<gt>Fernsteuerung Dialog)"
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Deaktiviert den PHP Interpreter (veraltet)"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "Erstellt die PHP-Seiten bei jedem Aufruf neu."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>PfadE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Pfad zur aMule Konfigurationsdatei. B<NICHT DIREKT BENUTZEN!> aMule benutzt dies zum starten von amuleweb wenn aMule startet. Diese Option sorgt dafür, das alle anderen Parameter ignoriert werden, und nur aus der angegeben Datei gelesen werden, und impliziert auch die B<-q -L> Optionen."
 
 # type: SH
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SKIN UNTERSTÜTZUNG"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> ist in der Lage Informationen mit unterschiedlichen Skins anzuzeigen.  Diese Skins werden Templates genannt, und due kannst über die Kommandozeilenoption B<-t> angeben welches geladen werden soll.  Templates werden in 2 verschiedenen Orten gesucht: zuerst in I<~/.aMule/webserver/> und dann in I</usr/share/amule/webserver/> wenn du mit --prefix=/usr installiert hast."
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Jedes Template muss in einem Unterverzeichnis des Templatenamens liegen, welches alle Dateien enthält, die das Template benötigt."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "Typischerweise wird amuleweb als erstes folgendermaßen gestartet:"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<hostname> B<-p> I<EC-Port> B<-P> I<EC-Passwort> B<-s> I<HTTP-Port> B<-A> I<Admin-Passwort> B<-w>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Natürlich kann man zusätzliche Optionen angeben und einzelne auch beim ersten Start weglassen, oder es komplett anders machen."
 

--- a/docs/man/po/manpages-es.po
+++ b/docs/man/po/manpages-es.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:29+0000\n"
 "Last-Translator: Mad-Soft <mad.soft@gmail.com>\n"
 "Language-Team: Spanish <es_ES@li.org>\n"
@@ -166,13 +166,13 @@ msgstr "Fijar categoría para enlace eD2k pasado a I<E<lt>numE<gt>>"
 
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "Mostrar el número de la versión actual."
 
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -215,24 +215,24 @@ msgid "a magnet link."
 msgstr "un enlace magnet."
 
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTAS"
 
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "Rutas"
 
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Todas las opciones que tengan I<E<lt>pathE<gt>> como valor, si I<path> no contiene una ruta de directorios (p.e. sólo un archivo normal), entones se usará el directorio de la configuración, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -245,7 +245,7 @@ msgstr "~/.aMule/*"
 
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -255,7 +255,7 @@ msgstr "INFORMANDO ERRORES"
 
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -264,7 +264,7 @@ msgstr "Por favor informe de fallos ya sea en nuestro foro (I<https://github.com
 
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -274,7 +274,7 @@ msgstr "COPYRIGHT"
 
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -283,7 +283,7 @@ msgstr "aMule y todas las demás utilidades relacionadas son distribuidas bajo l
 
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -293,7 +293,7 @@ msgstr "VÉASE TAMBIÉN"
 
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -302,7 +302,7 @@ msgid "AUTHOR"
 msgstr "AUTOR"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -357,72 +357,72 @@ msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> es un cliente basado en consola para controlar aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Host donde se está ejecutando aMule (por defecto: I<127.0.0.1>).  I<E<lt>hostE<gt>> debe ser o una dirección IP o un nombre DNS"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Puerto de conexión externa de aMule, puesto en Opciones-E<gt>Controles Remotos (por defecto: 4712)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "Contraseña de conexiones externas."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Usar la configuración dada por el archivo. El archivo de configuración por defecto es I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "No mostrar ninguna salida en stdout."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "Modo detallado - muestra también los mensajes de depuración."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Selecciona el idioma del programa. Ver la sección B<NOTAS> para la descripción del parámetro del I<E<lt>langE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "Escribe opciones de la línea de comando al archivo de configuración y termina"
 
@@ -438,18 +438,18 @@ msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt an
 msgstr "Ejecuta I<E<lt>commandE<gt>> como si se hubiera introducido en el prompt en amulecmd, y termina."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Crear archivo de configuración basado en I<E<lt>pathE<gt>>, el cual debe apuntar a un archivo de configuración válido, y entonces termina."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Forzar la compresión ZLIB en el protocolo de Conexiones Externas aunque se esté conectando a una IP local/LAN. Esto es útil cuando la conexión al servidor se realiza a través de un túnel VPN que se resuelve a una IP de LAN, lo que por defecto desactivaría la compresión."
 
@@ -750,43 +750,43 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr "Muestra el estado de la conexión, la velocidad de subida/descarga actual, etc."
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "Lenguajes"
 
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "El parámetro I<E<lt>langE<gt>> para la opción B<-l> tiene esta forma: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] donde I<lang> es el lenguaje primario, I<LANG> es un sublenguaje/territorio, I<encoding> es el conjunto de caracteres a usar y I<modifier> permite al usuario elegir una instancia específica de localización dentro de una única categoría."
 
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "Por ejemplo, las siguientes cadenas son válidas:"
 
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Aunque todas las cadenas previas son aceptadas como definiciones de lenguaje válidas, I<encoding> y I<modifier> aún no se usan."
 
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Además del formato previo, también se pueden especificar el nombre completo del idioma en inglés, por lo que B<-l german> es válido y equivale a B<-l de_DE>."
 
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Cuando no se define ninguna localización, ni por línea de comandos ni en fichero de configuración, se usará el lenguaje por defecto del sistema."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "EJEMPLO"
@@ -802,7 +802,7 @@ msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "o"
 
@@ -812,7 +812,7 @@ msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/usuario/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Esto guardará las opciones en I<$HOME/.aMule/remote.conf>, y después sólo tiene que escribir:"
 
@@ -982,159 +982,164 @@ msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
+#. type: Plain text
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> gestiona una sesión de amule a través del navegador web.  Puede iniciar amuleweb junto a B<amule>(1), o por separado en cualquier momento posterior.  Las opciones se pueden especificar en la línea de comando o en un fichero de configuración.  Las opciones de línea de comandos tienen prioridad sobre las del fichero de configuración."
 
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Carga la plantilla llamada I<E<lt>nameE<gt>>. Consulte la sección B<SKIN SUPPORT> para más detalles."
 
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Puerto HTTP del servidor web. Éste es el puerto al que debe apuntar su navegador (por defecto: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "Habilitar UPnP."
 
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "Puerto UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Activar compresión gzip para ahorrar tráfico HTTP."
 
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Deshabilitar la compresión gzip (esto es por defecto)."
 
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "Contraseña de acceso completo al servidor web."
 
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "Contraseña de invitado al servidor web."
 
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "Permitir acceso invitado."
 
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "Deniega el acceso invitado (por defecto)."
 
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Cargar/Guardar del aMule remoto la configuración del servidor web.  Esto hace que amuleweb ignore la configuración de la línea de comandos o del fichero de config, y que la cargue directamente de aMule.  Al guardarla, no se escribirá nada en el fichero de configuración, sino en aMule.  (Por supuesto, esto sólo funciona para los parámetros que pueden configurarse en las Preferencias de aMule-E<gt>Controles Remotos.)"
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Deshabilitar el intérprete PHP (obsoleto)"
 
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "Recompilar páginas PHP en cada solicitud."
 
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Ruta al fichero de configuración de aMule.  B<¡NO USAR DIRECTAMENTE!> aMule usa esta opción al arrancar amuleweb durante el arranque de aMule.  Esta opción hace que cualquier otra configuración de la línea de comandos o del fichero de configuración sea ignorada, y que las preferencias se lean del fichero especificado. También implica las opciones B<-q -L>."
 
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SOPORTE TEMAS"
 
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> es capaz de usar diferentes skins para mostrar información.  Estos skins se llaman plantillas, y puede cargarse una plantilla específica usando la opción B<-t> de la línea de comandos.  Las plantillas se buscan en dos ubicaciones: primero en I<~/.aMule/webserver/> y luego en I</usr/share/amule/webserver/> si se instaló con la opción --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Cada plantilla debe estar en un subdirectorio con el nombre de la plantilla, y este directorio debe contener todo los ficheros que la plantilla necesita."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "Normalmente amuleweb se ejecutará primero como:"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/usuario/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Por supuesto, puede especificar las opciones en el ejemplo de la primera línea, y también puede omitirlo."
 

--- a/docs/man/po/manpages-fr.po
+++ b/docs/man/po/manpages-fr.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:29+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -167,13 +167,13 @@ msgstr "Définir la catégorie pour les liens eD2k passé à I<E<lt>numE<gt>>"
 
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "Affiche le numéro de la version actuelle."
 
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -216,24 +216,24 @@ msgid "a magnet link."
 msgstr "un lien magnet."
 
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTES"
 
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "Chemins"
 
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Pour toutes les options prenant en paramètre un I<E<lt>cheminE<gt>>, si le I<chemin> ne contient pas de répertoire (c'est-à-dire juste un nom de fichier), alors il sera considéré comme étant dans le répertoire de configuration d'aMule, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -246,7 +246,7 @@ msgstr "~/.aMule/*"
 
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -256,7 +256,7 @@ msgstr "RAPPORTER DES BOGUES"
 
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -265,7 +265,7 @@ msgstr "Veuillez rapporter les bogues sur notre forum (I<https://github.com/amul
 
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -275,7 +275,7 @@ msgstr "COPYRIGHT"
 
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -284,7 +284,7 @@ msgstr "aMule et tous ses outils sont distribués sous la Licence publique gén�
 
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -294,7 +294,7 @@ msgstr "VOIR ÉGALEMENT"
 
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -303,7 +303,7 @@ msgid "AUTHOR"
 msgstr "AUTEUR"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -358,72 +358,72 @@ msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> est un client en mode texte pour contrôler aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>hôteE<gt>>, B<--host>=I<E<lt>hôteE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Hôte où aMule fonctionne (par défaut : I<127.0.0.1>).  I<E<lt>hôteE<gt>> peut être une adresse IP ou un nom DNS."
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Port d'aMule pour les Connexions Externes, tel que défini dans Préférences-E<gt>Contrôles à Distance (par défaut: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>motdepasseE<gt>>, B<--password>=I<E<lt>motdepasseE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "Mot de passe des connexions externes."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>cheminE<gt>>, B<--config-file>=I<E<lt>cheminE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Utiliser le fichier de configuration désigné.  Le fichier de configuration par défaut est I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "Ne pas afficher de sortie sur stdout."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "Mode bavard - afficher aussi les messages de débogage."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Définit les paramètres régionaux (langue). Voir la section B<NOTES> pour la description du paramètre I<E<lt>langE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "Écrire les options de la ligne de commande sur le fichier de configuration et quitter"
 
@@ -439,18 +439,18 @@ msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt an
 msgstr "Exécuter la I<E<lt>commandeE<gt>> comme si elle avait été entrée dans l'invite de commande d'amulecmd et quitter."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>cheminE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Créer un fichier de configuration basé sur I<E<lt>cheminE<gt>>, qui doit pointer sur un fichier de configuration d'aMule valide, et quitter ensuite."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Forcer la compression ZLIB sur le lien Connexion Externe quelle que soit l'adresse IP de destination.  Utile lorsque le serveur est accessible via un tunnel VPN qui se résout en une adresse IP du réseau local et que l'heuristique ignorerait autrement la compression."
 
@@ -751,43 +751,43 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr "Afficher l'état de la connexion, et la vitesse actuelle d'émission/réception, etc."
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "Langues"
 
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Le paramètre I<E<lt>langE<gt>> pour B<-l> l'option a la forme suivante : I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] où I<lang> est la langue principale, I<LANG> est le dialecte, I<encoding> est le jeu de caractères défini à utiliser et I<modifier> permet à l'utilisateur de sélectionner une instance spécifique des données de localisation dans une seule catégorie."
 
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "Par exemple, les chaînes de caractères suivantes sont valables :"
 
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Bien que toutes les chaînes ci-dessus soient acceptées comme des définitions de langue valide,  I<encoding> et I<modifier> ne sont pas encore utilisés."
 
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "En plus du format ci-dessus, vous pouvez également spécifier des noms entiers de langue en anglais - ainsi B<-l german> est également valide et équivaut à B<-l de_DE>."
 
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "En l'absence de paramètres linguistiques définis, soit sur ​​la ligne de commande ou sur le fichier de configuration, la langue utilisée par défaut sera celle du système d'exploitation."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "EXEMPLE"
@@ -803,7 +803,7 @@ msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<nom de l'hôte> B<-p> I<port EC> B<-P> I<mot de passe EC> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "ou"
 
@@ -813,7 +813,7 @@ msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Cela sauvegardera les options dans I<$HOME/.aMule/remote.conf>, et il suffira de taper plus tard :"
 
@@ -983,159 +983,164 @@ msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>cheminE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
+#. type: Plain text
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> gère votre accès à amule via un navigateur Web.  Vous pouvez démarrer ensemble amuleweb et B<amule>(1), ou séparément, à un moment ultérieur.  Les options peuvent être spécifiées par ligne de commande ou via fichier de configuration. Les options passées en ligne de commande prévalent sur les options de fichier de configuration."
 
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomE<gt>>, B<--template>=I<E<lt>nomE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Charge le modèle nommé I<E<lt>nomE<gt>>. Voir la section B<SKIN SUPPORT> pour plus de détails."
 
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Port HTTP du serveur Web. Il s'agit du port vers lequel votre navigateur doit pointer (par défaut : I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "Activer UPnP."
 
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "Port UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Activer la compression gzip pour le trafic HTTP pour économiser la bande passante."
 
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Désactive la compression gzip (c'est le réglage par défaut)."
 
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>motdepasseE<gt>>, B<--admin-pass>=I<E<lt>motdepasseE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "Mot de passe d'accès total pour le serveur web."
 
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>motdepasseE<gt>>, B<--guest-pass>=I<E<lt>motdepasseE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "Mot de passe invité pour le serveur web."
 
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "Autoriser l'accès invité."
 
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "Interdit l'accès invité (par défaut)."
 
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Charger/enregistrer les paramètres de serveur web à partir de/vers l'aMule distant.  amuleweb ignorera la ligne de commande et les paramètres de fichier de configuration, et les chargera à partir aMule. Lors de la sauvegarde, aucune préférence ne sera écrite sur le fichier de configuration, mais sur aMule.  (Bien sûr, cela ne fonctionne que pour les paramètres qui peuvent être définis dans les préférences de -E<gt>Contrôle à distance d'aMule.)"
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Désactiver l'interpréteur PHP (obsolète)"
 
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "Recompile les pages PHP à chaque requête."
 
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>cheminE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Chemin du fichier de configuration d'aMule.  B<NE PAS UTILISER DIRECTEMENT !> aMule utilise cette option lors du démarrage d'amuleweb au démarrage d'aMule.  Cette option permet d'ignorer toutes les autres options de ligne de commande et les paramètres de fichier de configuration, et lit les préférences depuis le fichier de configuration précisé, et implique également les options B<-q -L>."
 
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "PRISE EN CHARGE DES THÈMES"
 
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> est capable d'afficher des informations dans différents thèmes.  Ces thèmes sont appelés modèles, et vous pouvez faire de charger à amuleweb un modèle spécifique via l'option en ligne de commande B<-t>.  Les modèles sont recherchés dans deux endroits : d'abord dans : I<~/.aMule/webserver/> puis dans I</usr/share/amule/webserver/> si vous l'avez installé avec --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Chaque modèle doit être dans un sous répertoire du nom du modèle, et ce répertoire doit contenir tous les fichiers dont le modèle a besoin."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "Typiquement amuleweb sera lancée la première fois ainsi :"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<nom de l'hôte> B<-p> I<port EC> B<-P> I<mot de passe EC> B<-s> I<port HTTP> B<-A> I<mot de passe Admin> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Bien sûr, vous pouvez spécifier plus ou moins d'options sur la première ligne d'exemple, et vous pouvez également totalement le supprimer."
 

--- a/docs/man/po/manpages-hu.po
+++ b/docs/man/po/manpages-hu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: po 4a\n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:29+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: none\n"
@@ -163,13 +163,13 @@ msgstr "A megadott eD2k hivatkozást a I<E<lt>számE<gt>>-adik kategóriába tö
 
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "Megjeleníti a verziószámot."
 
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -212,24 +212,24 @@ msgid "a magnet link."
 msgstr "egy magnet hivatkozás."
 
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "MEGJEGYZÉSEK"
 
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "Elérési utak"
 
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Minden olyan opciónál amely I<E<lt>fájlE<gt>> paramétert kér, ha a megadott I<fájl> nem tartalmaz könyvtár komponenst (vagyis tisztán csak egy fájlnév), akkor azt az aMule konfigurációs könyvtárában (I<~/.aMule>) fogja keresni."
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -242,7 +242,7 @@ msgstr "~/.aMule/*"
 
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -252,7 +252,7 @@ msgstr "HIBÁK JELENTÉSE"
 
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -261,7 +261,7 @@ msgstr "A hibákat kérjük vagy a fórumon (I<https://github.com/amule-org/amul
 
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -271,7 +271,7 @@ msgstr "COPYRIGHT"
 
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -280,7 +280,7 @@ msgstr "Az aMule és az összes hozzá tartozó segédprogram a GNU General Publ
 
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -290,7 +290,7 @@ msgstr "LÁSD MÉG"
 
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -299,7 +299,7 @@ msgid "AUTHOR"
 msgstr "SZERZŐ"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -354,72 +354,72 @@ msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "Az amulecmd egy szöveges program az aMule vezérlésére."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>gépE<gt>>, B<--host>=I<E<lt>gépE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "A gép, amelyen az aMule fut (alapértelmezés: I<127.0.0.1>). A I<E<lt>gépE<gt>> lehet egy IP cím vagy egy DNS név."
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Az aMule távoli elérés portja, amint az a Beállítások-E<gt>Távoli Elérés panelen beállítható (alapértelemzés: I<4712>)."
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>jelszóE<gt>>, B<--password>=I<E<lt>jelszóE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "A távoli elérés jelszava."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>fájlE<gt>>, B<--config-file>=I<E<lt>fájlE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "A megadott konfigurációs fájl használata. Az alapértelmezett konfigurációs fájl: I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "Ne írjon semmit a szabvány kimenetre."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "Bőbeszédű mód - a hibakeresési üzenetek megjelenítése."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>nyelvE<gt>>, B<--locale>=I<E<lt>nyelvE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Beállítja a program nyelvét. Lásd a B<MEGJEGYZÉSEK> fejezetet a I<E<lt>nyelvE<gt>> paraméter bővebb leírásához."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "A parancssori paramétereket beírja a konfigurációs fájlba és kilép."
 
@@ -435,18 +435,18 @@ msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt an
 msgstr "Végrehajtja a megadott parancsot, mintha azt a saját parancssorába írtuk volna be, majd kilép."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>fájlE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Konfigurációs fájl készítése a I<E<lt>fájlE<gt>> alapján, amely az aMule érvényes konfigurációs fájlja kell legyen, majd utána kilép."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
@@ -751,43 +751,43 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr "Megjeleníti a kapcsolat állapotát, pillanatnyi fel-/letöltési sebességet, stb."
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "Nyelvek"
 
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "A B<-l> opció I<E<lt>nyelvE<gt>> paramétere a következőképpen adható meg: I<nyelv>[B<_>I<TERÜLET>][B<.>I<kódolás>][B<@>I<módosító>], ahol I<nyelv> az elsődleges nyelv, I<TERÜLET> egy nyelvváltozat/terület kódja, I<kódolás> a karakterkészlet kódja és a I<módosító> \\(Bqlehetővé teszi, hogy a felhasználó kiválasszon egy meghatározott esetet a helyi jellemzők adataiból egyetlen kategórián belül\\(rq."
 
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "Például a következő értékek mind érvényesek:"
 
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Habár a fentieket mind elfogadja a program, mint érvényes nyelvmeghatározást, a I<kódolás> és I<módosító> még nem használt."
 
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Ráadásként a fenti formátumhoz, megadható akár egy nyelv teljes angol megnevezése is, így például a B<-l german> szintén érvényes és egyenértékű a B<-l de_DE> megadással."
 
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Ha sem a konfigurációs fájlban, sem a parancssorban nincs megadva a nyelv, akkor a rendszer alapértelmezett nyelvét fogja használni."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "PÉLDA"
@@ -803,7 +803,7 @@ msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<gépnév> B<-p> I<EC-port> B<-P> I<EC-jelszó> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "vagy"
 
@@ -813,7 +813,7 @@ msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/felhasználónév/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Ez elmenti a beállításokat a I<$HOME/.aMule/remote.conf> fájlba, hogy később már csak ezt kelljen írni:"
 
@@ -984,160 +984,165 @@ msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>fájlE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
+#. type: Plain text
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "Az B<amuleweb> programmal egy web-böngésző segítségével vezérelhetjük az amule(d)-t. Az amuleweb-et az B<amule>(1)-vel együtt is lehet indítani, vagy külön, kézzel. A beállításait konfigurációs fájlban vagy parancssorban is megadhatjuk. A parancssori opciók elsőbbséget élveznek a konfigurácós fájlban találtakkal szemben."
 
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>sablonE<gt>>, B<--template>=I<E<lt>sablonE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Betölti a I<E<lt>névE<gt>> nevű sablont. Bővebb részletekért lásd a B<SABLONOK> fejezetet."
 
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Web kiszolgáló HTTP port. Erre a portra kell irányítanod a böngésződet (alapértelmezés: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "UPnP engedélyezése."
 
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, fuzzy, no-wrap
 #| msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "UPnP port."
 
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Engedélyezi a gzip tömörítést a HTTP adatátvitelnél a sávszélesség jobb kihasználása érdekében."
 
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "gzip tömörítés tiltása (alapértelmezett)."
 
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>jelszóE<gt>>, B<--admin-pass>=I<E<lt>jelszóE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "Teljes hozzáférésű jelszó a web kiszolgálóhoz."
 
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>jelszóE<gt>>, B<--guest-pass>=I<E<lt>jelszóE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "Web kiszolgáló vendég felhasználó jelszava."
 
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "Vendég felhasználó engedélyezése."
 
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "Vendég felhasználó tiltása (alapértelmezett)."
 
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Beállítások töltése/mentése a távoli aMule-ról/ra. Ebben az esetben az amuleweb figyelmen kívül hagyja azokat a parancssori és konfigurációs fájlbeli beállításokat, amelyeket az aMule-tól is be tud szerezni (ezek beállíthatók a Beállítások-E<gt>Távoli Elérés pontban). A beállítások mentésekor sem írja azokat fájlba (mint egyébként), hanem az aMule-t értesíti a beállítások megváltozásáról. Azon beállítások, melyek az aMule Beállítások párbeszédpaneljén nem szerepelnek, nem kerülnek mentésre."
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHP értelmező letiltása (elavult, ne használd)"
 
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "PHP oldalak újrafordítása minden kérésnél."
 
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>fájlE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "aMule konfigurációs fájl. B<NE HASZNÁLD!> Az aMule használja ezt a paramétert amikor automatikusan indítja az amuleweb-et. Ezen paraméter hatására minden más parancssori és konfigurációs fájl-béli beállítást figyelmen kívül hagy, a beállításait a megadott I<E<lt>fájlE<gt>>-ból olvassa, illetve bekapcsolja a B<-q -L> opciókat."
 
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SABLONOK"
 
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "Az B<amuleweb> képes az információ különböző felületekkel történő megjelenítésére. Ezeket hívjuk sablonoknak, és az amuleweb a B<-t> parancssori opcióval vehető rá egy adott sablon használatára. A sablonokat a következő helyeken keresi: először a I<~/.aMule/webserver/> könyvtárban, majd utána a I</usr/share/amule/webserver/> könyvtárban."
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Minden sablonnak a sablon nevével megegyező alkönyvtárban kell lennie, és ez a könyvtár kell tartalmazzon minden fájlt, amelyre a sablonnak szüksége van."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "Tipikusan az amuleweb-et először a következőképpen indítjuk:"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<gépnév> B<-p> I<EC-port> B<-P> I<EC-jelszó> B<-s> I<HTTP-port> B<-A> I<admin-jelszó> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/felhasználónév/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Természetesen más paraméterek is megadhatók az első példában, illetve teljesen el is hagyhatóak."
 

--- a/docs/man/po/manpages-it.po
+++ b/docs/man/po/manpages-it.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule SVN\n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: none\n"
@@ -188,14 +188,14 @@ msgstr "Imposta la categoria per i collegamenti eD2k ricevuti a I<E<lt>numeroE<g
 # type: Plain text
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "Visualizza il numero di versione corrente."
 
 # type: Plain text
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -246,27 +246,27 @@ msgstr "un collegamento magnet."
 
 # type: SH
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTE"
 
 # type: SS
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "Percorsi"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Per tutte le opzioni che accettano un I<E<lt>percorsoE<gt>>, se il I<percorso> non contiene una directory (ossia è solo un nome di file), allora si assume che esso sia presente nella directory di configurazione di aMule, I<~/.aMule>."
 
 # type: SH
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -281,7 +281,7 @@ msgstr "~/.aMule/*"
 # type: SH
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -292,7 +292,7 @@ msgstr "SEGNALARE I BUG"
 # type: Plain text
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -302,7 +302,7 @@ msgstr "Per favore segnalare i bug nel nostro forum (I<https://github.com/amule-
 # type: SH
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -313,7 +313,7 @@ msgstr "COPYRIGHT"
 # type: Plain text
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -323,7 +323,7 @@ msgstr "aMule e tutti i programmi di utilità correlati sono distribuiti in acco
 # type: SH
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -334,7 +334,7 @@ msgstr "VEDI ANCHE"
 # type: SH
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -344,7 +344,7 @@ msgstr "AUTORE"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -408,84 +408,84 @@ msgstr "B<amulecmd> è un client in console per controllare aMule."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Computer dove è in esecuzione aMule (default: I<127.0.0.1>). I<E<lt>hostE<gt>> può essere un indirizzo IP o un nome DNS"
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portaE<gt>>, B<--port>=I<E<lt>portaE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "porta di aMule per le connessioni esterne, come impostata nelle preferenze-E<gt>controllo remoto (default: I<4712>)"
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "Password delle connessioni esterne."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>percorsoE<gt>>, B<--config-file>=I<E<lt>percorsoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Usa il file di configurazione fornito. Il file di configurazione di default è I<~/.aMule/remote.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "Non scrivere nulla nello stdout."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "Mostra anche i messaggi di debug."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>linguaggioE<gt>>, B<--locale>=I<E<lt>linguaggioE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Imposta il linguaggio del programma. Vedi anche la sezione delle B<NOTE> per la descrizione del parametro I<E<lt>linguaggioE<gt>> ."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "Scrive le opzioni della riga di comando nel file di configurazione ed esce"
 
@@ -504,19 +504,19 @@ msgstr "Esegue il I<E<lt>comandoE<gt>> come se fosse stato immesso nel prompt di
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>percorsoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Crea un file di configurazione basandosi sul I<E<lt>percorsoE<gt>>, che deve puntare ad un file di configurazione di aMule valido, e quindi esce."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Forza la compressione ZLIB sulla connessione esterna indipendentemente dalla località dell'IP contattato.  Utile quando il server è raggiungibile attraverso un tunnel VPN che risolve a un IP di LAN e l'euristica salterebbe altrimenti la compressione."
 
@@ -877,50 +877,50 @@ msgstr "Mostra lo stato della connessione, le velocità correnti di up/download,
 
 # type: SS
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "Linguaggi"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Il parametro I<E<lt>linguaggioE<gt>> per l'opzione B<-l> ha la forma seguente: I<linguaggio>[B<_>I<LINGUAGGIO>][B<.>I<codifica>][B<@>I<modificatore>] dove I<linguaggio> è il linguaggio primario, I<LINGUAGGIO> è il sottotipo/territorio, I<codifica> è l'insieme di caratteri usato e I<modificatore> consente all'utente di selezionare una specifica istanza dei dati di localizzazione all'interno di una singola categoria."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "Per esempio, le stringhe seguenti sono valide:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Sebbene tutte le stringhe sopra elencate sono accettate come definizioni di linguaggio valide, I<codifica> e I<modificatore> sono ancora inutilizzati."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "In aggiunta al formato di cui sopra, si può anche specificare il nome completo del linguaggio in inglese, e quindi B<-l german> è valido ed equivalente a B<-l de_DE>."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Quando nessun linguaggio è definito in riga di comando o nel file di configurazione, verrà usato il linguaggio di default del sistema."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 # type: SH
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "ESEMPIO"
@@ -939,7 +939,7 @@ msgstr "B<amulecmd> B<-h> I<nomehost> B<-p> I<portaEC> B<-P> I<passwordEC> B<-w>
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "o"
 
@@ -951,7 +951,7 @@ msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "In questo modo la configurazione verrà salvata in I<$HOME/.aMule/remote.conf>, e le volte successive si dovrà solo digitare:"
 
@@ -1149,190 +1149,195 @@ msgstr "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>percorsoE<gt>>]"
 
+#. type: Plain text
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> gestisce l'accesso ad amule attraverso un browser web.  Si può eseguire amuleweb insieme ad B<amule>(1), o separatamente in qualunque momento successivo. Le opzioni possono essere specificate in riga di comando o nel file di configurazione. Le opzioni in riga di comando hanno la precedenza su quelle nel file di configurazione."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomeE<gt>>, B<--template>=I<E<lt>nomeE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Carica il modello chiamato I<E<lt>nomeE<gt>>. Vedi la sezione B<SUPPORTO AGLI SKIN> per i dettagli."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portaE<gt>>, B<--server-port>=I<E<lt>portaE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Porta HTTP del server web. Questa è la porta da indicare nel browser (default: I<4711>)."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "Abilita il supporto UPnP."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portaE<gt>>, B<--upnp-port>=I<E<lt>portaE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "Porta per l'UPnP."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Abilita la compressione gzip nel traffico HTTP per risparmiare banda."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Disabilita la compressione gzip (questo è il default)."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>passwordE<gt>>, B<--admin-pass>=I<E<lt>passwordE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "Password per l'accesso completo al web server."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>passwordE<gt>>, B<--guest-pass>=I<E<lt>passwordE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "Password for l'accesso ospite al web server."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "Permette l'accesso ospite."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "Nega l'accesso ospite (default)."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Carica/salva le configurazioni del webserver da/verso aMule remoto. amuleweb ignorerà le opzioni in linea di comando e nel file di configurazione, e le caricherà invece da aMule. Quando si salveranno le preferenze, niente verrà scritto nel file di configurazione, ma in aMule. (Ovviamente, questo funzionerà solo per quelle impostazioni che possono essere scritte nelle preferenze di aMule-E<gt>controllo remoto.)"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Disabilita l'interprete PHP (deprecato)"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "Ricompila le pagine PHP ad ogni richiesta."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>percorsoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "percorso del file di configurazione di aMule. B<NON USARE DIRETTAMENTE!> aMule usa questa opzione quando lancia amuleweb all'avvio di aMule. Questa opzione fa sì che tutte le altre impostazioni in riga di comando e nel file di configurazione vengano ignorate, le preferenze vengano lette dal file di configurazione dato, e anche implica le opzioni B<-q -L> ."
 
 # type: SH
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SUPPORTO AGLI SKIN"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> può visualizzare l'informazione utilizzando diversi 'skin'. Questi 'skin' sono contenuti in dei modelli, e si può far caricare da amuleweb un dato modello tramite l'opzione B<-t> in riga di comando. I modelli sono cercati in due posti: prima in I<~/.aMule/webserver/> e quindi in I</usr/share/amule/webserver/> se aMule è stato installato con --prefix=/usr."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Ogni modello deve essere in una sottodirectory del nome di modello, e questa directory deve contenere tutti i file necessari al modello."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "Di norma amuleweb sarà inizialmente eseguito con:"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<nomehost> B<-p> I<ECporta> B<-P> I<passwordEC> B<-s> I<portaHTTP> B<-A> I<PasswordAmministrazione> B<-w>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Ovviamente, si possono specificare più o meno opzioni della prima riga di esempio, e si si possono anche omettere completamente."
 

--- a/docs/man/po/manpages-pt_BR.po
+++ b/docs/man/po/manpages-pt_BR.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule man pages\n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: Marcelo Roberto Jimenez <mroberto@users.sourceforge.net>\n"
@@ -164,13 +164,13 @@ msgstr "Seta categoria para links eD2k para I<E<lt>numE<gt>>"
 
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "Mostra o número de versão atual."
 
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -213,24 +213,24 @@ msgid "a magnet link."
 msgstr "um link magnético."
 
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTAS"
 
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "Caminhos"
 
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Para todas as opções que recebem um valor I<E<lt>pathE<gt>>, se o I<path> não contém uma parte de diretório (i.e. apenas o nome de arquivo), então é considerado estar debaixo do diretório de configuração do aMule, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -243,7 +243,7 @@ msgstr "~/.aMule/*"
 
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -253,7 +253,7 @@ msgstr "RELATANDO BUGS"
 
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -262,7 +262,7 @@ msgstr "Por favor, relate bugs ou em nosso forum (I<https://github.com/amule-org
 
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -272,7 +272,7 @@ msgstr "DIREITOS DE CÓPIA"
 
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -281,7 +281,7 @@ msgstr "aMule e todos os seus utilitários relacionados são distribuídos sob a
 
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -291,7 +291,7 @@ msgstr "VEJA TAMBÉM"
 
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -300,7 +300,7 @@ msgid "AUTHOR"
 msgstr "AUTOR"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -355,72 +355,72 @@ msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> é um cliente de console para controlar o aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>anfitriãoE<gt>>, B<--host>=I<E<lt>anfitriãoE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Anfitrião onde o aMule está rodando (padrão: I<127.0.0.1>).  I<E<lt>anfitriãoE<gt>> pode ser um endereço IP ou um nome de DNS"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portaE<gt>>, B<--port>=I<E<lt>portaE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Porta do aMule para conexões externas, conforme configurado em Preferências-E<gt>Controles Remotos (padrão: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>senhaE<gt>>, B<--password>=I<E<lt>senhaE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "Senha das Conexões Externas."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>caminhoE<gt>>, B<--config-file>=I<E<lt>caminhoE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Use o arquivo de configuração dado. O arquivo de configuração padrão é I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "Não imprima mensagens em stdout."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "Seja verborrágico - mostre até as mensagens de debug."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>línguaE<gt>>, B<--locale>=I<E<lt>línguaE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Configura o local do programa (linguagem). Veja a seção B<NOTAS> para a descrição do parâmetro I<E<lt>langE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "Escrever as opções da linha de comando para o arquivo de configuração e sair"
 
@@ -436,18 +436,18 @@ msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt an
 msgstr "Executar I<E<lt>commandE<gt>> como se fosse digitado no prompt do amulecmd e sair."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>caminhoE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Criar arquivo de configuração baseado em I<E<lt>pathE<gt>>, que precisa apontar para um arquivo válido de configuração do aMule, e então sair."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Força compressão ZLIB no link de Conexões Externas independente da localidade IP-discada. Útil quando o lado do servidor for alcançável com um túnel VPN que resolve para um IP de LAN e a heurística iria pular a compressão."
 
@@ -748,43 +748,43 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr "Mostrar o estado das conexões, velocidades atuais de upload/download, etc."
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "Línguas"
 
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "O parâmetro I<E<lt>langE<gt>> da opção B<-l> tem a seguinte forma: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] onde I<lang> é a linguagem principal, I<LANG> é a sub-lingua/território, I<encoding> é o conjunto de caracteres a ser utilizado e I<modifier> permite ao usuário selecionar uma instância específica dos dados de localização dentro de uma única categoria."
 
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "Por exemplo, as seguintes strings são válidas:"
 
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Apesar de todas as strings acima serem aceitas como definições de línguas válidas, I<encoding> e I<modifier> não são utilizados ainda."
 
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Além do formato acima, você pode também especificar nomes completos de linguagens em Inglês - deste modo B<-l german> também é válido e é igual a B<-l de_DE>."
 
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Quando nenhum local está definido, seja na linha de comando ou no arquivo de configuração, a linguagem padrão do sistema será utilizada."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "EXEMPLO"
@@ -800,7 +800,7 @@ msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<nome do anfitrião> B<-p> I<porta EC> B<-P> I<senha EC> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "ou"
 
@@ -810,7 +810,7 @@ msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Estes savarão as configurações em I<$HOME/.aMule/remote.conf>, e posteriormente você só precisa digitar:"
 
@@ -980,159 +980,164 @@ msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>caminhoE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
+#. type: Plain text
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> gerencia seu acesso ao aMule através de um navegador web. Você pode iniciar o amuleweb junto com o B<amule>(1), ou separadamente, a qualquer momento depois. As opções podem ser especificadas via linha de comando ou via arquivo de configuração. Opções de linha de comando têm precedência sobre opções de arquivo de configuração."
 
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomeE<gt>>, B<--template>=I<E<lt>nomeE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Carrega o template chamado I<E<lt>nomeE<gt>>. Veja a seção B<SKIN SUPPORT> para detalhes."
 
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portaE<gt>>, B<--server-port>=I<E<lt>portaE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Porta HTTP do servidor web. Esta é a porta para a qual você precisa apontar seu navegador web (padrão: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "Habilita UPnP."
 
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portaE<gt>>, B<--upnp-port> I<E<lt>portaE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "Porta UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Habilita o uso de compressão gzip em tráfego HTTP para poupar largura de banda."
 
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Desabilita o uso de compressão gzip (este é o padrão)."
 
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>senhaE<gt>>, B<--admin-pass>=I<E<lt>senhaE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "Senha de acesso total para o servidor web."
 
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>senhaE<gt>>, B<--guest-pass>=I<E<lt>senhaE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "Senha do convidado para o servidor web."
 
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "Permite acesso do convidado."
 
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "Nega acesso ao convidado (padrão)."
 
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Carrega/salva a configuração do servidor web de/para o aMule remoto. Isto faz com que o amuleweb ignore configurações de linha de comando e de arquivo de configuração, e as carrega do aMule. Quando estiver salvando as preferências, nenhuma será escrita no arquivo de configuração, e sim para o aMule. (Claro que isto funciona apenas para as configurações que podem ser configuradas nas Preferências-E<gt>Controles Remotos do aMule.)"
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Desabilitar o interpretador PHP (obsoleto)"
 
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "Recompila as páginas PHP a cada pedido."
 
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>caminhoE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Caminho do arquivo de configuração do aMule.  B<NÃO USE DIRETAMENTE!> aMule usa esta opção quando inicia o amuleweb na inicialização. Esta opção faz com que todas as outras opções de linha de comando e de arquivo de configuração sejam ignoradas, preferências sejam lidas do arquivo de configuração dado, e também impica na escolha das opções B<-q -L>."
 
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SUPORTE À PELES"
 
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> é capaz de mostrar informação em peles diferentes. Estas peles são chamadas \"templates\", e você pode fazer o amuleweb carregar um template específico através da opção de linha de comando B<-t>. Templates são procurados em dois locais: primeiro em I<~/.aMule/webserver/> e depois em I</usr/share/amule/webserver/> se você instalou com --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Cada template precisa estar em um subdiretório do nome do template, e este diretório precisa conter todos os arquivos que o template necessita."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "Tipicamente o amuleweb será rodado primeiro assim:"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Claro que você pode especificar quaisquer opções a mais ou a menos na primeira linha de exemplo, e você pode também omiti-las totalmente."
 

--- a/docs/man/po/manpages-ro.po
+++ b/docs/man/po/manpages-ro.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Romanian <kde-i18n-doc@kde.org>\n"
@@ -163,13 +163,13 @@ msgstr "Configurați categoria pentru link-urile eD2k trecute la I<E<lt>numE<gt>
 
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "Afișează numărul versiunii curente."
 
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -212,24 +212,24 @@ msgid "a magnet link."
 msgstr "o legătură magnet."
 
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTE"
 
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "Căi"
 
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Pentru toate opțiunile care iau o I<E<lt>pathE<gt>> valoare, dacă I<path> nu conține nici o parte a unui director (ex. doar un nume de fișier simplu), atunci se consideră a fi sub directorul de configurare aMule, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -242,7 +242,7 @@ msgstr "~/.aMule/*"
 
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -252,7 +252,7 @@ msgstr "RAPORTAREA ERORILOR"
 
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -261,7 +261,7 @@ msgstr "Vă rugăm să raportați erorile fie pe forumul  nostru(I<https://githu
 
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -271,7 +271,7 @@ msgstr "DREPT DE AUTOR"
 
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -280,7 +280,7 @@ msgstr "aMule și toate utilitarele conexe sunt distribuite sub GNU General Publ
 
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -290,7 +290,7 @@ msgstr "VEDEȚI ȘI"
 
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -299,7 +299,7 @@ msgid "AUTHOR"
 msgstr "AUTOR"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -354,72 +354,72 @@ msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> este un client bazat pe terminal pentru a controla aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Gazda unde rulează aMule (implicit: I<127.0.0.1>).  I<E<lt>hostE<gt>> ar putea fi o adresă IP sau un nume DNS"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Portul aMule pentru conexiuni externe, cum este configurat în Preferințe-E<gt>Control la distanță (implicit: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "Parolă conexiuni externe."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Utilizează fișierul de configurare dat. Fișierul de configurare implicit este I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "Nu tipării nici o ieșire la stdout."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "Fi detaliat - arată și mesajele de depanare."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Configurați localizarea aplicației (limba). Vedeți secțiunea B<NOTES> pentru descrierea parametrului I<E<lt>langE<gt>> ."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "Scrie opțiunile liniei de comandă în fișierul de configurare și ieși"
 
@@ -435,18 +435,18 @@ msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt an
 msgstr "Execută I<E<lt>commandE<gt>> ca și cum ar fi fost introdusă în terminalul amulecmd și ieși."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Creează fișierul de configurare bazat pe I<E<lt>pathE<gt>>, care trebuie să indice la un fișier de configurare aMule valid, iar apoi ieși."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
@@ -751,43 +751,43 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr "Arată starea conexiunii, vitezele actuale de încărcare/descărcare, etc."
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "Limbi"
 
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Parametrul I<E<lt>langE<gt>> pentru opțiunea B<-l> are următoarea formă: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] unde I<lang> este limba primară, I<LANG> este dialectul/teritoriul, I<encoding> este setul de caractere de utilizat iar I<modifier> permite utilizatorului de a specifica o instanță specifică a datelor localizării în cadrul unei singure categorii."
 
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "De exemplu, următoarele șiruri sunt valide:"
 
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Deși toate șirurile de mai sus sunt acceptate ca definiții de limbă valide, I<encoding> și I<modifier> sunt momentan neutilizate."
 
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "În completare la formatul de mai sus, puteți specifica și numele întreg al limbii în engleză - so B<-l german> este valid și  similar cu B<-l de_DE>."
 
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Când nu este definită nici o limbă, în linia de comandă sau în fișierul de configurare, va fi utilizată limba implicită a sistemului de operare."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "EXEMPLU"
@@ -803,7 +803,7 @@ msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "sau"
 
@@ -813,7 +813,7 @@ msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Aceasta va salva configurările la I<$HOME/.aMule/remote.conf>, iar mai târziu trebuie doar să tastați:"
 
@@ -984,160 +984,165 @@ msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
+#. type: Plain text
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> vă administrează accesul la amule printr-un navigator web. Puteți porni amuleweb împreună cu B<amule>(1), sau separat, oricând mai târziu. Pot fi specificate opțiuni prin linia de comandă sau prin fișierul de configurare. Opțiunile din linia de comandă au prioritate față de opțiunile din fișierul de configurare."
 
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Încarcă modelul denumit I<E<lt>nameE<gt>>. Vedeți secțiunea B<SKIN SUPPORT> pentru detalii."
 
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Portul HTTP al serverului web. Acesta este portul pe care trebuie să-l indicați navigatorului (implicit: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "Activare UPnP."
 
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, fuzzy, no-wrap
 #| msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "Port UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Activează utilizând compresia gzip în traficul HTTP pentru a salva lățimea de bandă."
 
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Dezactivează utilizând compresia gzip (aceasta este implicita)."
 
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "Parola pentru accesul nerestricționat pentru serverul web."
 
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "Parolă oaspete pentru webserver."
 
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "Permite accesul oaspeților."
 
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "Interzice accesul oaspeților (implicit)."
 
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Încarcă/Salvează configurările serverului web din/la aMule distant. Aceasta determină amuleweb să ignore configurările din linia de comandă sau fișierul de configurare și să le încarece din aMule. Când se salvează preferințele nu se va scrie nimic în fișierul de configurare, doar la aMule. (Desigur, aceasta funcționează doar pentru acele configurări care pot fi configurate în aMule la Preferințe-E<gt>Control la distanță.)"
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Dezactivează interpretorul PHP (învechit)"
 
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "Recompilează paginile PHP la fiecare cerere."
 
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Calea fișierului de configurare aMule. B<NU UTILIZAȚI DIRECT!> aMule utilizează această opțiune când pornește amuleweb la pornirea aMule. Această opțiune cauzează tuturor celorlalte configurări din linia de comandă și fișiere de configurare să fie ignorate, preferințele vor fi citite din fișierul de configurare dat, de asemenea implică și opțiunile B<-q -L> ."
 
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SUPORT ASPECT"
 
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> este capabil să afișeze informația în diferite aspecte. Aceste aspecte se numesc modele, și puteți face ca amuleweb să încarce un model anumit prin B<-t> opțiune linie de comandă. Modelele sunt căutate în două locuri: întâi în I<~/.aMule/webserver/> apoi în I</usr/share/amule/webserver/> dacă a fost instalat cu --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Fiecare șablon trebuie să fie într-un subdirector al numelui șablonului, iar acest director trebuie să conțină toate fișierele de care șablonul are nevoie."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "De obicei amuleweb va rula la început ca:"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<nume gazdă> B<-p> I<ECport> B<-P> I<ECprolă> B<-s> I<HTTPport> B<-A> I<Parolă administrator> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Desigur, puteți specifica cât de multe sau cât de puține opțiuni în linia primului exemplu, și de asemenea le puteți omite integral."
 

--- a/docs/man/po/manpages-ru.po
+++ b/docs/man/po/manpages-ru.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: manpages-ru\n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Russian <LL@li.org>\n"
@@ -165,13 +165,13 @@ msgstr "Указать I<E<lt>номерE<gt>> категории для eD2k с
 
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "Выводит информацию о версии."
 
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -214,24 +214,24 @@ msgid "a magnet link."
 msgstr "magnet-ссылка."
 
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "ЗАМЕЧАНИЯ"
 
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "Пути"
 
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Для всех опций, в которых указывается I<E<lt>путьE<gt>>, если I<путь> не содержит каталога (т.е. только имя самого файла), то предполагается, что файл находится в каталоге конфигурации, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -244,7 +244,7 @@ msgstr "~/.aMule/*"
 
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -254,7 +254,7 @@ msgstr "СООБЩЕНИЕ ОБ ОШИБКАХ"
 
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -263,7 +263,7 @@ msgstr "Пожалуйста, сообщайте об ошибках либо н
 
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -273,7 +273,7 @@ msgstr "АВТОРСКИЕ ПРАВА"
 
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -282,7 +282,7 @@ msgstr "aMule и все прилагающиеся инструменты рас
 
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -292,7 +292,7 @@ msgstr "СМ. ТАКЖЕ"
 
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -301,7 +301,7 @@ msgid "AUTHOR"
 msgstr "АВТОРЫ"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -356,72 +356,72 @@ msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> консольный клиент для управления программой aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>хостE<gt>>, B<--host>=I<E<lt>хостE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Адрес компьютера на котором работает aMule (по умолчанию: I<127.0.0.1>). I<E<lt>ХостE<gt>> может быть IP-адресом или DNS-именем"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>портE<gt>>, B<--port>=I<E<lt>портE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Порт, который использует aMule для внешних соединений. Указывается в Настройках-E<gt>Удаленное управление (по умолчанию: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>парольE<gt>>, B<--password>=I<E<lt>парольE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "Пароль для внешних соединений."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>путьE<gt>>, B<--config-file>=I<E<lt>путьE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Использовать указанный файл конфигурации. По умолчанию используется I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "Не печетать ничего в стандартный вывод."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "Выводить также отладочную информацию."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>языкE<gt>>, B<--locale>=I<E<lt>языкE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Задать локаль (язык). См. секцию B<ЗАМЕЧАНИЯ> для дополнительной информации по параметру I<E<lt>языкE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "Записать параметр командной строки в файл конфигурации и выйти"
 
@@ -437,18 +437,18 @@ msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt an
 msgstr "Выполнить I<E<lt>командуE<gt>> как если бы она была введена в консоль amulecmd и выйти."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>путьE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Создать файл конфигурации на основе файла указанного в I<E<lt>путиE<gt>> и выйти. Указанный файл должен быть валидным файлом конфигурации aMule."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
@@ -753,43 +753,43 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr "Вывести статус соединения, скорости, итд."
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "Языки"
 
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Параметр I<E<lt>языкE<gt>> для опции B<-l> имеет следующую форму: I<язык>[B<_>I<ЯЗЫК>][B<.>I<кодировка>][B<@>I<модификатор>], где I<язык> является основным языком, I<ЯЗЫК> - диалект/территория, I<кодировка> - используемая кодировка символов и I<модификатор> позволяет пользователю использовать определенный вариант локализации в данной категории."
 
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "К примеру, все следующие строчки являются приемлемыми:"
 
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Хотя все приведенный строки будут приняты, поля I<кодировка> и I<модификатор> пока не используются."
 
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "К дополнению к приведенному формату, можно просто указать английское имя языка. Так, B<-l russian> тоже приемлемо и равносильно B<-l ru_RU>."
 
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Когда язык не указан ни в качестве опции ни в файле конфигурации, используется системный."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "ПРИМЕРЫ"
@@ -805,7 +805,7 @@ msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<имя_хоста> B<-p> I<EC_порт> B<-P> I<EC_пароль> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "или"
 
@@ -815,7 +815,7 @@ msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Это сохранит параметры в I<$HOME/.aMule/remote.conf>, и в дальнейшем надо будет только набрать:"
 
@@ -986,160 +986,165 @@ msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>путьE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
+#. type: Plain text
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> организует доступ к amule через веб браузер. Вы можете запустить amuleweb вместе с B<amule>(1), или отдельно позже. Настройки могут быть определены с помощью командной строки или файла конфигурации. Опции командной строки являются приоритетными по отношению к файлу конфигурации."
 
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>имяE<gt>>, B<--template>=I<E<lt>имяE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Устанавливает шаблон с указанным I<E<lt>именемE<gt>>. Подробности в секции B<ПОДДЕРЖКА СКИНОВ>."
 
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>портE<gt>>, B<--server-port>=I<E<lt>портE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "HTTP порт вебсервера. Этот порт должен быть указан в строке адреса браузера (по умолчанию: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "Включить UPnP."
 
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, fuzzy, no-wrap
 #| msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>портE<gt>>, B<--upnp-port> I<E<lt>портE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "Порт UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Включает использование gzip-сжатия HTTP данных для уменьшения трафика."
 
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Отключает использование gzip-сжатия (вариант по умолчанию)."
 
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>парольE<gt>>, B<--admin-pass>=I<E<lt>парольE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "Пароль для полного доступа к вебсерверу."
 
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>парольE<gt>>, B<--guest-pass>=I<E<lt>парольE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "Пароль для гостевого доступа к вебсерверу."
 
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "Разрешить гостевой доступ."
 
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "Запретить гостевой доступ (вариант по умолчанию)."
 
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Загрузить/сохранить настройки вебсервера из/в удаленный aMule. Это приводит к игнорированию параметров командной строки и конфигурационного файла, и загрузки их из aMule. При сохранении настроек они будут писаться не в файл конфигурации, а в aMule. (Конечно, работает только для настроек которые могут быть заданы через меню Настройки-E<gt>Удаленный контроль)"
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Отключить интерпретатор PHP (устарело)"
 
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "Перекомпилирует страницы PHP при каждом обращении."
 
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>путьE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Путь к файлу конфигурации aMule. B<НЕ ИСПОЛЬЗУЙТЕ НАПРЯМУЮ!> aMule использует данную опцию для запуска amuleweb вместе с amule. Эта опция приводит к игнорированию параметров командной строки и конфигурационного файла, настройки читаются из заданного файла. Также подразумеваются опции B<-q -L>."
 
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "ПОДДЕРЖКА СКИНОВ"
 
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> имеет возможность отображать информацию с разными скинами. Эти скины называются шаблонами, и вы можете переключить amuleweb на определенный шаблон использую опцию B<-t> командной строки. Шаблоны ищутся в двух местах: первое I<~/.aMule/webserver/>, затем I</usr/share/amule/webserver/>, если инсталяция была проведена с --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Каждый шаблон должен являться каталогом с именем шаблона, и все необходимые файлы должны находится внутри этого каталога."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "Как правило, в первый раз amuleweb запускается так:"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<имя_хоста> B<-p> I<EC_порт> B<-P> I<EC_пароль> B<-s> I<HTTP_порт> B<-A> I<пароль_полного_доступа> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Конечно, вы можете указать иное количество аргументов в первой строке примера, или не использовать ее вообще."
 

--- a/docs/man/po/manpages-tr.po
+++ b/docs/man/po/manpages-tr.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: \n"
@@ -162,13 +162,13 @@ msgstr "I<E<lt>sayıE<gt>>ya gönderilen eD2k bağlantılarının kategorilerini
 
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "Geçerli sürüm numarasını görüntüler."
 
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -211,24 +211,24 @@ msgid "a magnet link."
 msgstr "bir magnet bağlantısı."
 
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTLAR"
 
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "Yollar"
 
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "I<E<lt>yolE<gt>> değeri alan  tüm seçenekler için eğer I<yol> hiçbir dizin içermiyorsa (yani sadece bir dosya ismiyse) aMule yapılandırma dizini (I<~/.aMule>) varsayılır."
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -241,7 +241,7 @@ msgstr "~/.aMule/*"
 
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -251,7 +251,7 @@ msgstr "GERİBİLDİRİM"
 
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -260,7 +260,7 @@ msgstr "Hataları bildirmek için forumumuzu (I<https://github.com/amule-org/amu
 
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -270,7 +270,7 @@ msgstr "TELİF HAKKI"
 
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -279,7 +279,7 @@ msgstr "aMule ve ilgili tüm yardımcı araçları GNU Genel Kamu Lisansı çer�
 
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -289,7 +289,7 @@ msgstr "İLGİLİ BELGELER"
 
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -298,7 +298,7 @@ msgid "AUTHOR"
 msgstr "YAZAN"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -353,72 +353,72 @@ msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> aMule'ü yönetmek için konsol temelli bir programdır."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>sunucuE<gt>>, B<--host>=I<E<lt>sunucuE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "aMule'ün çalıştığı sunucu ya da bilgisayar (varsayılan: I<127.0.0.1>). I<E<lt>sunucuE<gt>> bir IP adresi ya da DNS ismi olabilir"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "aMule'ün dışarıya bağlandığında kullandığı port, Ayarlar-E<gt>Uzak Denetimler seçeneğinde belirlenir (varsayılan: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>şifreE<gt>>, B<--password>=I<E<lt>şifreE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "Dışarıdan kurulan bağlantılar için şifre."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>yolE<gt>>, B<--config-file>=I<E<lt>yolE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Belirtilen yapılandırma dosyasını kullanır. Varsayılan yapılandırma dosyası şudur: I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "Standart çıktıya hiçbir veri yazdırmaz."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "Geveze olur - debug mesajlarını da gösterir."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>dilE<gt>>, B<--locale>=I<E<lt>dilE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Programın kullandığı dili belirler. I<E<lt>dilE<gt>> parametresinin tanımlaması için B<NOTLAR> bölümüne bakınız."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "Komut satırı seçeneklerini yapılandırma dosyasına yazıp çıkar"
 
@@ -434,18 +434,18 @@ msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt an
 msgstr "I<E<lt>komutE<gt>>u amulecmd'ın komut istemine girilmiş gibi çalıştırır ve çıkar."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>yolE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "I<E<lt>yolE<gt>>a dayalı yapılandırma dosyası yaratır ve çıkar. Yolun geçerli bir aMule dosyasına işaret etmesi gerekir."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Seçilen IP adresinin konumuna bakılmaksızın Harici Bağlantı için ZLIB sıkıştırmasını zorlar.  Sunucuya, bir LAN IP adresine çözümlenen VPN tüneli üzerinden erişilebildiğinde ve aksi takdirde sezgisel algoritmanın sıkıştırmayı atlayacağı durumlarda kullanışlıdır."
 
@@ -746,43 +746,43 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr "Bağlantı durumunu, sürmekte olan indirmeleri ve aktarmaları vs. gösterir."
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "Diller"
 
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "B<-l> seçeneği için I<E<lt>dilE<gt>> parametresi şu biçimde kullanılmalıdır: I<dil>[B<_>I<DİL>][B<.>I<kodlama>][B<@>I<niteleyici>] ki burada I<dil> birinci dil, I<DİL> lehçe/bölge, I<kodlama> karakter setidir ve I<niteleyici> kullanıcıya belli bir kategori içinde belli yerelleştirme verileri kullanma olanağı sağlar."
 
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "Örnek olarak, aşağıdaki dizeler geçerlidir:"
 
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Yukarıdaki tüm dizeler geçerlidir ancak I<kodlama> ve I<niteleyici> henüz kullanılmamaktadır."
 
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Yukarıdakilere ek olarak dil isimlerini İngilizce olarak belirtebilirsiniz - yani B<-l german> ile B<-l de_DE> eşdeğerdir ve ikisi de geçerlidir."
 
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Ne komut satırında ne de yapılandırma dosyasında hiçbir dil belirtilmediği zaman sistemin varsayılan dili kullanılacaktır."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "ÖRNEK"
@@ -798,7 +798,7 @@ msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<bilgisayaradı> B<-p> I<DBport> B<-P> I<DBşifre> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "ya da"
 
@@ -808,7 +808,7 @@ msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/kullanıcıadı/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Ayarları I<$HOME/.aMule/remote.conf> dosyasına kayıt eder ve daha sonra sadece şunu girmeniz yeterli olacaktır:"
 
@@ -978,159 +978,164 @@ msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>yolE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
+#. type: Plain text
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> amule'e bir ağ tarayıcısı ile erişmenize olanak sağlar. amuleweb'i amule ile aynı anda ya da ayrı olarak, daha sonra ne zaman isterseniz başlatabilirsiniz. Seçenekleri komut satırı ya da yapılandırma dosyası ile belirtmek mümkündür. Komut satırı ile belirtilen seçenekler yapılandırma dosyası ile belirtilenlerden daha yüksek önceliklidir."
 
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>isimE<gt>>, B<--template>=I<E<lt>isimE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Adı I<E<lt>isimE<gt>> olan şablonu yükler. Ayrıntılar için B<TEMA DESTEĞİ> bölümüne bakınız."
 
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Web sunucusunun HTTP portu. Bu ağ tarayıcınızda kullanmanız gereken port numarasıdır (varsayılan: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "UPnP'yi etkinleştirir."
 
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "UPnP port numarası."
 
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Bant genişliğinden tasarruf etmek için gzip sıkıştırmasını etkinleştirir."
 
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Gzip sıkıştırmasını devre dışı bırakır (bu varsayılan değerdir)."
 
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>şifreE<gt>>, B<--admin-pass>=I<E<lt>şifreE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "Sunucuya tam erişim için şifre (parola)."
 
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>şifreE<gt>>, B<--guest-pass>=I<E<lt>şifreE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "Web sunucusu için misafir şifresi."
 
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "Misafir erişimini etkinleştirir."
 
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "Misafir erişimine izin vermez (varsayılan değer)."
 
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Web sunucusu ayarlarını uzaktaki aMule'den/aMule'e yükler/kaydeder. Bu amuleweb'in komut satırı ve yapılandırma dosyası ayarlarını görmezden gelmesine yol açar. Ayarlar kaydedilirken hiçbiri yapılandırma dosyasına yazılmaz, aMule'e yazılır. (Tabii ki bu sadece aMule'ün Ayarlar-E<gt>Uzak Denetiminde kurulabilen değerler için geçerlidir.)"
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHP yorumlayıcısını devre dışı bırakır (eskimiş)"
 
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "PHP sayfalarını her sorguda yeniden derler."
 
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>yolE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "aMule yapılandırma dosyasına erişim yolu.  B<DOĞRUDAN KULLANMAYIN!> aMule bu seçeneği amuleweb'i aMule ile başlatırken kullanır.  Bu seçenek diğer tüm komut satırı ve yapılandırma dosyası ayarlarının görmezden gelinmesine, ayarların verilen yapılandırma dosyasından okunmasına yol açar ve B<-q -L> seçeneklerinin kullanılacağı anlamına da gelir."
 
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "TEMA DESTEĞİ"
 
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> bilgileri çeşitli temalarda görüntüleyebilir. Bu temalara şablon adı verilir ve amuleweb'in belli bir şablonu yüklemesini B<-t> komut satırı seçeneği ile sağlayabilirsiniz. Şablonlar iki konumda aranır: önce I<~/.aMule/webserver/> konumunda, sonra da, kurulum --prefix=/usr ile yapıldıysa I</usr/share/amule/webserver/> konumunda."
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Her şablonun şablon isminin alt dizininde bulunması gerekir ve bu dizinin şablonun ihtiyaç duyduğu tüm dosyaları bulundurması şarttır."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "Tipik olarak amuleweb ilk defada şu şekilde başlayacaktır:"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<hostismi> B<-p> I<DBport> B<-P> I<DBşifresi> B<-s> I<HTTPport> B<-A> I<AdminŞifresi> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/kullanıcıadı/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Tabii ki ilk örnek satırında daha az ya da fazla seçenek belirtebilirsiniz, hatta onu tamamen görmezden gelebilirsiniz."
 

--- a/docs/man/po/manpages-zh_TW.po
+++ b/docs/man/po/manpages-zh_TW.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule Manual zh_TW\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-10 16:45+0200\n"
+"POT-Creation-Date: 2026-07-09 14:20+0200\n"
 "PO-Revision-Date: 2026-07-08 13:30+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -170,13 +170,13 @@ msgstr "給輸入成功的 eD2k 連結分類編號為 I<E<lt>號碼E<gt>>"
 
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr "顯示目前的版本號碼。"
 
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -219,24 +219,24 @@ msgid "a magnet link."
 msgstr "magnet 連結。"
 
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr "附註"
 
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr "路徑"
 
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "對於有 I<E<lt>路徑E<gt>> 的選項，如果 I<路徑> 裏面沒有含目錄 (即只有單純檔名)，則會被認為是在 aMule 的設定檔所在目錄 I<~/.aMule> 下。"
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -249,7 +249,7 @@ msgstr "~/.aMule/*"
 
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -259,7 +259,7 @@ msgstr "回報問題"
 
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -268,7 +268,7 @@ msgstr "請到我們的論壇 (I<https://github.com/amule-org/amule/discussions>
 
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -278,7 +278,7 @@ msgstr "版權"
 
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -287,7 +287,7 @@ msgstr "aMule 與附加的工具程式都遵守 GNU 的 GPL 協定。"
 
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -297,7 +297,7 @@ msgstr "參考"
 
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -306,7 +306,7 @@ msgid "AUTHOR"
 msgstr "作者"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -361,72 +361,72 @@ msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> 是終端機模式下控制 aMule 的的客戶端程式。"
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>主機E<gt>>, B<--host>=I<E<lt>主機E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "正在執行 aMule 核心的主機 (預設：I<127.0.0.1>)， I<E<lt>主機E<gt>> 可以是 IP 位址或網域名稱"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>通訊埠E<gt>>, B<--port>=I<E<lt>通訊埠E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "aMule 外部連線用的通訊埠，在 偏好設定 E<gt>  遠端控制 設定 (預設：I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>密碼E<gt>>, B<--password>=I<E<lt>密碼E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr "外部連線密碼。"
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>路徑E<gt>>, B<--config-file>=I<E<lt>路徑E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "使用指定的設定檔，預設是 I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr "不將任何資訊顯示在標準輸出。"
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr "詳細模式 - 也顯示除錯訊息。"
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>語言E<gt>>, B<--locale>=I<E<lt>語言E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "設定程式的語系 (語言)。請看 B<附註> 章節裏關於 I<E<lt>語言E<gt>> 參數的說明。"
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr "將命令列選項寫入設定檔後離開"
 
@@ -442,18 +442,18 @@ msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt an
 msgstr "像在 amulecmd 的命令列模式下一樣，執行 I<E<lt>指令E<gt>> 後離開。"
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>路徑E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "參考 I<E<lt>pathE<gt>> 裏的資料來建立設定檔後離開。(I<E<lt>pathE<gt>> 裏必須有有效的 aMule 設定檔)"
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
@@ -758,43 +758,43 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr "顯示 連線狀態、目前的上傳/下載速度 等等。"
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr "語言"
 
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "B<-l> 選項的 I<E<lt>語系E<gt>> 參數有以下幾種樣式：I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>]。其中：I<lang> 是主要的語系代碼，I<LANG> 是語系次分類、使用地區代碼，I<encoding> 是使用的編碼，I<modifier> 則讓使用者用一個代號就指定一組語系設定。例如：「zh_TW.UTF-8@Taiwan」"
 
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr "例如，以下的字串都有效："
 
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "雖然上面這些都是合於規定的語系設定參數，但 I<encoding> 和 I<modifier> 目前已經沒在使用了。"
 
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "你也可以使用完整的英文名稱來設定語系，例如：B<-l german> 也等於 B<-l de_DE>。"
 
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "沒有在命令列或設定檔中設定語系時，會使用系統預設語言。"
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "範例"
@@ -810,7 +810,7 @@ msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<主機名稱> B<-p> I<外部連線通訊埠> B<-P> I<外部連線密碼> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr "或"
 
@@ -820,7 +820,7 @@ msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "這樣就會將設定儲存到 I<$HOME/.aMule/remote.conf>，然後你只需要再輸入："
 
@@ -991,160 +991,165 @@ msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>路徑E<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
+#. type: Plain text
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> 可以經由網頁瀏覽器來管理 amule。你可以和 B<amule>(1) 一起執行 amuleweb，也可以稍候再另外執行。可以在命令列或是用用設定檔指定參數，命令列參數會優先於設定檔的參數。"
 
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>名稱E<gt>>, B<--template>=I<E<lt>名稱E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "載入 I<E<lt>名稱E<gt>> 這個模板。詳細請參考 B<外觀面板支援> 章節。"
 
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>通訊埠E<gt>>, B<--server-port>=I<E<lt>通訊埠E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "網頁伺服器的 HTTP 連接埠：要用瀏覽器連線時必須加以指定 (預設：I<4711>)。"
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr "啟用 UPnP。"
 
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, fuzzy, no-wrap
 #| msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>通訊埠E<gt>>, B<--upnp-port> I<E<lt>通訊埠E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr "UPnP 通訊埠。"
 
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "在 HTTP 傳輸時啟用 gzip 壓縮以節省頻寬。"
 
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr "停用 gzip 壓縮 (這是預設值)。"
 
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>密碼E<gt>>, B<--admin-pass>=I<E<lt>密碼E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr "網站伺服器的完整存取密碼。"
 
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>密碼E<gt>>, B<--guest-pass>=I<E<lt>密碼E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr "網站伺服器的訪客密碼。"
 
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr "允許訪客連線。"
 
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr "禁止訪客連線 (預設)。"
 
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "從遠端的 aMule 載入網頁伺服器設定/將設定儲存到遠端。這個會使 amuleweb 忽略命令列與設定檔內的設定、並從遠端載入新設定；儲存時則只會寫入遠端 aMule 的設定。(當然，只限於 aMule 的 偏好設定 E<gt> 遠端控制 裏的幾個設定項目)"
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "停用 PHP 解譯器 (不建議)"
 
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr "爲每個要求重編譯 PHP 頁面。"
 
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>路徑E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "aMule 設定擋路徑。B<請不要直接使用！>這個選項會導致原有命令列和設定檔的設定都被忽略都被忽略。 啟動 aMule 後在開啟 amuleweb 時會用這個選項，從指定的設定檔讀取偏好設定，並自行加上 B<-q -L> 選項。"
 
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "外觀面板支援"
 
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> 可以用不同的外觀面板顯示資訊；這些面板稱為「模板」，你可以用在命令列用 B<-t> 選項讓 amuleweb 載入指定的模板。程式會在兩個地方搜尋模板：先從 I<~/.aMule/webserver/>，然後如果是用 --prefix=/usr 安裝程式，就會再到 I</usr/share/amule/webserver/> 搜尋。"
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "每個模板都必須被放在以該模板名稱命名的子目錄下，這個目錄裏也必須包含所有模板需要的檔案。"
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr "通常 amuleweb 會優先以這樣執行："
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<主機名稱> B<-p> I<外部連線通訊埠> B<-P> I<外部連線密碼> B<-s> I<HTTP 通訊埠> B<-A> I<管理者密碼> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "當然，你可以指定比第一行範例裏更多或更少的選項，甚至您也可以完全不使用。"
 

--- a/docs/man/po/manpages.pot
+++ b/docs/man/po/manpages.pot
@@ -5,7 +5,7 @@
 #
 #, fuzzy
 msgid ""
-msgstr "Project-Id-Version: PACKAGE VERSION\nPOT-Creation-Date: 2026-06-10 16:45+0200\nPO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\nLast-Translator: FULL NAME <EMAIL@ADDRESS>\nLanguage-Team: LANGUAGE <LL@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n"
+msgstr "Project-Id-Version: PACKAGE VERSION\nPOT-Creation-Date: 2026-07-09 14:20+0200\nPO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\nLast-Translator: FULL NAME <EMAIL@ADDRESS>\nLanguage-Team: LANGUAGE <LL@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n"
 
 #. type: TH
 #: amule.1.in:1
@@ -154,13 +154,13 @@ msgstr ""
 
 #. type: Plain text
 #: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:130 ed2k.1.in:40
+#: amuleweb.1.in:134 ed2k.1.in:40
 msgid "Displays the current version number."
 msgstr ""
 
 #. type: Plain text
 #: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:127 ed2k.1.in:37
+#: amuleweb.1.in:131 ed2k.1.in:37
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
 #: ../../src/utils/cas/docs/cas.1.in:33
 msgid "Prints a short usage description."
@@ -203,24 +203,24 @@ msgid "a magnet link."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:136
+#: amule.1.in:77 amulecmd.1.in:233 amuleweb.1.in:140
 #, no-wrap
 msgid "NOTES"
 msgstr ""
 
 #. type: SS
-#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:137
+#: amule.1.in:78 amulecmd.1.in:234 amuleweb.1.in:141
 #, no-wrap
 msgid "Paths"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:141
+#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:145
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:175
+#: amule.1.in:82 amulecmd.1.in:266 amuled.1.in:85 amuleweb.1.in:179
 #: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
 #, no-wrap
 msgid "FILES"
@@ -233,7 +233,7 @@ msgstr ""
 
 #. type: SH
 #: amule.1.in:84 amulecmd.1.in:282 amuled.1.in:87 amulegui.1.in:63
-#: amuleweb.1.in:195 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
+#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
 #: ../../src/utils/cas/docs/cas.1.in:43
 #: ../../src/utils/wxCas/docs/wxcas.1.in:16
@@ -243,7 +243,7 @@ msgstr ""
 
 #. type: Plain text
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -252,7 +252,7 @@ msgstr ""
 
 #. type: SH
 #: amule.1.in:87 amulecmd.1.in:285 amuled.1.in:90 amulegui.1.in:66
-#: amuleweb.1.in:198 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
+#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
 #: ../../src/utils/cas/docs/cas.1.in:46
 #: ../../src/utils/wxCas/docs/wxcas.1.in:19
@@ -262,7 +262,7 @@ msgstr ""
 
 #. type: Plain text
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -271,7 +271,7 @@ msgstr ""
 
 #. type: SH
 #: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:68
-#: amuleweb.1.in:200 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
+#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
 #: ../../src/utils/cas/docs/cas.1.in:48
 #: ../../src/utils/wxCas/docs/wxcas.1.in:21
@@ -281,7 +281,7 @@ msgstr ""
 
 #. type: SH
 #: amule.1.in:91 amulecmd.1.in:289 amuled.1.in:94 amulegui.1.in:70
-#: amuleweb.1.in:202 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
+#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
 #: ../../src/utils/cas/docs/cas.1.in:50
 #: ../../src/utils/wxCas/docs/wxcas.1.in:23
@@ -290,7 +290,7 @@ msgid "AUTHOR"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:203
+#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amuleweb.1.in:207
 #: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
 #: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
 #: ../../src/utils/cas/docs/cas.1.in:51
@@ -345,72 +345,72 @@ msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:46
+#: amulecmd.1.in:29 amuleweb.1.in:50
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:50
+#: amulecmd.1.in:33 amuleweb.1.in:54
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:53
+#: amulecmd.1.in:36 amuleweb.1.in:57
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 msgid "External Connections password."
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:56
+#: amulecmd.1.in:39 amuleweb.1.in:60
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:60
+#: amulecmd.1.in:43 amuleweb.1.in:64
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:63
+#: amulecmd.1.in:46 amuleweb.1.in:67
 msgid "Do not print any output to stdout."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:67
+#: amulecmd.1.in:50 amuleweb.1.in:71
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:71
+#: amulecmd.1.in:54 amuleweb.1.in:75
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:74
+#: amulecmd.1.in:57 amuleweb.1.in:78
 msgid "Write command line options to config file and exit"
 msgstr ""
 
@@ -426,18 +426,18 @@ msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt an
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:117
+#: amulecmd.1.in:60 amuleweb.1.in:121
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:120
+#: amulecmd.1.in:63 amuleweb.1.in:124
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:124
+#: amulecmd.1.in:67 amuleweb.1.in:128
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
@@ -738,43 +738,43 @@ msgid "Show connection status, current up/download speeds, etc."
 msgstr ""
 
 #. type: SS
-#: amulecmd.1.in:238 amuleweb.1.in:141
+#: amulecmd.1.in:238 amuleweb.1.in:145
 #, no-wrap
 msgid "Languages"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:244 amuleweb.1.in:147
+#: amulecmd.1.in:244 amuleweb.1.in:151
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:246 amuleweb.1.in:149
+#: amulecmd.1.in:246 amuleweb.1.in:153
 msgid "For example, the following strings are valid:"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:260 amuleweb.1.in:163
+#: amulecmd.1.in:260 amuleweb.1.in:167
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:263 amuleweb.1.in:166
+#: amulecmd.1.in:263 amuleweb.1.in:170
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:266 amuleweb.1.in:169
+#: amulecmd.1.in:266 amuleweb.1.in:173
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:177
+#: amulecmd.1.in:268 amuleweb.1.in:181
 msgid "~/.aMule/remote.conf"
 msgstr ""
 
 #. type: SH
-#: amulecmd.1.in:268 amuleweb.1.in:181
+#: amulecmd.1.in:268 amuleweb.1.in:185
 #, no-wrap
 msgid "EXAMPLE"
 msgstr ""
@@ -790,7 +790,7 @@ msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:274 amuleweb.1.in:187
+#: amulecmd.1.in:274 amuleweb.1.in:191
 msgid "or"
 msgstr ""
 
@@ -800,7 +800,7 @@ msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:278 amuleweb.1.in:191
+#: amulecmd.1.in:278 amuleweb.1.in:195
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr ""
 
@@ -970,159 +970,164 @@ msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:46
+#: amuleweb.1.in:45
+msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
+msgstr ""
+
+#. type: Plain text
+#: amuleweb.1.in:50
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:74
+#: amuleweb.1.in:78
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:77
+#: amuleweb.1.in:81
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:80
+#: amuleweb.1.in:84
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 msgid "Enable UPnP."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:84
+#: amuleweb.1.in:88
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:87
+#: amuleweb.1.in:91
 msgid "UPnP port."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:90
+#: amuleweb.1.in:94
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 msgid "Disables using gzip compression (this is the default)."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:93
+#: amuleweb.1.in:97
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 msgid "Full access password for webserver."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:96
+#: amuleweb.1.in:100
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:99
+#: amuleweb.1.in:103
 msgid "Guest password for webserver."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:102
+#: amuleweb.1.in:106
 msgid "Allows guest access."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:105
+#: amuleweb.1.in:109
 msgid "Denies guest access (default)."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:111
+#: amuleweb.1.in:115
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:114
+#: amuleweb.1.in:118
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:117
+#: amuleweb.1.in:121
 msgid "Recompiles PHP pages on each request."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:130
+#: amuleweb.1.in:134
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:136
+#: amuleweb.1.in:140
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr ""
 
 #. type: SH
-#: amuleweb.1.in:169
+#: amuleweb.1.in:173
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:173
+#: amuleweb.1.in:177
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:175
+#: amuleweb.1.in:179
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in:183
 msgid "~/.aMule/webserver/"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:181
+#: amuleweb.1.in:185
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in:187
 msgid "Typically amuleweb will be first run as:"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in:189
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in:193
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:195
+#: amuleweb.1.in:199
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr ""
 

--- a/src/webserver/src/WebInterface.cpp
+++ b/src/webserver/src/WebInterface.cpp
@@ -99,6 +99,13 @@ bool CamulewebApp::OnInit()
 
 int CamulewebApp::OnRun()
 {
+	// Deprecation notice (printed once at startup, honours --quiet). amuleweb
+	// is not being removed yet -- this only warns operators that it may go
+	// away in a future release so they can plan a move to amuleapi. Kept as a
+	// plain (untranslated) operator-facing string to avoid churning every po
+	// catalogue for a transitional warning.
+	Show(wxT("\nNOTE: amuleweb is deprecated and may be removed in aMule 3.2 or later.\n"
+		 "      Consider migrating to amuleapi (the REST/SSE API). See amuleweb(1).\n\n"));
 	ConnectAndRun("aMuleweb", VERSION);
 	return 0;
 }


### PR DESCRIPTION
Soft-deprecates amuleweb ahead of amuleapi — informs users it may be removed in aMule 3.2 or later, without removing anything now (per the discussion in #115).

- **Startup notice** — amuleweb prints a one-line deprecation warning at startup (`Show()`, so it honours `--quiet`). Kept untranslated (a transitional operator warning) to avoid churning the app po catalogs.
- **Man page** — `amuleweb(1)` gains a `DEPRECATED` note at the top of DESCRIPTION; the manpage po catalogs are regenerated via `scripts/update-manpages-po.sh` (that's the large-but-mechanical po diff — 0 translations reverted, one new msgid).
- **Docs** — `QUICKSTART-AMULEAPI.md` notes amuleweb is deprecated and amuleapi is its intended replacement.

The prefs-UI "deprecated" marker on the web-server toggle lands in the follow-up amuleapi auto-start PR (where the amuleapi enable checkbox sits right next to it).

Real change is 13 lines across 3 files; the rest of the diff is the required manpage-catalog regen.