### PR TITLE
feat(amuleapi): expose media metadata in search results (#430)

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -412,11 +412,12 @@ Emitted per new result that appears in the results map between refresher ticks.
   "already_have": false,
   "rating": 0,
   "status": "new",
-  "type": "videos"
+  "type": "videos",
+  "media": { "length_s": 5400, "bitrate": 1500, "codec": "h264", "artist": "", "album": "", "title": "" }
 }
 ```
 
-Key results by `hash`. The payload is byte-for-byte identical to a `/search/results` array entry (including `status` and `type` — see [REFERENCE.md](REFERENCE.md#get-apiv0searchresults)) (`sources` is the nested `{total, complete}` object, same as the REST endpoint). amuled wipes its searchlist on every new `POST /search`, so subscribers must treat each search as a fresh result space — clear prior results when you start a new query.
+Key results by `hash`. The payload is byte-for-byte identical to a `/search/results` array entry (including `status` and `type` — see [REFERENCE.md](REFERENCE.md#get-apiv0searchresults)); `sources` is the nested `{total, complete}` object, and `media` — the audio/video metadata object — is present only for locally-known/probed hits and omitted otherwise, same as the REST endpoint. amuled wipes its searchlist on every new `POST /search`, so subscribers must treat each search as a fresh result space — clear prior results when you start a new query.
 
 #### `search_progress`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1480,7 +1480,8 @@ This endpoint does NOT busy-wait — it returns whatever amuled has in its resul
       "already_have": false,
       "rating":       0,
       "status":       "new",
-      "type":         "videos"
+      "type":         "videos",
+      "media":        { "length_s": 5400, "bitrate": 1500, "codec": "h264", "artist": "", "album": "", "title": "" }
     }
   ],
   "progress": {
@@ -1491,7 +1492,7 @@ This endpoint does NOT busy-wait — it returns whatever amuled has in its resul
 }
 ```
 
-Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension).
+Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints) — **present only** for a hit that is already known/probed locally, and **omitted entirely** for remote hits with no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list.
 
 The `progress` object carries the same `state` / `kind` / `percent` fields as the [`search_progress`](EVENTS.md#search_progress) SSE event, so REST pollers and stream consumers interpret progress identically. (The event additionally carries a `results` count, since — unlike this response — it has no `results` array beside it.)
 

--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -397,6 +397,32 @@ CEC_SearchFile_Tag::CEC_SearchFile_Tag(
 	if (file->HasRating()) {
 		AddTag(CECTag(EC_TAG_KNOWNFILE_RATING, (uint8)file->UserRating()), valuemap);
 	}
+	// Media metadata (issue #430). A hit carries FT_MEDIA_* tags only when
+	// the file is known/probed locally; emit each EC_TAG_KNOWNFILE_MEDIA_*
+	// (defined by issue #418) only when its value is present, so results
+	// without media cost nothing.
+	if (uint32 len = file->GetIntTagValue(FT_MEDIA_LENGTH)) {
+		AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_LENGTH, len), valuemap);
+	}
+	if (uint32 br = file->GetIntTagValue(FT_MEDIA_BITRATE)) {
+		AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_BITRATE, br), valuemap);
+	}
+	const wxString &codec = file->GetStrTagValue(FT_MEDIA_CODEC);
+	if (!codec.IsEmpty()) {
+		AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_CODEC, codec), valuemap);
+	}
+	const wxString &artist = file->GetStrTagValue(FT_MEDIA_ARTIST);
+	if (!artist.IsEmpty()) {
+		AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_ARTIST, artist), valuemap);
+	}
+	const wxString &album = file->GetStrTagValue(FT_MEDIA_ALBUM);
+	if (!album.IsEmpty()) {
+		AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_ALBUM, album), valuemap);
+	}
+	const wxString &title = file->GetStrTagValue(FT_MEDIA_TITLE);
+	if (!title.IsEmpty()) {
+		AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_TITLE, title), valuemap);
+	}
 }
 
 //

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -4305,6 +4305,25 @@ void WriteSearchObject(CJsonWriter &w, const webapi::SearchResult &r)
 	w.ValueString(wxString::FromUTF8(r.status.c_str()));
 	w.Key("type");
 	w.ValueString(wxString::FromUTF8(r.type.c_str()));
+	// Media metadata (issue #430) — same shape as the file-detail `media`
+	// object; omitted entirely when the hit carries no media tags.
+	if (r.has_media) {
+		w.Key("media");
+		w.BeginObject();
+		w.Key("length_s");
+		w.ValueInt(static_cast<int64_t>(r.media.length_s));
+		w.Key("bitrate");
+		w.ValueInt(static_cast<int64_t>(r.media.bitrate));
+		w.Key("codec");
+		w.ValueString(wxString::FromUTF8(r.media.codec.c_str()));
+		w.Key("artist");
+		w.ValueString(wxString::FromUTF8(r.media.artist.c_str()));
+		w.Key("album");
+		w.ValueString(wxString::FromUTF8(r.media.album.c_str()));
+		w.Key("title");
+		w.ValueString(wxString::FromUTF8(r.media.title.c_str()));
+		w.EndObject();
+	}
 	w.EndObject();
 }
 

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -538,8 +538,19 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 						<< (kv.second.already_have ? "true" : "false")
 						<< ",\"rating\":" << static_cast<int>(kv.second.rating)
 						<< ",\"status\":\"" << EscJson(kv.second.status) << "\""
-						<< ",\"type\":\"" << EscJson(kv.second.type) << "\""
-						<< "}";
+						<< ",\"type\":\"" << EscJson(kv.second.type) << "\"";
+					// Media metadata (issue #430) — same shape as
+					// WriteSearchObject; omitted when the hit has none.
+					if (kv.second.has_media) {
+						const auto &m = kv.second.media;
+						payload << ",\"media\":{\"length_s\":" << m.length_s
+							<< ",\"bitrate\":" << m.bitrate << ",\"codec\":\""
+							<< EscJson(m.codec) << "\",\"artist\":\""
+							<< EscJson(m.artist) << "\",\"album\":\""
+							<< EscJson(m.album) << "\",\"title\":\""
+							<< EscJson(m.title) << "\"}";
+					}
+					payload << "}";
 					bus.Publish("search_result_added", payload.str());
 				}
 			}

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1783,6 +1783,36 @@ void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult
 		}
 		// File type, computed from the filename (no EC data needed).
 		r.type = SearchTypeToken(r.name);
+		// Media metadata (issue #430): present only when the hit carried
+		// FT_MEDIA_* tags (known/probed locally). Any present tag marks
+		// has_media so the API emits the `media` object.
+		{
+			std::uint32_t v = 0;
+			if (sf->AssignIfExist(EC_TAG_KNOWNFILE_MEDIA_LENGTH, v)) {
+				r.media.length_s = v;
+				r.has_media = true;
+			}
+			if (sf->AssignIfExist(EC_TAG_KNOWNFILE_MEDIA_BITRATE, v)) {
+				r.media.bitrate = v;
+				r.has_media = true;
+			}
+		}
+		if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_CODEC)) {
+			r.media.codec = std::string(x->GetStringData().utf8_str());
+			r.has_media = true;
+		}
+		if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_ARTIST)) {
+			r.media.artist = std::string(x->GetStringData().utf8_str());
+			r.has_media = true;
+		}
+		if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_ALBUM)) {
+			r.media.album = std::string(x->GetStringData().utf8_str());
+			r.has_media = true;
+		}
+		if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_TITLE)) {
+			r.media.title = std::string(x->GetStringData().utf8_str());
+			r.has_media = true;
+		}
 		cache.emplace(r.ecid, std::move(r));
 	}
 }

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -468,6 +468,19 @@ struct SearchResult
 	// File-type token derived from the filename (like the shared-detail
 	// `file_type`), e.g. "video"/"audio"; "" if the name has no extension.
 	std::string type;
+	// Audio/video media metadata (issue #430), same shape as the file
+	// detail endpoints' `media` object. `has_media` gates it — omitted
+	// when the hit carries no FT_MEDIA_* tags (most remote results).
+	bool has_media = false;
+	struct Media
+	{
+		std::uint32_t length_s = 0;
+		std::uint32_t bitrate = 0;
+		std::string codec;
+		std::string artist;
+		std::string album;
+		std::string title;
+	} media;
 };
 
 // Refresher-tracked lifecycle of the currently-active (or last-finished)

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -197,6 +197,10 @@ if [ -n "$RESULT_HASH" ]; then
 	_assert_json_eq '[.results[0].status] | inside(["new","downloaded","queued","canceled","queued_canceled"])' \
 		true '/search/results[0].status is a known enum value'
 	_assert_json_eq '.results[0].type | type'   string '/search/results[0].type is string'
+	# Media metadata (issue #430): an object when the hit is locally
+	# known/probed, absent otherwise — both are valid.
+	_assert_json_eq '.results[0].media | type | test("^(object|null)$")' \
+		true '/search/results[0].media is an object or absent'
 
 	# progress envelope. `progress` exists on every GET /search/results
 	# response (even before any POST /search). `state` is canonical

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1105,6 +1105,41 @@ TEST(Refresher, SearchProgressIdleZeroesOutGracefully)
 	ASSERT_EQUALS(static_cast<uint32_t>(0), s.percent);
 }
 
+// Search result media metadata (issue #430): the EC_TAG_KNOWNFILE_MEDIA_*
+// tags (present only for hits known/probed locally) decode into the
+// SearchResult media sub-struct and set has_media; a hit with none stays
+// has_media=false so the API omits the `media` object.
+TEST(Refresher, SearchResultMediaDecode)
+{
+	std::map<std::uint32_t, SearchResult> cache;
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(80));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("show.s01e01.mkv")));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(999)));
+	sf.AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_LENGTH, static_cast<std::uint32_t>(1320)));
+	sf.AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_BITRATE, static_cast<std::uint32_t>(2500)));
+	sf.AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_CODEC, std::string("h264")));
+	resp.AddTag(sf);
+	// A second hit with no media tags stays has_media=false.
+	CECTag sf2(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(81));
+	sf2.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("nomedia.bin")));
+	sf2.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(4)));
+	resp.AddTag(sf2);
+
+	ApplySearchFull(&resp, cache);
+
+	const auto it = cache.find(80);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_TRUE(it->second.has_media);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1320), it->second.media.length_s);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(2500), it->second.media.bitrate);
+	ASSERT_EQUALS(std::string("h264"), it->second.media.codec);
+
+	const auto it2 = cache.find(81);
+	ASSERT_TRUE(it2 != cache.end());
+	ASSERT_TRUE(!it2->second.has_media);
+}
+
 // --- #359: peer software_version must be locale-independent ----------
 //
 // The daemon formats the version string with gettext, so an unidentified


### PR DESCRIPTION
Implements #430.

Search results now carry the same `media` object (length, bitrate, codec, artist, album, title) already exposed by the file-detail endpoints (#418), so a client can show duration/bitrate/codec next to a hit without a follow-up GET.

**amuled (EC):** `CEC_SearchFile_Tag` emits the `EC_TAG_KNOWNFILE_MEDIA_*` tags (from #418) out of the search file's `FT_MEDIA_*` values, each **only when present** — a hit with no metadata (most remote/Kad results) costs nothing on the wire.

**amuleapi (webapi):** `ApplySearchFull` decodes them into a `SearchResult::media` sub-struct behind a `has_media` gate; `WriteSearchObject` and the `search_result_added` SSE emitter emit the same `media` object, **omitted entirely** when absent — matching the blank Length/Bitrate/Codec columns in the desktop search list.

No new tag codes or JSON shape — reuses #418's `media` contract.

**Tests / docs**
- `RefresherTest.SearchResultMediaDecode` — a hit with media tags decodes to `has_media=true` + values; one without stays `false`.
- curl `19-search.sh` — asserts `results[0].media` is an object or absent.
- REST (`REFERENCE.md`) + SSE (`EVENTS.md`) docs updated (JSON example + prose, linking to the shared media-metadata definition).

Verified live on a connected daemon: a real search query returned 153 hits, 46 of which carried real `length_s`/`bitrate`/`codec`; the rest correctly omitted `media`.