### PR TITLE
refactor: unify release-version parse/compare in one shared helper

### DIFF
--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -33,6 +33,8 @@
 #include "config.h"      // Needed for a number of defines
 
 #include <wx/stdpaths.h> // Do_not_auto_remove
+#include <wx/regex.h>    // Needed for CompareLatestReleaseVersion tag parse
+#include <wx/tokenzr.h>  // Needed for CompareLatestReleaseVersion tokenizer
 #include <common/StringFunctions.h>
 #include <common/ClientVersion.h>
 #include <common/MD5Sum.h>
@@ -1441,6 +1443,55 @@ void DumpMem_DW(const uint32 *ptr, int count)
 			printf("\n");
 	}
 	printf("\n");
+}
+
+CVersionCompareResult CompareLatestReleaseVersion(const wxString &json)
+{
+	CVersionCompareResult result;
+
+	// Extract the `tag_name` string. /releases/latest excludes pre-releases,
+	// so the tag names a stable release. A regex on the one well-known field
+	// is robust against whitespace / field order without a full JSON parser.
+	wxRegEx tagRe(wxT("\"tag_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\""));
+	if (!tagRe.IsValid() || !tagRe.Matches(json)) {
+		return result; // ParseError
+	}
+	wxString tag = tagRe.GetMatch(json, 1);
+
+	// Tolerate an optional leading v/V (aMule tags are bare semver, but be
+	// defensive in case a future maintainer switches to vX.Y.Z).
+	if (tag.StartsWith(wxT("v")) || tag.StartsWith(wxT("V"))) {
+		tag = tag.Mid(1);
+	}
+	// Strip any pre-release / build-metadata suffix so the integer compare
+	// sees only MAJOR.MINOR.UPDATE.
+	size_t suffixPos = tag.find_first_of(wxT("-+"));
+	if (suffixPos != wxString::npos) {
+		tag = tag.Mid(0, suffixPos);
+	}
+	if (tag.IsEmpty()) {
+		return result; // ParseError
+	}
+
+	long fields[] = { 0, 0, 0 };
+	wxStringTokenizer tkz(tag, wxT("."));
+	for (int i = 0; i < 3 && tkz.HasMoreTokens(); ++i) {
+		// Tags with fewer than three components (e.g. "3.1") are valid;
+		// the missing fields stay 0.
+		if (!tkz.GetNextToken().ToLong(&fields[i])) {
+			return result; // ParseError
+		}
+	}
+
+	result.major = fields[0];
+	result.minor = fields[1];
+	result.update = fields[2];
+	result.latest = wxString::Format(wxT("%ld.%ld.%ld"), fields[0], fields[1], fields[2]);
+
+	const long curVer = make_full_ed2k_version(VERSION_MJR, VERSION_MIN, VERSION_UPDATE);
+	const long newVer = make_full_ed2k_version(fields[0], fields[1], fields[2]);
+	result.state = (curVer < newVer) ? CVersionCompareResult::Outdated : CVersionCompareResult::UpToDate;
+	return result;
 }
 
 wxString GetConfigDir(const wxString &configFileBase)

--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -1489,7 +1489,8 @@ CVersionCompareResult CompareLatestReleaseVersion(const wxString &json)
 	result.latest = wxString::Format(wxT("%ld.%ld.%ld"), fields[0], fields[1], fields[2]);
 
 	const long curVer = make_full_ed2k_version(VERSION_MJR, VERSION_MIN, VERSION_UPDATE);
-	const long newVer = make_full_ed2k_version(fields[0], fields[1], fields[2]);
+	const long newVer = make_full_ed2k_version(
+		static_cast<int>(fields[0]), static_cast<int>(fields[1]), static_cast<int>(fields[2]));
 	result.state = (curVer < newVer) ? CVersionCompareResult::Outdated : CVersionCompareResult::UpToDate;
 	return result;
 }

--- a/src/OtherFunctions.h
+++ b/src/OtherFunctions.h
@@ -317,6 +317,31 @@ inline long int make_full_ed2k_version(int a, int b, int c)
 	return ((a << 17) | (b << 10) | (c << 7));
 }
 
+// Outcome of comparing the latest published release against this build.
+struct CVersionCompareResult
+{
+	enum State
+	{
+		ParseError, // tag_name missing or unparseable
+		UpToDate,   // running version is >= the latest release
+		Outdated,   // a newer release exists
+	} state = ParseError;
+
+	// Parsed components of the latest release tag (0 on ParseError).
+	long major = 0;
+	long minor = 0;
+	long update = 0;
+	// "major.minor.update" convenience string; empty on ParseError.
+	wxString latest;
+};
+
+// Parse the `tag_name` from a GitHub /releases/latest JSON body and compare
+// it against this binary's compiled VERSION_MJR/MIN/UPDATE. Pure and
+// wxBase-only (no GUI, no preferences), so the daemon check
+// (CamuleApp::CheckNewVersion), the GUI check (CVersionCheck) and amuleapi
+// all share one implementation.
+CVersionCompareResult CompareLatestReleaseVersion(const wxString &json);
+
 wxString GetConfigDir(const wxString &configFile);
 
 /**

--- a/src/VersionCheck.cpp
+++ b/src/VersionCheck.cpp
@@ -24,17 +24,13 @@
 
 #include "VersionCheck.h"
 
-#include "config.h" // Needed for VERSION_MJR / MIN / UPDATE (via ClientVersion.h)
+#include "config.h" // Needed for ENABLE_VERSION_CHECK
 
 #ifdef ENABLE_VERSION_CHECK
 
-#include <common/ClientVersion.h> // VERSION_MJR / VERSION_MIN / VERSION_UPDATE
-#include "OtherFunctions.h"       // make_full_ed2k_version
-#include "Logger.h"               // AddDebugLogLineN / logGeneral
-#include "HTTPDownload.h"         // CreateAmuleWebRequest (shared curl session + interface bind)
-
-#include <wx/regex.h>
-#include <wx/tokenzr.h>
+#include "OtherFunctions.h" // CompareLatestReleaseVersion
+#include "Logger.h"         // AddDebugLogLineN / logGeneral
+#include "HTTPDownload.h"   // CreateAmuleWebRequest (shared curl session + interface bind)
 
 wxDEFINE_EVENT(wxEVT_VERSION_CHECK_DONE, wxCommandEvent);
 
@@ -106,48 +102,20 @@ void CVersionCheck::OnRequestState(wxWebRequestEvent &evt)
 
 CVersionCheck::Status CVersionCheck::Evaluate(const wxString &json)
 {
-	// Extract the `tag_name` string — the same field the daemon-side check
-	// reads. /releases/latest excludes pre-releases, so the tag names a
-	// stable release. A regex on the one well-known field is robust against
-	// whitespace and field-order changes without a full JSON parser.
-	wxRegEx tagRe(wxT("\"tag_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\""));
-	if (!tagRe.IsValid() || !tagRe.Matches(json)) {
-		return Failed;
-	}
-	wxString tag = tagRe.GetMatch(json, 1);
-
-	// Tolerate an optional leading v/V (aMule tags are bare semver, but be
-	// defensive in case a future maintainer switches to vX.Y.Z).
-	if (tag.StartsWith(wxT("v")) || tag.StartsWith(wxT("V"))) {
-		tag = tag.Mid(1);
-	}
-	// Strip any pre-release / build-metadata suffix so the integer compare
-	// sees only MAJOR.MINOR.UPDATE.
-	size_t suffixPos = tag.find_first_of(wxT("-+"));
-	if (suffixPos != wxString::npos) {
-		tag = tag.Mid(0, suffixPos);
-	}
-	if (tag.IsEmpty()) {
-		return Failed;
-	}
-
-	long fields[] = { 0, 0, 0 };
-	wxStringTokenizer tkz(tag, wxT("."));
-	for (int i = 0; i < 3 && tkz.HasMoreTokens(); ++i) {
-		// Tags with fewer than three components (e.g. "3.1") are valid;
-		// the missing fields stay 0.
-		if (!tkz.GetNextToken().ToLong(&fields[i])) {
-			return Failed;
-		}
-	}
-
-	long curVer = make_full_ed2k_version(VERSION_MJR, VERSION_MIN, VERSION_UPDATE);
-	long newVer = make_full_ed2k_version(fields[0], fields[1], fields[2]);
-	if (curVer < newVer) {
-		m_latest = wxString::Format(wxT("%ld.%ld.%ld"), fields[0], fields[1], fields[2]);
+	// Shared parse + compare (see OtherFunctions.cpp:CompareLatestReleaseVersion).
+	// Same logic the daemon check and amuleapi use, so there is a single
+	// source of truth for how a GitHub release tag is interpreted.
+	const CVersionCompareResult r = CompareLatestReleaseVersion(json);
+	switch (r.state) {
+	case CVersionCompareResult::Outdated:
+		m_latest = r.latest;
 		return Outdated;
+	case CVersionCompareResult::UpToDate:
+		return UpToDate;
+	case CVersionCompareResult::ParseError:
+	default:
+		return Failed;
 	}
-	return UpToDate;
 }
 
 void CVersionCheck::Finish(Status status)

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -2215,92 +2215,38 @@ void CamuleApp::CheckNewVersion(uint32 result)
 				jsonContent += file.GetLine(i);
 			}
 
-			// Extract the `tag_name` string from the JSON.  The
-			// /releases/latest endpoint excludes pre-releases by
-			// design, so any tag_name we see here represents the
-			// latest stable Release.  We don't need a full JSON
-			// parser for one well-known field — a regex on the
-			// `"tag_name": "..."` pair is robust against
-			// whitespace and field-order changes.
-			wxRegEx tagRe("\"tag_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\"");
-			if (!tagRe.IsValid() || !tagRe.Matches(jsonContent)) {
+			// Shared parse + compare (OtherFunctions.cpp:
+			// CompareLatestReleaseVersion) — the same logic the GUI
+			// check (CVersionCheck) and amuleapi use. Folds the
+			// former regex/strip/tokenize block into one call; the
+			// ParseError branch covers every "corrupt input" case the
+			// inline code returned on (bad regex, empty tag, non-numeric
+			// component).
+			const CVersionCompareResult vc = CompareLatestReleaseVersion(jsonContent);
+			if (vc.state == CVersionCompareResult::ParseError) {
 				AddLogLineC(_("Corrupted version check file"));
 				file.Close();
 				wxRemoveFile(filename);
 				return;
 			}
-			wxString versionLine = tagRe.GetMatch(jsonContent, 1);
-
-			// Strip the optional `v` prefix (aMule's tags are bare
-			// semver, but be tolerant in case a future maintainer
-			// switches to vX.Y.Z).
-			if (versionLine.StartsWith("v") || versionLine.StartsWith("V")) {
-				versionLine = versionLine.Mid(1);
-			}
-
-			// Strip any pre-release / build-metadata suffix so the
-			// integer comparison sees only MAJOR.MINOR.UPDATE.
-			// /releases/latest already excludes pre-releases, but
-			// be defensive: a stable tag like `3.0.0+build42`
-			// should still parse.
-			size_t suffixPos = versionLine.find_first_of(wxT("-+"));
-			if (suffixPos != wxString::npos) {
-				versionLine = versionLine.Mid(0, suffixPos);
-			}
-
-			// Catch degenerate inputs where the prefix/suffix
-			// strip leaves nothing behind (e.g. tag_name "v",
-			// "-foo", "v-rc1").  Without this guard the
-			// tokenizer returns no tokens, all three fields
-			// stay at 0, and the comparison silently reports
-			// "up to date" against an unparseable input.
-			if (versionLine.IsEmpty()) {
-				AddLogLineC(_("Corrupted version check file"));
-				file.Close();
-				wxRemoveFile(filename);
-				return;
-			}
-
-			wxStringTokenizer tkz(versionLine, ".");
 
 			AddDebugLogLineN(logGeneral,
-				wxString("Running: ") + VERSION + ", Version check: " + versionLine);
+				wxString("Running: ") + VERSION + ", Version check: " + vc.latest);
 
-			long fields[] = { 0, 0, 0 };
-			for (int i = 0; i < 3; ++i) {
-				if (!tkz.HasMoreTokens()) {
-					// Tags with fewer than three components (e.g.
-					// a maintainer tagging "3.1" instead of "3.1.0")
-					// are valid; treat the missing field as 0.
-					break;
-				}
-				wxString token = tkz.GetNextToken();
-
-				if (!token.ToLong(&fields[i])) {
-					AddLogLineC(_("Corrupted version check file"));
-					file.Close();
-					wxRemoveFile(filename);
-					return;
-				}
-			}
-
-			long curVer = make_full_ed2k_version(VERSION_MJR, VERSION_MIN, VERSION_UPDATE);
-			long newVer = make_full_ed2k_version(fields[0], fields[1], fields[2]);
-
-			if (curVer < newVer) {
+			if (vc.state == CVersionCompareResult::Outdated) {
 				AddLogLineC(_("You are using an outdated version of aMule!"));
 				// cppcheck-suppress zerodiv
 				AddLogLineN(CFormat(_("Your aMule version is %i.%i.%i and the latest version "
 						      "is %li.%li.%li")) %
-					    VERSION_MJR % VERSION_MIN % VERSION_UPDATE % fields[0] %
-					    fields[1] % fields[2]);
+					    VERSION_MJR % VERSION_MIN % VERSION_UPDATE % vc.major % vc.minor %
+					    vc.update);
 				AddLogLineN(_("The latest version can always be found at "
 					      "https://github.com/amule-org/amule/releases/latest"));
 #ifdef AMULE_DAEMON
 				AddLogLineCS(CFormat(_("WARNING: Your aMuled version is outdated: %i.%i.%i < "
 						       "%li.%li.%li")) %
-					     VERSION_MJR % VERSION_MIN % VERSION_UPDATE % fields[0] %
-					     fields[1] % fields[2]);
+					     VERSION_MJR % VERSION_MIN % VERSION_UPDATE % vc.major %
+					     vc.minor % vc.update);
 #endif
 			} else {
 				AddLogLineN(_("Your copy of aMule is up to date."));

--- a/unittests/tests/OtherFunctionsTest.cpp
+++ b/unittests/tests/OtherFunctionsTest.cpp
@@ -69,3 +69,89 @@ TEST(Base64, NoHeaderProducesPlainBase64)
 	ASSERT_FALSE(result.Contains(wxT("-----")));
 	ASSERT_TRUE(result.Contains(wxT("TWFu")));
 }
+
+// CompareLatestReleaseVersion — the shared release-tag parse + version
+// comparison used by the daemon check (CamuleApp::CheckNewVersion) and the
+// GUI check (CVersionCheck). Comparisons use extreme tags (999.x / 0.0.1) so
+// the up-to-date / outdated results are deterministic regardless of the
+// version this test binary was compiled with.
+
+DECLARE_SIMPLE(VersionCompare)
+
+TEST(VersionCompare, ParsesTagAndReportsOutdated)
+{
+	CVersionCompareResult r = CompareLatestReleaseVersion(wxT("{\"tag_name\": \"999.5.3\"}"));
+	ASSERT_TRUE(r.state == CVersionCompareResult::Outdated);
+	ASSERT_EQUALS(999, r.major);
+	ASSERT_EQUALS(5, r.minor);
+	ASSERT_EQUALS(3, r.update);
+	ASSERT_EQUALS(wxString(wxT("999.5.3")), r.latest);
+}
+
+TEST(VersionCompare, ReportsUpToDate)
+{
+	CVersionCompareResult r = CompareLatestReleaseVersion(wxT("{\"tag_name\": \"0.0.1\"}"));
+	ASSERT_TRUE(r.state == CVersionCompareResult::UpToDate);
+}
+
+// A leading v/V is tolerated.
+TEST(VersionCompare, StripsVPrefix)
+{
+	CVersionCompareResult r = CompareLatestReleaseVersion(wxT("{\"tag_name\": \"v999.5.3\"}"));
+	ASSERT_TRUE(r.state == CVersionCompareResult::Outdated);
+	ASSERT_EQUALS(999, r.major);
+	ASSERT_EQUALS(5, r.minor);
+	ASSERT_EQUALS(3, r.update);
+}
+
+// A pre-release / build-metadata suffix is stripped before comparison.
+TEST(VersionCompare, StripsSuffix)
+{
+	CVersionCompareResult a = CompareLatestReleaseVersion(wxT("{\"tag_name\": \"999.5.3-rc1\"}"));
+	ASSERT_EQUALS(999, a.major);
+	ASSERT_EQUALS(5, a.minor);
+	ASSERT_EQUALS(3, a.update);
+
+	CVersionCompareResult b = CompareLatestReleaseVersion(wxT("{\"tag_name\": \"999.5.3+build42\"}"));
+	ASSERT_EQUALS(3, b.update);
+}
+
+// Tags with fewer than three components are valid; missing fields are 0.
+TEST(VersionCompare, FewerComponents)
+{
+	CVersionCompareResult r = CompareLatestReleaseVersion(wxT("{\"tag_name\": \"999.5\"}"));
+	ASSERT_TRUE(r.state == CVersionCompareResult::Outdated);
+	ASSERT_EQUALS(999, r.major);
+	ASSERT_EQUALS(5, r.minor);
+	ASSERT_EQUALS(0, r.update);
+	ASSERT_EQUALS(wxString(wxT("999.5.0")), r.latest);
+}
+
+// Whitespace around the JSON colon is tolerated (regex match, not full parse).
+TEST(VersionCompare, WhitespaceTolerant)
+{
+	CVersionCompareResult r = CompareLatestReleaseVersion(wxT("{ \"tag_name\"  :   \"999.5.3\" }"));
+	ASSERT_TRUE(r.state == CVersionCompareResult::Outdated);
+	ASSERT_EQUALS(999, r.major);
+}
+
+// No tag_name field at all is a ParseError.
+TEST(VersionCompare, ParseErrorNoTag)
+{
+	CVersionCompareResult r = CompareLatestReleaseVersion(wxT("{\"name\": \"whatever\"}"));
+	ASSERT_TRUE(r.state == CVersionCompareResult::ParseError);
+}
+
+// A tag that reduces to empty after prefix/suffix strip is a ParseError.
+TEST(VersionCompare, ParseErrorEmptyAfterStrip)
+{
+	CVersionCompareResult r = CompareLatestReleaseVersion(wxT("{\"tag_name\": \"v\"}"));
+	ASSERT_TRUE(r.state == CVersionCompareResult::ParseError);
+}
+
+// A non-numeric version component is a ParseError.
+TEST(VersionCompare, ParseErrorNonNumeric)
+{
+	CVersionCompareResult r = CompareLatestReleaseVersion(wxT("{\"tag_name\": \"3.x.0\"}"));
+	ASSERT_TRUE(r.state == CVersionCompareResult::ParseError);
+}


### PR DESCRIPTION
The GitHub `/releases/latest` `tag_name` parse plus `MAJOR.MINOR.UPDATE` comparison existed as two near-identical copies: `CamuleApp::CheckNewVersion` (the daemon startup check, `amule.cpp`) and `CVersionCheck::Evaluate` (the GUI About-dialog check, `VersionCheck.cpp`).

This extracts them into a single `CompareLatestReleaseVersion(json)` in `OtherFunctions` (beside `make_full_ed2k_version`, which it uses), returning the parsed components plus a tri-state (`ParseError` / `UpToDate` / `Outdated`). Both call sites delegate to it.

- **No behavior change** — identical parse rules (optional `v` prefix, suffix strip, fewer-than-3 components, corrupt-input handling) and comparison. The daemon's log lines keep their exact `_()` msgids, so there is no catalog churn.
- **New coverage** — 9 `VersionCompare` unit tests in `OtherFunctionsTest` (prefix/suffix strip, short tags, whitespace tolerance, up-to-date vs outdated, and three parse-error paths).
- Builds clean across `amule`, `amuled`, `amulegui`, `amuleapi`; 23/23 unit tests pass. Verified end-to-end: the amulegui About-dialog check and the amuled startup check.
