### PR TITLE
feat(amuleapi): file comments & ratings in the REST API (#419)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -26,6 +26,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Downloads**
 - [`GET /api/v0/downloads`](#get-apiv0downloads) — list active queue
 - [`GET /api/v0/downloads/{hash}`](#get-apiv0downloadshash) — detail view; `{hash}` is the 32-char MD4 hex hash
+- [`GET /api/v0/downloads/{hash}/comments`](#get-apiv0downloadshashcomments) — per-source comments/ratings list
 - [`POST /api/v0/downloads`](#post-apiv0downloads) — add ed2k link(s)
 - [`PATCH /api/v0/downloads`](#patch-apiv0downloads) — bulk pause / resume / priority / category
 - [`DELETE /api/v0/downloads`](#delete-apiv0downloads) — bulk cancel + remove
@@ -543,8 +544,44 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 | `met_file` | string | The partfile's on-disk basename (e.g. `001.part`). |
 | `partmet_id` | int | Numeric partfile id. |
 | `queued_count` | int | Clients waiting on this file's upload queue. |
+| `comment` | string | The user's own comment on this file (`""` if none). |
+| `rating` | int | The user's own rating, `0`–`5` (`0` = unrated). See the [rating scale](#get-apiv0downloadshashcomments). |
 
 **Errors:** `404 not_found` (no partfile with that hash), `503 ec_unavailable`.
+
+#### `GET /api/v0/downloads/{hash}/comments`
+
+**Auth:** `GUEST`
+
+The comments and ratings this download's **sources** report for the file (the desktop "Show all comments" list). Downloads-only — a completed/shared file has no live source list.
+
+```sh
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/downloads/8b54a3c2…/comments"
+```
+
+```json
+{
+  "count": 2,
+  "comments": [
+    { "username": "alice", "filename": "Some.Movie.mkv", "rating": 5, "comment": "great quality" },
+    { "username": "bob",   "filename": "some_movie.avi", "rating": -1, "comment": "no rating here" }
+  ]
+}
+```
+
+A per-source `rating` of `-1` means the source left a comment but no rating. Rating scale (from the desktop `GetRateString()`):
+
+| value | meaning |
+|---|---|
+| 0 | Not rated |
+| 1 | Invalid / Corrupt / Fake |
+| 2 | Poor |
+| 3 | Fair |
+| 4 | Good |
+| 5 | Excellent |
+
+**Errors:** `404 not_found` (no download with that hash), `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads`
 
@@ -625,6 +662,7 @@ Mutates one or more fields of a single partfile. `{hash}` is the 32-char MD4 hex
 - `status` — `"paused"`, `"resumed"` or `"stopped"`. `"paused"` halts transfer but keeps the file's sources; `"stopped"` additionally drops all known sources and resets the Kad source search (a stopped file must rediscover sources from scratch on resume); `"resumed"` clears either state. A stopped file reports `status: "stopped"` in the download object (see [`GET /downloads`](#get-apiv0downloads)).
 - `priority` — `"low"` / `"normal"` / `"high"` / `"auto"`. Downloads support only these levels; the daemon clamps any other value to `normal`. (Shared files support the wider `very_low` … `release` set — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash).)
 - `category` — uint8
+- `comment` + `rating` — set the file's comment (string, ≤ 50 chars) and rating (integer `0`–`5`). Must be sent **together**; only settable when the partfile is also shared (≥ 1 complete chunk), else `409 not_shared`. Primarily a shared-file action — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash).
 
 ```sh
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
@@ -635,7 +673,7 @@ curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
 
 **Response:** `200 OK` — the updated download object (full detail envelope including `progress.parts`).
 
-**Errors:** `400 bad_request` (no recognised field, invalid enum), `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (no recognised field, invalid enum, or `comment`/`rating` sent alone), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
 
 #### `DELETE /api/v0/downloads/{hash}`
 
@@ -806,6 +844,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | `aich_hash` | string | AICH master hash (hex); `""` if not yet computed. |
 | `part_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |
 | `queued_count` | int | Clients waiting on this file's upload queue. |
+| `comment` | string | The user's own comment on this file (`""` if none). |
+| `rating` | int | The user's own rating, `0`–`5` (`0` = unrated). |
 
 **Errors:** `404 not_found` (no shared file with that hash), `503 ec_unavailable`.
 
@@ -844,17 +884,23 @@ Bulk upload-priority change over multiple shared files — the same `priority` a
 
 **Auth:** `ADMIN`
 
-Changes the upload priority of a single shared file. `{hash}` is the 32-char MD4 hex hash (case-insensitive).
+Changes the upload priority and/or the comment+rating of a single shared file. `{hash}` is the 32-char MD4 hex hash (case-insensitive). The body must include at least one of `priority` or the `comment`+`rating` pair.
 
 **Body:**
 
 ```json
-{ "priority": "very_low" | "low" | "normal" | "high" | "release" | "auto" }
+{
+  "priority": "very_low" | "low" | "normal" | "high" | "release" | "auto",
+  "comment":  "<string, ≤ 50 chars>",
+  "rating":   0
+}
 ```
 
-Send a bare level to pin it (the file's `priority_auto` becomes `false`). Send `"auto"` to hand level selection to amuled — it derives the level from the upload queue, and `GET /api/v0/shared` then reports the derived base `priority` with `priority_auto: true`. The combined `"*_auto"` strings are not accepted as input, since `"auto"` is the level the daemon computes rather than one the caller pins.
+Send a bare priority level to pin it (the file's `priority_auto` becomes `false`). Send `"auto"` to hand level selection to amuled — it derives the level from the upload queue, and `GET /api/v0/shared` then reports the derived base `priority` with `priority_auto: true`. The combined `"*_auto"` strings are not accepted as input, since `"auto"` is the level the daemon computes rather than one the caller pins.
 
-**Errors:** `400 bad_request`, `400 amuled_rejected`, `503 ec_unavailable`.
+`comment` and `rating` must be sent **together** (both or neither) — the daemon writes them as one atomic operation. `comment` is capped at 50 characters; `rating` is an integer `0`–`5`. Setting them requires the file to be shared. The same fields are accepted on [`PATCH /downloads/{hash}`](#patch-apiv0downloadshash) for a downloading file that is also shared.
+
+**Errors:** `400 bad_request` (missing/invalid fields, or `comment`/`rating` sent alone), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `503 ec_unavailable`.
 
 ---
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -978,6 +978,24 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
+	// /downloads/{hash}/comments — per-source comments/ratings list
+	// (issue #419). Downloads-only: needs a live source list. Matched
+	// before /downloads/{hash} (more segments).
+	{
+		static const auto dl_comments =
+			web_api_path::ParsePattern("/api/v0/downloads/{hash}/comments");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(dl_comments, path_segs, caps)) {
+			if (req.method != "GET" && req.method != "HEAD") {
+				return ErrorResponse(405,
+					"method_not_allowed",
+					"only GET / HEAD on /downloads/{hash}/comments");
+			}
+			return HandleDownloadComments(req, caps["hash"]);
+		}
+	}
+
 	// /downloads/{hash} — single-resource detail (GET / HEAD) and the
 	// mutation surface (PATCH for status/priority/category, DELETE for
 	// clear-completed single). `{hash}` is the lowercase 32-char hex
@@ -1686,6 +1704,10 @@ void WriteDownloadObject(
 		w.ValueInt(static_cast<int64_t>(f.download.partmet_id));
 		w.Key("queued_count");
 		w.ValueInt(static_cast<int64_t>(f.queued_count));
+		w.Key("comment");
+		w.ValueString(wxString::FromUTF8(f.comment.c_str()));
+		w.Key("rating");
+		w.ValueInt(static_cast<int64_t>(f.rating));
 	}
 	w.EndObject();
 }
@@ -1841,6 +1863,10 @@ void WriteSharedDetailObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.ValueInt(f.size == 0 ? 0 : static_cast<int64_t>((f.size + kPartSize - 1) / kPartSize));
 	w.Key("queued_count");
 	w.ValueInt(static_cast<int64_t>(f.queued_count));
+	w.Key("comment");
+	w.ValueString(wxString::FromUTF8(f.comment.c_str()));
+	w.Key("rating");
+	w.ValueInt(static_cast<int64_t>(f.rating));
 	w.EndObject();
 }
 
@@ -2385,6 +2411,55 @@ CHttpServer::Response CApiDispatcher::HandleSharedDetail(
 	return r;
 }
 
+CHttpServer::Response CApiDispatcher::HandleDownloadComments(
+	const CHttpServer::Request &req, const std::string &key)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	webapi::FileSnapshot d;
+	std::string needle = key;
+	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+		return std::tolower(c);
+	});
+	if (!m_state.FindDownload(needle, d)) {
+		return ErrorResponse(404, "not_found", "no download with that hash");
+	}
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("count");
+	w.ValueInt(static_cast<int64_t>(d.download.source_comments.size()));
+	w.Key("comments");
+	w.BeginArray();
+	for (const auto &c : d.download.source_comments) {
+		w.BeginObject();
+		w.Key("username");
+		w.ValueString(wxString::FromUTF8(c.username.c_str()));
+		w.Key("filename");
+		w.ValueString(wxString::FromUTF8(c.filename.c_str()));
+		w.Key("rating");
+		w.ValueInt(static_cast<int64_t>(c.rating));
+		w.Key("comment");
+		w.ValueString(wxString::FromUTF8(c.comment.c_str()));
+		w.EndObject();
+	}
+	w.EndArray();
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
 namespace
 {
 
@@ -2686,6 +2761,82 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 	return BulkResultsResponse(results, 202);
 }
 
+namespace
+{
+// Handle the optional `comment`+`rating` pair shared by PATCH
+// /downloads/{hash} and PATCH /shared/{hash} (issue #419). Both must be
+// present together or neither. Sends EC_OP_SHARED_FILE_SET_COMMENT, which
+// amuled resolves against the shared-files registry — so the file must be
+// shared. Returns false and fills `err` on any problem; sets `applied`
+// when a valid pair was written. A body with neither field is a no-op
+// (returns true, applied=false).
+bool TrySetCommentRating(CamuleapiApp &app,
+	const picojson::object &obj,
+	const webapi::FileSnapshot &f,
+	bool &applied,
+	CHttpServer::Response &err)
+{
+	applied = false;
+	const auto cit = obj.find("comment");
+	const auto rit = obj.find("rating");
+	const bool has_c = cit != obj.end();
+	const bool has_r = rit != obj.end();
+	if (!has_c && !has_r)
+		return true;
+	if (has_c != has_r) {
+		err = ErrorResponse(400, "bad_request", "`comment` and `rating` must be set together");
+		return false;
+	}
+	if (!cit->second.is<std::string>()) {
+		err = ErrorResponse(400, "bad_request", "`comment` must be a string");
+		return false;
+	}
+	const std::string comment = cit->second.get<std::string>();
+	// MAXFILECOMMENTLEN (include/protocol/ed2k/Constants.h) = 50.
+	if (comment.size() > 50) {
+		err = ErrorResponse(400, "bad_request", "`comment` exceeds 50 characters");
+		return false;
+	}
+	if (!rit->second.is<double>()) {
+		err = ErrorResponse(400, "bad_request", "`rating` must be an integer in [0, 5]");
+		return false;
+	}
+	const double rd = rit->second.get<double>();
+	const int rating = static_cast<int>(rd);
+	if (static_cast<double>(rating) != rd || rating < 0 || rating > 5) {
+		err = ErrorResponse(400, "bad_request", "`rating` must be an integer in [0, 5]");
+		return false;
+	}
+	if (!f.is_shared) {
+		err = ErrorResponse(409, "not_shared", "comment and rating can only be set on a shared file");
+		return false;
+	}
+	CMD4Hash file_hash;
+	if (!HashFromHex(f.hash, file_hash)) {
+		err = ErrorResponse(500, "internal_error", "failed to decode file hash");
+		return false;
+	}
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SHARED_FILE_SET_COMMENT));
+	ec_req->AddTag(CECTag(EC_TAG_KNOWNFILE, file_hash));
+	ec_req->AddTag(CECTag(EC_TAG_KNOWNFILE_COMMENT, comment));
+	ec_req->AddTag(CECTag(EC_TAG_KNOWNFILE_RATING, static_cast<std::uint8_t>(rating)));
+	const CECPacket *ec_resp = app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		err = ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for SET_COMMENT");
+		return false;
+	}
+	std::string ec_err;
+	if (IsEcFailedResponse(ec_resp, ec_err)) {
+		delete ec_resp;
+		err = ErrorResponse(400, "amuled_rejected", ec_err.c_str());
+		return false;
+	}
+	delete ec_resp;
+	applied = true;
+	return true;
+}
+} // namespace
+
 CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 	const CHttpServer::Request &req, const std::string &key)
 {
@@ -2828,11 +2979,23 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 		}
 	}
 
+	// comment + rating (both required together; issue #419). Only
+	// settable on a file that is shared (a downloading partfile with
+	// ≥1 complete chunk); otherwise TrySetCommentRating returns 409.
+	{
+		bool applied = false;
+		CHttpServer::Response cr_err;
+		if (!TrySetCommentRating(m_app, obj, d, applied, cr_err))
+			return cr_err;
+		if (applied)
+			any_change = true;
+	}
+
 	if (!any_change) {
 		return ErrorResponse(400,
 			"bad_request",
 			"request body must include at least one of "
-			"`status`, `priority`, or `category`");
+			"`status`, `priority`, `category`, or `comment`+`rating`");
 	}
 
 	// Inline refresh so the response below sees post-mutation state.
@@ -4930,40 +5093,58 @@ CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 	}
 	const auto &obj = root.get<picojson::object>();
 
+	bool any_change = false;
+
+	// priority (optional now that comment/rating share this endpoint).
 	const auto pit = obj.find("priority");
-	if (pit == obj.end()) {
-		return ErrorResponse(400, "bad_request", "request body must include `priority`");
-	}
-	if (!pit->second.is<std::string>()) {
-		return ErrorResponse(400, "bad_request", "`priority` must be a wire-string enum");
-	}
-	std::uint8_t code = 0;
-	if (!SharedPriorityToCode(pit->second.get<std::string>(), code)) {
-		return ErrorResponse(400,
-			"bad_request",
-			"`priority` must be one of "
-			"very_low, low, normal, high, release, auto");
-	}
+	if (pit != obj.end()) {
+		if (!pit->second.is<std::string>()) {
+			return ErrorResponse(400, "bad_request", "`priority` must be a wire-string enum");
+		}
+		std::uint8_t code = 0;
+		if (!SharedPriorityToCode(pit->second.get<std::string>(), code)) {
+			return ErrorResponse(400,
+				"bad_request",
+				"`priority` must be one of "
+				"very_low, low, normal, high, release, auto");
+		}
+		CMD4Hash file_hash;
+		if (!HashFromHex(s.hash, file_hash)) {
+			return ErrorResponse(500, "internal_error", "failed to decode file hash");
+		}
+		std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SHARED_SET_PRIO));
+		CECTag hash_tag(EC_TAG_PARTFILE, file_hash);
+		hash_tag.AddTag(CECTag(EC_TAG_PARTFILE_PRIO, code));
+		ec_req->AddTag(hash_tag);
 
-	CMD4Hash file_hash;
-	if (!HashFromHex(s.hash, file_hash)) {
-		return ErrorResponse(500, "internal_error", "failed to decode file hash");
-	}
-	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SHARED_SET_PRIO));
-	CECTag hash_tag(EC_TAG_PARTFILE, file_hash);
-	hash_tag.AddTag(CECTag(EC_TAG_PARTFILE_PRIO, code));
-	ec_req->AddTag(hash_tag);
-
-	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
-	if (!ec_resp) {
-		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for SHARED_SET_PRIO");
-	}
-	std::string ec_err_msg;
-	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+		if (!ec_resp) {
+			return ErrorResponse(
+				503, "ec_unavailable", "EC roundtrip failed for SHARED_SET_PRIO");
+		}
+		std::string ec_err_msg;
+		if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+			delete ec_resp;
+			return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+		}
 		delete ec_resp;
-		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+		any_change = true;
 	}
-	delete ec_resp;
+
+	// comment + rating (both required together; issue #419).
+	{
+		bool applied = false;
+		CHttpServer::Response cr_err;
+		if (!TrySetCommentRating(m_app, obj, s, applied, cr_err))
+			return cr_err;
+		if (applied)
+			any_change = true;
+	}
+
+	if (!any_change) {
+		return ErrorResponse(
+			400, "bad_request", "request body must include `priority` or `comment`+`rating`");
+	}
 
 	(void)RefresherTick(m_app, m_state);
 

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -103,6 +103,8 @@ private:
 	CHttpServer::Response HandleDownloads(const CHttpServer::Request &);
 	// `key` accepts the lowercase 32-char hex hash OR the decimal ECID.
 	CHttpServer::Response HandleDownloadDetail(const CHttpServer::Request &, const std::string &key);
+	// per-source comments/ratings list. `key` = 32-char MD4 hash.
+	CHttpServer::Response HandleDownloadComments(const CHttpServer::Request &, const std::string &key);
 	// download lifecycle mutations.
 	CHttpServer::Response HandleDownloadAdd(const CHttpServer::Request &);
 	CHttpServer::Response HandleDownloadPatch(const CHttpServer::Request &, const std::string &key);

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -415,8 +415,8 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 	// absent container keeps the prior list).
 	if (const CECTag *cont = pf->GetTagByName(EC_TAG_PARTFILE_COMMENTS)) {
 		std::vector<const CECTag *> kids;
-		for (CECTag::const_iterator cit = cont->begin(); cit != cont->end(); ++cit)
-			kids.push_back(&*cit);
+		for (const CECTag &kid : *cont)
+			kids.push_back(&kid);
 		f.download.source_comments.clear();
 		for (std::size_t i = 0; i + 3 < kids.size(); i += 4) {
 			FileSnapshot::DownloadSide::SourceComment c;

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -290,6 +290,12 @@ void MergeKnownFileDetail(const CECTag *t, FileSnapshot &f)
 		f.queued_count = q;
 	if (const CECTag *fn = t->GetTagByName(EC_TAG_KNOWNFILE_FILENAME))
 		f.knownfile_filename = std::string(fn->GetStringData().utf8_str());
+	// The user's own comment + rating (issue #419).
+	if (const CECTag *cm = t->GetTagByName(EC_TAG_KNOWNFILE_COMMENT))
+		f.comment = std::string(cm->GetStringData().utf8_str());
+	std::uint32_t rt = 0;
+	if (t->AssignIfExist(EC_TAG_KNOWNFILE_RATING, rt))
+		f.rating = static_cast<std::int32_t>(rt);
 }
 
 void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
@@ -401,6 +407,26 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 			f.download.lost_to_corruption = v;
 		if (pf->AssignIfExist(EC_TAG_PARTFILE_GAINED_COMPRESSION, v))
 			f.download.gained_by_compression = v;
+	}
+	// Per-source comments/ratings (issue #419). The EC container packs
+	// four children per source, evaluated by index: username, filename,
+	// rating (int8; -1 = unrated), comment. Rebuild the list whenever the
+	// container is present (CValueMap-suppressed when unchanged, so an
+	// absent container keeps the prior list).
+	if (const CECTag *cont = pf->GetTagByName(EC_TAG_PARTFILE_COMMENTS)) {
+		std::vector<const CECTag *> kids;
+		for (CECTag::const_iterator cit = cont->begin(); cit != cont->end(); ++cit)
+			kids.push_back(&*cit);
+		f.download.source_comments.clear();
+		for (std::size_t i = 0; i + 3 < kids.size(); i += 4) {
+			FileSnapshot::DownloadSide::SourceComment c;
+			c.username = std::string(kids[i]->GetStringData().utf8_str());
+			c.filename = std::string(kids[i + 1]->GetStringData().utf8_str());
+			c.rating =
+				static_cast<std::int32_t>(static_cast<std::int64_t>(kids[i + 2]->GetInt()));
+			c.comment = std::string(kids[i + 3]->GetStringData().utf8_str());
+			f.download.source_comments.push_back(std::move(c));
+		}
 	}
 	// Base CKnownFile detail tags (aich_hash, queued_count, met_file).
 	MergeKnownFileDetail(pf, f);

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -95,6 +95,8 @@ struct FileSnapshot
 	// Detail-only (the list endpoints don't emit them).
 	std::string aich_hash;          // AICH master hash (hex); "" if none
 	std::uint32_t queued_count = 0; // clients on this file's upload queue
+	std::string comment;            // the user's own file comment
+	std::int32_t rating = 0;        // the user's own rating, 0-5 (0 = unrated)
 	// EC_TAG_KNOWNFILE_FILENAME: a partfile's on-disk basename (e.g.
 	// `001.part`), or a completed known file's directory path.
 	// Interpreted per endpoint — `met_file` on /downloads/{hash},
@@ -134,6 +136,18 @@ struct FileSnapshot
 		std::uint64_t gained_by_compression = 0; // bytes
 		std::uint32_t saved_by_ich = 0;          // packets recovered by ICH
 		std::uint32_t partmet_id = 0;            // numeric partfile id
+
+		// Per-source comments/ratings (GET /downloads/{hash}/comments,
+		// issue #419). Downloads-only — needs a live source list. A
+		// `rating` of -1 means the source left a comment but no rating.
+		struct SourceComment
+		{
+			std::string username;
+			std::string filename;
+			std::int32_t rating = 0;
+			std::string comment;
+		};
+		std::vector<SourceComment> source_comments;
 
 		// Decoded per-part state, populated by the refresher's RLE
 		// decoder pass on EC_TAG_PARTFILE_GAP_STATUS +

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -153,6 +153,18 @@ if [ "$COUNT" -gt 0 ]; then
 		'/downloads/{hash} carries met_file'
 	_assert_json_eq '.queued_count | type' number \
 		'/downloads/{hash} carries queued_count'
+	_assert_json_eq '.comment | type' string \
+		'/downloads/{hash} carries comment'
+	_assert_json_eq '.rating | type' number \
+		'/downloads/{hash} carries rating'
+
+	# Per-source comments sub-resource (issue #419).
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/comments"
+	_assert_status 200 "GET /downloads/{hash}/comments → 200"
+	_assert_json_eq '.count | type' number \
+		'/downloads/{hash}/comments carries numeric count'
+	_assert_json_eq '.comments | type' array \
+		'/downloads/{hash}/comments.comments is an array'
 
 	# Uppercase hash → same hit (case-insensitive route).
 	HASH_UPPER=$(echo "$HASH" | tr '[:lower:]' '[:upper:]')
@@ -207,6 +219,10 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		'/shared/{hash} carries aich_hash'
 	_assert_json_eq '.part_count | type' number \
 		'/shared/{hash} carries part_count'
+	_assert_json_eq '.comment | type' string \
+		'/shared/{hash} carries comment'
+	_assert_json_eq '.rating | type' number \
+		'/shared/{hash} carries rating'
 fi
 
 # --- 6c. /shared/{hash} missing-hash 404. -------------------------

--- a/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
+++ b/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
@@ -188,6 +188,27 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-d '{"priority":"high_auto"}' "$HOST/api/v0/shared/$TEST_HASH"
 _assert_status 400 "PATCH removed variant high_auto → 400"
 
+# --- 3c. PATCH comment + rating (issue #419). ---------------------
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"comment":"nice file","rating":4}' "$HOST/api/v0/shared/$TEST_HASH"
+_assert_status 200 "PATCH comment+rating → 200"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/$TEST_HASH"
+_assert_json_eq '.comment' "nice file" "GET /shared/{hash} shows the set comment"
+_assert_json_eq '.rating' 4 "GET /shared/{hash} shows the set rating"
+
+# Partial (comment without rating) → 400 (both required together).
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"comment":"solo"}' "$HOST/api/v0/shared/$TEST_HASH"
+_assert_status 400 "PATCH comment without rating → 400"
+
+# Rating out of range → 400.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"comment":"x","rating":9}' "$HOST/api/v0/shared/$TEST_HASH"
+_assert_status 400 "PATCH rating out of range → 400"
+
 # --- 4. Error paths. ----------------------------------------------
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -544,6 +544,44 @@ TEST(Refresher, SharedDetailTagsDecodeIntoSnapshot)
 	ASSERT_EQUALS(std::string("/home/kizar/Incoming"), s.knownfile_filename);
 }
 
+// Comment/rating (issue #419): the user's own comment+rating land at the
+// top level; the per-source EC_TAG_PARTFILE_COMMENTS container decodes
+// into download.source_comments (4 index-grouped children per source,
+// rating -1 = unrated).
+TEST(Refresher, CommentRatingAndSourceCommentsDecode)
+{
+	FileMap cache;
+	std::map<std::uint32_t, PartFileEncoderData> rle_state;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(303));
+	pf.AddTag(CECTag(EC_TAG_KNOWNFILE_COMMENT, std::string("my own note")));
+	pf.AddTag(CECTag(EC_TAG_KNOWNFILE_RATING, static_cast<std::uint32_t>(4)));
+	CECEmptyTag comments(EC_TAG_PARTFILE_COMMENTS);
+	comments.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, std::string("alice")));
+	comments.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, std::string("movie.mkv")));
+	comments.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, static_cast<std::uint64_t>(5)));
+	comments.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, std::string("great quality")));
+	comments.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, std::string("bob")));
+	comments.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, std::string("film.avi")));
+	comments.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, static_cast<std::uint64_t>(-1))); // unrated
+	comments.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, std::string("no rating here")));
+	pf.AddTag(comments);
+	resp.AddTag(pf);
+
+	ApplyGetUpdateToDownloads(&resp, cache, rle_state);
+
+	const auto it = cache.find(303);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_EQUALS(std::string("my own note"), it->second.comment);
+	ASSERT_EQUALS(4, static_cast<int>(it->second.rating));
+	ASSERT_EQUALS(static_cast<size_t>(2), it->second.download.source_comments.size());
+	ASSERT_EQUALS(std::string("alice"), it->second.download.source_comments[0].username);
+	ASSERT_EQUALS(std::string("movie.mkv"), it->second.download.source_comments[0].filename);
+	ASSERT_EQUALS(5, static_cast<int>(it->second.download.source_comments[0].rating));
+	ASSERT_EQUALS(-1, static_cast<int>(it->second.download.source_comments[1].rating));
+	ASSERT_EQUALS(std::string("no rating here"), it->second.download.source_comments[1].comment);
+}
+
 // ----------------------------------------------------------------------
 // /servers — GET_UPDATE wraps per-server tags in an EC_TAG_SERVER
 // container at top level. Walker iterates INTO the container and


### PR DESCRIPTION
Implements #419 (second in the File-Details parity cluster, on top of #417). webapi-only — no amuled or EC-protocol change.

### Read
- Inline `comment` (string) + `rating` (int 0–5, 0 = unrated) on `GET /downloads/{hash}` and `GET /shared/{hash}`, decoded from the base `CKnownFile` tags via the shared `MergeKnownFileDetail` helper #417 added.
- New `GET /downloads/{hash}/comments` → the per-source list `{count, comments:[{username, filename, rating, comment}]}` from `EC_TAG_PARTFILE_COMMENTS` (a per-source `rating` of `-1` = commented but unrated). Downloads-only (needs a live source list).

### Write
- `PATCH /shared/{hash}` and `PATCH /downloads/{hash}` accept a `comment`+`rating` pair → `EC_OP_SHARED_FILE_SET_COMMENT`. **Both fields are required together** (`400` otherwise); `comment` ≤ 50 chars, `rating` 0–5. Only settable on a shared file — amuled resolves the hash against the shared-files registry, so a non-shared file returns `409 not_shared`.

### Tests / docs
- `RefresherTest.CommentRatingAndSourceCommentsDecode` (34 cases green).
- Curl `04` (read fields + `/comments`) and `17` (PATCH round-trip + both-required/out-of-range 400s) — verified live: **04 → 51/51, 17 → 37/37**.
- `docs/api/REFERENCE.md`: both detail fields, the new endpoint (+ rating scale), and the PATCH fields.