### PR TITLE
feat(amuleapi): enrich GET /downloads/{hash} + add GET /shared/{hash} (#417)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -38,6 +38,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 
 **Shared files**
 - [`GET /api/v0/shared`](#get-apiv0shared) — list shared files
+- [`GET /api/v0/shared/{hash}`](#get-apiv0sharedhash) — detail view; every list field plus shared-detail fields
 - [`POST /api/v0/shared/reload`](#post-apiv0sharedreload) — re-walk shared directories
 - [`PATCH /api/v0/shared`](#patch-apiv0shared) — bulk change upload priority
 - [`PATCH /api/v0/shared/{hash}`](#patch-apiv0sharedhash) — change upload priority
@@ -523,7 +524,25 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/downloads/8b54a3c20fae9e4b9f7e0c2c8c01b6b1"
 ```
 
-Same envelope as the list item, plus a `progress.parts` array — one entry per ~9.28 MiB chunk with `state` (transferring / complete / empty / corrupt / etc.) and `sources` (count of peers offering that chunk).
+Same envelope as the list item, plus the detail-only fields below (all omitted from the `GET /downloads` list to keep it lean):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `progress.parts` | array | One entry per ~9.28 MiB chunk: `{ "state": string, "sources": int }` — `state` is `transferring`/`complete`/`empty`/`corrupt`/…, `sources` counts peers offering that chunk. |
+| `last_seen_complete` | int | Unix ts a complete copy was last seen across sources; `0` = never/unknown. |
+| `last_changed` | int | Unix ts the partfile last received data. |
+| `download_active_time` | int | Seconds spent actively downloading. |
+| `available_part_count` | int | Number of parts available across the current sources. |
+| `part_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |
+| `remaining_time` | int | ETA in seconds; `-1` when stalled or paused (speed ≈ 0). |
+| `hashing_progress` | int | Index of the part currently being hashed (0 when idle). |
+| `lost_to_corruption` | int | Bytes discarded to corruption. |
+| `gained_by_compression` | int | Bytes saved by on-the-wire compression. |
+| `saved_by_ich` | int | Packets recovered by Intelligent Corruption Handling. |
+| `aich_hash` | string | AICH master hash (hex); `""` if not yet computed. |
+| `met_file` | string | The partfile's on-disk basename (e.g. `001.part`). |
+| `partmet_id` | int | Numeric partfile id. |
+| `queued_count` | int | Clients waiting on this file's upload queue. |
 
 **Errors:** `404 not_found` (no partfile with that hash), `503 ec_unavailable`.
 
@@ -766,6 +785,29 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
 The SSE `shared_added` / `shared_updated` event payload matches this object byte-for-byte, so a subscriber that received `shared_updated` does not need to re-GET to see the moved counters.
 
 **Errors:** `503 ec_unavailable`.
+
+#### `GET /api/v0/shared/{hash}`
+
+**Auth:** `GUEST`
+
+Detail view for a single shared file. `{hash}` is the 32-char MD4 hex hash (case-insensitive). Returns every field of the [`GET /shared`](#get-apiv0shared) list item plus the detail-only fields below — one call for everything about a shared file. The list endpoint is unchanged.
+
+```sh
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/shared/8b54a3c20fae9e4b9f7e0c2c8c01b6b1"
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `file_type` | string | Category token derived from the extension, lowercased: `"audio"`, `"videos"`, `"archives"`, `"cd-images"`, `"pictures"`, `"texts"`, `"programs"`, or `"any"` for unknown. |
+| `share_ratio` | number | `xfer.total / size`; `0` when `size == 0`. |
+| `path` | string | Directory path of the on-disk file, or `"[PartFile]"` when the shared file is still an incomplete partfile. |
+| `complete_sources_range` | object | `{ "low": int, "high": int }` — the estimated full-copy source range behind the scalar `complete_sources`. |
+| `aich_hash` | string | AICH master hash (hex); `""` if not yet computed. |
+| `part_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |
+| `queued_count` | int | Clients waiting on this file's upload queue. |
+
+**Errors:** `404 not_found` (no shared file with that hash), `503 ec_unavailable`.
 
 #### `POST /api/v0/shared/reload`
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -38,6 +38,8 @@
 #include "State.h"
 
 #include "Constants.h"
+#include "OtherFunctions.h" // GetFiletypeByName for the shared file_type token
+#include <common/Path.h>    // CPath
 
 #include <ec/cpp/ECPacket.h>
 #include <ec/cpp/ECCodes.h>
@@ -848,9 +850,13 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		const auto path_segs = web_api_path::SplitPath(path);
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(shared_detail, path_segs, caps)) {
+			if (req.method == "GET" || req.method == "HEAD") {
+				return HandleSharedDetail(req, caps["hash"]);
+			}
 			if (req.method != "PATCH") {
-				return ErrorResponse(
-					405, "method_not_allowed", "only PATCH on /shared/{hash}");
+				return ErrorResponse(405,
+					"method_not_allowed",
+					"only GET / HEAD / PATCH on /shared/{hash}");
 			}
 			return HandleSharedPatch(req, caps["hash"]);
 		}
@@ -1592,7 +1598,8 @@ void WriteProgressParts(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.EndArray();
 }
 
-void WriteDownloadObject(CJsonWriter &w, const webapi::FileSnapshot &f, bool include_parts = false)
+void WriteDownloadObject(
+	CJsonWriter &w, const webapi::FileSnapshot &f, bool include_parts = false, bool detail = false)
 {
 	w.BeginObject();
 	w.Key("hash");
@@ -1636,6 +1643,50 @@ void WriteDownloadObject(CJsonWriter &w, const webapi::FileSnapshot &f, bool inc
 		WriteProgressParts(w, f);
 	}
 	w.EndObject();
+	if (detail) {
+		// Detail-only fields (GET /downloads/{hash}); omitted from the
+		// list. `part_count` and `remaining_time` are computed here from
+		// the snapshot — no EC tag exists for them.
+		const std::int64_t part_count =
+			(f.size == 0) ? 0 : static_cast<std::int64_t>((f.size + kPartSize - 1) / kPartSize);
+		// ETA seconds; -1 when stalled/paused (speed ~0), mirroring the
+		// desktop getTimeRemaining().
+		std::int64_t remaining_time = -1;
+		if (f.download.speed_bps > 0) {
+			remaining_time = (f.size > f.download.size_done)
+						 ? static_cast<std::int64_t>((f.size - f.download.size_done) /
+									     f.download.speed_bps)
+						 : 0;
+		}
+		w.Key("last_seen_complete");
+		w.ValueInt(static_cast<int64_t>(f.download.last_seen_complete));
+		w.Key("last_changed");
+		w.ValueInt(static_cast<int64_t>(f.download.last_changed));
+		w.Key("download_active_time");
+		w.ValueInt(static_cast<int64_t>(f.download.download_active_time));
+		w.Key("available_part_count");
+		w.ValueInt(static_cast<int64_t>(f.download.available_part_count));
+		w.Key("part_count");
+		w.ValueInt(part_count);
+		w.Key("remaining_time");
+		w.ValueInt(remaining_time);
+		w.Key("hashing_progress");
+		w.ValueInt(static_cast<int64_t>(f.download.hashing_progress));
+		w.Key("lost_to_corruption");
+		w.ValueInt(static_cast<int64_t>(f.download.lost_to_corruption));
+		w.Key("gained_by_compression");
+		w.ValueInt(static_cast<int64_t>(f.download.gained_by_compression));
+		w.Key("saved_by_ich");
+		w.ValueInt(static_cast<int64_t>(f.download.saved_by_ich));
+		w.Key("aich_hash");
+		w.ValueString(wxString::FromUTF8(f.aich_hash.c_str()));
+		w.Key("met_file");
+		w.ValueString(wxString::FromUTF8(f.knownfile_filename.c_str()));
+		w.Key("partmet_id");
+		w.ValueInt(static_cast<int64_t>(f.download.partmet_id));
+		w.Key("queued_count");
+		w.ValueInt(static_cast<int64_t>(f.queued_count));
+	}
 	w.EndObject();
 }
 
@@ -1698,9 +1749,10 @@ void WriteClientObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.EndObject();
 }
 
-void WriteSharedObject(CJsonWriter &w, const webapi::FileSnapshot &f)
+// Base shared-file fields, shared by the list writer and the detail
+// writer. Emits keys into an already-open object (no Begin/End).
+void WriteSharedBaseFields(CJsonWriter &w, const webapi::FileSnapshot &f)
 {
-	w.BeginObject();
 	w.Key("hash");
 	w.ValueString(wxString::FromUTF8(f.hash.c_str()));
 	w.Key("name");
@@ -1736,6 +1788,59 @@ void WriteSharedObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.Key("total");
 	w.ValueInt(static_cast<int64_t>(f.shared.accepts_total));
 	w.EndObject();
+}
+
+void WriteSharedObject(CJsonWriter &w, const webapi::FileSnapshot &f)
+{
+	w.BeginObject();
+	WriteSharedBaseFields(w, f);
+	w.EndObject();
+}
+
+// Locale-independent file-type token for the shared detail endpoint:
+// the desktop's own category label (GetFiletypeByName, untranslated)
+// lowercased — e.g. "audio", "video"(s), "cd-images", "any". Reuses the
+// GUI categorization rather than duplicating the extension table.
+std::string FileTypeToken(const std::string &name)
+{
+	const wxString desc =
+		GetFiletypeByName(CPath(wxString::FromUTF8(name.c_str())), /*translated=*/false);
+	std::string s(desc.utf8_str());
+	std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+		return static_cast<char>(std::tolower(c));
+	});
+	return s;
+}
+
+// GET /shared/{hash} detail: every list field plus the shared-table gaps
+// + shared-applicable identity fields. See issue #417 Part B.
+void WriteSharedDetailObject(CJsonWriter &w, const webapi::FileSnapshot &f)
+{
+	w.BeginObject();
+	WriteSharedBaseFields(w, f);
+	w.Key("file_type");
+	w.ValueString(wxString::FromUTF8(FileTypeToken(f.name).c_str()));
+	w.Key("share_ratio");
+	w.ValueDouble(
+		f.size > 0 ? static_cast<double>(f.shared.xfer_total) / static_cast<double>(f.size) : 0.0);
+	w.Key("path");
+	// A shared partfile has no real directory path (its EC_TAG_KNOWNFILE
+	// _FILENAME is the .part.met basename); the desktop shows "[PartFile]".
+	w.ValueString(f.is_downloading ? wxString::FromAscii("[PartFile]")
+				       : wxString::FromUTF8(f.knownfile_filename.c_str()));
+	w.Key("complete_sources_range");
+	w.BeginObject();
+	w.Key("low");
+	w.ValueInt(static_cast<int64_t>(f.shared.complete_sources_low));
+	w.Key("high");
+	w.ValueInt(static_cast<int64_t>(f.shared.complete_sources_high));
+	w.EndObject();
+	w.Key("aich_hash");
+	w.ValueString(wxString::FromUTF8(f.aich_hash.c_str()));
+	w.Key("part_count");
+	w.ValueInt(f.size == 0 ? 0 : static_cast<int64_t>((f.size + kPartSize - 1) / kPartSize));
+	w.Key("queued_count");
+	w.ValueInt(static_cast<int64_t>(f.queued_count));
 	w.EndObject();
 }
 
@@ -2238,7 +2343,44 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDetail(
 	r.status = 200;
 	r.content_type = "application/json";
 	CJsonWriter w;
-	WriteDownloadObject(w, d, /*include_parts=*/true);
+	WriteDownloadObject(w, d, /*include_parts=*/true, /*detail=*/true);
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleSharedDetail(
+	const CHttpServer::Request &req, const std::string &key)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	// {hash} is the 32-char MD4; URL is case-tolerant, State keys are
+	// lowercase — down-case before the O(1) lookup (mirrors the download
+	// detail handler).
+	webapi::FileSnapshot s;
+	std::string needle = key;
+	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+		return std::tolower(c);
+	});
+	if (!m_state.FindShared(needle, s)) {
+		return ErrorResponse(404, "not_found", "no shared file with that hash");
+	}
+
+	// Bare object (the detail resource itself), same shape contract as
+	// GET /downloads/{hash}: every GET /shared list field plus the
+	// Part-B detail fields.
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	WriteSharedDetailObject(w, s);
 	FinalizeJsonBody(w, r);
 	return r;
 }

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -134,6 +134,8 @@ private:
 	CHttpServer::Response HandleNetworksConnect(const CHttpServer::Request &);
 	CHttpServer::Response HandleNetworksDisconnect(const CHttpServer::Request &);
 	CHttpServer::Response HandleKadBootstrap(const CHttpServer::Request &);
+	// single shared-file detail (GET / HEAD). `key` = 32-char MD4 hash.
+	CHttpServer::Response HandleSharedDetail(const CHttpServer::Request &, const std::string &key);
 	// shared file priority PATCH. `key` = hash OR ECID.
 	CHttpServer::Response HandleSharedPatch(const CHttpServer::Request &, const std::string &key);
 	// bulk shared-priority PATCH over a `hashes` array (#358).

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -275,6 +275,23 @@ std::string TagHashLower(const CEC_SharedFile_Tag *sf)
 // `is_new` distinguishes first-encounter from INC update — used only
 // for the status-string re-derive (idle-on-status-suppressed shouldn't
 // silently lose the prior status).
+
+// Decode the base CKnownFile detail tags carried by BOTH EC_TAG_PARTFILE
+// and EC_TAG_KNOWNFILE (via the CEC_SharedFile_Tag base ctor), so the
+// download and shared detail endpoints share one decode. Detail-only;
+// absent from the list payloads. INC-safe: only assigns when a tag is
+// present this frame, otherwise the prior value is retained.
+void MergeKnownFileDetail(const CECTag *t, FileSnapshot &f)
+{
+	if (const CECTag *aich = t->GetTagByName(EC_TAG_KNOWNFILE_AICH_MASTERHASH))
+		f.aich_hash = std::string(aich->GetStringData().utf8_str());
+	std::uint32_t q = 0;
+	if (t->AssignIfExist(EC_TAG_KNOWNFILE_ON_QUEUE, q))
+		f.queued_count = q;
+	if (const CECTag *fn = t->GetTagByName(EC_TAG_KNOWNFILE_FILENAME))
+		f.knownfile_filename = std::string(fn->GetStringData().utf8_str());
+}
+
 void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 {
 	wxString fn;
@@ -357,6 +374,36 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 		if (pf->AssignIfExist(EC_TAG_PARTFILE_SOURCE_COUNT_A4AF, v))
 			f.download.sources_a4af = v;
 	}
+	// Detail-only fields (surfaced on GET /downloads/{hash} only).
+	{
+		std::uint32_t v = 0;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_LAST_SEEN_COMP, v))
+			f.download.last_seen_complete = v;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_LAST_RECV, v))
+			f.download.last_changed = v;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_DOWNLOAD_ACTIVE, v))
+			f.download.download_active_time = v;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_SAVED_ICH, v))
+			f.download.saved_by_ich = v;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_PARTMETID, v))
+			f.download.partmet_id = v;
+	}
+	{
+		std::uint16_t v = 0;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_AVAILABLE_PARTS, v))
+			f.download.available_part_count = v;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_HASHED_PART_COUNT, v))
+			f.download.hashing_progress = v;
+	}
+	{
+		std::uint64_t v = 0;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_LOST_CORRUPTION, v))
+			f.download.lost_to_corruption = v;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_GAINED_COMPRESSION, v))
+			f.download.gained_by_compression = v;
+	}
+	// Base CKnownFile detail tags (aich_hash, queued_count, met_file).
+	MergeKnownFileDetail(pf, f);
 	// Recompute percent unconditionally — both inputs may have moved.
 	f.download.percent =
 		(f.size > 0)
@@ -749,6 +796,11 @@ void MergeSharedTag(const CEC_SharedFile_Tag *sf, FileSnapshot &f)
 		std::uint16_t v = 0;
 		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_COMPLETE_SOURCES, v))
 			f.shared.complete_sources = v;
+		// Detail-only complete-sources range (GET /shared/{hash}).
+		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_COMPLETE_SOURCES_LOW, v))
+			f.shared.complete_sources_low = v;
+		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_COMPLETE_SOURCES_HIGH, v))
+			f.shared.complete_sources_high = v;
 	}
 	{
 		std::uint8_t pr = 0;
@@ -758,6 +810,8 @@ void MergeSharedTag(const CEC_SharedFile_Tag *sf, FileSnapshot &f)
 			f.shared.priority_auto = sh_auto;
 		}
 	}
+	// Base CKnownFile detail tags (aich_hash, queued_count, path source).
+	MergeKnownFileDetail(sf, f);
 }
 
 } // namespace

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -90,6 +90,17 @@ struct FileSnapshot
 	bool is_downloading = false;
 	bool is_shared = false;
 
+	// File-level attributes carried by the base CKnownFile EC tags, so
+	// they're available on both the download and shared detail endpoints.
+	// Detail-only (the list endpoints don't emit them).
+	std::string aich_hash;          // AICH master hash (hex); "" if none
+	std::uint32_t queued_count = 0; // clients on this file's upload queue
+	// EC_TAG_KNOWNFILE_FILENAME: a partfile's on-disk basename (e.g.
+	// `001.part`), or a completed known file's directory path.
+	// Interpreted per endpoint — `met_file` on /downloads/{hash},
+	// `path` on /shared/{hash}.
+	std::string knownfile_filename;
+
 	// Download-side state — meaningful when `is_downloading` is true,
 	// reset to default on the true→false transition (and never read
 	// by `/downloads` when the flag is false).
@@ -110,6 +121,19 @@ struct FileSnapshot
 		std::uint32_t sources_not_current = 0;
 		std::uint32_t sources_transferring = 0;
 		std::uint32_t sources_a4af = 0;
+
+		// Detail-only fields (GET /downloads/{hash}); the list endpoint
+		// omits them. All decoded from tags CEC_PartFile_Tag already
+		// emits under INC_UPDATE.
+		std::uint32_t last_seen_complete = 0;    // unix ts; 0 = unknown
+		std::uint32_t last_changed = 0;          // unix ts of last change
+		std::uint32_t download_active_time = 0;  // seconds downloading
+		std::uint16_t available_part_count = 0;  // parts across sources
+		std::uint16_t hashing_progress = 0;      // part being hashed
+		std::uint64_t lost_to_corruption = 0;    // bytes
+		std::uint64_t gained_by_compression = 0; // bytes
+		std::uint32_t saved_by_ich = 0;          // packets recovered by ICH
+		std::uint32_t partmet_id = 0;            // numeric partfile id
 
 		// Decoded per-part state, populated by the refresher's RLE
 		// decoder pass on EC_TAG_PARTFILE_GAP_STATUS +
@@ -141,6 +165,12 @@ struct FileSnapshot
 		std::uint32_t accepts_session = 0;
 		std::uint32_t accepts_total = 0;
 		std::uint32_t complete_sources = 0;
+
+		// Detail-only (GET /shared/{hash}). The complete-sources range
+		// backs the desktop `< N` / `N - M` display; the scalar
+		// `complete_sources` above stays as-is.
+		std::uint16_t complete_sources_low = 0;
+		std::uint16_t complete_sources_high = 0;
 	} shared;
 };
 

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -142,6 +142,17 @@ if [ "$COUNT" -gt 0 ]; then
 		'/downloads/{hash} has no snapshot_at envelope (bare object)'
 	_assert_json_eq '.progress.percent | type' number \
 		'/downloads/{hash} carries progress.percent'
+	# Part-A detail fields (issue #417) — detail-only, type-tolerant.
+	_assert_json_eq '.part_count | type' number \
+		'/downloads/{hash} carries part_count'
+	_assert_json_eq '.remaining_time | type' number \
+		'/downloads/{hash} carries remaining_time'
+	_assert_json_eq '.aich_hash | type' string \
+		'/downloads/{hash} carries aich_hash'
+	_assert_json_eq '.met_file | type' string \
+		'/downloads/{hash} carries met_file'
+	_assert_json_eq '.queued_count | type' number \
+		'/downloads/{hash} carries queued_count'
 
 	# Uppercase hash → same hit (case-insensitive route).
 	HASH_UPPER=$(echo "$HASH" | tr '[:lower:]' '[:upper:]')
@@ -175,7 +186,33 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		'/shared[0].priority is string'
 	_assert_json_eq '.shared[0].priority_auto | type' boolean \
 		'/shared[0].priority_auto is boolean'
+
+	# --- 6b. GET /shared/{hash} detail endpoint (issue #417 Part B). ---
+	SHASH=$(printf '%s' "$CURL_BODY" | jq -r '.shared[0].hash')
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/$SHASH"
+	_assert_status 200 "GET /api/v0/shared/{hash} → 200 (new detail endpoint)"
+	_assert_json_eq '.hash' "$SHASH" \
+		'/shared/{hash} returns bare object keyed by hash'
+	_assert_json_eq '.snapshot_at | type' null \
+		'/shared/{hash} has no snapshot_at envelope (bare object)'
+	_assert_json_eq '.file_type | type' string \
+		'/shared/{hash} carries file_type'
+	_assert_json_eq '.share_ratio | type' number \
+		'/shared/{hash} carries share_ratio'
+	_assert_json_eq '.path | type' string \
+		'/shared/{hash} carries path'
+	_assert_json_eq '.complete_sources_range | type' object \
+		'/shared/{hash} carries complete_sources_range'
+	_assert_json_eq '.aich_hash | type' string \
+		'/shared/{hash} carries aich_hash'
+	_assert_json_eq '.part_count | type' number \
+		'/shared/{hash} carries part_count'
 fi
+
+# --- 6c. /shared/{hash} missing-hash 404. -------------------------
+_curl -H "Authorization: Bearer $TOKEN" \
+	"$HOST/api/v0/shared/baadbaadbaadbaadbaadbaadbaadbaad"
+_assert_status 404 "GET /shared/{nonexistent-hash} → 404"
 
 # --- 7. Method gate. DELETE is method-gated on the /shared collection
 # (no bulk-unshare endpoint); the /downloads collection now accepts a bulk

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -472,6 +472,79 @@ TEST(Refresher, SharedPriorityLatchedBeforeSharingSurvivesSuppression)
 }
 
 // ----------------------------------------------------------------------
+// Single-file detail decode (issue #417). The download-detail and
+// shared-detail endpoints read these off the same snapshot the walkers
+// build, so pin that the new tags land in the right sub-blocks.
+// ----------------------------------------------------------------------
+
+TEST(Refresher, DownloadDetailTagsDecodeIntoSnapshot)
+{
+	FileMap cache;
+	std::map<std::uint32_t, PartFileEncoderData> rle_state;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(101));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_LAST_SEEN_COMP, static_cast<std::uint32_t>(1700000000)));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_LAST_RECV, static_cast<std::uint32_t>(1700000123)));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_DOWNLOAD_ACTIVE, static_cast<std::uint32_t>(3600)));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_AVAILABLE_PARTS, static_cast<std::uint16_t>(12)));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_HASHED_PART_COUNT, static_cast<std::uint16_t>(3)));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_LOST_CORRUPTION, static_cast<std::uint64_t>(9728000)));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_GAINED_COMPRESSION, static_cast<std::uint64_t>(4096)));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_SAVED_ICH, static_cast<std::uint32_t>(7)));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_PARTMETID, static_cast<std::uint32_t>(42)));
+	// Base CKnownFile tags carried on the partfile tag too.
+	pf.AddTag(CECTag(EC_TAG_KNOWNFILE_ON_QUEUE, static_cast<std::uint32_t>(5)));
+	pf.AddTag(CECTag(EC_TAG_KNOWNFILE_AICH_MASTERHASH, std::string("ABCDEF0123")));
+	pf.AddTag(CECTag(EC_TAG_KNOWNFILE_FILENAME, std::string("042.part.met")));
+	resp.AddTag(pf);
+
+	ApplyGetUpdateToDownloads(&resp, cache, rle_state);
+
+	const auto it = cache.find(101);
+	ASSERT_TRUE(it != cache.end());
+	const auto &d = it->second;
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1700000000), d.download.last_seen_complete);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1700000123), d.download.last_changed);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(3600), d.download.download_active_time);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(12), d.download.available_part_count);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(3), d.download.hashing_progress);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(9728000), d.download.lost_to_corruption);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(4096), d.download.gained_by_compression);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(7), d.download.saved_by_ich);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(42), d.download.partmet_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(5), d.queued_count);
+	ASSERT_EQUALS(std::string("ABCDEF0123"), d.aich_hash);
+	ASSERT_EQUALS(std::string("042.part.met"), d.knownfile_filename);
+}
+
+TEST(Refresher, SharedDetailTagsDecodeIntoSnapshot)
+{
+	FileMap cache;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	CECTag kf(EC_TAG_KNOWNFILE, static_cast<std::uint32_t>(202));
+	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_COMPLETE_SOURCES, static_cast<std::uint16_t>(8)));
+	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_COMPLETE_SOURCES_LOW, static_cast<std::uint16_t>(5)));
+	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_COMPLETE_SOURCES_HIGH, static_cast<std::uint16_t>(11)));
+	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_ON_QUEUE, static_cast<std::uint32_t>(9)));
+	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_AICH_MASTERHASH, std::string("FEDCBA9876")));
+	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_FILENAME, std::string("/home/kizar/Incoming")));
+	resp.AddTag(kf);
+
+	ApplyGetUpdateToShared(&resp, cache);
+
+	const auto it = cache.find(202);
+	ASSERT_TRUE(it != cache.end());
+	const auto &s = it->second;
+	ASSERT_EQUALS(static_cast<std::uint16_t>(5), s.shared.complete_sources_low);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(11), s.shared.complete_sources_high);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(9), s.queued_count);
+	ASSERT_EQUALS(std::string("FEDCBA9876"), s.aich_hash);
+	// Completed known file → the tag is the directory path (the write
+	// layer maps a shared partfile to "[PartFile]" instead).
+	ASSERT_EQUALS(std::string("/home/kizar/Incoming"), s.knownfile_filename);
+}
+
+// ----------------------------------------------------------------------
 // /servers — GET_UPDATE wraps per-server tags in an EC_TAG_SERVER
 // container at top level. Walker iterates INTO the container and
 // merges per-ECID; cache entries not seen in the response get evicted


### PR DESCRIPTION
Implements #417 (the foundation of the File-Details parity cluster). webapi-only — no amuled or EC-protocol change.

### Part A — `GET /downloads/{hash}` detail fields
Surfaces the desktop File-Details fields the endpoint previously dropped, all decoded from tags `CEC_PartFile_Tag` already emits under `INC_UPDATE`: `last_seen_complete`, `last_changed`, `download_active_time`, `available_part_count`, `part_count`, `remaining_time`, `hashing_progress`, `lost_to_corruption`, `gained_by_compression`, `saved_by_ich`, `aich_hash`, `met_file`, `partmet_id`, `queued_count`. `part_count` and `remaining_time` (ETA; `-1` when stalled/paused) are computed in the backend. Detail-only — the `GET /downloads` list payload is unchanged.

### Part B — new `GET /api/v0/shared/{hash}`
The route was `PATCH`-only; adds a `GET` detail view returning every `GET /shared` list field plus `file_type` (the desktop's own category label, lowercased — e.g. `audio`), `share_ratio`, `path` (`"[PartFile]"` for a shared partfile), `complete_sources_range {low, high}`, `aich_hash`, `part_count`, `queued_count`. `GET /shared` (the list) is unchanged.

### Tests / docs
- `RefresherTest`: two decode cases (`DownloadDetailTagsDecodeIntoSnapshot`, `SharedDetailTagsDecodeIntoSnapshot`) — 33 cases green.
- `04-read-downloads-shared.sh`: covers the new download fields, the new `/shared/{hash}` endpoint, and its 404 — verified **44/44 against a live amuled + amuleapi** (real values confirmed, e.g. `.mp3` → `file_type: "audio"`, `remaining_time: -1` when stalled).
- `docs/api/REFERENCE.md`: documents both, plus the index entry.