### PR TITLE
fix(amuleapi): restrict category priority to the download set (low/normal/high/auto)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -950,7 +950,7 @@ amuled's category system lets users tag downloads with one of N user-defined buc
 }
 ```
 
-`name` required; others optional. `color` is a 24-bit RGB integer; `priority` is the same enum the shared-file PATCH accepts.
+`name` required; others optional. `color` is a 24-bit RGB integer. `priority` is applied to the category's member files as a download priority, so it takes the same restricted set as [`PATCH /downloads`](#patch-apiv0downloads) — `"low"` / `"normal"` / `"high"` / `"auto"`. `very_low` and `release` are rejected (the daemon would clamp them to `normal` on the next restart).
 
 **Response:** `201 Created` → the new category object.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -5175,14 +5175,16 @@ bool ParseCategoryIndex(const std::string &s, std::uint8_t &out)
 }
 
 // Inverse of CategoryPriorityName (Refresher.cpp's ParseCategoryTag).
-// Categories use the SAME priority enum as downloads, including the
-// `+10` auto-flag offset. Maps wire strings to PR_* codes.
+// A category priority is applied to member files as a DOWNLOAD priority
+// (CDownloadQueue::SetCatPrio -> CPartFile::SetDownPriority), so it must use
+// the same restricted set as DownloadPriorityToCode: low / normal / high /
+// auto. very_low and release are not real download levels -- the .part.met
+// loader clamps anything but PR_LOW/PR_NORMAL/PR_HIGH back to Normal on the
+// next restart -- so accepting them here would be the same silent downgrade
+// #396 fixed for the direct download PATCH path (issue #384).
 bool CategoryPriorityToCode(const std::string &name, std::uint8_t &out)
 {
-	if (name == "very_low") {
-		out = PR_VERY_LOW;
-		return true;
-	} else if (name == "low") {
+	if (name == "low") {
 		out = PR_LOW;
 		return true;
 	} else if (name == "normal") {
@@ -5190,9 +5192,6 @@ bool CategoryPriorityToCode(const std::string &name, std::uint8_t &out)
 		return true;
 	} else if (name == "high") {
 		out = PR_HIGH;
-		return true;
-	} else if (name == "release") {
-		out = PR_VERYHIGH;
 		return true;
 	} else if (name == "auto") {
 		out = PR_AUTO;
@@ -5300,8 +5299,7 @@ CHttpServer::Response ParseCategoryFields(const picojson::object &obj, CategoryF
 			if (!CategoryPriorityToCode(it->second.get<std::string>(), out.prio)) {
 				return ErrorResponse(400,
 					"bad_request",
-					"`priority` must be one of low, normal, high, "
-					"release, very_low, auto");
+					"`priority` must be one of low, normal, high, auto");
 			}
 			out.has_prio = true;
 		}

--- a/unittests/curl-tests/amuleapi/18-categories-crud.sh
+++ b/unittests/curl-tests/amuleapi/18-categories-crud.sh
@@ -145,6 +145,17 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-d "{\"name\":\"x\",\"priority\":\"bogus\"}" "$HOST/api/v0/categories"
 _assert_status 400 "POST /categories (bad priority enum) → 400"
 
+# A category priority is applied to its files as a DOWNLOAD priority, so it
+# takes the restricted download set (low/normal/high/auto). very_low and
+# release are downloads-invalid — the daemon clamps them to Normal on the
+# next restart — so they must be rejected here too (issue #384).
+for p in very_low release; do
+	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"name\":\"x\",\"priority\":\"$p\"}" "$HOST/api/v0/categories"
+	_assert_status 400 "POST /categories (priority=$p rejected) → 400"
+done
+
 # --- 4. PATCH /categories/{idx}. ----------------------------------
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
@@ -171,6 +182,13 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"priority":"bogus"}' "$HOST/api/v0/categories/$NEW_IDX"
 _assert_status 400 "PATCH /categories bogus enum → 400"
+
+for p in very_low release; do
+	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"priority\":\"$p\"}" "$HOST/api/v0/categories/$NEW_IDX"
+	_assert_status 400 "PATCH /categories (priority=$p rejected) → 400"
+done
 
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \


### PR DESCRIPTION
A category priority is applied to its member files as a *download* priority (`CDownloadQueue::SetCatPrio` → `CPartFile::SetDownPriority`), but `CategoryPriorityToCode` accepted the full six-level set including `very_low` and `release`. Those aren't real download levels — `CPartFile`'s `.part.met` loader clamps anything but `PR_LOW`/`PR_NORMAL`/`PR_HIGH` back to Normal on the next restart — so setting a category to `very_low`/`release` was the same silent downgrade #396 fixed for the direct download PATCH path. The category path was missed (spotted by @ngosang on #384).

This trims `CategoryPriorityToCode` to match `DownloadPriorityToCode` (`low`/`normal`/`high`/`auto`) and updates the 400 error string. No core/EC change — the core already clamps; only the amuleapi validator was too permissive. The monolithic and amulegui category editors already offer just Low/Normal/High/Auto, so no GUI change is needed either.

Coverage: `18-categories-crud` gains POST + PATCH assertions that `very_low`/`release` now return 400 (verified locally, 28/28); `REFERENCE.md` corrects the category `priority` description (it wrongly said "the same enum the shared-file PATCH accepts"). Builds clean; clang-format (v18) + clang-tidy (Tier-2) clean.

Follow-up to #396 (issue #384).
