### PR TITLE
fix(remote-gui): batch the download-list bulk load

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -191,7 +191,7 @@ CDownloadListCtrl::~CDownloadListCtrl()
 	}
 }
 
-void CDownloadListCtrl::AddFile(CPartFile *file)
+void CDownloadListCtrl::AddFile(CPartFile *file, bool deferView)
 {
 	wxASSERT(file);
 
@@ -202,6 +202,15 @@ void CDownloadListCtrl::AddFile(CPartFile *file)
 
 		m_ListItems.insert(ListItemsPair(file, newitem));
 
+		// During a bulk load (remote GUI first sync) the caller defers
+		// the display: showing and, above all, re-sorting the list on
+		// every one of thousands of files is O(n^2) and freezes the GUI
+		// (issue #414). ShowFileList() shows and sorts the whole list
+		// once afterwards, mirroring the shared-files view.
+		if (deferView) {
+			return;
+		}
+
 		// Check if the new file is visible in the current category
 		if (file->CheckShowItemInGivenCat(m_category)) {
 			ShowFile(file, true);
@@ -211,6 +220,35 @@ void CDownloadListCtrl::AddFile(CPartFile *file)
 			SortList();
 		}
 	}
+}
+
+void CDownloadListCtrl::ShowFileList()
+{
+	// Batch counterpart to AddFile()'s per-item path: show every model
+	// item that belongs in the current category, then sort the list a
+	// single time. Used after a deferred bulk load (remote GUI first
+	// sync) so a large queue populates in one pass instead of paying an
+	// O(n^2) per-item sort. Freeze()/Thaw() collapses the repaints into
+	// one. Mirrors CSharedFilesCtrl::ShowFileList().
+	Freeze();
+
+	bool hasCompletedDownloads = false;
+
+	for (const auto &entry : m_ListItems) {
+		CPartFile *file = entry.second->GetFile();
+		if (file->CheckShowItemInGivenCat(m_category)) {
+			ShowFile(file, true);
+			if (file->IsCompleted()) {
+				hasCompletedDownloads = true;
+			}
+		}
+	}
+
+	CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(hasCompletedDownloads);
+
+	SortList();
+
+	Thaw();
 }
 
 void CDownloadListCtrl::RemoveFile(CPartFile *file)

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -72,11 +72,27 @@ public:
 	/**
 	 * Adds a file to the list, but it wont show unless it matches the current category.
 	 *
-	 * @param A valid pointer to a new partfile.
+	 * @param file A valid pointer to a new partfile.
+	 * @param deferView If true, only the internal model entry is created;
+	 *                  the file is not shown and the list is not sorted.
+	 *                  Used for a bulk load (remote GUI first sync), where
+	 *                  the caller shows and sorts the whole list once
+	 *                  afterwards via ShowFileList() instead of paying an
+	 *                  O(n^2) per-item sort. See issue #414.
 	 *
 	 * Please note that duplicates wont be added.
 	 */
-	void AddFile(CPartFile *file);
+	void AddFile(CPartFile *file, bool deferView = false);
+
+	/**
+	 * Shows every model item belonging to the current category and sorts
+	 * the list a single time, wrapped in Freeze()/Thaw().
+	 *
+	 * Batch counterpart to AddFile()'s per-item path, used after a
+	 * deferred bulk load so a large queue populates in one pass. Mirrors
+	 * CSharedFilesCtrl::ShowFileList().
+	 */
+	void ShowFileList();
 
 	/**
 	 * Removes the specified file from the list.

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1533,7 +1533,11 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 						new CPartFile(static_cast<const CEC_PartFile_Tag *>(tag));
 					ProcessItemUpdate(tag, file);
 					(*theApp->downloadqueue)[id] = file;
-					theApp->amuledlg->m_transferwnd->downloadlistctrl->AddFile(file);
+					// On the initial full sync, defer the per-item show +
+					// sort; the whole list is shown and sorted once below
+					// via ShowFileList() (issue #414 — O(n^2) otherwise).
+					theApp->amuledlg->m_transferwnd->downloadlistctrl->AddFile(
+						file, /*deferView=*/m_initialUpdate);
 					newFile = file;
 				} else {
 					newFile = new CKnownFile(tag);
@@ -1551,6 +1555,7 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 
 	if (m_initialUpdate) {
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->ShowFileList();
+		theApp->amuledlg->m_transferwnd->downloadlistctrl->ShowFileList();
 		m_initialUpdate = false;
 	} else if (partial_update) {
 		// Apply explicit removals from `EC_TAG_FILE_REMOVED` markers.


### PR DESCRIPTION
On a remote GUI first sync, the download list is populated one partfile at a time, and `CDownloadListCtrl::AddFile()` re-sorts the entire list on **every** insert. For a large queue that is O(n²·log n): issue #414 reports ~10k downloads taking **~20 minutes** to load with the GUI frozen the whole time (the WebUI, being virtual/paginated, is far faster).

**Fix** — port the pattern the shared-files view already uses (the `m_initialUpdate` flag): during the initial bulk load, defer the per-item show + sort and only build the model entries, then show and sort the whole list **once** via a new `CDownloadListCtrl::ShowFileList()` (`Freeze` + a single `SortList()` + `Thaw`), mirroring `CSharedFilesCtrl::ShowFileList()`. N sorts + N repaints collapse into one.

`AddFile()` gains a `deferView` parameter (default `false`), so the normal single-add path (`GuiEvents.cpp`) and every incremental update are unchanged — only the first full sync defers.

**Verification:** amulegui builds clean; clang-format (v18) clean; clang-tidy-21 Tier-1 and Tier-2 both clean on the changed lines. The end-to-end speed-up is being validated by the reporter on their 10k-file queue.

Refs #414
