### PR TITLE
fix(amuleapi): report download and upload priority independently

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -504,7 +504,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/downloads"
 
 `status` is one of `"downloading"`, `"waiting"`, `"hashing"`, `"allocating"`, `"paused"`, `"stopped"`, `"completing"` or `"completed"`. `"stopped"` is a paused file that has also dropped all its sources and reset its Kad source search (set via `PATCH` `status:"stopped"`); it is distinct from `"paused"`, which retains its sources.
 
-`priority` is the download priority — one of `"low"`, `"normal"` or `"high"` — and `priority_auto` is `true` when amuled is deriving that level automatically. Downloads never report `very_low` or `release`; those are shared/upload-side levels only.
+`priority` is the download priority — one of `"low"`, `"normal"` or `"high"` — and `priority_auto` is `true` when amuled is deriving that level automatically. Downloads never report `very_low` or `release`; those are shared/upload-side levels only. A file that is simultaneously downloading and shared carries two independent priorities: this download priority, and the upload priority reported by [`GET /api/v0/shared`](#get-apiv0shared). Changing one does not affect the other.
 
 The list shape omits `progress.parts` to keep large libraries compact. Use the detail endpoint for per-part state.
 
@@ -761,7 +761,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
 
 `xfer.session` / `xfer.total` are bytes uploaded during the current amuled process vs over the file's lifetime. `requests` counts how many peers have asked for the file; `accepts` counts how many of those requests were granted an upload slot. The `session` counters reset on amuled restart; `total` is persisted in `known.met`.
 
-`priority` is the upload priority — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` — and `priority_auto` is `true` when amuled is deriving that level automatically from the upload queue. This mirrors the `/downloads` shape (base `priority` + separate `priority_auto` flag); on an auto file `priority` reports the current derived level, not the literal string `"auto"`.
+`priority` is the upload priority — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` — and `priority_auto` is `true` when amuled is deriving that level automatically from the upload queue. This mirrors the `/downloads` shape (base `priority` + separate `priority_auto` flag); on an auto file `priority` reports the current derived level, not the literal string `"auto"`. For a file that is both downloading and shared this upload priority is independent of the download priority reported by [`GET /api/v0/downloads`](#get-apiv0downloads).
 
 The SSE `shared_added` / `shared_updated` event payload matches this object byte-for-byte, so a subscriber that received `shared_updated` does not need to re-GET to see the moved counters.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1612,7 +1612,7 @@ void WriteDownloadObject(CJsonWriter &w, const webapi::FileSnapshot &f, bool inc
 	w.Key("status");
 	w.ValueString(wxString::FromUTF8(f.download.status.c_str()));
 	w.Key("priority");
-	w.ValueString(wxString::FromUTF8(f.priority.c_str()));
+	w.ValueString(wxString::FromUTF8(f.download.priority.c_str()));
 	w.Key("priority_auto");
 	w.ValueBool(f.download.priority_auto);
 	w.Key("category");
@@ -1710,7 +1710,7 @@ void WriteSharedObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.Key("size");
 	w.ValueInt(static_cast<int64_t>(f.size));
 	w.Key("priority");
-	w.ValueString(wxString::FromUTF8(f.priority.c_str()));
+	w.ValueString(wxString::FromUTF8(f.shared.priority.c_str()));
 	w.Key("priority_auto");
 	w.ValueBool(f.shared.priority_auto);
 	w.Key("complete_sources");

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -107,7 +107,7 @@ std::string ToJsonDownloadEvent(const FileSnapshot &f)
 	  << ",\"size\":" << f.size << ",\"size_done\":" << f.download.size_done
 	  << ",\"size_xfer\":" << f.download.size_xfer << ",\"speed_bps\":" << f.download.speed_bps
 	  << ",\"status\":\"" << EscJson(f.download.status) << "\""
-	  << ",\"priority\":\"" << EscJson(f.priority) << "\""
+	  << ",\"priority\":\"" << EscJson(f.download.priority) << "\""
 	  << ",\"priority_auto\":" << (f.download.priority_auto ? "true" : "false")
 	  << ",\"category\":" << f.download.category << ",\"sources\":{"
 	  << "\"total\":" << f.download.sources_total << ",\"not_current\":" << f.download.sources_not_current
@@ -127,7 +127,7 @@ std::string ToJsonSharedEvent(const FileSnapshot &f)
 	  << "\"hash\":\"" << EscJson(f.hash) << "\""
 	  << ",\"name\":\"" << EscJson(f.name) << "\""
 	  << ",\"ed2k_link\":\"" << EscJson(f.ed2k_link) << "\""
-	  << ",\"size\":" << f.size << ",\"priority\":\"" << EscJson(f.priority) << "\""
+	  << ",\"size\":" << f.size << ",\"priority\":\"" << EscJson(f.shared.priority) << "\""
 	  << ",\"priority_auto\":" << (f.shared.priority_auto ? "true" : "false")
 	  << ",\"complete_sources\":" << f.shared.complete_sources
 	  << ",\"xfer\":{\"session\":" << f.shared.xfer_session << ",\"total\":" << f.shared.xfer_total << "}"
@@ -233,9 +233,9 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 bool EqualDownload(const FileSnapshot &a, const FileSnapshot &b)
 {
 	return a.ecid == b.ecid && a.hash == b.hash && a.name == b.name && a.ed2k_link == b.ed2k_link &&
-	       a.size == b.size && a.priority == b.priority && a.download.size_done == b.download.size_done &&
-	       a.download.size_xfer == b.download.size_xfer && a.download.speed_bps == b.download.speed_bps &&
-	       a.download.status == b.download.status &&
+	       a.size == b.size && a.download.priority == b.download.priority &&
+	       a.download.size_done == b.download.size_done && a.download.size_xfer == b.download.size_xfer &&
+	       a.download.speed_bps == b.download.speed_bps && a.download.status == b.download.status &&
 	       a.download.priority_auto == b.download.priority_auto &&
 	       a.download.category == b.download.category &&
 	       a.download.sources_total == b.download.sources_total &&
@@ -246,7 +246,7 @@ bool EqualDownload(const FileSnapshot &a, const FileSnapshot &b)
 bool EqualShared(const FileSnapshot &a, const FileSnapshot &b)
 {
 	return a.ecid == b.ecid && a.hash == b.hash && a.name == b.name && a.ed2k_link == b.ed2k_link &&
-	       a.size == b.size && a.priority == b.priority &&
+	       a.size == b.size && a.shared.priority == b.shared.priority &&
 	       a.shared.priority_auto == b.shared.priority_auto &&
 	       a.shared.complete_sources == b.shared.complete_sources &&
 	       a.shared.xfer_session == b.shared.xfer_session && a.shared.xfer_total == b.shared.xfer_total &&

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -323,7 +323,7 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 		std::uint8_t pr_raw = 0;
 		if (pf->AssignIfExist(EC_TAG_PARTFILE_PRIO, pr_raw)) {
 			bool prio_auto = false;
-			f.priority = PriorityName(pr_raw, prio_auto);
+			f.download.priority = PriorityName(pr_raw, prio_auto);
 			f.download.priority_auto = prio_auto;
 		}
 	}
@@ -740,7 +740,7 @@ void MergeSharedTag(const CEC_SharedFile_Tag *sf, FileSnapshot &f)
 		std::uint8_t pr = 0;
 		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_PRIO, pr)) {
 			bool sh_auto = false;
-			f.priority = PriorityName(pr, sh_auto);
+			f.shared.priority = PriorityName(pr, sh_auto);
 			f.shared.priority_auto = sh_auto;
 		}
 	}

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -86,8 +86,6 @@ struct FileSnapshot
 	std::string name;
 	std::string ed2k_link;
 	std::uint64_t size = 0;
-	std::string priority; // "very_low" | "low" | "normal"
-			      // | "high"     | "release" | "auto"
 
 	bool is_downloading = false;
 	bool is_shared = false;
@@ -102,6 +100,9 @@ struct FileSnapshot
 		std::uint32_t speed_bps = 0;
 		std::string status; // "downloading" | "paused"
 				    // | "completed" | "hashing" | ...
+		// Download priority: "very_low" | "low" | "normal" | "high"
+		// | "release" | "auto".
+		std::string priority;
 		bool priority_auto = false;
 		std::uint32_t category = 0;
 		double percent = 0.0;
@@ -125,9 +126,13 @@ struct FileSnapshot
 	// reset on the true→false transition.
 	struct SharedSide
 	{
-		// Upload-side auto-priority flag, mirroring `download.priority_auto`.
-		// The base level lands in the top-level `priority` field; this says
-		// whether amuled is deriving it automatically from the upload queue.
+		// Upload priority level, distinct from the download-side value —
+		// a partfile that is both downloading and shared carries two
+		// independent priorities, so each side stores its own.
+		std::string priority; // upload priority: "very_low" | "low"
+				      // | "normal" | "high" | "release" | "auto"
+		// Upload-side auto-priority flag, mirroring `download.priority_auto`;
+		// says whether amuled is deriving it automatically from the queue.
 		bool priority_auto = false;
 		std::uint64_t xfer_session = 0;
 		std::uint64_t xfer_total = 0;

--- a/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
+++ b/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
@@ -210,6 +210,77 @@ _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/shared/$TEST_HASH"
 _assert_status 405 "DELETE /shared/{hash} → 405"
 
+# --- 5b. Both-file priority independence. --------------------------
+# A partfile that is BOTH downloading and shared carries two independent
+# priorities: a download priority (EC_TAG_PARTFILE_PRIO) on /downloads and
+# an upload priority (EC_TAG_KNOWNFILE_PRIO) on /shared. They must not
+# clobber each other — a prior build stored a single `priority` on the
+# snapshot entry, so the shared refresher pass overwrote the download
+# value and /downloads reported the UPLOAD level. The scenario needs a
+# file present in both lists (a partfile with >=1 completed part, which
+# requires a live source), so skip when none exists; the unit test
+# (RefresherTest.BothFilePrioritiesAreIndependent) covers the split
+# against crafted EC packets.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/downloads"
+DL_BODY=$CURL_BODY
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared"
+SH_BODY=$CURL_BODY
+BOTH_HASH=$(jq -rn --argjson d "$DL_BODY" --argjson s "$SH_BODY" \
+	'([$d.downloads[].hash] - ([$d.downloads[].hash] - [$s.shared[].hash]))[0] // ""')
+if [ -z "$BOTH_HASH" ]; then
+	echo "    info: no downloading-and-shared partfile present; skipping independence check"
+else
+	echo "    info: both-file hash=$BOTH_HASH"
+	B_DL_PRIO=$(jq -rn --argjson d "$DL_BODY" --arg h "$BOTH_HASH" \
+		'$d.downloads[] | select(.hash == $h) | .priority')
+	B_DL_AUTO=$(jq -rn --argjson d "$DL_BODY" --arg h "$BOTH_HASH" \
+		'$d.downloads[] | select(.hash == $h) | .priority_auto')
+	B_SH_PRIO=$(jq -rn --argjson s "$SH_BODY" --arg h "$BOTH_HASH" \
+		'$s.shared[] | select(.hash == $h) | .priority')
+	B_SH_AUTO=$(jq -rn --argjson s "$SH_BODY" --arg h "$BOTH_HASH" \
+		'$s.shared[] | select(.hash == $h) | .priority_auto')
+	# Set the two sides to DISTINCT levels. On the buggy build the shared
+	# pass clobbers the download value, so /downloads reports "low".
+	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"priority":"high"}' "$HOST/api/v0/downloads/$BOTH_HASH"
+	_assert_status 200 "PATCH download priority=high (both-file) → 200"
+	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"priority":"low"}' "$HOST/api/v0/shared/$BOTH_HASH"
+	_assert_status 200 "PATCH shared priority=low (both-file) → 200"
+
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/downloads"
+	OBS_DL=$(printf '%s' "$CURL_BODY" | jq -r --arg h "$BOTH_HASH" \
+		'.downloads[] | select(.hash == $h) | .priority')
+	if [ "$OBS_DL" = "high" ]; then
+		_pass "/downloads reports download priority (high), not clobbered by shared PATCH"
+	else
+		_fail "/downloads priority independence" \
+			"expected high, got $OBS_DL (shared priority leaked onto /downloads)"
+	fi
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared"
+	OBS_SH=$(printf '%s' "$CURL_BODY" | jq -r --arg h "$BOTH_HASH" \
+		'.shared[] | select(.hash == $h) | .priority')
+	if [ "$OBS_SH" = "low" ]; then
+		_pass "/shared reports upload priority (low), not clobbered by download PATCH"
+	else
+		_fail "/shared priority independence" \
+			"expected low, got $OBS_SH (download priority leaked onto /shared)"
+	fi
+
+	# Restore both sides. (If BOTH_HASH == TEST_HASH, section 6 restores
+	# the shared side again — idempotent.)
+	[ "$B_DL_AUTO" = "true" ] && B_DL_RESTORE=auto || B_DL_RESTORE=$B_DL_PRIO
+	[ "$B_SH_AUTO" = "true" ] && B_SH_RESTORE=auto || B_SH_RESTORE=$B_SH_PRIO
+	curl -s -o /dev/null -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"priority\":\"$B_DL_RESTORE\"}" "$HOST/api/v0/downloads/$BOTH_HASH"
+	curl -s -o /dev/null -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"priority\":\"$B_SH_RESTORE\"}" "$HOST/api/v0/shared/$BOTH_HASH"
+fi
+
 # --- 6. Restore saved priority. -----------------------------------
 # If the file was on auto, restore "auto" (SAVED_PRIORITY holds the
 # derived base level, not the literal "auto"); otherwise restore the

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -369,6 +369,53 @@ TEST(Refresher, NewPartfileInsertedInOneTick)
 }
 
 // ----------------------------------------------------------------------
+// A partfile that is BOTH downloading and shared carries two independent
+// priorities: the download priority (EC_TAG_PARTFILE_PRIO, surfaced on
+// /downloads) and the upload priority (EC_TAG_KNOWNFILE_PRIO, surfaced on
+// /shared). They live in separate sub-blocks; the shared-walker pass must
+// not clobber the download value written by the downloads-walker pass.
+// (Regression: a single top-level snapshot `priority` field let the two
+// overwrite each other — /downloads reported the upload level.)
+// ----------------------------------------------------------------------
+
+TEST(Refresher, BothFilePrioritiesAreIndependent)
+{
+	FileMap cache;
+	std::map<std::uint32_t, PartFileEncoderData> rle_state;
+
+	// Downloads pass: partfile ECID 77 at download priority PR_HIGH (=2,
+	// Constants.h) → "high".
+	{
+		CECPacket resp(EC_OP_SHARED_FILES);
+		CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(77));
+		pf.AddTag(CECTag(EC_TAG_PARTFILE_PRIO, static_cast<std::uint8_t>(2)));
+		resp.AddTag(pf);
+		ApplyGetUpdateToDownloads(&resp, cache, rle_state);
+	}
+	ASSERT_TRUE(cache.find(77) != cache.end());
+	ASSERT_TRUE(cache.find(77)->second.is_downloading);
+	ASSERT_EQUALS(std::string("high"), cache.find(77)->second.download.priority);
+
+	// Shared pass: SAME ECID, shared flag on, upload priority PR_LOW (=0)
+	// → "low". Must land in shared.priority and leave download.priority.
+	{
+		CECPacket resp(EC_OP_SHARED_FILES);
+		CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(77));
+		pf.AddTag(CECTag(EC_TAG_PARTFILE_SHARED, static_cast<std::uint8_t>(1)));
+		pf.AddTag(CECTag(EC_TAG_KNOWNFILE_PRIO, static_cast<std::uint8_t>(0)));
+		resp.AddTag(pf);
+		ApplyGetUpdateToShared(&resp, cache);
+	}
+
+	const auto it = cache.find(77);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_TRUE(it->second.is_downloading);
+	ASSERT_TRUE(it->second.is_shared);
+	ASSERT_EQUALS(std::string("high"), it->second.download.priority); // not clobbered
+	ASSERT_EQUALS(std::string("low"), it->second.shared.priority);
+}
+
+// ----------------------------------------------------------------------
 // /servers — GET_UPDATE wraps per-server tags in an EC_TAG_SERVER
 // container at top level. Walker iterates INTO the container and
 // merges per-ECID; cache entries not seen in the response get evicted

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -118,7 +118,7 @@ TEST(State, MutateDownloadsRoundtripAndFind)
 		a.size = 1000;
 		a.is_downloading = true;
 		a.download.size_done = 250;
-		a.priority = "high";
+		a.download.priority = "high";
 		a.download.status = "downloading";
 		a.download.percent = 25.0;
 		cache.emplace(a.ecid, a);
@@ -228,7 +228,7 @@ TEST(State, MutateClientsAndSharedRoundtrip)
 		x.name = "shared.iso";
 		x.size = 4096;
 		x.is_shared = true;
-		x.priority = "normal";
+		x.shared.priority = "normal";
 		cache.emplace(x.ecid, x);
 	});
 	ASSERT_EQUALS(static_cast<size_t>(1), s.Shared().size());


### PR DESCRIPTION
A partfile that is both downloading and shared carries two independent priorities — a download priority (`SetDownPriority`, `EC_TAG_PARTFILE_PRIO`) and an upload priority (`SetUpPriority`, `EC_TAG_KNOWNFILE_PRIO`). amuleapi stored a single `priority` on its snapshot entry, written by both the downloads and shared refresher passes over the unified file map. The shared pass merges into the same entry *after* the downloads pass, so it overwrote the download value: `GET /api/v0/downloads` reported the **upload** priority for such a file, and the SSE diff comparators fired a spurious `download_updated` when only the upload priority moved (and vice versa).

This splits the snapshot field into `download.priority` and `shared.priority`, each written and read by its own side. The wire shape is unchanged — `/downloads` and `/shared` (and their `*_updated` SSE events) still carry a `priority` string, now the correct one per endpoint. `PATCH` routing was already correct on both sides; only the read/snapshot path was wrong.

- **State** — `FileSnapshot` gains `download.priority` / `shared.priority`; the single top-level `priority` is gone.
- **Refresher** — the downloads pass writes `download.priority` (`EC_TAG_PARTFILE_PRIO`), the shared pass writes `shared.priority` (`EC_TAG_KNOWNFILE_PRIO`).
- **Api / EventDiff** — `WriteDownloadObject` / `WriteSharedObject`, the SSE emitters, and `EqualDownload` / `EqualShared` each read their own side.

Coverage: a new `RefresherTest.BothFilePrioritiesAreIndependent` crafts a both-downloading-and-shared partfile and asserts the shared pass leaves the download priority intact; a live both-file independence check is folded into the `17-shared-priority-patch` curl smoke (skips when no such file is present). `REFERENCE.md` notes the independence on both endpoints. Builds clean (amuleapi + unit tests); RefresherTest + StateTest pass. No new translatable strings.
