### PR TITLE
fix(webui): hide software_version for unidentified peers

### DIFF
--- a/src/webapi/static/js/views/peers.js
+++ b/src/webapi/static/js/views/peers.js
@@ -23,7 +23,7 @@ const isUp = (c) => (c.upload_speed_bps || 0) > 0 || ACTIVE(c.upload_state);
 const ALL = ["all", "downloads", "uploads"];
 const DL = ["all", "downloads"];
 const UL = ["all", "uploads"];
-const softLabel = (c) => [c.software ? t("downloads_peer_soft_" + c.software) : "", c.software_version].filter(Boolean).join(" ") || "—";
+const softLabel = (c) => [c.software ? t("downloads_peer_soft_" + c.software) : "", c.software === "unknown" ? "" : c.software_version].filter(Boolean).join(" ") || "—";
 const rankLabel = (c) => !c.remote_queue_rank ? "—" : c.remote_queue_rank >= 0xFFFF ? t("downloads_peer_queue_full") : c.remote_queue_rank;
 const bytesOf = (c, k) => formatBytes((c.xfer || {})[k]);
 


### PR DESCRIPTION
Backend commit 192db942 made /clients[].software_version locale-independent: an unidentified peer now reports the lowercase "unknown" sentinel for both software and software_version instead of a daemon-localized string.

The Peers panel built the Software column from both fields, so an unknown peer rendered "Unknown unknown" -- the localized software label plus the literal version sentinel.

Omit software_version in softLabel when software is "unknown", so unidentified peers show only the localized "Unknown" / "Desconocido". Identified peers are unchanged (e.g. "eMule v0.50a").