### PR TITLE
feat(amuleapi): expose download status + file type in search results (#429)

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -410,11 +410,13 @@ Emitted per new result that appears in the results map between refresher ticks.
   "size": 5765873664,
   "sources": { "total": 12, "complete": 7 },
   "already_have": false,
-  "rating": 0
+  "rating": 0,
+  "status": "new",
+  "type": "videos"
 }
 ```
 
-Key results by `hash`. The payload is byte-for-byte identical to a `/search/results` array entry (`sources` is the nested `{total, complete}` object, same as the REST endpoint). amuled wipes its searchlist on every new `POST /search`, so subscribers must treat each search as a fresh result space — clear prior results when you start a new query.
+Key results by `hash`. The payload is byte-for-byte identical to a `/search/results` array entry (including `status` and `type` — see [REFERENCE.md](REFERENCE.md#get-apiv0searchresults)) (`sources` is the nested `{total, complete}` object, same as the REST endpoint). amuled wipes its searchlist on every new `POST /search`, so subscribers must treat each search as a fresh result space — clear prior results when you start a new query.
 
 #### `search_progress`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1478,7 +1478,9 @@ This endpoint does NOT busy-wait — it returns whatever amuled has in its resul
       "size":         3825205248,
       "sources":      { "total": 217, "complete": 142 },
       "already_have": false,
-      "rating":       0
+      "rating":       0,
+      "status":       "new",
+      "type":         "videos"
     }
   ],
   "progress": {
@@ -1489,7 +1491,7 @@ This endpoint does NOT busy-wait — it returns whatever amuled has in its resul
 }
 ```
 
-Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated).
+Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension).
 
 The `progress` object carries the same `state` / `kind` / `percent` fields as the [`search_progress`](EVENTS.md#search_progress) SSE event, so REST pollers and stream consumers interpret progress identically. (The event additionally carries a `results` count, since — unlike this response — it has no `results` array beside it.)
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -4301,6 +4301,10 @@ void WriteSearchObject(CJsonWriter &w, const webapi::SearchResult &r)
 	w.ValueBool(r.already_have);
 	w.Key("rating");
 	w.ValueInt(static_cast<int64_t>(r.rating));
+	w.Key("status");
+	w.ValueString(wxString::FromUTF8(r.status.c_str()));
+	w.Key("type");
+	w.ValueString(wxString::FromUTF8(r.type.c_str()));
 	w.EndObject();
 }
 

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -537,6 +537,8 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 						<< ",\"already_have\":"
 						<< (kv.second.already_have ? "true" : "false")
 						<< ",\"rating\":" << static_cast<int>(kv.second.rating)
+						<< ",\"status\":\"" << EscJson(kv.second.status) << "\""
+						<< ",\"type\":\"" << EscJson(kv.second.type) << "\""
 						<< "}";
 					bus.Publish("search_result_added", payload.str());
 				}

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -31,6 +31,8 @@
 #include "State.h"
 
 #include "Constants.h"                            // PS_* / PR_* / US_* / DS_* / OBST_* enums
+#include "OtherFunctions.h"                       // GetFiletypeByName for the search-result `type`
+#include <common/Path.h>                          // CPath
 #include "ClientList.h"                           // buddyState enum (Disconnected/Connecting/Connected)
 #include "ClientCredits.h"                        // EIdentState (IS_NOTAVAILABLE / IS_IDENTIFIED / ...)
 #include "Server.h"                               // SRV_PR_* server priority constants
@@ -1699,6 +1701,43 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
 
 // --- /search/results (full fetch per tick) -----------------------------
 
+namespace
+{
+// CSearchFile::DownloadStatus (SearchFile.h) → wire string (issue #429).
+// Values are ABI-stable (serialized over EC as EC_TAG_PARTFILE_STATUS).
+const char *SearchStatusName(std::uint32_t code)
+{
+	switch (code) {
+	case 0: // NEW
+		return "new";
+	case 1: // DOWNLOADED
+		return "downloaded";
+	case 2: // QUEUED
+		return "queued";
+	case 3: // CANCELED
+		return "canceled";
+	case 4: // QUEUEDCANCELED
+		return "queued_canceled";
+	default:
+		return "new";
+	}
+}
+
+// Locale-independent file-type token from the filename, mirroring the
+// desktop's GetFiletypeByName (untranslated) lowercased — same tokens as
+// the shared-detail `file_type`.
+std::string SearchTypeToken(const std::string &name)
+{
+	const wxString desc =
+		GetFiletypeByName(CPath(wxString::FromUTF8(name.c_str())), /*translated=*/false);
+	std::string s(desc.utf8_str());
+	std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+		return static_cast<char>(std::tolower(c));
+	});
+	return s;
+}
+} // namespace
+
 void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult> &cache)
 {
 	cache.clear();
@@ -1736,6 +1775,14 @@ void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult
 			if (sf->AssignIfExist(EC_TAG_KNOWNFILE_RATING, v))
 				r.rating = v;
 		}
+		// Download status (issue #429): amuled packs the CSearchFile
+		// status in EC_TAG_PARTFILE_STATUS on every search-result tag.
+		{
+			std::uint32_t v = 0;
+			r.status = SearchStatusName(sf->AssignIfExist(EC_TAG_PARTFILE_STATUS, v) ? v : 0);
+		}
+		// File type, computed from the filename (no EC data needed).
+		r.type = SearchTypeToken(r.name);
 		cache.emplace(r.ecid, std::move(r));
 	}
 }

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -461,6 +461,13 @@ struct SearchResult
 	std::uint32_t complete_source_count = 0;
 	bool already_have = false;
 	std::uint8_t rating = 0;
+	// Download status of the result on this node (issue #429), a lowercase
+	// string from the CSearchFile enum: "new" | "downloaded" | "queued" |
+	// "canceled" | "queued_canceled".
+	std::string status;
+	// File-type token derived from the filename (like the shared-detail
+	// `file_type`), e.g. "video"/"audio"; "" if the name has no extension.
+	std::string type;
 };
 
 // Refresher-tracked lifecycle of the currently-active (or last-finished)

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -193,6 +193,10 @@ if [ -n "$RESULT_HASH" ]; then
 	_assert_json_eq '.results[0].hash | length' 32     '/search/results[0].hash is 32-char hex'
 	_assert_json_eq '.results[0].name | type'   string '/search/results[0].name is string'
 	_assert_json_eq '.results[0].size | type'   number '/search/results[0].size is numeric'
+	# Download status + file type (issue #429).
+	_assert_json_eq '[.results[0].status] | inside(["new","downloaded","queued","canceled","queued_canceled"])' \
+		true '/search/results[0].status is a known enum value'
+	_assert_json_eq '.results[0].type | type'   string '/search/results[0].type is string'
 
 	# progress envelope. `progress` exists on every GET /search/results
 	# response (even before any POST /search). `state` is canonical

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1018,6 +1018,38 @@ constexpr std::uint32_t LIFECYCLE_FINISHED = 2;
 
 } // namespace
 
+// Search result status + type (issue #429): EC_TAG_PARTFILE_STATUS decodes
+// to the lowercase status string, and `type` is derived from the filename.
+TEST(Refresher, SearchResultStatusAndTypeDecode)
+{
+	std::map<std::uint32_t, SearchResult> cache;
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("cool.movie.mkv")));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(123)));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_STATUS, static_cast<std::uint32_t>(2))); // QUEUED
+	resp.AddTag(sf);
+	// A second result with no status tag defaults to "new"; a .mp3 → audio.
+	CECTag sf2(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(71));
+	sf2.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("song.mp3")));
+	sf2.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(4)));
+	resp.AddTag(sf2);
+
+	ApplySearchFull(&resp, cache);
+
+	const auto it = cache.find(70);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_EQUALS(std::string("queued"), it->second.status);
+	// GetFiletypeByName's label lowercased — "videos", same tokens as the
+	// shared-detail file_type (issue #417), not a bespoke "video".
+	ASSERT_EQUALS(std::string("videos"), it->second.type);
+
+	const auto it2 = cache.find(71);
+	ASSERT_TRUE(it2 != cache.end());
+	ASSERT_EQUALS(std::string("new"), it2->second.status);
+	ASSERT_EQUALS(std::string("audio"), it2->second.type);
+}
+
 TEST(Refresher, SearchProgressRunningCarriesPercentForGlobal)
 {
 	using webapi::AdvanceSearchProgress;


### PR DESCRIPTION
Implements #429 (first of the search-enrichment mini-cluster). webapi-only — no EC-protocol change.

### Change
- **`status`** — amuled already packs the per-result download status in `EC_TAG_PARTFILE_STATUS` on every search-result tag; the refresher just dropped it. `ApplySearchFull` now decodes it into a lowercase string: `new` / `downloaded` / `queued` / `canceled` / `queued_canceled`.
- **`type`** — derived from the filename via `GetFiletypeByName` (same lowercased tokens as the shared-detail `file_type`, e.g. `videos` / `audio`), no EC data needed.

Both are stored on `webapi::SearchResult`, so the REST `WriteSearchObject` and the byte-identical SSE `search_result_added` emitter stay consistent for free.

### Tests / docs
- `RefresherTest.SearchResultStatusAndTypeDecode` (38 cases green).
- Curl `19-search.sh` gains `status`/`type` shape checks. **Verified live against a network-connected daemon** (global search "ubuntu"/"euphoria"): status observed across `new`/`downloaded`/`canceled`, type across `videos`/`audio`/`texts`/`cd-images`/… — 19/19 search checks + 41/41 total pass.
- REST reference + SSE `EVENTS.md` document both fields.