### PR TITLE
feat(amuleapi): finish stable keys, raw values and typed sentinels for /stats/tree (#373)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1098,11 +1098,13 @@ The ed2k server-info log buffer. Unlike `/logs/amule`, amuled ships this one as 
 
 A tree mirroring amuled's "Statistics" tree (transfers, connections, clients, servers, downloads). Cached with a 1 s TTL.
 
-The envelope is `{ "nodes": [...] }`. Each node is `{ "key": "<id>", "label": "<template>", "values": [...], "children": [...] }`. A leaf is a node whose `children` array is empty.
+The envelope is `{ "nodes": [...] }`. Each node is `{ "key": "<id>", "raw": "<value>", "label": "<template>", "values": [...], "children": [...] }`. A leaf is a node whose `children` array is empty. `key` and `raw` are optional (see below).
 
 `label` is the **untranslated English template** (e.g. `"Total uploaded: %s"`), and `values` are the **typed, raw** values that fill its `%s` placeholders in order — the client formats and localizes them. This keeps the response identical regardless of the amuleapi/amuled `--locale` (see [Response model](#response-model)). A container node (one that only groups children) has an empty `values` array.
 
-`key` is a **stable, machine-readable identifier** for the node (e.g. `"upload_data"`, `"ul_dl_ratio"`, `"servers_working"`). Unlike `label`, it does not change when the label is reworded, and it is never translated — use it to locate a specific field instead of matching on the label string. The `key` is optional: it is present only for nodes the daemon assigns one to, and it is omitted entirely when absent (older daemons that predate this field emit no `key` at all). Keys are unique within the tree.
+`key` is a **stable, machine-readable identifier** for the node (e.g. `"upload_data"`, `"ul_dl_ratio"`, `"servers_working"`). Unlike `label`, it does not change when the label is reworded, and it is never translated — use it to locate a specific field instead of matching on the label string. The `key` is optional: it is present only for nodes the daemon assigns one to, and it is omitted entirely when absent (older daemons that predate this field emit no `key` at all). Keys are unique among the fixed skeleton nodes; the dynamic per-client-software rows share a key by kind (see below).
+
+`raw` is the **raw, untranslated machine value** for nodes whose `label` is itself data — the per-client-software breakdown rows, where the label is a version or OS string (`"v0.70b: %s"`, `"Linux: %s"`). It carries just that value (`"v0.70b"`, `"Linux"`) so a client reads it directly instead of parsing it out of the `label`. Present only on those rows; omitted otherwise and on daemons that predate the field. These rows are grouped under the `client_versions` / `client_operating_system` container nodes and each row carries `key: "client_version"` / `key: "client_os"` — so the `key` tells you the kind and `raw` gives the value.
 
 Each value is `{ "type": "<type>", "value": <raw> }`:
 
@@ -1114,6 +1116,8 @@ Each value is `{ "type": "<type>", "value": <raw> }`:
 | `time` | number | raw seconds |
 | `double` | number | raw double |
 | `string` | string | opaque English string (e.g. a ratio, or `"Not available"`) |
+
+A `string` value that is a **well-known sentinel** additionally carries an `enum` field with a stable, locale-independent token — currently `"never"` (a "Never" timestamp, e.g. max-connection-limit-reached) and `"not_available"` (a ratio with no data yet). The English `value` is left in place unchanged, so this is purely additive: prefer `enum` when present and fall back to `value` otherwise. It is absent on non-sentinel values and on daemons that predate the field.
 
 A value may carry a nested `extra` value of the same shape — the parenthetical "(total …)" some nodes append (e.g. session vs. total transfer).
 
@@ -1150,6 +1154,26 @@ The UL:DL ratio node (`key: "ul_dl_ratio"`) additionally carries a `ratio` objec
       ]
     }
   ]
+}
+```
+
+A per-client-software version row (note `raw`), and a sentinel value (note the additive `enum`):
+
+```json
+{
+  "key": "client_version",
+  "raw": "v0.70b",
+  "label": "v0.70b: %s",
+  "values": [ { "type": "istring", "value": 42, "extra": { "type": "double", "value": 12.5 } } ],
+  "children": []
+}
+```
+
+```json
+{
+  "label": "Max Connection Limit Reached: %s",
+  "values": [ { "type": "string", "value": "Never", "enum": "never" } ],
+  "children": []
 }
 ```
 

--- a/src/StatTree.cpp
+++ b/src/StatTree.cpp
@@ -195,6 +195,9 @@ CECTag *CStatTreeItemBase::CreateECTag(uint32_t max_children)
 		if (!m_key.IsEmpty()) {
 			tag->AddTag(CECTag(EC_TAG_STAT_NODE_KEY, m_key));
 		}
+		if (!m_rawvalue.IsEmpty()) {
+			tag->AddTag(CECTag(EC_TAG_STAT_NODE_RAW, m_rawvalue));
+		}
 		AddECValues(tag);
 		m_visible_counter = max_children - 1;
 		for (std::list<CStatTreeItemBase *>::const_iterator it = m_children.begin();
@@ -590,16 +593,23 @@ void CStatTreeItemRatio::AddECValues(CECTag *tag) const
 	// CFormat (honours LC_NUMERIC) and translates "Not available" at the daemon
 	// locale, so the wire value uses GetString(true) instead. The GUI path
 	// (GetDisplayString -> GetString()) is unaffected.
+	const double v1 = static_cast<double>(m_counter1->GetValue());
+	const double v2 = static_cast<double>(m_counter2->GetValue());
 	CECTag value(EC_TAG_STAT_NODE_VALUE, GetString(true));
 	value.AddTag(CECTag(EC_TAG_STAT_VALUE_TYPE, (uint8)EC_VALUE_STRING));
+	// Same guard as GetString(): with no session ratio the value is the
+	// "Not available" sentinel -- tag it with a locale-independent token.
+	// The English string above stays for GUI/legacy consumers (which ignore
+	// this sub-tag); API clients prefer the token.
+	if (!(v1 > 0 && v2 > 0)) {
+		value.AddTag(CECTag(EC_TAG_STAT_VALUE_ENUM, wxString(wxT("not_available"))));
+	}
 	tag->AddTag(value);
 
 	// Raw numeric ratios (download-per-upload, i.e. received/sent) so API
 	// clients don't have to parse the composite string above. Distinct tag
 	// names, so the display formatter and legacy consumers ignore them.
 	// Same guards as GetString(): only emitted when both sides are > 0.
-	double v1 = static_cast<double>(m_counter1->GetValue());
-	double v2 = static_cast<double>(m_counter2->GetValue());
 	if (v1 > 0 && v2 > 0) {
 		tag->AddTag(CECTag(EC_TAG_STAT_NODE_RATIO, v2 / v1));
 	}
@@ -643,6 +653,7 @@ wxString CStatTreeItemMaxConnLimitReached::GetDisplayString() const
 void CStatTreeItemMaxConnLimitReached::AddECValues(CECTag *tag) const
 {
 	wxString result;
+	const bool never = (m_count == 0);
 	if (m_count) {
 		result = CFormat("%i : %s %s") % m_count % m_time.FormatISODate() % m_time.FormatISOTime();
 	} else {
@@ -650,6 +661,12 @@ void CStatTreeItemMaxConnLimitReached::AddECValues(CECTag *tag) const
 	}
 	CECTag value(EC_TAG_STAT_NODE_VALUE, result);
 	value.AddTag(CECTag(EC_TAG_STAT_VALUE_TYPE, (uint8)EC_VALUE_STRING));
+	// Additive, locale-independent token for the sentinel; the English
+	// display string above stays for GUI/legacy consumers (which ignore
+	// this sub-tag), API clients prefer the token.
+	if (never) {
+		value.AddTag(CECTag(EC_TAG_STAT_VALUE_ENUM, wxString(wxT("never"))));
+	}
 	tag->AddTag(value);
 }
 

--- a/src/StatTree.h
+++ b/src/StatTree.h
@@ -184,6 +184,24 @@ public:
 
 	//! Returns the stable machine key for this node (empty if none).
 	const wxString &GetKey() const { return m_key; }
+
+	/**
+	 * Attach a raw, untranslated machine value for a node whose label is
+	 * data (e.g. a client version or OS string). Serialized as
+	 * EC_TAG_STAT_NODE_RAW so API clients need not parse it out of the
+	 * composite label. Returns this node so the call can be chained.
+	 *
+	 * @param raw the raw value; empty means "none" (tag omitted).
+	 * @return this node.
+	 */
+	CStatTreeItemBase *SetRawValue(const wxString &raw)
+	{
+		m_rawvalue = raw;
+		return this;
+	}
+
+	//! Returns the raw machine value for this node (empty if none).
+	const wxString &GetRawValue() const { return m_rawvalue; }
 #endif
 
 	/**
@@ -339,6 +357,10 @@ protected:
 
 	//! Stable, untranslated machine key (empty = none). @see SetKey
 	wxString m_key;
+
+	//! Raw untranslated machine value for data-labelled nodes (empty = none).
+	//! @see SetRawValue
+	wxString m_rawvalue;
 #endif
 
 private:

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -1161,6 +1161,9 @@ void CStatistics::AddKnownClient(CUpDownClient *pClient)
 			(versionStr.IsEmpty() ? wxString(wxTRANSLATE("Unknown")) : versionStr) + ": %s",
 			stShowPercent | stHideIfZero);
 		version->SetKey("client_version");
+		// Raw version string (empty for "Unknown" -> tag omitted), so API
+		// clients read it without parsing the composite label.
+		version->SetRawValue(versionStr);
 		++(*version);
 		versionRoot->AddChild(version, clientVersion, SupportsOSInfo(clientSoft));
 	}
@@ -1178,6 +1181,8 @@ void CStatistics::AddKnownClient(CUpDownClient *pClient)
 				(OS_ID ? OSInfo : wxString(wxTRANSLATE("Not Received"))) + ": %s",
 				stShowPercent | stHideIfZero);
 			OSNode->SetKey("client_os");
+			// Raw OS string (empty for "Not Received" -> tag omitted).
+			OSNode->SetRawValue(OSInfo);
 			++(*OSNode);
 			OSRoot->AddChild(OSNode, OS_ID, true);
 		}

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -1137,11 +1137,13 @@ void CStatistics::AddKnownClient(CUpDownClient *pClient)
 		++(*client);
 		s_clients->AddChild(client, id);
 		if (SupportsOSInfo(clientSoft)) {
-			client->AddChild(
-				new CStatTreeItemBase(wxTRANSLATE("Version"), stSortChildren | stCapChildren),
+			client->AddChild((new CStatTreeItemBase(
+						  wxTRANSLATE("Version"), stSortChildren | stCapChildren))
+						 ->SetKey("client_versions"),
 				2);
-			client->AddChild(new CStatTreeItemBase(wxTRANSLATE("Operating System"),
-						 stSortChildren | stSortByValue),
+			client->AddChild((new CStatTreeItemBase(wxTRANSLATE("Operating System"),
+						  stSortChildren | stSortByValue))
+						 ->SetKey("client_operating_system"),
 				1);
 		}
 	}
@@ -1158,6 +1160,7 @@ void CStatistics::AddKnownClient(CUpDownClient *pClient)
 		CStatTreeItemCounter *version = new CStatTreeItemCounter(
 			(versionStr.IsEmpty() ? wxString(wxTRANSLATE("Unknown")) : versionStr) + ": %s",
 			stShowPercent | stHideIfZero);
+		version->SetKey("client_version");
 		++(*version);
 		versionRoot->AddChild(version, clientVersion, SupportsOSInfo(clientSoft));
 	}
@@ -1174,6 +1177,7 @@ void CStatistics::AddKnownClient(CUpDownClient *pClient)
 			OSNode = new CStatTreeItemCounter(
 				(OS_ID ? OSInfo : wxString(wxTRANSLATE("Not Received"))) + ": %s",
 				stShowPercent | stHideIfZero);
+			OSNode->SetKey("client_os");
 			++(*OSNode);
 			OSRoot->AddChild(OSNode, OS_ID, true);
 		}

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -471,6 +471,8 @@ EC_TAG_SELECT_PREFS                       0x1000
 		EC_TAG_STAT_NODE_KEY                      0x1B0F
 		EC_TAG_STAT_NODE_RATIO                    0x1B10
 		EC_TAG_STAT_NODE_RATIO_TOTAL              0x1B11
+		EC_TAG_STAT_NODE_RAW                      0x1B12
+		EC_TAG_STAT_VALUE_ENUM                    0x1B13
 
 	EC_TAG_PREFS_SECURITY                     0x1C00
 		EC_TAG_SECURITY_CAN_SEE_SHARES            0x1C01

--- a/src/libs/ec/cpp/ECCodes.h
+++ b/src/libs/ec/cpp/ECCodes.h
@@ -434,6 +434,16 @@ enum ECTagNames
 	// all-time ratio. Present only when computable (both sides > 0).
 	EC_TAG_STAT_NODE_RATIO = 0x1B10,
 	EC_TAG_STAT_NODE_RATIO_TOTAL = 0x1B11,
+	// Raw, untranslated machine value for a node whose label is data
+	// (client version / OS string). Optional sibling of the display label;
+	// legacy consumers skip it. Lets API clients read the value without
+	// parsing it out of the composite label.
+	EC_TAG_STAT_NODE_RAW = 0x1B12,
+	// Stable, locale-independent token for a well-known sentinel *value*
+	// (e.g. "never", "not_available"). Optional sub-tag of an
+	// EC_TAG_STAT_NODE_VALUE; the English display string stays alongside it
+	// (EC_VALUE_STRING) so GUI/legacy consumers are unaffected.
+	EC_TAG_STAT_VALUE_ENUM = 0x1B13,
 	EC_TAG_PREFS_SECURITY = 0x1C00,
 	EC_TAG_SECURITY_CAN_SEE_SHARES = 0x1C01,
 	EC_TAG_IPFILTER_CLIENTS = 0x1C02,
@@ -1278,6 +1288,10 @@ wxString GetDebugNameECTagNames(uint16 arg)
 		return "EC_TAG_STAT_NODE_RATIO";
 	case 0x1B11:
 		return "EC_TAG_STAT_NODE_RATIO_TOTAL";
+	case 0x1B12:
+		return "EC_TAG_STAT_NODE_RAW";
+	case 0x1B13:
+		return "EC_TAG_STAT_VALUE_ENUM";
 	case 0x1C00:
 		return "EC_TAG_PREFS_SECURITY";
 	case 0x1C01:

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3490,6 +3490,13 @@ void WriteStatsValue(CJsonWriter &w, const webapi::StatsTreeValue &v)
 		w.ValueString(wxString::FromUTF8(v.str.c_str()));
 		break;
 	}
+	// Additive, locale-independent token for well-known sentinel values
+	// ("never"/"not_available"); the English "value" above is kept so old
+	// clients keep working. Omitted when the value is not a sentinel.
+	if (!v.enum_token.empty()) {
+		w.Key("enum");
+		w.ValueString(wxString::FromUTF8(v.enum_token.c_str()));
+	}
 	// Optional nested sub-value (the parenthetical "(total …)" some nodes carry).
 	if (!v.extra.empty()) {
 		w.Key("extra");
@@ -3506,6 +3513,12 @@ void WriteStatsNode(CJsonWriter &w, const webapi::StatsTreeNode &n)
 	if (!n.key.empty()) {
 		w.Key("key");
 		w.ValueString(wxString::FromUTF8(n.key.c_str()));
+	}
+	// Raw machine value (client version / OS string) for data-labelled
+	// nodes; omitted when absent so clients read it without parsing `label`.
+	if (!n.raw.empty()) {
+		w.Key("raw");
+		w.ValueString(wxString::FromUTF8(n.raw.c_str()));
 	}
 	w.Key("label");
 	w.ValueString(wxString::FromUTF8(n.label.c_str()));

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1333,6 +1333,13 @@ void ExtractStatsValue(const CECTag *v, StatsTreeValue &out)
 		out.num = v->GetInt();
 		break;
 	}
+	// Locale-independent sentinel token, when the daemon tagged this value
+	// (e.g. "never"/"not_available"). Additive: the English string above is
+	// left intact; enum_token stays empty and is dropped otherwise.
+	const CECTag *et = v->GetTagByName(EC_TAG_STAT_VALUE_ENUM);
+	if (et) {
+		out.enum_token = std::string(et->GetStringData().utf8_str());
+	}
 	const CECTag *nested = v->GetTagByName(EC_TAG_STAT_NODE_VALUE);
 	if (nested) {
 		StatsTreeValue e;
@@ -1353,6 +1360,12 @@ void ParseStatsTreeNode(const CECTag *node, StatsTreeNode &out)
 	const CECTag *keyTag = n->GetTagByName(EC_TAG_STAT_NODE_KEY);
 	if (keyTag) {
 		out.key = std::string(keyTag->GetStringData().utf8_str());
+	}
+	// Raw machine value (client version / OS string) for data-labelled
+	// nodes. Legacy daemons omit it; out.raw stays empty and is dropped.
+	const CECTag *rawTag = n->GetTagByName(EC_TAG_STAT_NODE_RAW);
+	if (rawTag) {
+		out.raw = std::string(rawTag->GetStringData().utf8_str());
 	}
 	// Raw numeric ratio (download-per-upload), only present on the ratio node
 	// and only when the daemon could compute it. Legacy daemons omit both.

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -298,6 +298,11 @@ struct StatsTreeValue
 	std::uint64_t num = 0;
 	double dbl = 0.0;
 	std::string str;
+	// Locale-independent token for a well-known sentinel value
+	// (EC_TAG_STAT_VALUE_ENUM, e.g. "never"/"not_available"). Empty when the
+	// value is not a sentinel; surfaced as an additive "enum" field so
+	// clients need not match the English `value`/`str`.
+	std::string enum_token;
 	std::vector<StatsTreeValue> extra;
 };
 
@@ -312,6 +317,10 @@ struct StatsTreeNode
 	// Stable, untranslated machine key (EC_TAG_STAT_NODE_KEY). Empty when
 	// the node carries no key; omitted from JSON in that case.
 	std::string key;
+	// Raw, untranslated machine value for data-labelled nodes (client
+	// version / OS string), from EC_TAG_STAT_NODE_RAW. Empty when absent;
+	// surfaced as "raw" so clients need not parse it out of `label`.
+	std::string raw;
 	std::string label;
 	std::vector<StatsTreeValue> values;
 	std::vector<StatsTreeNode> children;

--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -105,9 +105,12 @@ _assert_json_eq '.nodes[0].key' uptime '/stats/tree first node key is "uptime"'
 _assert_json_eq '[.. | objects | select(has("key")) | .key] as $k
 	| (["ul_dl_ratio","download_data","servers_working"] | all(($k | index(.)) != null))' \
 	true '/stats/tree carries the expected stable keys'
+# Skeleton keys are unique; the dynamic per-client-software rows deliberately
+# share a key by kind (client_version / client_os), so exclude those.
 _assert_json_eq '[.. | objects | select(has("key")) | .key]
+	| map(select(. != "client_version" and . != "client_os"))
 	| (length > 0) and (length == (unique | length))' \
-	true '/stats/tree keys are present and unique'
+	true '/stats/tree skeleton keys are present and unique'
 # The ratio node keeps its composite string value for legacy consumers...
 _assert_json_eq '[.. | objects | select(.key? == "ul_dl_ratio") | .values[0].type] | .[0]' \
 	string '/stats/tree ratio node still carries its composite string value'
@@ -116,6 +119,20 @@ _assert_json_eq '[.. | objects | select(.key? == "ul_dl_ratio") | .values[0].typ
 _assert_json_eq '[.. | objects | select(has("ratio")) | .ratio | (.session, .total)
 	| select(. != null) | type] | all(. == "number")' \
 	true '/stats/tree ratio fields, when present, are numbers'
+# raw: the untranslated version/OS value on per-client-software rows. Absent
+# unless peers with version/OS info have connected, so assert shape, not
+# presence -- when present it is a string and rides a keyed dynamic row.
+_assert_json_eq '[.. | objects | select(has("raw")) | .raw | type] | all(. == "string")' \
+	true '/stats/tree raw fields, when present, are strings'
+# enum: additive locale-independent token on well-known sentinel string values
+# ("never"/"not_available"). Assert the tokens are from the known set and always
+# accompany a string value (the English value is kept alongside).
+_assert_json_eq '([.. | objects | .values? // empty | .[]? | select(has("enum")) | .enum]
+	| unique) - ["never","not_available"] | length == 0' \
+	true '/stats/tree enum tokens are from the known set'
+_assert_json_eq '[.. | objects | .values? // empty | .[]? | select(has("enum"))
+	| (.type == "string" and (.value | type) == "string")] | all(.)' \
+	true '/stats/tree enum tokens ride on a string value (kept for legacy clients)'
 
 # --- 3. /stats/graphs/{graph} — all four named graphs. -------------
 for g in download upload connections kad; do


### PR DESCRIPTION
Closes #373. Completes what #311 started so `/stats/tree` is fully locale-independent — a client can locate and interpret every node/value by a stable machine identifier, with no English-label/value matching.

**Three parts:**
1. **Keys on the remaining nodes** — the per-client-software breakdown: containers `client_versions` / `client_operating_system`, and the rows `client_version` / `client_os`.
2. **`raw` field** — the per-version/per-OS rows have a data label (`"v0.70b: %s"`); they now also carry `EC_TAG_STAT_NODE_RAW` with the bare value (`"v0.70b"`), surfaced as a `"raw"` JSON field so clients don't parse it out of `label`.
3. **Typed `enum` sentinels** — the `"Never"` / `"Not available"` string *values* now carry `EC_TAG_STAT_VALUE_ENUM` with a stable token (`"never"` / `"not_available"`), surfaced as an additive `"enum"` JSON field.

**Why additive (not "replace `type` with `enum`", as the issue floated):** the stat-tree value is consumed by two independent layers. amulegui/amuleweb format it via `ECSpecialTags::FormatValue`, a `switch` over the `EC_VALUE_*` codes with no graceful default — a new EC value type would fall through and mis-render, and changing the wire value from `"Never"` to `"never"` would show the untranslated token in the GUI. So we **keep** the English `EC_VALUE_STRING` value untouched and **add** a sibling tag that only the API reads. Same for JSON: existing `type`/`value`/`label`/`key` are unchanged; `raw` and `enum` are new optional fields. Nothing existing — EC or JSON — changes value or meaning, so no GUI, older-daemon, or older-client consumer breaks (mirrors how #311's `ratio` tags behave).

**Verification:** builds clean on macOS + Linux (monolithic, daemon, remote GUI, amuleapi). The amuleapi curl smoke test (`07-…`) passes 53/53 with new assertions for `raw`/`enum`/skeleton-key-uniqueness; live against a local amuled, `/stats/tree` returns `{"type":"string","value":"Not available","enum":"not_available"}` and `…"Never","enum":"never"}`. The `client_*`/`raw` rows only exist once peers with version/OS info connect (they're built in `AddKnownClient`), so they need real transfer activity to observe — @ngosang, that's the one path worth a look on your side.

Docs: `docs/api/REFERENCE.md` updated (REST; no SSE event carries the tree, so nothing there). No new user-facing strings.
