### PR TITLE
feat(webui): use bulk endpoints and report per-item results

### DIFF
--- a/src/webapi/static/i18n/en.json
+++ b/src/webapi/static/i18n/en.json
@@ -10,6 +10,7 @@
   "common_err_ec_unavailable": "No connection to the aMule core ({message})",
   "common_err_amuled_rejected": "aMule rejected the operation: {message}",
   "common_apierr_Server not added": "Server not added",
+  "common_bulk_partial": "{failed} of {total} failed: {message}",
   "common_yes": "Yes",
   "common_cancel": "Cancel",
   "common_legend_current": "Current",

--- a/src/webapi/static/i18n/es.json
+++ b/src/webapi/static/i18n/es.json
@@ -10,6 +10,7 @@
   "common_err_ec_unavailable": "Sin conexión con el núcleo de aMule ({message})",
   "common_err_amuled_rejected": "aMule rechazó la operación: {message}",
   "common_apierr_Server not added": "Servidor no añadido",
+  "common_bulk_partial": "{failed} de {total} fallaron: {message}",
   "common_yes": "Sí",
   "common_cancel": "Cancelar",
   "common_legend_current": "Actual",

--- a/src/webapi/static/js/api.js
+++ b/src/webapi/static/js/api.js
@@ -20,6 +20,11 @@ export class ApiError extends Error {
   }
 }
 
+// Failed entries of a bulk `results` envelope ([] if all ok / not a bulk resp).
+export function bulkFailures(res) {
+  return ((res && res.results) || []).filter((r) => !r.ok);
+}
+
 // path -> { etag, data }
 const etagCache = new Map();
 
@@ -83,7 +88,7 @@ export const api = {
   get: (path, opts) => request("GET", path, { useEtag: true, ...opts }),
   post: (path, body) => request("POST", path, { body }),
   patch: (path, body) => request("PATCH", path, { body }),
-  del: (path) => request("DELETE", path),
+  del: (path, body) => request("DELETE", path, { body }),
 
   // auth
   login: (password) => request("POST", "auth/login", { body: { password } }),

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -7,7 +7,7 @@
 //  - Views live in views/<section>.js and default-export a component;
 //    a missing/failed module shows a friendly placeholder.
 
-import { api, setUnauthorizedHandler } from "./api.js";
+import { api, bulkFailures, setUnauthorizedHandler } from "./api.js";
 import { data } from "./events.js";
 import { html, render, useState, useEffect, useStore } from "./dom.js";
 import { toast, Placeholder, confirmDialog } from "./components.js";
@@ -98,9 +98,17 @@ function Toolbar({ route, onLogout }) {
     const payload = links.length > 0 ? { links } : { ed2k_link: value };
 
     try {
-      await api.post("downloads", payload);
-      setLink("");
-      toast(t("app_toast_link_added"), "success");
+      // POST /downloads returns the bulk `results` envelope keyed by link; on a
+      // 207 partial some links were rejected, so report them and keep the input.
+      const failed = bulkFailures(await api.post("downloads", payload));
+      if (failed.length) {
+        toast(t("common_bulk_partial", { failed: failed.length,
+                total: (payload.links ? payload.links.length : 1),
+                message: terr(failed[0].error) }), "warn");
+      } else {
+        setLink("");
+        toast(t("app_toast_link_added"), "success");
+      }
       if (currentRoute() === "downloads") data.refresh("downloads");
     } catch (e) {
       toast(terr(e) || t("app_error"), "error");

--- a/src/webapi/static/js/views/downloads.js
+++ b/src/webapi/static/js/views/downloads.js
@@ -4,7 +4,7 @@
 // bulk actions, clear-completed, live totals, an ed2k adder for mobile, and a
 // bottom Peers panel (see peers.js).
 
-import { api } from "../api.js";
+import { api, bulkFailures } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
 import { ProgressBar, Badge, Placeholder, Tabs, toast, confirmDialog } from "../components.js";
@@ -84,31 +84,34 @@ export default function Downloads({ isGuest }) {
     mutate(() => api.del("downloads/" + d.hash));
   };
 
-  const bulk = async (action) => {
+  // Run one collection-level bulk mutation and report per-item failures (207).
+  const runBulk = async (fn, { clearSelection = false } = {}) => {
     const hashes = Array.from(selection);
     if (!hashes.length) { toast(t("downloads_toast_no_files_selected"), "warn"); return; }
-    if (action === "delete" && !(await confirmDialog(tn("downloads_confirm_cancel_selected", hashes.length)))) return;
-    const op = (h) => action === "pause" ? api.patch("downloads/" + h, { status: "paused" })
-      : action === "resume" ? api.patch("downloads/" + h, { status: "resumed" })
-      : api.del("downloads/" + h);
     try {
-      await Promise.all(hashes.map(op));
-      if (action === "delete") setSelection(new Set());
-      toast(t("downloads_toast_done"), "success");
+      const failed = bulkFailures(await fn(hashes));
+      if (failed.length)
+        toast(t("common_bulk_partial", { failed: failed.length, total: hashes.length,
+                message: terr(failed[0].error) }), "warn");
+      else toast(t("downloads_toast_done"), "success");
+      if (clearSelection) setSelection(new Set());
     } catch (e) { toast(terr(e) || t("downloads_error"), "error"); }
     data.refresh("downloads");
   };
 
-  // Apply the same field change (priority/category) to every selected row.
-  const bulkPatch = async (patch) => {
-    const hashes = Array.from(selection);
-    if (!hashes.length) { toast(t("downloads_toast_no_files_selected"), "warn"); return; }
-    try {
-      await Promise.all(hashes.map((h) => api.patch("downloads/" + h, patch)));
-      toast(t("downloads_toast_done"), "success");
-    } catch (e) { toast(terr(e) || t("downloads_error"), "error"); }
-    data.refresh("downloads");
+  const bulk = async (action) => {
+    if (action === "delete") {
+      const hashes = Array.from(selection);
+      if (!hashes.length) { toast(t("downloads_toast_no_files_selected"), "warn"); return; }
+      if (!(await confirmDialog(tn("downloads_confirm_cancel_selected", hashes.length)))) return;
+      return runBulk((h) => api.del("downloads", { hashes: h }), { clearSelection: true });
+    }
+    const status = action === "pause" ? "paused" : "resumed";
+    return runBulk((h) => api.patch("downloads", { hashes: h, status }));
   };
+
+  // Apply the same field change (priority/category) to every selected row.
+  const bulkPatch = (patch) => runBulk((h) => api.patch("downloads", { hashes: h, ...patch }));
 
   const clearCompleted = async () => {
     if (!(await confirmDialog(t("downloads_confirm_clear_completed")))) return;

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -3,7 +3,7 @@
 // multi-select with select-all, text filter, live totals, reload shares.
 // Live via the SSE "shared" channel.
 
-import { api } from "../api.js";
+import { api, bulkFailures } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
 import { Placeholder, toast } from "../components.js";
@@ -47,8 +47,13 @@ export default function Shared({ isGuest }) {
   const bulkPriority = async (p) => {
     const hashes = Array.from(selection);
     if (!hashes.length) { toast(t("shared_toast_no_files_selected"), "warn"); return; }
-    try { await api.patch("shared", { hashes, priority: p }); toast(t("shared_toast_done"), "success"); }
-    catch (e) { toast(terr(e) || t("shared_error"), "error"); }
+    try {
+      const failed = bulkFailures(await api.patch("shared", { hashes, priority: p }));
+      if (failed.length)
+        toast(t("common_bulk_partial", { failed: failed.length, total: hashes.length,
+                message: terr(failed[0].error) }), "warn");
+      else toast(t("shared_toast_done"), "success");
+    } catch (e) { toast(terr(e) || t("shared_error"), "error"); }
     data.refresh("shared");
   };
   const reload = async () => {


### PR DESCRIPTION
Align the frontend with the #358 bulk-mutation contract so multi-item actions issue one collection-level request and surface per-item failures instead of a blanket success.

- api.js: add bulkFailures() to extract failed entries from the `results` envelope; let del() carry a body (needed for bulk DELETE /downloads).
- downloads.js: replace the per-hash Promise.all fan-out in the bulk pause/resume/delete and priority/category actions with single PATCH/DELETE /downloads calls via a shared runBulk() helper.
- shared.js: inspect the bulk PATCH /shared results and report partials.
- app.js: read the POST /downloads results envelope on add; on a 207 partial, warn which links failed and keep the input for a retry.
- i18n: add common_bulk_partial (en/es) for the partial-failure toast.