### PR TITLE
fix(webapi): report upload priority for late-sharing partfiles

### DIFF
--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -328,6 +328,20 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 		}
 	}
 	{
+		// Upload priority also rides on the partfile tag (the base
+		// CEC_SharedFile_Tag ctor adds EC_TAG_KNOWNFILE_PRIO). Capture
+		// it here, from the file's first downloading tick, so a partfile
+		// that starts sharing only later still has a shared `priority`:
+		// by then amuled has CValueMap-suppressed the unchanged tag and
+		// the shared walker would never see it (empty-priority bug).
+		std::uint8_t up_raw = 0;
+		if (pf->AssignIfExist(EC_TAG_KNOWNFILE_PRIO, up_raw)) {
+			bool up_auto = false;
+			f.shared.priority = PriorityName(up_raw, up_auto);
+			f.shared.priority_auto = up_auto;
+		}
+	}
+	{
 		std::uint8_t cat = 0;
 		if (pf->AssignIfExist(EC_TAG_PARTFILE_CAT, cat))
 			f.download.category = cat;
@@ -777,6 +791,21 @@ void DecodeRleBlobsForPartFile(
 	}
 }
 
+// Clear the shared *session statistics* on a share-role-off transition
+// while preserving the upload priority. The stats (xfer/requests/accepts
+// counters) are per-share-session and must not survive; the upload
+// priority is a persistent file attribute that amuled CValueMap-
+// suppresses once sent, so wiping it here would strand a partfile that
+// re-shares later with an empty `priority`.
+void ClearSharedRoleKeepPriority(FileSnapshot &f)
+{
+	std::string prio = std::move(f.shared.priority);
+	const bool prio_auto = f.shared.priority_auto;
+	f.shared = FileSnapshot::SharedSide{};
+	f.shared.priority = std::move(prio);
+	f.shared.priority_auto = prio_auto;
+}
+
 } // namespace
 
 void ApplyGetUpdateToDownloads(
@@ -865,9 +894,10 @@ void ApplyGetUpdateToShared(const CECPacket *resp, FileMap &cache)
 			auto fit = cache.find(ecid);
 			if (fit != cache.end()) {
 				fit->second.is_shared = false;
-				fit->second.shared = FileSnapshot::SharedSide{};
 				if (!fit->second.is_downloading)
 					cache.erase(fit);
+				else
+					ClearSharedRoleKeepPriority(fit->second);
 			}
 			continue;
 		}
@@ -884,14 +914,15 @@ void ApplyGetUpdateToShared(const CECPacket *resp, FileMap &cache)
 				if (!is_shared) {
 					// Partfile is_shared transitioned false (or
 					// arrived for the first time unshared).
-					// Reset the shared sub-block; entry stays in
-					// m_files because downloading role may still
+					// Reset the shared session stats; entry stays
+					// in m_files because downloading role may still
 					// hold it. If it doesn't, the downloads-walker
-					// FILE_REMOVED will drop it.
+					// FILE_REMOVED will drop it. Upload priority is
+					// preserved (persistent file attribute).
 					auto fit = cache.find(ecid);
 					if (fit != cache.end()) {
 						fit->second.is_shared = false;
-						fit->second.shared = FileSnapshot::SharedSide{};
+						ClearSharedRoleKeepPriority(fit->second);
 					}
 					continue;
 				}

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -416,6 +416,62 @@ TEST(Refresher, BothFilePrioritiesAreIndependent)
 }
 
 // ----------------------------------------------------------------------
+// A partfile that starts downloading BEFORE it shares. Its upload
+// priority (EC_TAG_KNOWNFILE_PRIO) is emitted on early ticks while it is
+// still download-only; amuled then CValueMap-suppresses the unchanged
+// tag. When the file later flips shared, the shared walker never sees
+// the priority tag again. The downloads walker must therefore latch the
+// upload priority from the partfile tag, and the share-off reset must
+// preserve it, so /shared reports a real level instead of "".
+// (Regression: amule-org/amule#384 follow-up — empty shared `priority`.)
+// ----------------------------------------------------------------------
+
+TEST(Refresher, SharedPriorityLatchedBeforeSharingSurvivesSuppression)
+{
+	FileMap cache;
+	std::map<std::uint32_t, PartFileEncoderData> rle_state;
+
+	// Tick 1 — download-only. The partfile tag carries both priorities
+	// (download PR_HIGH=2 → "high", upload PR_LOW=0 → "low") and an
+	// explicit not-shared flag. Downloads walker runs first, then shared.
+	{
+		CECPacket resp(EC_OP_SHARED_FILES);
+		CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(78));
+		pf.AddTag(CECTag(EC_TAG_PARTFILE_PRIO, static_cast<std::uint8_t>(2)));
+		pf.AddTag(CECTag(EC_TAG_KNOWNFILE_PRIO, static_cast<std::uint8_t>(0)));
+		pf.AddTag(CECTag(EC_TAG_PARTFILE_SHARED, static_cast<std::uint8_t>(0)));
+		resp.AddTag(pf);
+		ApplyGetUpdateToDownloads(&resp, cache, rle_state);
+		ApplyGetUpdateToShared(&resp, cache);
+	}
+	{
+		const auto it = cache.find(78);
+		ASSERT_TRUE(it != cache.end());
+		ASSERT_TRUE(!it->second.is_shared);
+		// Upload priority was latched by the downloads walker and NOT
+		// wiped by the share-off reset.
+		ASSERT_EQUALS(std::string("low"), it->second.shared.priority);
+	}
+
+	// Tick 2 — file flips shared, but the unchanged upload priority is
+	// now suppressed (no EC_TAG_KNOWNFILE_PRIO child). Without the latch
+	// the shared walker would leave shared.priority empty.
+	{
+		CECPacket resp(EC_OP_SHARED_FILES);
+		CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(78));
+		pf.AddTag(CECTag(EC_TAG_PARTFILE_SHARED, static_cast<std::uint8_t>(1)));
+		resp.AddTag(pf);
+		ApplyGetUpdateToShared(&resp, cache);
+	}
+
+	const auto it = cache.find(78);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_TRUE(it->second.is_shared);
+	ASSERT_EQUALS(std::string("high"), it->second.download.priority);
+	ASSERT_EQUALS(std::string("low"), it->second.shared.priority); // not empty
+}
+
+// ----------------------------------------------------------------------
 // /servers — GET_UPDATE wraps per-server tags in an EC_TAG_SERVER
 // container at top level. Walker iterates INTO the container and
 // merges per-ECID; cache entries not seen in the response get evicted


### PR DESCRIPTION
Reported by @ngosang in [#384 (comment)](https://github.com/amule-org/amule/issues/384#issuecomment-4938114862): some `/shared` entries return `priority: ""` / `priority_auto: false`. They're incomplete downloads (partfiles) that are also being shared; `/downloads` reports their priority fine. Separate from #384's set/enum work.

### Root cause
A partfile's upload priority rides on `EC_TAG_KNOWNFILE_PRIO` (added by the `CEC_SharedFile_Tag` base ctor). While the file is download-only the shared walker skips it (`EC_TAG_PARTFILE_SHARED` is false/absent). amuled CValueMap-suppresses the unchanged tag on later ticks, so when the file finally flips shared the priority tag is already gone — and `shared.priority` was never populated. `/downloads` is unaffected because the downloads walker engages from the file's first tick and catches `EC_TAG_PARTFILE_PRIO` before suppression.

### Fix (no wire-contract change)
- Latch the upload priority in the downloads walker — the partfile tag carries `EC_TAG_KNOWNFILE_PRIO` from the first tick, so record it into `shared.priority` regardless of current shared state.
- Preserve `priority`/`priority_auto` across the share-off reset (`ClearSharedRoleKeepPriority`): upload priority is a persistent file attribute, not a per-share-session statistic. Session counters are still cleared.

### Tests / docs
- Adds `RefresherTest.SharedPriorityLatchedBeforeSharingSurvivesSuppression`, covering the two-tick latch-then-suppress sequence. Full suite green (31 cases).
- No REST/SSE doc change: the `/shared` `priority` field is already documented as the upload level; this restores the documented behavior rather than altering the contract.