### PR TITLE
amuleapi: expose connected amuled version as daemon_version on /version

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -277,9 +277,17 @@ curl -s http://$HOST/api/v0/version
 {
   "name": "amuleapi",
   "api_version": "v0",
-  "amule_version": "2.4.0-29-g..."
+  "amule_version": "2.4.0-29-g...",
+  "daemon_version": "2.4.0-29-g..."
 }
 ```
+
+| Field | Meaning |
+| --- | --- |
+| `name` | Always `"amuleapi"`. |
+| `api_version` | REST contract version served on this path (`"v0"`). |
+| `amule_version` | amuleapi's **own** build version. |
+| `daemon_version` | Version of the **connected amuled**, from the EC handshake. Empty string when EC is not (yet) connected, or when the daemon is old enough not to advertise it. Normally equal to `amule_version` (both are built from the same source tree), but they can differ if a mismatched amuleapi is pointed at a different amuled. |
 
 #### `GET /api/v0/status`
 

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -176,6 +176,10 @@ public:
 	}
 	void SendPacket(const CECPacket *request) { m_ECClient->SendPacket(request); }
 	bool IsServerPartialUpdateActive() const { return m_ECClient->ServerSupportsPartialUpdate(); }
+	// Version string of the connected core, from the EC AUTH_OK handshake.
+	// Empty when not connected (m_ECClient null) or when the daemon is old
+	// enough to omit the EC_TAG_SERVER_VERSION tag.
+	wxString GetServerVersion() const { return m_ECClient ? m_ECClient->GetServerVersion() : wxString(); }
 	void ConnectAndRun(const wxString &ProgName, const wxString &ProgVersion);
 	void ShowGreet();
 

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -346,8 +346,9 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 			m_ec_state = EC_OK;
 			result = true;
 			if (reply->GetTagByName(EC_TAG_SERVER_VERSION)) {
-				m_server_reply = _("Succeeded! Connection established to aMule ") +
-						 reply->GetTagByName(EC_TAG_SERVER_VERSION)->GetStringData();
+				m_serverVersion = reply->GetTagByName(EC_TAG_SERVER_VERSION)->GetStringData();
+				m_server_reply =
+					_("Succeeded! Connection established to aMule ") + m_serverVersion;
 			} else {
 				m_server_reply = _("Succeeded! Connection established.");
 			}

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -81,6 +81,7 @@ private:
 
 	wxString m_connectionPassword;
 	wxString m_server_reply;
+	wxString m_serverVersion;
 	wxString m_client;
 	wxString m_version;
 
@@ -136,6 +137,11 @@ public:
 		const wxString &version);
 
 	const wxString &GetServerReply() const { return m_server_reply; }
+
+	// Version string of the connected aMule core, as reported in the
+	// EC_TAG_SERVER_VERSION tag of the AUTH_OK reply. Empty until the
+	// handshake completes (or if an old daemon omits the tag).
+	const wxString &GetServerVersion() const { return m_serverVersion; }
 
 	bool RequestFifoFull() { return m_req_count > m_req_fifo_thr; }
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1088,6 +1088,12 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 	w.ValueString(wxT("v0"));
 	w.Key("amule_version");
 	w.ValueString(wxString::FromAscii(VERSION));
+	// Version of the connected amuled, from the EC handshake. Empty
+	// string when EC is not (yet) connected or the daemon predates the
+	// EC_TAG_SERVER_VERSION tag. Distinct from amule_version above,
+	// which is amuleapi's own build version.
+	w.Key("daemon_version");
+	w.ValueString(m_app.GetDaemonVersion());
 	w.EndObject();
 	const wxString js = w.GetBuffer();
 	const wxScopedCharBuffer ub = js.utf8_str();

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -511,6 +511,14 @@ bool CamuleapiApp::IsServerPartialUpdateActive()
 	return CaMuleExternalConnector::IsServerPartialUpdateActive();
 }
 
+wxString CamuleapiApp::GetDaemonVersion()
+{
+	// Serialize with the rest of the EC access: m_ECClient is torn down
+	// and rebuilt across reconnects. The base accessor is null-safe.
+	std::lock_guard<std::mutex> lock(m_ec_mtx);
+	return CaMuleExternalConnector::GetServerVersion();
+}
+
 int CamuleapiApp::OnExit()
 {
 	// Tear down in reverse construction order: HTTP server first

--- a/src/webapi/App.h
+++ b/src/webapi/App.h
@@ -89,6 +89,13 @@ public:
 	// entries we didn't see this tick" path.
 	bool IsServerPartialUpdateActive();
 
+	// Version string of the connected amuled, captured from the
+	// EC_TAG_SERVER_VERSION tag of the AUTH_OK handshake. Empty string
+	// when EC is not (yet) connected, or when talking to a daemon old
+	// enough to omit the tag. Read under m_ec_mtx since m_ECClient is
+	// torn down / rebuilt across reconnects.
+	wxString GetDaemonVersion();
+
 	// Refresher needs the cache. Single CState instance per process.
 	webapi::CState &State() { return m_state; }
 

--- a/unittests/curl-tests/amuleapi/01-version-and-errors.sh
+++ b/unittests/curl-tests/amuleapi/01-version-and-errors.sh
@@ -86,6 +86,15 @@ _assert_json_eq '.api_version' v0       '/api/v0/version reports api_version=v0'
 _assert_json_eq '.amule_version | length > 0' \
 	true '/api/v0/version reports a non-empty amule_version'
 
+# 2b. daemon_version field — the connected amuled's version, taken from
+#     the EC_TAG_SERVER_VERSION handshake tag. Distinct from
+#     amule_version (which is amuleapi's own build). The regression
+#     amuled is a live modern build that always advertises the tag, so
+#     assert it's populated. (Against a daemon old enough to omit the
+#     tag, or before EC connects, this field is legitimately empty.)
+_assert_json_eq '.daemon_version | length > 0' \
+	true '/api/v0/version reports a non-empty daemon_version'
+
 # 3. Method other than GET/HEAD → 405 with the canonical error envelope.
 _curl -X DELETE "$HOST/api/v0/version"
 _assert_status 405 "DELETE /api/v0/version yields 405"


### PR DESCRIPTION
`GET /api/v0/version` already returns `amule_version`, which is amuleapi's own build version. This adds a `daemon_version` field carrying the version of the connected amuled, read from the `EC_TAG_SERVER_VERSION` tag of the EC `AUTH_OK` handshake (amuleapi was already folding it into the human-readable connection string; this exposes it as a discrete field).

The two are normally equal — amuleapi and amuled ship from the same source tree — but differ when a mismatched amuleapi is pointed at a different amuled. `daemon_version` is an empty string when EC is not (yet) connected, or when the daemon is old enough to omit the tag.

- `CRemoteConnect`: capture `EC_TAG_SERVER_VERSION` into `m_serverVersion` + `GetServerVersion()`
- `CaMuleExternalConnector`: null-safe `GetServerVersion()` wrapper
- `CamuleapiApp::GetDaemonVersion()` reads it under the EC lock
- `/version`: emit `daemon_version`; curl smoke (01) + REFERENCE.md updated
- No new translatable strings.

Follow-up to #115.
