### PR TITLE
fix(amuleapi): Restrict download priority enum to low/normal/high/auto

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -461,6 +461,8 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/downloads"
 
 `status` is one of `"downloading"`, `"waiting"`, `"hashing"`, `"allocating"`, `"paused"`, `"stopped"`, `"completing"` or `"completed"`. `"stopped"` is a paused file that has also dropped all its sources and reset its Kad source search (set via `PATCH` `status:"stopped"`); it is distinct from `"paused"`, which retains its sources.
 
+`priority` is the download priority — one of `"low"`, `"normal"` or `"high"` — and `priority_auto` is `true` when amuled is deriving that level automatically. Downloads never report `very_low` or `release`; those are shared/upload-side levels only.
+
 The list shape omits `progress.parts` to keep large libraries compact. Use the detail endpoint for per-part state.
 
 The SSE `download_added` / `download_updated` event payload matches this object byte-for-byte.
@@ -527,7 +529,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 
 Bulk pause/resume, priority, or category change over multiple downloads — the same patch applied to every listed hash.
 
-**Body:** `{ "hashes": ["<md4>", …], … }` — a non-empty `hashes` array (max 500) plus at least one of the single-item PATCH fields: `status` (`"paused"` | `"resumed"` | `"stopped"`), `priority` (`low` | `normal` | `high` | `release` | `auto`), `category` (integer 0–255).
+**Body:** `{ "hashes": ["<md4>", …], … }` — a non-empty `hashes` array (max 500) plus at least one of the single-item PATCH fields: `status` (`"paused"` | `"resumed"` | `"stopped"`), `priority` (`low` | `normal` | `high` | `auto`), `category` (integer 0–255).
 
 ```sh
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
@@ -559,7 +561,7 @@ Mutates one or more fields of a single partfile. `{hash}` is the 32-char MD4 hex
 **Body:** at least one of:
 
 - `status` — `"paused"`, `"resumed"` or `"stopped"`. `"paused"` halts transfer but keeps the file's sources; `"stopped"` additionally drops all known sources and resets the Kad source search (a stopped file must rediscover sources from scratch on resume); `"resumed"` clears either state. A stopped file reports `status: "stopped"` in the download object (see [`GET /downloads`](#get-apiv0downloads)).
-- `priority` — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` / `"auto"`
+- `priority` — `"low"` / `"normal"` / `"high"` / `"auto"`. Downloads support only these levels; the daemon clamps any other value to `normal`. (Shared files support the wider `very_low` … `release` set — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash).)
 - `category` — uint8
 
 ```sh

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1952,12 +1952,14 @@ bool IsEcFailedResponse(const CECPacket *resp, std::string &out_msg)
 }
 
 // Map our wire-string priorities back to amule's PR_* encoding (the
-// inverse of DownloadPriorityName in Refresher.cpp). Note: amule's
-// PR_* values for DOWNLOADS only span LOW/NORMAL/HIGH/VERYHIGH/AUTO —
-// no `very_low` (that's a shared/upload-side enum). `release` is the
-// wire string for the highest priority (`PR_VERYHIGH`, raw code 3).
-// `PR_AUTO=5` is the magic value amule's PartFile uses internally
-// when the user picks "auto".
+// inverse of DownloadPriorityName in Refresher.cpp). Downloads support
+// only LOW/NORMAL/HIGH plus AUTO: CPartFile's .part.met loader clamps
+// any download priority that isn't one of those back to PR_NORMAL on
+// load (PR_AUTO=5 is the magic value stored as High + the auto flag),
+// so `very_low` and `release` are shared/upload-side levels only. They
+// are intentionally rejected here so the download PATCH enum matches
+// what the daemon can actually hold; the shared side keeps the full
+// set in SharedPriorityToCode.
 // Returns false if the wire string isn't a known download priority.
 bool DownloadPriorityToCode(const std::string &name, std::uint8_t &out)
 {
@@ -1969,9 +1971,6 @@ bool DownloadPriorityToCode(const std::string &name, std::uint8_t &out)
 		return true;
 	} else if (name == "high") {
 		out = PR_HIGH;
-		return true;
-	} else if (name == "release") {
-		out = PR_VERYHIGH;
 		return true;
 	} else if (name == "auto") {
 		out = PR_AUTO;
@@ -2561,7 +2560,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 				return ErrorResponse(400,
 					"bad_request",
 					"`priority` must be one of "
-					"low, normal, high, release, auto");
+					"low, normal, high, auto");
 			}
 			auto err = send_op(
 				EC_OP_PARTFILE_PRIO_SET, /*has_inner=*/true, EC_TAG_PARTFILE_PRIO, code);
@@ -4824,7 +4823,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer
 			if (!DownloadPriorityToCode(it->second.get<std::string>(), code))
 				return ErrorResponse(400,
 					"bad_request",
-					"`priority` must be one of low, normal, high, release, auto");
+					"`priority` must be one of low, normal, high, auto");
 			ops.push_back({ EC_OP_PARTFILE_PRIO_SET, true, EC_TAG_PARTFILE_PRIO, code });
 		}
 	}

--- a/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
+++ b/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
@@ -260,17 +260,18 @@ else
 	_pass "IMMEDIATE GET after resume-from-stopped shows active status ($UNSTOPPED)"
 fi
 
-# 5c. PATCH priority=release. Response + immediate GET both show
-# release.
+# 5c. PATCH priority=high. Response + immediate GET both show high.
+# Downloads support low/normal/high/auto only (very_low and release are
+# shared/upload-side levels — rejected below in section 6).
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
-	-d '{"priority":"release"}' "$HOST/api/v0/downloads/$TEST_HASH"
-_assert_status 200 "PATCH priority=release → 200"
-_assert_json_eq '.priority' release 'PATCH response shows priority=release'
+	-d '{"priority":"high"}' "$HOST/api/v0/downloads/$TEST_HASH"
+_assert_status 200 "PATCH priority=high → 200"
+_assert_json_eq '.priority' high 'PATCH response shows priority=high'
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/downloads/$TEST_HASH"
-_assert_json_eq '.priority' release \
-	'IMMEDIATE GET after PATCH priority=release shows priority=release'
+_assert_json_eq '.priority' high \
+	'IMMEDIATE GET after PATCH priority=high shows priority=high'
 
 # 5d. Combined PATCH — status + priority + category in one body.
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -296,6 +297,19 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"priority":"bogus"}' "$HOST/api/v0/downloads/$TEST_HASH"
 _assert_status 400 "PATCH unknown priority enum → 400"
+
+# Downloads reject the shared/upload-only levels: very_low and release
+# are not valid download priorities (the daemon would clamp them to
+# normal), so the API refuses them rather than silently downgrading.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"priority":"very_low"}' "$HOST/api/v0/downloads/$TEST_HASH"
+_assert_status 400 "PATCH priority=very_low (shared-only) → 400"
+
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"priority":"release"}' "$HOST/api/v0/downloads/$TEST_HASH"
+_assert_status 400 "PATCH priority=release (shared-only) → 400"
 
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \


### PR DESCRIPTION
Closes #384.

The download and shared/upload priority sets are intentionally different. Shared files genuinely support all six levels (`very_low / low / normal / high / release / auto`) and persist them. Downloads support only **Low / Normal / High / Auto** — enforced in the core: `CPartFile`'s `.part.met` loader clamps any download priority that isn't `PR_LOW`/`PR_NORMAL`/`PR_HIGH` back to `PR_NORMAL` on load (`PR_AUTO` is stored as High + the auto flag).

But `DownloadPriorityToCode()` accepted `release` (→ `PR_VERYHIGH`). A `PATCH … {"priority":"release"}` on a download therefore returned `200`, the daemon held `PR_VERYHIGH` in memory, and it silently reverted to Normal on the next restart. `very_low` was already rejected, so the two sides were inconsistent.

**Change:** drop `release` from the download validator (single + bulk) so the download PATCH enum matches what the daemon can actually hold — `low, normal, high, auto`. `SharedPriorityToCode()` is untouched; shared files keep the full six. Since we're pre-1.0, removing `release` from the download validator is fine — no back-compat to preserve.

Note: no core/EC change is needed. The emit side reports via the shared `PriorityName()`, which keeps emitting `very_low`/`release` for the shared/category callers; no stock client (amulegui/amulecmd/amuleweb) ever sets those on a download, so once the validator is trimmed the API can't report them for a download either.

- `src/webapi/Api.cpp` — `DownloadPriorityToCode` drops `release`; single + bulk error strings updated. Shared/category validators unchanged.
- `docs/api/REFERENCE.md` — split the two enums explicitly (downloads = 4, shared = 6); document that downloads never report `very_low`/`release`.
- `unittests/curl-tests/amuleapi/12-downloads-add-patch.sh` — assert `very_low` and `release` now `400` on a download PATCH; happy-path priority switched to `high`.

Built clean on macOS (amuleapi); curl test 12 passes 40/40 against a live amuled+amuleapi; clang-format-18 clean. The download menu keeps Low/Normal/High/Auto (declined adding Very low/Release — a level the core clamps to Normal is worse than none).
