### PR TITLE
feat(amuleapi): expose a "stop" action for downloads

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -459,6 +459,8 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/downloads"
 }
 ```
 
+`status` is one of `"downloading"`, `"waiting"`, `"hashing"`, `"allocating"`, `"paused"`, `"stopped"`, `"completing"` or `"completed"`. `"stopped"` is a paused file that has also dropped all its sources and reset its Kad source search (set via `PATCH` `status:"stopped"`); it is distinct from `"paused"`, which retains its sources.
+
 The list shape omits `progress.parts` to keep large libraries compact. Use the detail endpoint for per-part state.
 
 The SSE `download_added` / `download_updated` event payload matches this object byte-for-byte.
@@ -525,7 +527,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 
 Bulk pause/resume, priority, or category change over multiple downloads — the same patch applied to every listed hash.
 
-**Body:** `{ "hashes": ["<md4>", …], … }` — a non-empty `hashes` array (max 500) plus at least one of the single-item PATCH fields: `status` (`"paused"` | `"resumed"`), `priority` (`low` | `normal` | `high` | `release` | `auto`), `category` (integer 0–255).
+**Body:** `{ "hashes": ["<md4>", …], … }` — a non-empty `hashes` array (max 500) plus at least one of the single-item PATCH fields: `status` (`"paused"` | `"resumed"` | `"stopped"`), `priority` (`low` | `normal` | `high` | `release` | `auto`), `category` (integer 0–255).
 
 ```sh
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
@@ -556,7 +558,7 @@ Mutates one or more fields of a single partfile. `{hash}` is the 32-char MD4 hex
 
 **Body:** at least one of:
 
-- `status` — `"paused"` or `"resumed"`
+- `status` — `"paused"`, `"resumed"` or `"stopped"`. `"paused"` halts transfer but keeps the file's sources; `"stopped"` additionally drops all known sources and resets the Kad source search (a stopped file must rediscover sources from scratch on resume); `"resumed"` clears either state. A stopped file reports `status: "stopped"` in the download object (see [`GET /downloads`](#get-apiv0downloads)).
 - `priority` — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` / `"auto"`
 - `category` — uint8
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2519,14 +2519,14 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 
 	bool any_change = false;
 
-	// status: "paused" | "resumed"
+	// status: "paused" | "resumed" | "stopped"
 	{
 		const auto it = obj.find("status");
 		if (it != obj.end()) {
 			if (!it->second.is<std::string>()) {
 				return ErrorResponse(400,
 					"bad_request",
-					"`status` must be one of \"paused\" or \"resumed\"");
+					"`status` must be one of \"paused\", \"resumed\" or \"stopped\"");
 			}
 			const std::string &v = it->second.get<std::string>();
 			ec_opcode_t op;
@@ -2534,10 +2534,12 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 				op = EC_OP_PARTFILE_PAUSE;
 			else if (v == "resumed")
 				op = EC_OP_PARTFILE_RESUME;
+			else if (v == "stopped")
+				op = EC_OP_PARTFILE_STOP;
 			else {
 				return ErrorResponse(400,
 					"bad_request",
-					"`status` must be one of \"paused\" or \"resumed\"");
+					"`status` must be one of \"paused\", \"resumed\" or \"stopped\"");
 			}
 			auto err = send_op(op, /*has_inner=*/false, static_cast<ec_tagname_t>(0), 0);
 			if (err.status >= 400)
@@ -4795,7 +4797,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer
 			if (!it->second.is<std::string>())
 				return ErrorResponse(400,
 					"bad_request",
-					"`status` must be one of \"paused\" or \"resumed\"");
+					"`status` must be one of \"paused\", \"resumed\" or \"stopped\"");
 			const std::string &v = it->second.get<std::string>();
 			if (v == "paused")
 				ops.push_back(
@@ -4803,10 +4805,13 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer
 			else if (v == "resumed")
 				ops.push_back(
 					{ EC_OP_PARTFILE_RESUME, false, static_cast<ec_tagname_t>(0), 0 });
+			else if (v == "stopped")
+				ops.push_back(
+					{ EC_OP_PARTFILE_STOP, false, static_cast<ec_tagname_t>(0), 0 });
 			else
 				return ErrorResponse(400,
 					"bad_request",
-					"`status` must be one of \"paused\" or \"resumed\"");
+					"`status` must be one of \"paused\", \"resumed\" or \"stopped\"");
 		}
 	}
 	{

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -161,8 +161,12 @@ const char *DownloadStatusName(std::uint8_t ps_code, bool stopped)
 		return "completing";
 
 	if (stopped)
-		return "paused"; // PS_PAUSED is implied
-				 // by EC_TAG_PARTFILE_STOPPED
+		return "stopped"; // stop = pause + drop all sources +
+				  // stop searching; the daemon reports it as
+				  // PS_PAUSED with EC_TAG_PARTFILE_STOPPED set,
+				  // surfaced here as a distinct wire status so
+				  // clients can tell it apart from a plain pause
+				  // (see /downloads PATCH status="stopped")
 	switch (ps_code) {
 	case PS_READY:
 		return "downloading";

--- a/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
+++ b/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
@@ -230,6 +230,36 @@ else
 	_pass "IMMEDIATE GET after PATCH resumed shows non-paused (status=$RESUMED)"
 fi
 
+# 5b2. PATCH status=stopped — the stop action (pause + drop all
+# sources + reset the Kad source search). amuleapi surfaces it as the
+# distinct wire status "stopped" (vs "paused", which keeps its
+# sources). Response body + immediate GET must both show it.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"status":"stopped"}' "$HOST/api/v0/downloads/$TEST_HASH"
+_assert_status 200 "PATCH /downloads/{hash} status=stopped → 200"
+_assert_json_eq '.status' stopped 'PATCH response body shows status=stopped'
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/downloads/$TEST_HASH"
+_assert_json_eq '.status' stopped \
+	'IMMEDIATE GET after PATCH stopped shows status=stopped (no stale cache)'
+
+# 5b3. Resume clears the stopped state (ResumeFile clears both the
+# paused and stopped flags), so the next GET must be neither.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"status":"resumed"}' "$HOST/api/v0/downloads/$TEST_HASH"
+_assert_status 200 "PATCH status=resumed (clear stop) → 200"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/downloads/$TEST_HASH"
+UNSTOPPED=$(printf '%s' "$CURL_BODY" | jq -r '.status')
+if [ "$UNSTOPPED" = "stopped" ] || [ "$UNSTOPPED" = "paused" ]; then
+	_fail "IMMEDIATE GET after resume-from-stopped" \
+		"still inactive (status=$UNSTOPPED) — resume did not clear stop"
+else
+	_pass "IMMEDIATE GET after resume-from-stopped shows active status ($UNSTOPPED)"
+fi
+
 # 5c. PATCH priority=release. Response + immediate GET both show
 # release.
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \

--- a/unittests/curl-tests/amuleapi/29-bulk-mutations.sh
+++ b/unittests/curl-tests/amuleapi/29-bulk-mutations.sh
@@ -66,6 +66,13 @@ _jq '.results[0].id'    "$H0"            "  results[0].id echoes the hash"
 _jq '.results[0].ok'    false            "  results[0].ok is false"
 _jq '.results[0].error.code' not_found   "  results[0].error.code is not_found"
 
+# status:"stopped" is a recognized bulk value — it reaches the per-hash
+# loop (bogus hash → not_found), proving the parse accepts it, unlike a
+# bad enum (see the 400 section).
+_req PATCH /api/v0/downloads "{\"hashes\":[\"$H0\"],\"status\":\"stopped\"}"
+_status 207 "PATCH /downloads status=stopped [bogus hash]"
+_jq '.results[0].error.code' not_found   "  bulk status=stopped results[0] not_found (value accepted)"
+
 _req DELETE /api/v0/downloads "{\"hashes\":[\"$H0\"]}"
 _status 207 "DELETE /downloads [bogus hash]"
 _jq '.results[0].error.code' not_found   "  DELETE results[0] not_found"
@@ -86,6 +93,7 @@ _req PATCH /api/v0/downloads "{\"priority\":\"high\"}";            _status 400 "
 _req PATCH /api/v0/downloads "{\"hashes\":[]}";                    _status 400 "PATCH /downloads empty hashes"
 _req PATCH /api/v0/downloads "{\"hashes\":[\"$H0\"]}";            _status 400 "PATCH /downloads no patch fields"
 _req PATCH /api/v0/downloads "{\"hashes\":[\"$H0\"],\"priority\":\"bogus\"}"; _status 400 "PATCH /downloads bad priority"
+_req PATCH /api/v0/downloads "{\"hashes\":[\"$H0\"],\"status\":\"bogus\"}";   _status 400 "PATCH /downloads bad status"
 _req DELETE /api/v0/downloads "{}";                               _status 400 "DELETE /downloads missing hashes"
 _req PATCH /api/v0/shared "{\"hashes\":[\"$H0\"]}";              _status 400 "PATCH /shared missing priority"
 _req PATCH /api/v0/shared "{\"hashes\":[\"$H0\"],\"priority\":\"nope\"}";     _status 400 "PATCH /shared bad priority"

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -556,19 +556,21 @@ TEST(Refresher, StatusDecodeCompletingOverridesStopped)
 	ASSERT_EQUALS(std::string("completing"), cache.find(102)->second.download.status);
 }
 
-TEST(Refresher, StatusDecodeStoppedNonCompleteStaysPaused)
+TEST(Refresher, StatusDecodeStoppedNonCompleteReportsStopped)
 {
-	// Sanity check the other direction: a download that's stopped
-	// but NOT yet completed (user paused mid-transfer) must still
-	// report "paused" — the fix only carves out
-	// PS_COMPLETE/PS_COMPLETING.
+	// A download that's stopped but NOT yet completed (user hit Stop
+	// mid-transfer) surfaces as the distinct wire status "stopped":
+	// stop = pause + drop all sources + reset the Kad source search,
+	// and clients need to tell it apart from a plain "paused" (which
+	// keeps its sources). PS_COMPLETE / PS_COMPLETING still take
+	// priority over the stopped flag — see the two tests above.
 	FileMap cache;
 	std::map<std::uint32_t, PartFileEncoderData> rle_state;
 
 	CECPacket resp(EC_OP_SHARED_FILES);
 	{
 		CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(103));
-		// PS_READY = 0 (transferring). User paused it.
+		// PS_READY = 0 (transferring). User stopped it.
 		pf.AddTag(CECTag(EC_TAG_PARTFILE_STATUS, static_cast<std::uint8_t>(0)));
 		pf.AddTag(CECTag(EC_TAG_PARTFILE_STOPPED, true));
 		resp.AddTag(pf);
@@ -576,7 +578,29 @@ TEST(Refresher, StatusDecodeStoppedNonCompleteStaysPaused)
 
 	ApplyGetUpdateToDownloads(&resp, cache, rle_state);
 	ASSERT_TRUE(cache.find(103) != cache.end());
-	ASSERT_EQUALS(std::string("paused"), cache.find(103)->second.download.status);
+	ASSERT_EQUALS(std::string("stopped"), cache.find(103)->second.download.status);
+}
+
+TEST(Refresher, StatusDecodePausedNotStoppedReportsPaused)
+{
+	// The complement: a paused file that is NOT stopped (PS_PAUSED with
+	// the stopped flag clear) keeps its sources and reports "paused",
+	// distinct from the "stopped" state above. Pins that the "stopped"
+	// wire status is gated on EC_TAG_PARTFILE_STOPPED, not on PS_PAUSED.
+	FileMap cache;
+	std::map<std::uint32_t, PartFileEncoderData> rle_state;
+
+	CECPacket resp(EC_OP_SHARED_FILES);
+	{
+		CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(104));
+		pf.AddTag(CECTag(EC_TAG_PARTFILE_STATUS, static_cast<std::uint8_t>(7 /* PS_PAUSED */)));
+		pf.AddTag(CECTag(EC_TAG_PARTFILE_STOPPED, false));
+		resp.AddTag(pf);
+	}
+
+	ApplyGetUpdateToDownloads(&resp, cache, rle_state);
+	ASSERT_TRUE(cache.find(104) != cache.end());
+	ASSERT_EQUALS(std::string("paused"), cache.find(104)->second.download.status);
 }
 
 TEST(Refresher, ParseStatsTreeStripsRootAndRecursesChildren)


### PR DESCRIPTION
Issue #389: the Web API only offered pause/resume for downloads, while the core/EC layer already fully supports stop (`EC_OP_PARTFILE_STOP`, handled in `ExternalConn.cpp` and used by amulegui). This wires the missing HTTP layer.

**API changes**

- `PATCH /api/v0/downloads/{hash}` and the bulk `PATCH /api/v0/downloads` now accept `status: "stopped"`, mapped to `EC_OP_PARTFILE_STOP` (alongside `"paused"`/`"resumed"`). Unknown values still return `400`.
- A stopped file is now surfaced with the distinct wire status `"stopped"` (previously collapsed to `"paused"`). amuled reports a stopped file as `PS_PAUSED` + `EC_TAG_PARTFILE_STOPPED`; `Refresher::DownloadStatusName` maps that to `"stopped"`, so clients can tell a stopped file (sources dropped, Kad search reset) apart from a plain pause (sources retained). `PS_COMPLETE`/`PS_COMPLETING` still take priority over the stopped flag.

**Out of scope:** the WebUI (Stop button / badge) is left to the issue author (@ngosang); this PR is the REST/API contract only.

**Docs + tests**

- `docs/api/REFERENCE.md`: documented `status:"stopped"` on both PATCH endpoints and added `"stopped"` to the download `status` enum with stop-vs-pause semantics.
- cctest `RefresherTest`: updated the test that asserted the old `stopped→"paused"` behaviour, and added the `paused`-not-`stopped` complement.
- curl suite: extended `12-downloads-add-patch.sh` (single stop + resume-clears-stop + no-stale-cache invariant) and `29-bulk-mutations.sh` (bulk `stopped` accepted + bulk bad-status → 400).

**Verification:** amuleapi + tests build clean; `RefresherTest` passes; clang-format clean; both curl scripts pass end-to-end against a live amuled (12: 38/38, 29: 30/30).

Refs #389
