### PR TITLE
fix(windows): activate prevent-sleep-while-downloading 

### DIFF
--- a/src/PlatformSpecific.cpp
+++ b/src/PlatformSpecific.cpp
@@ -337,7 +337,7 @@ static IOPMAssertionID assertionID;
 void PlatformSpecific::PreventSleepMode()
 {
 	if (!m_preventingSleepMode) {
-#ifdef _MSC_VER
+#ifdef __WINDOWS__
 		SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
 		m_preventingSleepMode = true;
 
@@ -377,7 +377,7 @@ void PlatformSpecific::PreventSleepMode()
 void PlatformSpecific::AllowSleepMode()
 {
 	if (m_preventingSleepMode) {
-#ifdef _MSC_VER
+#ifdef __WINDOWS__
 		SetThreadExecutionState(ES_CONTINUOUS); // Clear the system request flag.
 		m_preventingSleepMode = false;
 #elif defined(__WXMAC__) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1050 // 10.5 only


### PR DESCRIPTION
The **"Disable computer's timed standby mode"** option never worked on Windows.

### Root cause
The capability macro `PLATFORMSPECIFIC_CAN_PREVENT_SLEEP_MODE` keys off `__WINDOWS__ || __WXMAC__`, so on Windows the preferences checkbox is enabled and `DownloadQueue` calls `PreventSleepMode()` / `AllowSleepMode()` while downloading. But the actual `SetThreadExecutionState(...)` calls were gated on `#ifdef _MSC_VER` — a macro defined **only by MSVC**. aMule on Windows is built exclusively with **mingw-w64** (the `Build CMake mingw-w64` CI job; dev toolchain is CLANGARM64/MINGW64), which never defines `_MSC_VER`, so both function bodies compiled to the `#else` no-op. The checkbox was live and wired through, but the OS was never told to stay awake — the machine slept mid-download.

### Fix
Gate the Windows implementation on `__WINDOWS__` instead — the same macro that already guards the `<winbase.h>` include at the top of the file. One token, two sites. macOS and Linux paths are untouched.

### Verification
Reproduced on the real Windows toolchain (clang 22, CLANGARM64) with a standalone program mirroring the exact preprocessor structure:

- `_MSC_VER` is **not** defined → current guard resolves to *NOT IMPLEMENTED*; `__WINDOWS__` guard resolves to the real implementation.
- `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)` returns success, and `powercfg /requests` lists the process under **SYSTEM** with *"Sleep Idle State Disabled"* while held.

No behavior change on non-Windows platforms; the mingw CI job now compiles the newly-live branch.