### PR TITLE
fix(ui): remove stray border around Category dialog OK/Cancel buttons

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -2166,8 +2166,9 @@ wxSizer *CategoriesEditWindow( wxWindow *parent, bool call_fit, bool set_sizer )
     item16->Add( item21, wxSizerFlags().CenterVertical().Right().Border(wxLEFT|wxRIGHT, 5) );
     item1->Add( item16, wxSizerFlags().Expand().CenterVertical() );
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
-    wxStaticBox *item23 = new wxStaticBox( parent, -1, "" );
-    wxStaticBoxSizer *item22 = new wxStaticBoxSizer( item23, wxHORIZONTAL );
+    // Plain button row (no static-box container) so no border is drawn
+    // around OK/Cancel, matching the Settings dialog.
+    wxBoxSizer *item22 = new wxBoxSizer( wxHORIZONTAL );
 
     wxButton *item24 = new wxButton( parent, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
     item24->SetDefault();


### PR DESCRIPTION
The **Add new category** / **Edit category** dialog wrapped its OK/Cancel buttons in an empty-title `wxStaticBoxSizer`, which renders a stray framed border around the button row. Same issue fixed for the Settings dialog in #369.

Replaces the empty static box with a plain `wxBoxSizer` in `CategoriesEditWindow` — the single layout shared by both the new and edit paths in `CCatDialog` — so the buttons sit flush with no border. Purely cosmetic; no behavior or string changes.