### PR TITLE
feat(amuleapi): A4AF source list & swap in the REST API (#421)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -28,6 +28,8 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/downloads/{hash}`](#get-apiv0downloadshash) — detail view; `{hash}` is the 32-char MD4 hex hash
 - [`GET /api/v0/downloads/{hash}/comments`](#get-apiv0downloadshashcomments) — per-source comments/ratings list
 - [`GET /api/v0/downloads/{hash}/filenames`](#get-apiv0downloadshashfilenames) — source-reported filenames + counts
+- [`GET /api/v0/downloads/{hash}/a4af`](#get-apiv0downloadshasha4af) — A4AF source list + auto flag
+- [`POST /api/v0/downloads/{hash}/a4af`](#post-apiv0downloadshasha4af) — force A4AF source-swapping
 - [`POST /api/v0/downloads`](#post-apiv0downloads) — add ed2k link(s)
 - [`PATCH /api/v0/downloads`](#patch-apiv0downloads) — bulk pause / resume / priority / category
 - [`DELETE /api/v0/downloads`](#delete-apiv0downloads) — bulk cancel + remove
@@ -547,6 +549,7 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 | `queued_count` | int | Clients waiting on this file's upload queue. |
 | `comment` | string | The user's own comment on this file (`""` if none). |
 | `rating` | int | The user's own rating, `0`–`5` (`0` = unrated). See the [rating scale](#get-apiv0downloadshashcomments). |
+| `a4af_auto` | bool | Whether automatic A4AF source-swapping is on for this file. See [A4AF](#get-apiv0downloadshasha4af). |
 
 **Errors:** `404 not_found` (no partfile with that hash), `503 ec_unavailable`.
 
@@ -605,6 +608,43 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 ```
 
 **Errors:** `404 not_found` (no download with that hash), `503 ec_unavailable`.
+
+#### `GET /api/v0/downloads/{hash}/a4af`
+
+**Auth:** `GUEST`
+
+The download's **A4AF** (asked-for-another-file) sources — peers that hold this file but are currently serving another. Downloads-only.
+
+```sh
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/downloads/8b54a3c2…/a4af"
+```
+
+```json
+{ "a4af_auto": false, "sources": [ 1234, 5678 ] }
+```
+
+`sources` are client ECIDs, joinable against [`GET /clients`](#get-apiv0clients)'s `client_ecid`. The scalar `sources.a4af` count on the download object is unchanged.
+
+**Errors:** `404 not_found` (no download with that hash), `503 ec_unavailable`.
+
+#### `POST /api/v0/downloads/{hash}/a4af`
+
+**Auth:** `ADMIN`
+
+Force A4AF source-swapping for this download. Downloads-only.
+
+**Body:** `{ "action": "<action>" }`
+
+| action | Effect |
+|---|---|
+| `swap_this` | Make other files' A4AF sources take over **this** file. |
+| `swap_this_auto` | Toggle automatic A4AF swapping for this file. |
+| `swap_others` | Release this file's sources to the other files that want them. |
+
+**Response:** `200 OK` — the post-action A4AF view (same shape as the `GET`).
+
+**Errors:** `400 bad_request` (missing or unknown `action`), `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads`
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1013,6 +1013,25 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
+	// /downloads/{hash}/a4af — A4AF source list (GET) + swap actions
+	// (POST). Downloads-only (issue #421).
+	{
+		static const auto dl_a4af = web_api_path::ParsePattern("/api/v0/downloads/{hash}/a4af");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(dl_a4af, path_segs, caps)) {
+			if (req.method == "GET" || req.method == "HEAD") {
+				return HandleDownloadA4af(req, caps["hash"]);
+			}
+			if (req.method == "POST") {
+				return HandleDownloadA4afAction(req, caps["hash"]);
+			}
+			return ErrorResponse(405,
+				"method_not_allowed",
+				"only GET / HEAD / POST on /downloads/{hash}/a4af");
+		}
+	}
+
 	// /downloads/{hash} — single-resource detail (GET / HEAD) and the
 	// mutation surface (PATCH for status/priority/category, DELETE for
 	// clear-completed single). `{hash}` is the lowercase 32-char hex
@@ -1725,6 +1744,8 @@ void WriteDownloadObject(
 		w.ValueString(wxString::FromUTF8(f.comment.c_str()));
 		w.Key("rating");
 		w.ValueInt(static_cast<int64_t>(f.rating));
+		w.Key("a4af_auto");
+		w.ValueBool(f.download.a4af_auto);
 	}
 	w.EndObject();
 }
@@ -2516,6 +2537,133 @@ CHttpServer::Response CApiDispatcher::HandleDownloadFilenames(
 	}
 	w.EndArray();
 	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+// Serialize the A4AF view (auto flag + source client ECIDs) for a
+// resolved download snapshot.
+namespace
+{
+void WriteA4afObject(CJsonWriter &w, const webapi::FileSnapshot &d)
+{
+	w.BeginObject();
+	w.Key("a4af_auto");
+	w.ValueBool(d.download.a4af_auto);
+	w.Key("sources");
+	w.BeginArray();
+	for (const std::uint32_t ecid : d.download.a4af_sources) {
+		w.ValueInt(static_cast<int64_t>(ecid));
+	}
+	w.EndArray();
+	w.EndObject();
+}
+} // namespace
+
+CHttpServer::Response CApiDispatcher::HandleDownloadA4af(
+	const CHttpServer::Request &req, const std::string &key)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	webapi::FileSnapshot d;
+	std::string needle = key;
+	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+		return std::tolower(c);
+	});
+	if (!m_state.FindDownload(needle, d)) {
+		return ErrorResponse(404, "not_found", "no download with that hash");
+	}
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	WriteA4afObject(w, d);
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
+	const CHttpServer::Request &req, const std::string &key)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	webapi::FileSnapshot d;
+	std::string needle = key;
+	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+		return std::tolower(c);
+	});
+	if (!m_state.FindDownload(needle, d)) {
+		return ErrorResponse(404, "not_found", "no download with that hash");
+	}
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	}
+	const auto &obj = root.get<picojson::object>();
+	const auto ait = obj.find("action");
+	if (ait == obj.end() || !ait->second.is<std::string>()) {
+		return ErrorResponse(400, "bad_request", "request body must include a string `action`");
+	}
+	const std::string &action = ait->second.get<std::string>();
+	ec_opcode_t op;
+	if (action == "swap_this")
+		op = EC_OP_PARTFILE_SWAP_A4AF_THIS;
+	else if (action == "swap_this_auto")
+		op = EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO;
+	else if (action == "swap_others")
+		op = EC_OP_PARTFILE_SWAP_A4AF_OTHERS;
+	else {
+		return ErrorResponse(
+			400, "bad_request", "`action` must be one of swap_this, swap_this_auto, swap_others");
+	}
+
+	CMD4Hash file_hash;
+	if (!HashFromHex(d.hash, file_hash)) {
+		return ErrorResponse(500, "internal_error", "failed to decode partfile hash");
+	}
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(op));
+	ec_req->AddTag(CECTag(EC_TAG_PARTFILE, file_hash));
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for A4AF swap");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+	}
+	delete ec_resp;
+
+	(void)RefresherTick(m_app, m_state);
+	webapi::FileSnapshot d_after = d;
+	(void)m_state.FindDownload(d.hash, d_after);
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	WriteA4afObject(w, d_after);
 	FinalizeJsonBody(w, r);
 	return r;
 }

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -107,6 +107,9 @@ private:
 	CHttpServer::Response HandleDownloadComments(const CHttpServer::Request &, const std::string &key);
 	// source-reported filenames + counts. `key` = 32-char MD4 hash.
 	CHttpServer::Response HandleDownloadFilenames(const CHttpServer::Request &, const std::string &key);
+	// A4AF source list (GET) + swap actions (POST). `key` = 32-char MD4 hash.
+	CHttpServer::Response HandleDownloadA4af(const CHttpServer::Request &, const std::string &key);
+	CHttpServer::Response HandleDownloadA4afAction(const CHttpServer::Request &, const std::string &key);
 	// download lifecycle mutations.
 	CHttpServer::Response HandleDownloadAdd(const CHttpServer::Request &);
 	CHttpServer::Response HandleDownloadPatch(const CHttpServer::Request &, const std::string &key);

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -455,6 +455,19 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 			}
 		}
 	}
+	// A4AF (issue #421): the auto flag + the full source-ECID list.
+	{
+		bool v = false;
+		if (pf->AssignIfExist(EC_TAG_PARTFILE_A4AFAUTO, v))
+			f.download.a4af_auto = v;
+	}
+	// amuled rebuilds the whole A4AF-source container when it changes, so
+	// replace the list wholesale when present (absent = unchanged, keep).
+	if (const CECTag *a4af = pf->GetTagByName(EC_TAG_PARTFILE_A4AF_SOURCES)) {
+		f.download.a4af_sources.clear();
+		for (const CECTag &src : *a4af)
+			f.download.a4af_sources.push_back(static_cast<std::uint32_t>(src.GetInt()));
+	}
 	// Base CKnownFile detail tags (aich_hash, queued_count, met_file).
 	MergeKnownFileDetail(pf, f);
 	// Recompute percent unconditionally — both inputs may have moved.

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -161,6 +161,13 @@ struct FileSnapshot
 		};
 		std::map<std::uint32_t, SourceName> source_names;
 
+		// A4AF (asked-for-another-file) source scheduling (issue #421).
+		// `a4af_auto` is the auto-swap flag; `a4af_sources` are the client
+		// ECIDs currently parked as A4AF sources for this download (full
+		// list re-sent by amuled when it changes).
+		bool a4af_auto = false;
+		std::vector<std::uint32_t> a4af_sources;
+
 		// Decoded per-part state, populated by the refresher's RLE
 		// decoder pass on EC_TAG_PARTFILE_GAP_STATUS +
 		// EC_TAG_PARTFILE_PART_STATUS. Both arrays are sized to

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -157,6 +157,8 @@ if [ "$COUNT" -gt 0 ]; then
 		'/downloads/{hash} carries comment'
 	_assert_json_eq '.rating | type' number \
 		'/downloads/{hash} carries rating'
+	_assert_json_eq '.a4af_auto | type' boolean \
+		'/downloads/{hash} carries a4af_auto'
 
 	# Per-source comments sub-resource (issue #419).
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/comments"
@@ -171,6 +173,29 @@ if [ "$COUNT" -gt 0 ]; then
 	_assert_status 200 "GET /downloads/{hash}/filenames → 200"
 	_assert_json_eq '.filenames | type' array \
 		'/downloads/{hash}/filenames.filenames is an array'
+
+	# A4AF source list sub-resource (issue #421).
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/a4af"
+	_assert_status 200 "GET /downloads/{hash}/a4af → 200"
+	_assert_json_eq '.a4af_auto | type' boolean \
+		'/downloads/{hash}/a4af carries a4af_auto'
+	_assert_json_eq '.sources | type' array \
+		'/downloads/{hash}/a4af.sources is an array'
+
+	# Unknown action → 400 (mutation validation; admin token).
+	_curl -X POST -H "Authorization: Bearer $TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"action":"bogus"}' "$HOST/api/v0/downloads/$HASH/a4af"
+	_assert_status 400 "POST /downloads/{hash}/a4af unknown action → 400"
+
+	# Valid action → 200 (no-op on a download with no A4AF sources, but
+	# exercises the EC op path). Response echoes the A4AF view.
+	_curl -X POST -H "Authorization: Bearer $TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"action":"swap_others"}' "$HOST/api/v0/downloads/$HASH/a4af"
+	_assert_status 200 "POST /downloads/{hash}/a4af swap_others → 200"
+	_assert_json_eq '.sources | type' array \
+		'POST /a4af response carries sources array'
 
 	# Uppercase hash → same hit (case-insensitive route).
 	HASH_UPPER=$(echo "$HASH" | tr '[:lower:]' '[:upper:]')

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -636,6 +636,32 @@ TEST(Refresher, SourceNamesDeltaAccumulate)
 	ASSERT_TRUE(it->second.download.source_names.find(2) == it->second.download.source_names.end());
 }
 
+// A4AF (issue #421): the auto flag decodes into download.a4af_auto and
+// the EC_TAG_PARTFILE_A4AF_SOURCES container's EC_TAG_ECID children into
+// the a4af_sources list (full replace when present).
+TEST(Refresher, A4afAutoAndSourcesDecode)
+{
+	FileMap cache;
+	std::map<std::uint32_t, PartFileEncoderData> rle_state;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	CECTag pf(EC_TAG_PARTFILE, static_cast<std::uint32_t>(505));
+	pf.AddTag(CECTag(EC_TAG_PARTFILE_A4AFAUTO, true));
+	CECEmptyTag a4af(EC_TAG_PARTFILE_A4AF_SOURCES);
+	a4af.AddTag(CECTag(EC_TAG_ECID, static_cast<std::uint32_t>(1234)));
+	a4af.AddTag(CECTag(EC_TAG_ECID, static_cast<std::uint32_t>(5678)));
+	pf.AddTag(a4af);
+	resp.AddTag(pf);
+
+	ApplyGetUpdateToDownloads(&resp, cache, rle_state);
+
+	const auto it = cache.find(505);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_TRUE(it->second.download.a4af_auto);
+	ASSERT_EQUALS(static_cast<size_t>(2), it->second.download.a4af_sources.size());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1234), it->second.download.a4af_sources[0]);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(5678), it->second.download.a4af_sources[1]);
+}
+
 // ----------------------------------------------------------------------
 // /servers — GET_UPDATE wraps per-server tags in an EC_TAG_SERVER
 // container at top level. Walker iterates INTO the container and


### PR DESCRIPTION
Implements #421 — the last of the File-Details parity cluster (#417). webapi-only — no amuled or EC-protocol change.

### Read
- Inline `a4af_auto` (bool) on `GET /downloads/{hash}`.
- New `GET /downloads/{hash}/a4af` → `{ "a4af_auto": false, "sources": [1234, 5678] }`, from `EC_TAG_PARTFILE_A4AFAUTO` + the `EC_TAG_PARTFILE_A4AF_SOURCES` container (full list, re-sent by amuled when it changes). `sources` are client ECIDs, joinable against `GET /clients`'s `client_ecid`; the scalar `sources.a4af` count is unchanged.

### Write
`POST /downloads/{hash}/a4af` with an `action` → the matching `EC_OP_PARTFILE_SWAP_A4AF_*` op:

| action | effect |
|---|---|
| `swap_this` | make other files' A4AF sources take over this file |
| `swap_this_auto` | toggle automatic A4AF for this file |
| `swap_others` | release this file's sources to other files |

Unknown `action` → `400`. Downloads-only.

### Tests / docs
- `RefresherTest.A4afAutoAndSourcesDecode` (36 cases green).
- Curl `04`: the inline field, the `/a4af` GET, the swap action + unknown-action `400` — verified live **60/60**.
- `docs/api/REFERENCE.md`: both endpoints + the `a4af_auto` field + index entries.