### PR TITLE
feat(amuleapi): source-reported filenames + rename in the REST API (#420)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -27,6 +27,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/downloads`](#get-apiv0downloads) — list active queue
 - [`GET /api/v0/downloads/{hash}`](#get-apiv0downloadshash) — detail view; `{hash}` is the 32-char MD4 hex hash
 - [`GET /api/v0/downloads/{hash}/comments`](#get-apiv0downloadshashcomments) — per-source comments/ratings list
+- [`GET /api/v0/downloads/{hash}/filenames`](#get-apiv0downloadshashfilenames) — source-reported filenames + counts
 - [`POST /api/v0/downloads`](#post-apiv0downloads) — add ed2k link(s)
 - [`PATCH /api/v0/downloads`](#patch-apiv0downloads) — bulk pause / resume / priority / category
 - [`DELETE /api/v0/downloads`](#delete-apiv0downloads) — bulk cancel + remove
@@ -583,6 +584,28 @@ A per-source `rating` of `-1` means the source left a comment but no rating. Rat
 
 **Errors:** `404 not_found` (no download with that hash), `503 ec_unavailable`.
 
+#### `GET /api/v0/downloads/{hash}/filenames`
+
+**Auth:** `GUEST`
+
+The distinct filenames this download's **sources** report for it, each with how many sources use that name (the desktop "File Names" list). Downloads-only — needs a live source list. Pair it with `PATCH /downloads/{hash}` `{ "name": … }` to implement the desktop "Takeover" flow (pick a source name, then rename).
+
+```sh
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/downloads/8b54a3c2…/filenames"
+```
+
+```json
+{
+  "filenames": [
+    { "name": "Some.Movie.2024.mkv", "count": 7 },
+    { "name": "some_movie.mkv", "count": 2 }
+  ]
+}
+```
+
+**Errors:** `404 not_found` (no download with that hash), `503 ec_unavailable`.
+
 #### `POST /api/v0/downloads`
 
 **Auth:** `ADMIN`
@@ -663,6 +686,7 @@ Mutates one or more fields of a single partfile. `{hash}` is the 32-char MD4 hex
 - `priority` — `"low"` / `"normal"` / `"high"` / `"auto"`. Downloads support only these levels; the daemon clamps any other value to `normal`. (Shared files support the wider `very_low` … `release` set — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash).)
 - `category` — uint8
 - `comment` + `rating` — set the file's comment (string, ≤ 50 chars) and rating (integer `0`–`5`). Must be sent **together**; only settable when the partfile is also shared (≥ 1 complete chunk), else `409 not_shared`. Primarily a shared-file action — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash).
+- `name` — rename the file (string). Must be non-empty and contain no path separators (`/` or `\`). See the [Takeover flow](#get-apiv0downloadshashfilenames).
 
 ```sh
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
@@ -900,7 +924,9 @@ Send a bare priority level to pin it (the file's `priority_auto` becomes `false`
 
 `comment` and `rating` must be sent **together** (both or neither) — the daemon writes them as one atomic operation. `comment` is capped at 50 characters; `rating` is an integer `0`–`5`. Setting them requires the file to be shared. The same fields are accepted on [`PATCH /downloads/{hash}`](#patch-apiv0downloadshash) for a downloading file that is also shared.
 
-**Errors:** `400 bad_request` (missing/invalid fields, or `comment`/`rating` sent alone), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `503 ec_unavailable`.
+`name` renames the file — a non-empty string with no path separators (`/` or `\`, rejected to prevent the rename escaping the file's directory). Rename works on any known file, so it is accepted on both this endpoint and [`PATCH /downloads/{hash}`](#patch-apiv0downloadshash).
+
+**Errors:** `400 bad_request` (missing/invalid fields, `comment`/`rating` sent alone, or a `name` that is empty or contains a path separator), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `503 ec_unavailable`.
 
 ---
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -996,6 +996,23 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
+	// /downloads/{hash}/filenames — source-reported filenames + counts
+	// (issue #420). Downloads-only.
+	{
+		static const auto dl_filenames =
+			web_api_path::ParsePattern("/api/v0/downloads/{hash}/filenames");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(dl_filenames, path_segs, caps)) {
+			if (req.method != "GET" && req.method != "HEAD") {
+				return ErrorResponse(405,
+					"method_not_allowed",
+					"only GET / HEAD on /downloads/{hash}/filenames");
+			}
+			return HandleDownloadFilenames(req, caps["hash"]);
+		}
+	}
+
 	// /downloads/{hash} — single-resource detail (GET / HEAD) and the
 	// mutation surface (PATCH for status/priority/category, DELETE for
 	// clear-completed single). `{hash}` is the lowercase 32-char hex
@@ -2460,6 +2477,49 @@ CHttpServer::Response CApiDispatcher::HandleDownloadComments(
 	return r;
 }
 
+CHttpServer::Response CApiDispatcher::HandleDownloadFilenames(
+	const CHttpServer::Request &req, const std::string &key)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	webapi::FileSnapshot d;
+	std::string needle = key;
+	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+		return std::tolower(c);
+	});
+	if (!m_state.FindDownload(needle, d)) {
+		return ErrorResponse(404, "not_found", "no download with that hash");
+	}
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("filenames");
+	w.BeginArray();
+	for (const auto &kv : d.download.source_names) {
+		w.BeginObject();
+		w.Key("name");
+		w.ValueString(wxString::FromUTF8(kv.second.name.c_str()));
+		w.Key("count");
+		w.ValueInt(static_cast<int64_t>(kv.second.count));
+		w.EndObject();
+	}
+	w.EndArray();
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
 namespace
 {
 
@@ -2835,6 +2895,60 @@ bool TrySetCommentRating(CamuleapiApp &app,
 	applied = true;
 	return true;
 }
+
+// Handle the optional `name` (rename) field shared by PATCH
+// /downloads/{hash} and PATCH /shared/{hash} (issue #420). Maps to
+// EC_OP_RENAME_FILE. Rejects empty names and names containing path
+// separators — amuled's RenameFile JoinPaths()es the value, so a
+// separator would let the rename escape the file's directory. Returns
+// false + fills `err` on a problem; sets `applied` when a rename was
+// sent. Absent `name` is a no-op (returns true, applied=false).
+bool TryRename(CamuleapiApp &app,
+	const picojson::object &obj,
+	const webapi::FileSnapshot &f,
+	bool &applied,
+	CHttpServer::Response &err)
+{
+	applied = false;
+	const auto nit = obj.find("name");
+	if (nit == obj.end())
+		return true;
+	if (!nit->second.is<std::string>()) {
+		err = ErrorResponse(400, "bad_request", "`name` must be a string");
+		return false;
+	}
+	const std::string name = nit->second.get<std::string>();
+	if (name.empty()) {
+		err = ErrorResponse(400, "bad_request", "`name` must not be empty");
+		return false;
+	}
+	if (name.find('/') != std::string::npos || name.find('\\') != std::string::npos) {
+		err = ErrorResponse(400, "bad_request", "`name` must not contain path separators");
+		return false;
+	}
+	CMD4Hash file_hash;
+	if (!HashFromHex(f.hash, file_hash)) {
+		err = ErrorResponse(500, "internal_error", "failed to decode file hash");
+		return false;
+	}
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_RENAME_FILE));
+	ec_req->AddTag(CECTag(EC_TAG_KNOWNFILE, file_hash));
+	ec_req->AddTag(CECTag(EC_TAG_PARTFILE_NAME, name));
+	const CECPacket *ec_resp = app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		err = ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for RENAME_FILE");
+		return false;
+	}
+	std::string ec_err;
+	if (IsEcFailedResponse(ec_resp, ec_err)) {
+		delete ec_resp;
+		err = ErrorResponse(400, "amuled_rejected", ec_err.c_str());
+		return false;
+	}
+	delete ec_resp;
+	applied = true;
+	return true;
+}
 } // namespace
 
 CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
@@ -2991,11 +3105,21 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 			any_change = true;
 	}
 
+	// name (rename; issue #420).
+	{
+		bool applied = false;
+		CHttpServer::Response rn_err;
+		if (!TryRename(m_app, obj, d, applied, rn_err))
+			return rn_err;
+		if (applied)
+			any_change = true;
+	}
+
 	if (!any_change) {
 		return ErrorResponse(400,
 			"bad_request",
 			"request body must include at least one of "
-			"`status`, `priority`, `category`, or `comment`+`rating`");
+			"`status`, `priority`, `category`, `comment`+`rating`, or `name`");
 	}
 
 	// Inline refresh so the response below sees post-mutation state.
@@ -5141,9 +5265,20 @@ CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 			any_change = true;
 	}
 
+	// name (rename; issue #420).
+	{
+		bool applied = false;
+		CHttpServer::Response rn_err;
+		if (!TryRename(m_app, obj, s, applied, rn_err))
+			return rn_err;
+		if (applied)
+			any_change = true;
+	}
+
 	if (!any_change) {
-		return ErrorResponse(
-			400, "bad_request", "request body must include `priority` or `comment`+`rating`");
+		return ErrorResponse(400,
+			"bad_request",
+			"request body must include `priority`, `comment`+`rating`, or `name`");
 	}
 
 	(void)RefresherTick(m_app, m_state);

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -105,6 +105,8 @@ private:
 	CHttpServer::Response HandleDownloadDetail(const CHttpServer::Request &, const std::string &key);
 	// per-source comments/ratings list. `key` = 32-char MD4 hash.
 	CHttpServer::Response HandleDownloadComments(const CHttpServer::Request &, const std::string &key);
+	// source-reported filenames + counts. `key` = 32-char MD4 hash.
+	CHttpServer::Response HandleDownloadFilenames(const CHttpServer::Request &, const std::string &key);
 	// download lifecycle mutations.
 	CHttpServer::Response HandleDownloadAdd(const CHttpServer::Request &);
 	CHttpServer::Response HandleDownloadPatch(const CHttpServer::Request &, const std::string &key);

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -428,6 +428,33 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 			f.download.source_comments.push_back(std::move(c));
 		}
 	}
+	// Source-reported filenames (issue #420). amuled delta-encodes the
+	// container keyed by a stable per-name id: a child carrying a name
+	// subtag is a new/updated entry; a child with COUNTS==0 and no name
+	// is a removal; otherwise it's a count update. The container is only
+	// sent when something changed (HasChildTags gate on the daemon), so
+	// an absent container keeps the accumulated map.
+	if (const CECTag *names = pf->GetTagByName(EC_TAG_PARTFILE_SOURCE_NAMES)) {
+		for (const CECTag &child : *names) {
+			const std::uint32_t id = static_cast<std::uint32_t>(child.GetInt());
+			const CECTag *name_tag = child.GetTagByName(EC_TAG_PARTFILE_SOURCE_NAMES);
+			const CECTag *count_tag = child.GetTagByName(EC_TAG_PARTFILE_SOURCE_NAMES_COUNTS);
+			const std::uint32_t count =
+				count_tag ? static_cast<std::uint32_t>(count_tag->GetInt()) : 0;
+			if (name_tag) {
+				FileSnapshot::DownloadSide::SourceName sn;
+				sn.name = std::string(name_tag->GetStringData().utf8_str());
+				sn.count = count;
+				f.download.source_names[id] = std::move(sn);
+			} else if (count == 0) {
+				f.download.source_names.erase(id);
+			} else {
+				auto mit = f.download.source_names.find(id);
+				if (mit != f.download.source_names.end())
+					mit->second.count = count;
+			}
+		}
+	}
 	// Base CKnownFile detail tags (aich_hash, queued_count, met_file).
 	MergeKnownFileDetail(pf, f);
 	// Recompute percent unconditionally — both inputs may have moved.

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -149,6 +149,18 @@ struct FileSnapshot
 		};
 		std::vector<SourceComment> source_comments;
 
+		// Source-reported filenames (GET /downloads/{hash}/filenames,
+		// issue #420). amuled delta-encodes these keyed by a stable id
+		// (new = name+count, count 0 = removed, else count update); the
+		// refresher accumulates into this map across ticks. Reset with
+		// the rest of DownloadSide when the download role drops.
+		struct SourceName
+		{
+			std::string name;
+			std::uint32_t count = 0;
+		};
+		std::map<std::uint32_t, SourceName> source_names;
+
 		// Decoded per-part state, populated by the refresher's RLE
 		// decoder pass on EC_TAG_PARTFILE_GAP_STATUS +
 		// EC_TAG_PARTFILE_PART_STATUS. Both arrays are sized to

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -166,6 +166,12 @@ if [ "$COUNT" -gt 0 ]; then
 	_assert_json_eq '.comments | type' array \
 		'/downloads/{hash}/comments.comments is an array'
 
+	# Source-reported filenames sub-resource (issue #420).
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/filenames"
+	_assert_status 200 "GET /downloads/{hash}/filenames → 200"
+	_assert_json_eq '.filenames | type' array \
+		'/downloads/{hash}/filenames.filenames is an array'
+
 	# Uppercase hash → same hit (case-insensitive route).
 	HASH_UPPER=$(echo "$HASH" | tr '[:lower:]' '[:upper:]')
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH_UPPER"

--- a/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
+++ b/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
@@ -209,6 +209,24 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-d '{"comment":"x","rating":9}' "$HOST/api/v0/shared/$TEST_HASH"
 _assert_status 400 "PATCH rating out of range → 400"
 
+# --- 3d. PATCH name (rename; issue #420). -------------------------
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"name":"renamed-by-test.dat"}' "$HOST/api/v0/shared/$TEST_HASH"
+_assert_status 200 "PATCH name (rename) → 200"
+
+# Path separators rejected (directory-traversal guard).
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"name":"../evil.dat"}' "$HOST/api/v0/shared/$TEST_HASH"
+_assert_status 400 "PATCH name with path separator → 400"
+
+# Empty name rejected.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"name":""}' "$HOST/api/v0/shared/$TEST_HASH"
+_assert_status 400 "PATCH empty name → 400"
+
 # --- 4. Error paths. ----------------------------------------------
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -582,6 +582,60 @@ TEST(Refresher, CommentRatingAndSourceCommentsDecode)
 	ASSERT_EQUALS(std::string("no rating here"), it->second.download.source_comments[1].comment);
 }
 
+// Source-reported filenames (issue #420) are delta-encoded by amuled and
+// accumulated across ticks: tick 1 adds two names; tick 2 removes one
+// (COUNTS=0) and updates the other's count (COUNTS-only child).
+TEST(Refresher, SourceNamesDeltaAccumulate)
+{
+	FileMap cache;
+	std::map<std::uint32_t, PartFileEncoderData> rle_state;
+
+	{
+		CECPacket resp(EC_OP_SHARED_FILES);
+		CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(404));
+		CECEmptyTag names(EC_TAG_PARTFILE_SOURCE_NAMES);
+		CECTag c1(EC_TAG_PARTFILE_SOURCE_NAMES, static_cast<std::uint32_t>(1));
+		c1.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_NAMES, std::string("Movie.mkv")));
+		c1.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_NAMES_COUNTS, static_cast<std::uint32_t>(7)));
+		names.AddTag(c1);
+		CECTag c2(EC_TAG_PARTFILE_SOURCE_NAMES, static_cast<std::uint32_t>(2));
+		c2.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_NAMES, std::string("movie.avi")));
+		c2.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_NAMES_COUNTS, static_cast<std::uint32_t>(2)));
+		names.AddTag(c2);
+		pf.AddTag(names);
+		resp.AddTag(pf);
+		ApplyGetUpdateToDownloads(&resp, cache, rle_state);
+	}
+	{
+		const auto it = cache.find(404);
+		ASSERT_TRUE(it != cache.end());
+		ASSERT_EQUALS(static_cast<size_t>(2), it->second.download.source_names.size());
+		ASSERT_EQUALS(std::string("Movie.mkv"), it->second.download.source_names[1].name);
+		ASSERT_EQUALS(static_cast<std::uint32_t>(7), it->second.download.source_names[1].count);
+	}
+
+	// Tick 2: remove id 2 (count 0), bump id 1's count to 9 (no name).
+	{
+		CECPacket resp(EC_OP_SHARED_FILES);
+		CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(404));
+		CECEmptyTag names(EC_TAG_PARTFILE_SOURCE_NAMES);
+		CECTag rem(EC_TAG_PARTFILE_SOURCE_NAMES, static_cast<std::uint32_t>(2));
+		rem.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_NAMES_COUNTS, static_cast<std::uint32_t>(0)));
+		names.AddTag(rem);
+		CECTag upd(EC_TAG_PARTFILE_SOURCE_NAMES, static_cast<std::uint32_t>(1));
+		upd.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_NAMES_COUNTS, static_cast<std::uint32_t>(9)));
+		names.AddTag(upd);
+		pf.AddTag(names);
+		resp.AddTag(pf);
+		ApplyGetUpdateToDownloads(&resp, cache, rle_state);
+	}
+	const auto it = cache.find(404);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_EQUALS(static_cast<size_t>(1), it->second.download.source_names.size());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(9), it->second.download.source_names[1].count);
+	ASSERT_TRUE(it->second.download.source_names.find(2) == it->second.download.source_names.end());
+}
+
 // ----------------------------------------------------------------------
 // /servers — GET_UPDATE wraps per-server tags in an EC_TAG_SERVER
 // container at top level. Walker iterates INTO the container and


### PR DESCRIPTION
Implements #420 (third in the File-Details parity cluster, on top of #417). webapi-only — no amuled or EC-protocol change.

### Read
New `GET /downloads/{hash}/filenames` → the distinct filenames this download's sources report, each with a source `count` (the desktop "File Names" list):

```json
{ "filenames": [ { "name": "Some.Movie.2024.mkv", "count": 7 }, { "name": "some_movie.mkv", "count": 2 } ] }
```

amuled delta-encodes the `EC_TAG_PARTFILE_SOURCE_NAMES` container (id-keyed: name+count = add/update, count 0 = removal); the refresher accumulates it into a persistent per-download map across ticks. Downloads-only.

### Write
`PATCH /downloads/{hash}` and `PATCH /shared/{hash}` accept a `name` field → `EC_OP_RENAME_FILE`. Rejects empty names and any name containing a path separator (`/` or `\`) — `RenameFile` `JoinPaths()`es the value, so a separator would let the rename escape the file's directory. The desktop "Takeover" is client-side: `GET …/filenames` → pick one → `PATCH … {name}`.

### Tests / docs
- `RefresherTest.SourceNamesDeltaAccumulate` — two-tick add/remove/update (35 cases green).
- Curl `04` (filenames endpoint) and `17` (rename round-trip + traversal/empty 400s) — verified live: **04 → 53/53, 17 → 40/40**.
- `docs/api/REFERENCE.md`: the new endpoint, the `name` PATCH field, and the Takeover flow note.