### PR TITLE
feat(amulegui): gate the version-check checkbox on the daemon's capability

### DIFF
--- a/src/ECSpecialMuleTags.cpp
+++ b/src/ECSpecialMuleTags.cpp
@@ -422,6 +422,18 @@ void CEC_Prefs_Packet::Apply() const
 		if ((oneTag = thisTab->GetTagByName(EC_TAG_GENERAL_CHECK_NEW_VERSION)) != NULL) {
 			thePrefs::SetCheckNewVersion(oneTag->GetInt() != 0);
 		}
+#ifdef CLIENT_GUI
+		// Capability of the connected daemon. 3.1+ daemons always send this
+		// bool (true = can check, false = ENABLE_VERSION_CHECK compiled out).
+		// A pre-3.1 daemon omits it but still supports the NewVersionCheck
+		// preference, so treat "absent" as available (keep the checkbox) —
+		// only an explicit false hides it.
+		if (const CECTag *vc = thisTab->GetTagByName(EC_TAG_GENERAL_VERSION_CHECK_AVAILABLE)) {
+			thePrefs::SetVersionCheckAvailable(vc->GetInt() != 0);
+		} else {
+			thePrefs::SetVersionCheckAvailable(true);
+		}
+#endif
 	}
 
 	//

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -230,6 +230,10 @@ bool CPreferences::s_ExcludeSharePatternsUseRegex;
 CShareExcludeFilter CPreferences::s_ShareExcludeFilter;
 bool CPreferences::s_AutoSortDownload;
 bool CPreferences::s_NewVersionCheck;
+// Default true so the monolithic app (which never receives the capability tag
+// over EC and doesn't consult this flag) is unaffected; the remote GUI
+// overwrites it from each prefs-apply.
+bool CPreferences::s_versionCheckAvailable = true;
 bool CPreferences::s_MediaMetadataEnabled;
 wxString CPreferences::s_MediaMetadataFFProbePath;
 bool CPreferences::s_ConnectToKad;
@@ -1546,15 +1550,18 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	 **/
 	NewCfgItem(IDC_AUTOSORT, (new Cfg_Bool("/eMule/AutoSortDownloads", s_AutoSortDownload, false)));
 
-#ifdef ENABLE_VERSION_CHECK
+#if defined(ENABLE_VERSION_CHECK) || defined(CLIENT_GUI)
 	/**
-	 * Version check. Only registered when the feature is compiled in
+	 * Version check. Registered when the feature is compiled in
 	 * (-DENABLE_VERSION_CHECK, ON by default; OFF for OS-package builds where
-	 * the distro's package manager owns updates). Defaults to on; the user can
-	 * still turn it off in Preferences.
+	 * the distro's package manager owns updates), OR in the remote GUI
+	 * (CLIENT_GUI) regardless of its own build — there the checkbox edits the
+	 * *connected daemon's* preference, so it must stay wired even when amulegui
+	 * itself was built without the feature. PrefsUnifiedDlg hides the checkbox
+	 * when the daemon can't check. Defaults to on; the user can turn it off.
 	 */
 	NewCfgItem(IDC_NEWVERSION, (new Cfg_Bool("/eMule/NewVersionCheck", s_NewVersionCheck, true)));
-#endif // ENABLE_VERSION_CHECK
+#endif // ENABLE_VERSION_CHECK || CLIENT_GUI
 
 	/**
 	 * Media metadata extraction (issue #140). Off by default so an

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -718,6 +718,12 @@ public:
 
 	static bool GetCheckNewVersion() { return s_NewVersionCheck; }
 	static void SetCheckNewVersion(bool val) { s_NewVersionCheck = val; }
+	// Runtime-only (not persisted): whether the connected daemon can actually
+	// perform version checks (advertised via EC_TAG_GENERAL_VERSION_CHECK_AVAILABLE).
+	// Set from the EC prefs-apply; the remote GUI reads it to hide the
+	// "check for new version" checkbox against a daemon that can't check.
+	static bool GetVersionCheckAvailable() { return s_versionCheckAvailable; }
+	static void SetVersionCheckAvailable(bool val) { s_versionCheckAvailable = val; }
 
 	// Media metadata (issue #140) — probe local shared files with
 	// ffprobe so we advertise Length / Bitrate / Codec to peers.
@@ -1064,6 +1070,8 @@ protected:
 
 	// Version check
 	static bool s_NewVersionCheck;
+	// Runtime-only capability of the connected daemon (not persisted).
+	static bool s_versionCheckAvailable;
 
 	// Media metadata (issue #140)
 	static bool s_MediaMetadataEnabled;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -384,8 +384,23 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 
 		if (pages[i].m_function == PreferencesGeneralTab) {
 // This must be done now or pages won't Fit();
-#ifndef ENABLE_VERSION_CHECK
-			// The in-app version check is compiled out (OS-package build):
+#if defined(CLIENT_GUI)
+			// Remote GUI: this checkbox toggles the *daemon's* version-check
+			// preference, so its visibility follows the connected daemon's
+			// capability, NOT amulegui's own build. An amulegui compiled
+			// without ENABLE_VERSION_CHECK still shows it against a capable
+			// daemon — it is only a remote editor of the daemon's pref. The
+			// capability arrives via the EC tag on prefs-apply: a 3.1+ daemon
+			// built without ENABLE_VERSION_CHECK reports false (hide); a
+			// pre-3.1 daemon omits the tag and is treated as capable (show),
+			// since it still supports the preference.
+			if (!thePrefs::GetVersionCheckAvailable()) {
+				if (wxWindow *vc = FindWindow(IDC_NEWVERSION)) {
+					vc->Hide();
+				}
+			}
+#elif !defined(ENABLE_VERSION_CHECK)
+			// Monolithic built without the in-app check (OS-package build):
 			// hide the now-dead "Check for new version at startup" checkbox.
 			if (wxWindow *vc = FindWindow(IDC_NEWVERSION)) {
 				vc->Hide();


### PR DESCRIPTION
Follow-up to #395. The "Check for new version at startup" checkbox (Preferences -> General) controls the **daemon's** `NewVersionCheck` preference, so the remote GUI should show it based on the **connected daemon's** capability — not amulegui's own `ENABLE_VERSION_CHECK` build flag.

- **Read** the `EC_TAG_GENERAL_VERSION_CHECK_AVAILABLE` capability bool (added in #395) on prefs-apply into a runtime `thePrefs` flag (`CLIENT_GUI` only): explicit `false` → daemon can't check; **tag absent → treated as capable** (a pre-3.1 daemon that still supports the preference — backward compat).
- **Gate** `IDC_NEWVERSION` in `PrefsUnifiedDlg`: for the remote GUI, hide only when the daemon reports no capability; the monolithic keeps its own `ENABLE_VERSION_CHECK` gate.
- **Register** the checkbox's Cfg binding for `CLIENT_GUI` regardless of amulegui's own flag, so an amulegui built without the feature can still edit a capable daemon's preference.

Coverage (all `CLIENT_GUI`-gated, so independent of amulegui's own build): a capable 3.1+ daemon → shown; a 3.1+ daemon built `OFF` → hidden; a pre-3.1 daemon → shown. Builds clean (amulegui + amule + amuled, including an `ENABLE_VERSION_CHECK=OFF` amulegui); no new translatable strings.

Follow-up to #388.
