### PR TITLE
feat(amuleapi): expose all EC-carried preference categories (#437)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -62,8 +62,8 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`DELETE /api/v0/categories/{index}`](#delete-apiv0categoriesindex) — remove
 
 **Preferences**
-- [`GET /api/v0/preferences`](#get-apiv0preferences) — read connection + general prefs
-- [`PATCH /api/v0/preferences`](#patch-apiv0preferences) — update subset of prefs
+- [`GET /api/v0/preferences`](#get-apiv0preferences) — read all EC-carried preference categories
+- [`PATCH /api/v0/preferences`](#patch-apiv0preferences) — update any subset of prefs
 
 **Network control**
 - [`POST /api/v0/networks/connect`](#post-apiv0networksconnect) — connect ed2k / kad / both
@@ -1221,6 +1221,8 @@ Deleting `index 0` is rejected by amuled (`400 amuled_rejected`).
 
 **Auth:** `GUEST`
 
+Returns every preference category amuled carries over EC. The `general` and `connection` sub-objects are the original common-case set; the remaining nine categories (issue #437) map 1:1 to the daemon's own settings and mirror the desktop "Preferences" tabs.
+
 ```json
 {
   "general": {
@@ -1232,6 +1234,8 @@ Deleting `index 0` is rejected by amuled (`400 amuled_rejected`).
   "connection": {
     "max_upload_kbps":   50,
     "max_download_kbps": 0,
+    "max_upload_cap_kbps":   0,
+    "max_download_cap_kbps": 0,
     "slot_allocation":   3,
     "tcp_port":          4662,
     "udp_port":          4672,
@@ -1242,9 +1246,60 @@ Deleting `index 0` is rejected by amuled (`400 amuled_rejected`).
     "reconnect":   true,
     "network_ed2k": true,
     "network_kad":  true
-  }
+  },
+  "directories": {
+    "incoming": "/home/me/.aMule/Incoming",
+    "temp":     "/home/me/.aMule/Temp",
+    "shared":   ["/home/me/media"],
+    "share_hidden":    false,
+    "auto_rescan":     true,
+    "follow_symlinks": false,
+    "exclude_patterns": "",
+    "exclude_regex":    false
+  },
+  "files": {
+    "ich_enabled": true, "aich_trust": false,
+    "new_paused": false, "new_auto_dl_prio": false, "new_auto_ul_prio": false,
+    "preview_prio": false, "start_next_paused": false, "resume_same_cat": false,
+    "save_sources": true, "extract_metadata": false, "alloc_full_size": false,
+    "check_free_space": true, "min_free_space_mb": 1, "create_normal": false
+  },
+  "servers": {
+    "remove_dead": true, "dead_server_retries": 3, "auto_update": false,
+    "add_from_server": true, "add_from_client": true, "use_score_system": true,
+    "smart_id_check": true, "safe_server_connect": false,
+    "autoconn_static_only": false, "manual_high_prio": false,
+    "update_url": "http://upd.emule-security.org/server.met"
+  },
+  "security": {
+    "can_see_shares": false,
+    "ipfilter_clients": true, "ipfilter_servers": true,
+    "ipfilter_auto_update": false, "ipfilter_update_url": "",
+    "ipfilter_level": 127, "ipfilter_filter_lan": true,
+    "use_secident": true,
+    "obfuscation_supported": true, "obfuscation_requested": true, "obfuscation_required": false
+  },
+  "message_filter": {
+    "enabled": false, "all": false, "friends": false,
+    "secure": false, "by_keyword": false, "keywords": ""
+  },
+  "remote_controls": {
+    "webserver_enabled": false, "webserver_port": 4711, "webserver_use_gzip": true,
+    "webserver_refresh": 120, "webserver_template": "",
+    "webserver_guest_enabled": false,
+    "amuleapi_enabled": true, "amuleapi_port": 4713, "amuleapi_bind": "0.0.0.0"
+  },
+  "online_signature": { "enabled": false },
+  "core_tweaks": {
+    "max_conn_per_five": 200, "verbose": false, "filebuffer": 240000,
+    "ul_queue": 5000, "srv_keepalive_timeout": 0, "kad_max_searches": 50,
+    "kad_reask_ms": 1800000, "source_reask_ms": 900000
+  },
+  "kademlia": { "update_url": "http://upd.emule-security.org/nodes.dat" }
 }
 ```
+
+Booleans are plain JSON `true`/`false` regardless of how amuled encodes them on the wire. **Passwords are never returned** — the webserver admin/guest and amuleapi passwords are write-only (see PATCH). `general.user_hash` is the node's own identity hash, not a password.
 
 **Errors:** `503 ec_unavailable`.
 
@@ -1252,15 +1307,19 @@ Deleting `index 0` is rejected by amuled (`400 amuled_rejected`).
 
 **Auth:** `ADMIN`
 
-Body shape mirrors the GET; every field is optional. Fields not present are left unchanged. Subset example:
+Body shape mirrors the GET; every sub-object and every field is optional, and fields not present are left unchanged. Subset example:
 
 ```json
-{ "connection": { "max_upload_kbps": 100 } }
+{ "files": { "new_paused": true }, "servers": { "dead_server_retries": 5 } }
 ```
 
-**Response:** `200 OK` — full preferences object (post-mutation).
+**Write-only passwords** (accepted here, never echoed on GET) live under `remote_controls`: `webserver_password`, `webserver_guest_password`, `amuleapi_password`. Send the plaintext — amuled stores the hash. `webserver_guest_password` requires that guest access be enabled (pass `webserver_guest_enabled: true` in the same request, or leave it already enabled).
 
-**Errors:** `400 bad_request`, `400 amuled_rejected`, `503 ec_unavailable`.
+> **Note:** these are the daemon's live settings — the same ones the desktop GUI edits. Some are self-affecting: changing `remote_controls.amuleapi_port` / `amuleapi_bind`, or `directories.incoming` / `temp`, alters the very daemon you are talking to. A port/bind change only takes effect on the next amuled restart, so it will not drop your current connection mid-request.
+
+**Response:** `200 OK` — full preferences object (post-mutation), so a read-modify-write client can confirm what landed without a follow-up GET.
+
+**Errors:** `400 bad_request` (unknown/mis-typed field, or a body with no recognized fields), `400 amuled_rejected`, `503 ec_unavailable`.
 
 ---
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -4877,23 +4877,17 @@ CHttpServer::Response CApiDispatcher::HandleLogServerinfoReset(const CHttpServer
 	return r;
 }
 
-CHttpServer::Response CApiDispatcher::HandlePreferences(const CHttpServer::Request &req)
+namespace
 {
-	auto a = AuthenticateRequestRateLimited(
-		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
-	if (!a.ok)
-		return a.rejection;
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
 
-	const webapi::PreferencesSnapshot p = m_state.Preferences();
-	CHttpServer::Response r;
-	r.status = 200;
-	r.content_type = "application/json";
-	CJsonWriter w;
+// Emit the full /preferences JSON object (general + connection + the
+// issue-#437 categories). Shared by the GET handler and the PATCH echo
+// so the response shape is defined exactly once. Passwords are never
+// emitted (write-only).
+void WritePreferencesBody(CJsonWriter &w, const webapi::PreferencesSnapshot &p)
+{
 	w.BeginObject();
+
 	w.Key("general");
 	w.BeginObject();
 	w.Key("nickname");
@@ -4905,6 +4899,7 @@ CHttpServer::Response CApiDispatcher::HandlePreferences(const CHttpServer::Reque
 	w.Key("check_new_version");
 	w.ValueBool(p.check_new_version);
 	w.EndObject();
+
 	w.Key("connection");
 	w.BeginObject();
 	w.Key("max_upload_kbps");
@@ -4936,7 +4931,207 @@ CHttpServer::Response CApiDispatcher::HandlePreferences(const CHttpServer::Reque
 	w.Key("network_kad");
 	w.ValueBool(p.network_kad);
 	w.EndObject();
+
+	w.Key("directories");
+	w.BeginObject();
+	w.Key("incoming");
+	w.ValueString(wxString::FromUTF8(p.directories.incoming.c_str()));
+	w.Key("temp");
+	w.ValueString(wxString::FromUTF8(p.directories.temp.c_str()));
+	w.Key("shared");
+	w.BeginArray();
+	for (const std::string &dir : p.directories.shared) {
+		w.ValueString(wxString::FromUTF8(dir.c_str()));
+	}
+	w.EndArray();
+	w.Key("share_hidden");
+	w.ValueBool(p.directories.share_hidden);
+	w.Key("auto_rescan");
+	w.ValueBool(p.directories.auto_rescan);
+	w.Key("follow_symlinks");
+	w.ValueBool(p.directories.follow_symlinks);
+	w.Key("exclude_patterns");
+	w.ValueString(wxString::FromUTF8(p.directories.exclude_patterns.c_str()));
+	w.Key("exclude_regex");
+	w.ValueBool(p.directories.exclude_regex);
 	w.EndObject();
+
+	w.Key("files");
+	w.BeginObject();
+	w.Key("ich_enabled");
+	w.ValueBool(p.files.ich_enabled);
+	w.Key("aich_trust");
+	w.ValueBool(p.files.aich_trust);
+	w.Key("new_paused");
+	w.ValueBool(p.files.new_paused);
+	w.Key("new_auto_dl_prio");
+	w.ValueBool(p.files.new_auto_dl_prio);
+	w.Key("new_auto_ul_prio");
+	w.ValueBool(p.files.new_auto_ul_prio);
+	w.Key("preview_prio");
+	w.ValueBool(p.files.preview_prio);
+	w.Key("start_next_paused");
+	w.ValueBool(p.files.start_next_paused);
+	w.Key("resume_same_cat");
+	w.ValueBool(p.files.resume_same_cat);
+	w.Key("save_sources");
+	w.ValueBool(p.files.save_sources);
+	w.Key("extract_metadata");
+	w.ValueBool(p.files.extract_metadata);
+	w.Key("alloc_full_size");
+	w.ValueBool(p.files.alloc_full_size);
+	w.Key("check_free_space");
+	w.ValueBool(p.files.check_free_space);
+	w.Key("min_free_space_mb");
+	w.ValueInt(static_cast<int64_t>(p.files.min_free_space_mb));
+	w.Key("create_normal");
+	w.ValueBool(p.files.create_normal);
+	w.EndObject();
+
+	w.Key("servers");
+	w.BeginObject();
+	w.Key("remove_dead");
+	w.ValueBool(p.servers.remove_dead);
+	w.Key("dead_server_retries");
+	w.ValueInt(static_cast<int64_t>(p.servers.dead_server_retries));
+	w.Key("auto_update");
+	w.ValueBool(p.servers.auto_update);
+	w.Key("add_from_server");
+	w.ValueBool(p.servers.add_from_server);
+	w.Key("add_from_client");
+	w.ValueBool(p.servers.add_from_client);
+	w.Key("use_score_system");
+	w.ValueBool(p.servers.use_score_system);
+	w.Key("smart_id_check");
+	w.ValueBool(p.servers.smart_id_check);
+	w.Key("safe_server_connect");
+	w.ValueBool(p.servers.safe_server_connect);
+	w.Key("autoconn_static_only");
+	w.ValueBool(p.servers.autoconn_static_only);
+	w.Key("manual_high_prio");
+	w.ValueBool(p.servers.manual_high_prio);
+	w.Key("update_url");
+	w.ValueString(wxString::FromUTF8(p.servers.update_url.c_str()));
+	w.EndObject();
+
+	w.Key("security");
+	w.BeginObject();
+	w.Key("can_see_shares");
+	w.ValueBool(p.security.can_see_shares);
+	w.Key("ipfilter_clients");
+	w.ValueBool(p.security.ipfilter_clients);
+	w.Key("ipfilter_servers");
+	w.ValueBool(p.security.ipfilter_servers);
+	w.Key("ipfilter_auto_update");
+	w.ValueBool(p.security.ipfilter_auto_update);
+	w.Key("ipfilter_update_url");
+	w.ValueString(wxString::FromUTF8(p.security.ipfilter_update_url.c_str()));
+	w.Key("ipfilter_level");
+	w.ValueInt(static_cast<int64_t>(p.security.ipfilter_level));
+	w.Key("ipfilter_filter_lan");
+	w.ValueBool(p.security.ipfilter_filter_lan);
+	w.Key("use_secident");
+	w.ValueBool(p.security.use_secident);
+	w.Key("obfuscation_supported");
+	w.ValueBool(p.security.obfuscation_supported);
+	w.Key("obfuscation_requested");
+	w.ValueBool(p.security.obfuscation_requested);
+	w.Key("obfuscation_required");
+	w.ValueBool(p.security.obfuscation_required);
+	w.EndObject();
+
+	w.Key("message_filter");
+	w.BeginObject();
+	w.Key("enabled");
+	w.ValueBool(p.message_filter.enabled);
+	w.Key("all");
+	w.ValueBool(p.message_filter.all);
+	w.Key("friends");
+	w.ValueBool(p.message_filter.friends);
+	w.Key("secure");
+	w.ValueBool(p.message_filter.secure);
+	w.Key("by_keyword");
+	w.ValueBool(p.message_filter.by_keyword);
+	w.Key("keywords");
+	w.ValueString(wxString::FromUTF8(p.message_filter.keywords.c_str()));
+	w.EndObject();
+
+	w.Key("remote_controls");
+	w.BeginObject();
+	w.Key("webserver_enabled");
+	w.ValueBool(p.remote_controls.webserver_enabled);
+	w.Key("webserver_port");
+	w.ValueInt(static_cast<int64_t>(p.remote_controls.webserver_port));
+	w.Key("webserver_use_gzip");
+	w.ValueBool(p.remote_controls.webserver_use_gzip);
+	w.Key("webserver_refresh");
+	w.ValueInt(static_cast<int64_t>(p.remote_controls.webserver_refresh));
+	w.Key("webserver_template");
+	w.ValueString(wxString::FromUTF8(p.remote_controls.webserver_template.c_str()));
+	w.Key("webserver_guest_enabled");
+	w.ValueBool(p.remote_controls.webserver_guest_enabled);
+	w.Key("amuleapi_enabled");
+	w.ValueBool(p.remote_controls.amuleapi_enabled);
+	w.Key("amuleapi_port");
+	w.ValueInt(static_cast<int64_t>(p.remote_controls.amuleapi_port));
+	w.Key("amuleapi_bind");
+	w.ValueString(wxString::FromUTF8(p.remote_controls.amuleapi_bind.c_str()));
+	w.EndObject();
+
+	w.Key("online_signature");
+	w.BeginObject();
+	w.Key("enabled");
+	w.ValueBool(p.online_signature.enabled);
+	w.EndObject();
+
+	w.Key("core_tweaks");
+	w.BeginObject();
+	w.Key("max_conn_per_five");
+	w.ValueInt(static_cast<int64_t>(p.core_tweaks.max_conn_per_five));
+	w.Key("verbose");
+	w.ValueBool(p.core_tweaks.verbose);
+	w.Key("filebuffer");
+	w.ValueInt(static_cast<int64_t>(p.core_tweaks.filebuffer));
+	w.Key("ul_queue");
+	w.ValueInt(static_cast<int64_t>(p.core_tweaks.ul_queue));
+	w.Key("srv_keepalive_timeout");
+	w.ValueInt(static_cast<int64_t>(p.core_tweaks.srv_keepalive_timeout));
+	w.Key("kad_max_searches");
+	w.ValueInt(static_cast<int64_t>(p.core_tweaks.kad_max_searches));
+	w.Key("kad_reask_ms");
+	w.ValueInt(static_cast<int64_t>(p.core_tweaks.kad_reask_ms));
+	w.Key("source_reask_ms");
+	w.ValueInt(static_cast<int64_t>(p.core_tweaks.source_reask_ms));
+	w.EndObject();
+
+	w.Key("kademlia");
+	w.BeginObject();
+	w.Key("update_url");
+	w.ValueString(wxString::FromUTF8(p.kademlia.update_url.c_str()));
+	w.EndObject();
+
+	w.EndObject();
+}
+
+} // namespace
+
+CHttpServer::Response CApiDispatcher::HandlePreferences(const CHttpServer::Request &req)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	const webapi::PreferencesSnapshot p = m_state.Preferences();
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	WritePreferencesBody(w, p);
 	FinalizeJsonBody(w, r);
 	return r;
 }
@@ -4959,6 +5154,152 @@ struct PrefsParseError
 // boolean tags (CEC_Prefs_Packet::Apply checks
 // `use_tag = (GetDetailLevel() == EC_DETAIL_FULL)` before calling
 // ApplyBoolean). FULL is also what amulegui sends.
+
+// --- Generic optional-field extractors for the #437 categories -------
+//
+// Each pulls one optional key from a sub-object into the EC group tag,
+// validating its JSON type. Returns false and sets `err` on a type/
+// range error; returns true (and leaves `group` untouched) when the
+// key is simply absent. `any` is set true when a field is written.
+// Booleans always pack as a value tag (uint8 0/1): CEC_Prefs_Packet::
+// Apply reads `GetInt()!=0` under EC_DETAIL_FULL, so an empty presence
+// tag would be read as false.
+bool PrefTakeUint(const picojson::object &o,
+	CECTag &group,
+	const char *key,
+	ec_tagname_t name,
+	std::uint32_t max,
+	bool &any,
+	std::string &err)
+{
+	const auto it = o.find(key);
+	if (it == o.end())
+		return true;
+	if (!it->second.is<double>()) {
+		err = std::string(key) + " must be a non-negative integer";
+		return false;
+	}
+	const double v = it->second.get<double>();
+	if (v < 0 || v > static_cast<double>(max)) {
+		err = std::string(key) + " out of range";
+		return false;
+	}
+	group.AddTag(CECTag(name, static_cast<std::uint32_t>(v)));
+	any = true;
+	return true;
+}
+
+bool PrefTakeBool(const picojson::object &o,
+	CECTag &group,
+	const char *key,
+	ec_tagname_t name,
+	bool &any,
+	std::string &err)
+{
+	const auto it = o.find(key);
+	if (it == o.end())
+		return true;
+	if (!it->second.is<bool>()) {
+		err = std::string(key) + " must be a bool";
+		return false;
+	}
+	group.AddTag(CECTag(name, static_cast<std::uint8_t>(it->second.get<bool>() ? 1 : 0)));
+	any = true;
+	return true;
+}
+
+bool PrefTakeString(const picojson::object &o,
+	CECTag &group,
+	const char *key,
+	ec_tagname_t name,
+	bool &any,
+	std::string &err)
+{
+	const auto it = o.find(key);
+	if (it == o.end())
+		return true;
+	if (!it->second.is<std::string>()) {
+		err = std::string(key) + " must be a string";
+		return false;
+	}
+	group.AddTag(CECTag(name, wxString::FromUTF8(it->second.get<std::string>().c_str())));
+	any = true;
+	return true;
+}
+
+// String-array field (directories.shared): a JSON array of strings
+// packed as EC_TAG_STRING children, mirroring the core serializer.
+bool PrefTakeStringArray(const picojson::object &o,
+	CECTag &group,
+	const char *key,
+	ec_tagname_t name,
+	bool &any,
+	std::string &err)
+{
+	const auto it = o.find(key);
+	if (it == o.end())
+		return true;
+	if (!it->second.is<picojson::array>()) {
+		err = std::string(key) + " must be an array of strings";
+		return false;
+	}
+	const auto &arr = it->second.get<picojson::array>();
+	CECTag list(name, static_cast<std::uint32_t>(arr.size()));
+	for (const auto &el : arr) {
+		if (!el.is<std::string>()) {
+			err = std::string(key) + " must be an array of strings";
+			return false;
+		}
+		list.AddTag(CECTag(EC_TAG_STRING, wxString::FromUTF8(el.get<std::string>().c_str())));
+	}
+	group.AddTag(list);
+	any = true;
+	return true;
+}
+
+// Write-only password: hash the plaintext with MD5 (matching how the
+// daemon stores WS/amuleapi passwords) and pack the 16-byte digest as
+// the given hash tag. Never round-trips on GET.
+bool PrefTakePassword(const picojson::object &o,
+	CECTag &group,
+	const char *key,
+	ec_tagname_t name,
+	bool &any,
+	std::string &err)
+{
+	const auto it = o.find(key);
+	if (it == o.end())
+		return true;
+	if (!it->second.is<std::string>()) {
+		err = std::string(key) + " must be a string";
+		return false;
+	}
+	const wxString md5hex = MD5Sum(wxString::FromUTF8(it->second.get<std::string>().c_str())).GetHash();
+	CMD4Hash hash;
+	if (!HashFromHex(std::string(md5hex.utf8_str()), hash)) {
+		err = std::string(key) + " could not be hashed";
+		return false;
+	}
+	group.AddTag(CECTag(name, hash));
+	any = true;
+	return true;
+}
+
+// Resolve an optional sub-object by key. Returns false + err when the
+// key is present but not an object; leaves `out` null when absent.
+bool PrefFindSubObject(
+	const picojson::object &obj, const char *key, const picojson::object *&out, std::string &err)
+{
+	const auto it = obj.find(key);
+	if (it == obj.end())
+		return true;
+	if (!it->second.is<picojson::object>()) {
+		err = std::string("`") + key + "` must be an object";
+		return false;
+	}
+	out = &it->second.get<picojson::object>();
+	return true;
+}
 } // namespace
 
 CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::Request &req)
@@ -5002,12 +5343,9 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 		}
 	}
 
-	if (general_obj == nullptr && connection_obj == nullptr) {
-		return ErrorResponse(400,
-			"bad_request",
-			"request body must include at least one of `general` or "
-			"`connection` sub-objects");
-	}
+	// The set of recognized sub-objects widened well past general/
+	// connection (issue #437); a body with none of them is caught by
+	// the `any_change` guard after parsing, which returns the same 400.
 
 	// Build the SET_PREFERENCES packet at EC_DETAIL_FULL (required for
 	// boolean fields — Apply() gates ApplyBoolean on detail==FULL).
@@ -5155,6 +5493,480 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 		}
 	}
 
+	// --- Extended EC-carried categories (issue #437). ----------------
+	// Each optional sub-object is validated and packed into its EC group
+	// tag via the generic PrefTake* helpers; a chained `|| !...` stops at
+	// the first bad field and returns its 400. Port caps use 65535;
+	// counters/durations use a generous uint32 ceiling.
+	const std::uint32_t kU32Max = 0xFFFFFFFFu;
+	std::string perr;
+
+	const picojson::object *directories_obj = nullptr;
+	const picojson::object *files_obj = nullptr;
+	const picojson::object *servers_obj = nullptr;
+	const picojson::object *security_obj = nullptr;
+	const picojson::object *message_filter_obj = nullptr;
+	const picojson::object *remote_controls_obj = nullptr;
+	const picojson::object *online_signature_obj = nullptr;
+	const picojson::object *core_tweaks_obj = nullptr;
+	const picojson::object *kademlia_obj = nullptr;
+	if (!PrefFindSubObject(obj, "directories", directories_obj, perr) ||
+		!PrefFindSubObject(obj, "files", files_obj, perr) ||
+		!PrefFindSubObject(obj, "servers", servers_obj, perr) ||
+		!PrefFindSubObject(obj, "security", security_obj, perr) ||
+		!PrefFindSubObject(obj, "message_filter", message_filter_obj, perr) ||
+		!PrefFindSubObject(obj, "remote_controls", remote_controls_obj, perr) ||
+		!PrefFindSubObject(obj, "online_signature", online_signature_obj, perr) ||
+		!PrefFindSubObject(obj, "core_tweaks", core_tweaks_obj, perr) ||
+		!PrefFindSubObject(obj, "kademlia", kademlia_obj, perr)) {
+		return ErrorResponse(400, "bad_request", perr.c_str());
+	}
+
+	if (directories_obj) {
+		CECTag g(EC_TAG_PREFS_DIRECTORIES, static_cast<std::uint32_t>(0));
+		bool any = false;
+		if (!PrefTakeString(
+			    *directories_obj, g, "incoming", EC_TAG_DIRECTORIES_INCOMING, any, perr) ||
+			!PrefTakeString(*directories_obj, g, "temp", EC_TAG_DIRECTORIES_TEMP, any, perr) ||
+			!PrefTakeStringArray(
+				*directories_obj, g, "shared", EC_TAG_DIRECTORIES_SHARED, any, perr) ||
+			!PrefTakeBool(*directories_obj,
+				g,
+				"share_hidden",
+				EC_TAG_DIRECTORIES_SHARE_HIDDEN,
+				any,
+				perr) ||
+			!PrefTakeBool(*directories_obj,
+				g,
+				"auto_rescan",
+				EC_TAG_DIRECTORIES_AUTO_RESCAN,
+				any,
+				perr) ||
+			!PrefTakeBool(*directories_obj,
+				g,
+				"follow_symlinks",
+				EC_TAG_DIRECTORIES_FOLLOW_SYMLINKS,
+				any,
+				perr) ||
+			!PrefTakeString(*directories_obj,
+				g,
+				"exclude_patterns",
+				EC_TAG_DIRECTORIES_EXCLUDE_PATTERNS,
+				any,
+				perr) ||
+			!PrefTakeBool(*directories_obj,
+				g,
+				"exclude_regex",
+				EC_TAG_DIRECTORIES_EXCLUDE_REGEX,
+				any,
+				perr)) {
+			return ErrorResponse(400, "bad_request", perr.c_str());
+		}
+		if (any) {
+			ec_req->AddTag(g);
+			any_change = true;
+		}
+	}
+
+	if (files_obj) {
+		CECTag g(EC_TAG_PREFS_FILES, static_cast<std::uint32_t>(0));
+		bool any = false;
+		if (!PrefTakeBool(*files_obj, g, "ich_enabled", EC_TAG_FILES_ICH_ENABLED, any, perr) ||
+			!PrefTakeBool(*files_obj, g, "aich_trust", EC_TAG_FILES_AICH_TRUST, any, perr) ||
+			!PrefTakeBool(*files_obj, g, "new_paused", EC_TAG_FILES_NEW_PAUSED, any, perr) ||
+			!PrefTakeBool(*files_obj,
+				g,
+				"new_auto_dl_prio",
+				EC_TAG_FILES_NEW_AUTO_DL_PRIO,
+				any,
+				perr) ||
+			!PrefTakeBool(*files_obj,
+				g,
+				"new_auto_ul_prio",
+				EC_TAG_FILES_NEW_AUTO_UL_PRIO,
+				any,
+				perr) ||
+			!PrefTakeBool(*files_obj, g, "preview_prio", EC_TAG_FILES_PREVIEW_PRIO, any, perr) ||
+			!PrefTakeBool(*files_obj,
+				g,
+				"start_next_paused",
+				EC_TAG_FILES_START_NEXT_PAUSED,
+				any,
+				perr) ||
+			!PrefTakeBool(
+				*files_obj, g, "resume_same_cat", EC_TAG_FILES_RESUME_SAME_CAT, any, perr) ||
+			!PrefTakeBool(*files_obj, g, "save_sources", EC_TAG_FILES_SAVE_SOURCES, any, perr) ||
+			!PrefTakeBool(*files_obj,
+				g,
+				"extract_metadata",
+				EC_TAG_FILES_EXTRACT_METADATA,
+				any,
+				perr) ||
+			!PrefTakeBool(
+				*files_obj, g, "alloc_full_size", EC_TAG_FILES_ALLOC_FULL_SIZE, any, perr) ||
+			!PrefTakeBool(*files_obj,
+				g,
+				"check_free_space",
+				EC_TAG_FILES_CHECK_FREE_SPACE,
+				any,
+				perr) ||
+			!PrefTakeUint(*files_obj,
+				g,
+				"min_free_space_mb",
+				EC_TAG_FILES_MIN_FREE_SPACE,
+				kU32Max,
+				any,
+				perr) ||
+			!PrefTakeBool(
+				*files_obj, g, "create_normal", EC_TAG_FILES_CREATE_NORMAL, any, perr)) {
+			return ErrorResponse(400, "bad_request", perr.c_str());
+		}
+		if (any) {
+			ec_req->AddTag(g);
+			any_change = true;
+		}
+	}
+
+	if (servers_obj) {
+		CECTag g(EC_TAG_PREFS_SERVERS, static_cast<std::uint32_t>(0));
+		bool any = false;
+		if (!PrefTakeBool(*servers_obj, g, "remove_dead", EC_TAG_SERVERS_REMOVE_DEAD, any, perr) ||
+			!PrefTakeUint(*servers_obj,
+				g,
+				"dead_server_retries",
+				EC_TAG_SERVERS_DEAD_SERVER_RETRIES,
+				65535,
+				any,
+				perr) ||
+			!PrefTakeBool(
+				*servers_obj, g, "auto_update", EC_TAG_SERVERS_AUTO_UPDATE, any, perr) ||
+			!PrefTakeBool(*servers_obj,
+				g,
+				"add_from_server",
+				EC_TAG_SERVERS_ADD_FROM_SERVER,
+				any,
+				perr) ||
+			!PrefTakeBool(*servers_obj,
+				g,
+				"add_from_client",
+				EC_TAG_SERVERS_ADD_FROM_CLIENT,
+				any,
+				perr) ||
+			!PrefTakeBool(*servers_obj,
+				g,
+				"use_score_system",
+				EC_TAG_SERVERS_USE_SCORE_SYSTEM,
+				any,
+				perr) ||
+			!PrefTakeBool(*servers_obj,
+				g,
+				"smart_id_check",
+				EC_TAG_SERVERS_SMART_ID_CHECK,
+				any,
+				perr) ||
+			!PrefTakeBool(*servers_obj,
+				g,
+				"safe_server_connect",
+				EC_TAG_SERVERS_SAFE_SERVER_CONNECT,
+				any,
+				perr) ||
+			!PrefTakeBool(*servers_obj,
+				g,
+				"autoconn_static_only",
+				EC_TAG_SERVERS_AUTOCONN_STATIC_ONLY,
+				any,
+				perr) ||
+			!PrefTakeBool(*servers_obj,
+				g,
+				"manual_high_prio",
+				EC_TAG_SERVERS_MANUAL_HIGH_PRIO,
+				any,
+				perr) ||
+			!PrefTakeString(
+				*servers_obj, g, "update_url", EC_TAG_SERVERS_UPDATE_URL, any, perr)) {
+			return ErrorResponse(400, "bad_request", perr.c_str());
+		}
+		if (any) {
+			ec_req->AddTag(g);
+			any_change = true;
+		}
+	}
+
+	if (security_obj) {
+		CECTag g(EC_TAG_PREFS_SECURITY, static_cast<std::uint32_t>(0));
+		bool any = false;
+		if (!PrefTakeBool(
+			    *security_obj, g, "can_see_shares", EC_TAG_SECURITY_CAN_SEE_SHARES, any, perr) ||
+			!PrefTakeBool(
+				*security_obj, g, "ipfilter_clients", EC_TAG_IPFILTER_CLIENTS, any, perr) ||
+			!PrefTakeBool(
+				*security_obj, g, "ipfilter_servers", EC_TAG_IPFILTER_SERVERS, any, perr) ||
+			!PrefTakeBool(*security_obj,
+				g,
+				"ipfilter_auto_update",
+				EC_TAG_IPFILTER_AUTO_UPDATE,
+				any,
+				perr) ||
+			!PrefTakeString(*security_obj,
+				g,
+				"ipfilter_update_url",
+				EC_TAG_IPFILTER_UPDATE_URL,
+				any,
+				perr) ||
+			!PrefTakeUint(
+				*security_obj, g, "ipfilter_level", EC_TAG_IPFILTER_LEVEL, 255, any, perr) ||
+			!PrefTakeBool(*security_obj,
+				g,
+				"ipfilter_filter_lan",
+				EC_TAG_IPFILTER_FILTER_LAN,
+				any,
+				perr) ||
+			!PrefTakeBool(
+				*security_obj, g, "use_secident", EC_TAG_SECURITY_USE_SECIDENT, any, perr) ||
+			!PrefTakeBool(*security_obj,
+				g,
+				"obfuscation_supported",
+				EC_TAG_SECURITY_OBFUSCATION_SUPPORTED,
+				any,
+				perr) ||
+			!PrefTakeBool(*security_obj,
+				g,
+				"obfuscation_requested",
+				EC_TAG_SECURITY_OBFUSCATION_REQUESTED,
+				any,
+				perr) ||
+			!PrefTakeBool(*security_obj,
+				g,
+				"obfuscation_required",
+				EC_TAG_SECURITY_OBFUSCATION_REQUIRED,
+				any,
+				perr)) {
+			return ErrorResponse(400, "bad_request", perr.c_str());
+		}
+		if (any) {
+			ec_req->AddTag(g);
+			any_change = true;
+		}
+	}
+
+	if (message_filter_obj) {
+		CECTag g(EC_TAG_PREFS_MESSAGEFILTER, static_cast<std::uint32_t>(0));
+		bool any = false;
+		if (!PrefTakeBool(*message_filter_obj, g, "enabled", EC_TAG_MSGFILTER_ENABLED, any, perr) ||
+			!PrefTakeBool(*message_filter_obj, g, "all", EC_TAG_MSGFILTER_ALL, any, perr) ||
+			!PrefTakeBool(
+				*message_filter_obj, g, "friends", EC_TAG_MSGFILTER_FRIENDS, any, perr) ||
+			!PrefTakeBool(*message_filter_obj, g, "secure", EC_TAG_MSGFILTER_SECURE, any, perr) ||
+			!PrefTakeBool(*message_filter_obj,
+				g,
+				"by_keyword",
+				EC_TAG_MSGFILTER_BY_KEYWORD,
+				any,
+				perr) ||
+			!PrefTakeString(
+				*message_filter_obj, g, "keywords", EC_TAG_MSGFILTER_KEYWORDS, any, perr)) {
+			return ErrorResponse(400, "bad_request", perr.c_str());
+		}
+		if (any) {
+			ec_req->AddTag(g);
+			any_change = true;
+		}
+	}
+
+	if (remote_controls_obj) {
+		CECTag g(EC_TAG_PREFS_REMOTECTRL, static_cast<std::uint32_t>(0));
+		bool any = false;
+		if (!PrefTakeBool(*remote_controls_obj,
+			    g,
+			    "webserver_enabled",
+			    EC_TAG_WEBSERVER_AUTORUN,
+			    any,
+			    perr) ||
+			!PrefTakeUint(*remote_controls_obj,
+				g,
+				"webserver_port",
+				EC_TAG_WEBSERVER_PORT,
+				65535,
+				any,
+				perr) ||
+			!PrefTakeBool(*remote_controls_obj,
+				g,
+				"webserver_use_gzip",
+				EC_TAG_WEBSERVER_USEGZIP,
+				any,
+				perr) ||
+			!PrefTakeUint(*remote_controls_obj,
+				g,
+				"webserver_refresh",
+				EC_TAG_WEBSERVER_REFRESH,
+				kU32Max,
+				any,
+				perr) ||
+			!PrefTakeString(*remote_controls_obj,
+				g,
+				"webserver_template",
+				EC_TAG_WEBSERVER_TEMPLATE,
+				any,
+				perr) ||
+			!PrefTakeBool(*remote_controls_obj,
+				g,
+				"amuleapi_enabled",
+				EC_TAG_AMULEAPI_AUTORUN,
+				any,
+				perr) ||
+			!PrefTakeUint(*remote_controls_obj,
+				g,
+				"amuleapi_port",
+				EC_TAG_AMULEAPI_PORT,
+				65535,
+				any,
+				perr) ||
+			!PrefTakeString(
+				*remote_controls_obj, g, "amuleapi_bind", EC_TAG_AMULEAPI_BIND, any, perr) ||
+			!PrefTakePassword(*remote_controls_obj,
+				g,
+				"webserver_password",
+				EC_TAG_PASSWD_HASH,
+				any,
+				perr) ||
+			!PrefTakePassword(*remote_controls_obj,
+				g,
+				"amuleapi_password",
+				EC_TAG_AMULEAPI_PASSWD,
+				any,
+				perr)) {
+			return ErrorResponse(400, "bad_request", perr.c_str());
+		}
+		// webserver_guest_enabled + webserver_guest_password share one EC
+		// tag (EC_TAG_WEBSERVER_GUEST carries the enable bool as its value
+		// and the password as a child), so pack them together to avoid two
+		// conflicting tags. When only the password is given, the enable
+		// bit falls back to the current snapshot value.
+		{
+			const auto en_it = remote_controls_obj->find("webserver_guest_enabled");
+			const auto pw_it = remote_controls_obj->find("webserver_guest_password");
+			const bool has_en = en_it != remote_controls_obj->end();
+			const bool has_pw = pw_it != remote_controls_obj->end();
+			if (has_en || has_pw) {
+				if (has_en && !en_it->second.is<bool>()) {
+					return ErrorResponse(
+						400, "bad_request", "webserver_guest_enabled must be a bool");
+				}
+				if (has_pw && !pw_it->second.is<std::string>()) {
+					return ErrorResponse(400,
+						"bad_request",
+						"webserver_guest_password must be a string");
+				}
+				const bool enabled =
+					has_en ? en_it->second.get<bool>()
+					       : m_state.Preferences()
+							 .remote_controls.webserver_guest_enabled;
+				CECTag guest(
+					EC_TAG_WEBSERVER_GUEST, static_cast<std::uint8_t>(enabled ? 1 : 0));
+				if (has_pw) {
+					const wxString md5hex = MD5Sum(
+						wxString::FromUTF8(pw_it->second.get<std::string>().c_str()))
+									.GetHash();
+					CMD4Hash h;
+					if (HashFromHex(std::string(md5hex.utf8_str()), h)) {
+						guest.AddTag(CECTag(EC_TAG_PASSWD_HASH, h));
+					}
+				}
+				g.AddTag(guest);
+				any = true;
+			}
+		}
+		if (any) {
+			ec_req->AddTag(g);
+			any_change = true;
+		}
+	}
+
+	if (online_signature_obj) {
+		CECTag g(EC_TAG_PREFS_ONLINESIG, static_cast<std::uint32_t>(0));
+		bool any = false;
+		if (!PrefTakeBool(*online_signature_obj, g, "enabled", EC_TAG_ONLINESIG_ENABLED, any, perr)) {
+			return ErrorResponse(400, "bad_request", perr.c_str());
+		}
+		if (any) {
+			ec_req->AddTag(g);
+			any_change = true;
+		}
+	}
+
+	if (core_tweaks_obj) {
+		CECTag g(EC_TAG_PREFS_CORETWEAKS, static_cast<std::uint32_t>(0));
+		bool any = false;
+		if (!PrefTakeUint(*core_tweaks_obj,
+			    g,
+			    "max_conn_per_five",
+			    EC_TAG_CORETW_MAX_CONN_PER_FIVE,
+			    kU32Max,
+			    any,
+			    perr) ||
+			!PrefTakeBool(*core_tweaks_obj, g, "verbose", EC_TAG_CORETW_VERBOSE, any, perr) ||
+			!PrefTakeUint(*core_tweaks_obj,
+				g,
+				"filebuffer",
+				EC_TAG_CORETW_FILEBUFFER,
+				kU32Max,
+				any,
+				perr) ||
+			!PrefTakeUint(*core_tweaks_obj,
+				g,
+				"ul_queue",
+				EC_TAG_CORETW_UL_QUEUE,
+				kU32Max,
+				any,
+				perr) ||
+			!PrefTakeUint(*core_tweaks_obj,
+				g,
+				"srv_keepalive_timeout",
+				EC_TAG_CORETW_SRV_KEEPALIVE_TIMEOUT,
+				kU32Max,
+				any,
+				perr) ||
+			!PrefTakeUint(*core_tweaks_obj,
+				g,
+				"kad_max_searches",
+				EC_TAG_CORETW_KAD_MAX_SEARCHES,
+				kU32Max,
+				any,
+				perr) ||
+			!PrefTakeUint(*core_tweaks_obj,
+				g,
+				"kad_reask_ms",
+				EC_TAG_CORETW_KAD_REASK_MS,
+				kU32Max,
+				any,
+				perr) ||
+			!PrefTakeUint(*core_tweaks_obj,
+				g,
+				"source_reask_ms",
+				EC_TAG_CORETW_SOURCE_REASK_MS,
+				kU32Max,
+				any,
+				perr)) {
+			return ErrorResponse(400, "bad_request", perr.c_str());
+		}
+		if (any) {
+			ec_req->AddTag(g);
+			any_change = true;
+		}
+	}
+
+	if (kademlia_obj) {
+		CECTag g(EC_TAG_PREFS_KADEMLIA, static_cast<std::uint32_t>(0));
+		bool any = false;
+		if (!PrefTakeString(*kademlia_obj, g, "update_url", EC_TAG_KADEMLIA_UPDATE_URL, any, perr)) {
+			return ErrorResponse(400, "bad_request", perr.c_str());
+		}
+		if (any) {
+			ec_req->AddTag(g);
+			any_change = true;
+		}
+	}
+
 	if (!any_change) {
 		return ErrorResponse(
 			400, "bad_request", "request body did not include any known pref fields");
@@ -5183,50 +5995,7 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 	r.status = 200;
 	r.content_type = "application/json";
 	CJsonWriter w;
-	w.BeginObject();
-	w.Key("general");
-	w.BeginObject();
-	w.Key("nickname");
-	w.ValueString(wxString::FromUTF8(p.nickname.c_str()));
-	w.Key("user_hash");
-	w.ValueString(wxString::FromUTF8(p.user_hash.c_str()));
-	w.Key("host_name");
-	w.ValueString(wxString::FromUTF8(p.host_name.c_str()));
-	w.Key("check_new_version");
-	w.ValueBool(p.check_new_version);
-	w.EndObject();
-	w.Key("connection");
-	w.BeginObject();
-	w.Key("max_upload_kbps");
-	w.ValueInt(static_cast<int64_t>(p.max_upload_kbps));
-	w.Key("max_download_kbps");
-	w.ValueInt(static_cast<int64_t>(p.max_download_kbps));
-	w.Key("max_upload_cap_kbps");
-	w.ValueInt(static_cast<int64_t>(p.max_upload_cap_kbps));
-	w.Key("max_download_cap_kbps");
-	w.ValueInt(static_cast<int64_t>(p.max_download_cap_kbps));
-	w.Key("slot_allocation");
-	w.ValueInt(static_cast<int64_t>(p.slot_allocation));
-	w.Key("tcp_port");
-	w.ValueInt(static_cast<int64_t>(p.tcp_port));
-	w.Key("udp_port");
-	w.ValueInt(static_cast<int64_t>(p.udp_port));
-	w.Key("udp_disabled");
-	w.ValueBool(p.udp_disabled);
-	w.Key("max_sources_per_file");
-	w.ValueInt(static_cast<int64_t>(p.max_sources_per_file));
-	w.Key("max_connections");
-	w.ValueInt(static_cast<int64_t>(p.max_connections));
-	w.Key("autoconnect");
-	w.ValueBool(p.autoconnect);
-	w.Key("reconnect");
-	w.ValueBool(p.reconnect);
-	w.Key("network_ed2k");
-	w.ValueBool(p.network_ed2k);
-	w.Key("network_kad");
-	w.ValueBool(p.network_kad);
-	w.EndObject();
-	w.EndObject();
+	WritePreferencesBody(w, p);
 	FinalizeJsonBody(w, r);
 	return r;
 }

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -2032,6 +2032,178 @@ void ParseConnectionPrefs(const CECTag *conn, PreferencesSnapshot &out)
 	}
 }
 
+// --- Extended EC-carried preference categories (issue #437) ----------
+//
+// Boolean encoding follows the core serializer (ECSpecialMuleTags.cpp):
+// most bools are emitted as a bare CECEmptyTag only when true, so
+// presence == true; a few (directories.share_hidden/auto_rescan/
+// follow_symlinks/exclude_regex, security.can_see_shares) are emitted
+// as a value tag every time, so they read GetInt() != 0.
+
+void ParseDirectoriesPrefs(const CECTag *d, PreferencesSnapshot &out)
+{
+	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_INCOMING)) {
+		out.directories.incoming = std::string(t->GetStringData().utf8_str());
+	}
+	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_TEMP)) {
+		out.directories.temp = std::string(t->GetStringData().utf8_str());
+	}
+	if (const CECTag *shared = d->GetTagByName(EC_TAG_DIRECTORIES_SHARED)) {
+		out.directories.shared.clear();
+		for (const CECTag &child : *shared) {
+			if (child.GetTagName() == EC_TAG_STRING)
+				out.directories.shared.emplace_back(child.GetStringData().utf8_str());
+		}
+	}
+	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_SHARE_HIDDEN))
+		out.directories.share_hidden = t->GetInt() != 0;
+	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_AUTO_RESCAN))
+		out.directories.auto_rescan = t->GetInt() != 0;
+	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_FOLLOW_SYMLINKS))
+		out.directories.follow_symlinks = t->GetInt() != 0;
+	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_EXCLUDE_PATTERNS)) {
+		out.directories.exclude_patterns = std::string(t->GetStringData().utf8_str());
+	}
+	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_EXCLUDE_REGEX))
+		out.directories.exclude_regex = t->GetInt() != 0;
+}
+
+void ParseFilesPrefs(const CECTag *f, PreferencesSnapshot &out)
+{
+	out.files.ich_enabled = f->GetTagByName(EC_TAG_FILES_ICH_ENABLED) != nullptr;
+	out.files.aich_trust = f->GetTagByName(EC_TAG_FILES_AICH_TRUST) != nullptr;
+	out.files.new_paused = f->GetTagByName(EC_TAG_FILES_NEW_PAUSED) != nullptr;
+	out.files.new_auto_dl_prio = f->GetTagByName(EC_TAG_FILES_NEW_AUTO_DL_PRIO) != nullptr;
+	out.files.new_auto_ul_prio = f->GetTagByName(EC_TAG_FILES_NEW_AUTO_UL_PRIO) != nullptr;
+	out.files.preview_prio = f->GetTagByName(EC_TAG_FILES_PREVIEW_PRIO) != nullptr;
+	out.files.start_next_paused = f->GetTagByName(EC_TAG_FILES_START_NEXT_PAUSED) != nullptr;
+	out.files.resume_same_cat = f->GetTagByName(EC_TAG_FILES_RESUME_SAME_CAT) != nullptr;
+	out.files.save_sources = f->GetTagByName(EC_TAG_FILES_SAVE_SOURCES) != nullptr;
+	out.files.extract_metadata = f->GetTagByName(EC_TAG_FILES_EXTRACT_METADATA) != nullptr;
+	out.files.alloc_full_size = f->GetTagByName(EC_TAG_FILES_ALLOC_FULL_SIZE) != nullptr;
+	out.files.check_free_space = f->GetTagByName(EC_TAG_FILES_CHECK_FREE_SPACE) != nullptr;
+	if (const CECTag *t = f->GetTagByName(EC_TAG_FILES_MIN_FREE_SPACE)) {
+		out.files.min_free_space_mb = static_cast<std::uint32_t>(t->GetInt());
+	}
+	out.files.create_normal = f->GetTagByName(EC_TAG_FILES_CREATE_NORMAL) != nullptr;
+}
+
+void ParseServersPrefs(const CECTag *s, PreferencesSnapshot &out)
+{
+	out.servers.remove_dead = s->GetTagByName(EC_TAG_SERVERS_REMOVE_DEAD) != nullptr;
+	if (const CECTag *t = s->GetTagByName(EC_TAG_SERVERS_DEAD_SERVER_RETRIES)) {
+		out.servers.dead_server_retries = static_cast<std::uint32_t>(t->GetInt());
+	}
+	out.servers.auto_update = s->GetTagByName(EC_TAG_SERVERS_AUTO_UPDATE) != nullptr;
+	out.servers.add_from_server = s->GetTagByName(EC_TAG_SERVERS_ADD_FROM_SERVER) != nullptr;
+	out.servers.add_from_client = s->GetTagByName(EC_TAG_SERVERS_ADD_FROM_CLIENT) != nullptr;
+	out.servers.use_score_system = s->GetTagByName(EC_TAG_SERVERS_USE_SCORE_SYSTEM) != nullptr;
+	out.servers.smart_id_check = s->GetTagByName(EC_TAG_SERVERS_SMART_ID_CHECK) != nullptr;
+	out.servers.safe_server_connect = s->GetTagByName(EC_TAG_SERVERS_SAFE_SERVER_CONNECT) != nullptr;
+	out.servers.autoconn_static_only = s->GetTagByName(EC_TAG_SERVERS_AUTOCONN_STATIC_ONLY) != nullptr;
+	out.servers.manual_high_prio = s->GetTagByName(EC_TAG_SERVERS_MANUAL_HIGH_PRIO) != nullptr;
+	if (const CECTag *t = s->GetTagByName(EC_TAG_SERVERS_UPDATE_URL)) {
+		out.servers.update_url = std::string(t->GetStringData().utf8_str());
+	}
+}
+
+void ParseSecurityPrefs(const CECTag *s, PreferencesSnapshot &out)
+{
+	if (const CECTag *t = s->GetTagByName(EC_TAG_SECURITY_CAN_SEE_SHARES))
+		out.security.can_see_shares = t->GetInt() != 0;
+	out.security.ipfilter_clients = s->GetTagByName(EC_TAG_IPFILTER_CLIENTS) != nullptr;
+	out.security.ipfilter_servers = s->GetTagByName(EC_TAG_IPFILTER_SERVERS) != nullptr;
+	out.security.ipfilter_auto_update = s->GetTagByName(EC_TAG_IPFILTER_AUTO_UPDATE) != nullptr;
+	if (const CECTag *t = s->GetTagByName(EC_TAG_IPFILTER_UPDATE_URL)) {
+		out.security.ipfilter_update_url = std::string(t->GetStringData().utf8_str());
+	}
+	if (const CECTag *t = s->GetTagByName(EC_TAG_IPFILTER_LEVEL)) {
+		out.security.ipfilter_level = static_cast<std::uint32_t>(t->GetInt());
+	}
+	out.security.ipfilter_filter_lan = s->GetTagByName(EC_TAG_IPFILTER_FILTER_LAN) != nullptr;
+	out.security.use_secident = s->GetTagByName(EC_TAG_SECURITY_USE_SECIDENT) != nullptr;
+	out.security.obfuscation_supported =
+		s->GetTagByName(EC_TAG_SECURITY_OBFUSCATION_SUPPORTED) != nullptr;
+	out.security.obfuscation_requested =
+		s->GetTagByName(EC_TAG_SECURITY_OBFUSCATION_REQUESTED) != nullptr;
+	out.security.obfuscation_required = s->GetTagByName(EC_TAG_SECURITY_OBFUSCATION_REQUIRED) != nullptr;
+}
+
+void ParseMessageFilterPrefs(const CECTag *m, PreferencesSnapshot &out)
+{
+	out.message_filter.enabled = m->GetTagByName(EC_TAG_MSGFILTER_ENABLED) != nullptr;
+	out.message_filter.all = m->GetTagByName(EC_TAG_MSGFILTER_ALL) != nullptr;
+	out.message_filter.friends = m->GetTagByName(EC_TAG_MSGFILTER_FRIENDS) != nullptr;
+	out.message_filter.secure = m->GetTagByName(EC_TAG_MSGFILTER_SECURE) != nullptr;
+	out.message_filter.by_keyword = m->GetTagByName(EC_TAG_MSGFILTER_BY_KEYWORD) != nullptr;
+	if (const CECTag *t = m->GetTagByName(EC_TAG_MSGFILTER_KEYWORDS)) {
+		out.message_filter.keywords = std::string(t->GetStringData().utf8_str());
+	}
+}
+
+void ParseRemoteControlsPrefs(const CECTag *rc, PreferencesSnapshot &out)
+{
+	out.remote_controls.webserver_enabled = rc->GetTagByName(EC_TAG_WEBSERVER_AUTORUN) != nullptr;
+	if (const CECTag *t = rc->GetTagByName(EC_TAG_WEBSERVER_PORT)) {
+		out.remote_controls.webserver_port = static_cast<std::uint32_t>(t->GetInt());
+	}
+	out.remote_controls.webserver_use_gzip = rc->GetTagByName(EC_TAG_WEBSERVER_USEGZIP) != nullptr;
+	if (const CECTag *t = rc->GetTagByName(EC_TAG_WEBSERVER_REFRESH)) {
+		out.remote_controls.webserver_refresh = static_cast<std::uint32_t>(t->GetInt());
+	}
+	if (const CECTag *t = rc->GetTagByName(EC_TAG_WEBSERVER_TEMPLATE)) {
+		out.remote_controls.webserver_template = std::string(t->GetStringData().utf8_str());
+	}
+	out.remote_controls.webserver_guest_enabled = rc->GetTagByName(EC_TAG_WEBSERVER_GUEST) != nullptr;
+	out.remote_controls.amuleapi_enabled = rc->GetTagByName(EC_TAG_AMULEAPI_AUTORUN) != nullptr;
+	if (const CECTag *t = rc->GetTagByName(EC_TAG_AMULEAPI_PORT)) {
+		out.remote_controls.amuleapi_port = static_cast<std::uint32_t>(t->GetInt());
+	}
+	if (const CECTag *t = rc->GetTagByName(EC_TAG_AMULEAPI_BIND)) {
+		out.remote_controls.amuleapi_bind = std::string(t->GetStringData().utf8_str());
+	}
+	// Passwords (EC_TAG_PASSWD_HASH / EC_TAG_AMULEAPI_PASSWD) are
+	// deliberately NOT read — write-only, never surfaced on GET.
+}
+
+void ParseOnlineSigPrefs(const CECTag *o, PreferencesSnapshot &out)
+{
+	out.online_signature.enabled = o->GetTagByName(EC_TAG_ONLINESIG_ENABLED) != nullptr;
+}
+
+void ParseCoreTweaksPrefs(const CECTag *c, PreferencesSnapshot &out)
+{
+	if (const CECTag *t = c->GetTagByName(EC_TAG_CORETW_MAX_CONN_PER_FIVE)) {
+		out.core_tweaks.max_conn_per_five = static_cast<std::uint32_t>(t->GetInt());
+	}
+	out.core_tweaks.verbose = c->GetTagByName(EC_TAG_CORETW_VERBOSE) != nullptr;
+	if (const CECTag *t = c->GetTagByName(EC_TAG_CORETW_FILEBUFFER)) {
+		out.core_tweaks.filebuffer = static_cast<std::uint32_t>(t->GetInt());
+	}
+	if (const CECTag *t = c->GetTagByName(EC_TAG_CORETW_UL_QUEUE)) {
+		out.core_tweaks.ul_queue = static_cast<std::uint32_t>(t->GetInt());
+	}
+	if (const CECTag *t = c->GetTagByName(EC_TAG_CORETW_SRV_KEEPALIVE_TIMEOUT)) {
+		out.core_tweaks.srv_keepalive_timeout = static_cast<std::uint32_t>(t->GetInt());
+	}
+	if (const CECTag *t = c->GetTagByName(EC_TAG_CORETW_KAD_MAX_SEARCHES)) {
+		out.core_tweaks.kad_max_searches = static_cast<std::uint32_t>(t->GetInt());
+	}
+	if (const CECTag *t = c->GetTagByName(EC_TAG_CORETW_KAD_REASK_MS)) {
+		out.core_tweaks.kad_reask_ms = static_cast<std::uint32_t>(t->GetInt());
+	}
+	if (const CECTag *t = c->GetTagByName(EC_TAG_CORETW_SOURCE_REASK_MS)) {
+		out.core_tweaks.source_reask_ms = static_cast<std::uint32_t>(t->GetInt());
+	}
+}
+
+void ParseKademliaPrefs(const CECTag *k, PreferencesSnapshot &out)
+{
+	if (const CECTag *t = k->GetTagByName(EC_TAG_KADEMLIA_UPDATE_URL)) {
+		out.kademlia.update_url = std::string(t->GetStringData().utf8_str());
+	}
+}
+
 } // namespace
 
 void ParsePreferencesFromPacket(
@@ -2049,6 +2221,33 @@ void ParsePreferencesFromPacket(
 	}
 	if (const CECTag *conn = resp->GetTagByName(EC_TAG_PREFS_CONNECTIONS)) {
 		ParseConnectionPrefs(conn, out_prefs);
+	}
+	if (const CECTag *d = resp->GetTagByName(EC_TAG_PREFS_DIRECTORIES)) {
+		ParseDirectoriesPrefs(d, out_prefs);
+	}
+	if (const CECTag *f = resp->GetTagByName(EC_TAG_PREFS_FILES)) {
+		ParseFilesPrefs(f, out_prefs);
+	}
+	if (const CECTag *s = resp->GetTagByName(EC_TAG_PREFS_SERVERS)) {
+		ParseServersPrefs(s, out_prefs);
+	}
+	if (const CECTag *s = resp->GetTagByName(EC_TAG_PREFS_SECURITY)) {
+		ParseSecurityPrefs(s, out_prefs);
+	}
+	if (const CECTag *m = resp->GetTagByName(EC_TAG_PREFS_MESSAGEFILTER)) {
+		ParseMessageFilterPrefs(m, out_prefs);
+	}
+	if (const CECTag *rc = resp->GetTagByName(EC_TAG_PREFS_REMOTECTRL)) {
+		ParseRemoteControlsPrefs(rc, out_prefs);
+	}
+	if (const CECTag *o = resp->GetTagByName(EC_TAG_PREFS_ONLINESIG)) {
+		ParseOnlineSigPrefs(o, out_prefs);
+	}
+	if (const CECTag *c = resp->GetTagByName(EC_TAG_PREFS_CORETWEAKS)) {
+		ParseCoreTweaksPrefs(c, out_prefs);
+	}
+	if (const CECTag *k = resp->GetTagByName(EC_TAG_PREFS_KADEMLIA)) {
+		ParseKademliaPrefs(k, out_prefs);
 	}
 	if (const CECTag *cats = resp->GetTagByName(EC_TAG_PREFS_CATEGORIES)) {
 		for (CECTag::const_iterator it = cats->begin(); it != cats->end(); ++it) {

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -203,14 +203,20 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	}
 
 	// /preferences + /categories — one EC roundtrip populates both.
-	// Selection bitmask: CATEGORIES (0x01) + GENERAL (0x02) +
-	// CONNECTIONS (0x04). Using the named enums (rather than hex
-	// literals) so a future bit shuffle in ECCodes.h doesn't
-	// silently zero out a section — bit-positional bugs here are
-	// hard to spot in JSON (empty defaults look like "0 KB/s" not
-	// "field not requested").
+	// Selection bitmask requests every category the endpoint exposes
+	// (issue #437 widened this from GENERAL|CONNECTIONS to all EC-
+	// carried groups). Using the named enums (rather than hex literals)
+	// so a future bit shuffle in ECCodes.h doesn't silently zero out a
+	// section — bit-positional bugs here are hard to spot in JSON
+	// (empty defaults look like "0 KB/s" not "field not requested").
+	// STATISTICS is intentionally omitted (its serialize block is empty
+	// — the 0x1B* tags carry live graph data, not stored prefs).
 	{
-		const std::uint32_t selection = EC_PREFS_CATEGORIES | EC_PREFS_GENERAL | EC_PREFS_CONNECTIONS;
+		const std::uint32_t selection = EC_PREFS_CATEGORIES | EC_PREFS_GENERAL |
+						EC_PREFS_CONNECTIONS | EC_PREFS_DIRECTORIES | EC_PREFS_FILES |
+						EC_PREFS_SERVERS | EC_PREFS_SECURITY |
+						EC_PREFS_MESSAGEFILTER | EC_PREFS_REMOTECONTROLS |
+						EC_PREFS_ONLINESIG | EC_PREFS_CORETWEAKS | EC_PREFS_KADEMLIA;
 		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_GET_PREFERENCES));
 		req->AddTag(CECTag(EC_TAG_SELECT_PREFS, selection));
 		const CECPacket *resp = app.SendRecvSerialized(req.get());

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -593,6 +593,127 @@ struct PreferencesSnapshot
 	bool reconnect = false;
 	bool network_ed2k = false;
 	bool network_kad = false;
+
+	// --- Extended EC-carried categories (issue #437) -----------------
+	// Every field below maps 1:1 to an EC tag the daemon already
+	// serializes in CEC_Prefs_Packet and applies in Apply(); the webapi
+	// just requests the wider selection bitmask and plumbs them through.
+	// Nested sub-structs mirror the nested JSON the endpoint emits.
+
+	// [Directories] EC_TAG_PREFS_DIRECTORIES
+	struct DirectoriesPrefs
+	{
+		std::string incoming;
+		std::string temp;
+		std::vector<std::string> shared;
+		bool share_hidden = false;
+		bool auto_rescan = false;
+		bool follow_symlinks = false;
+		std::string exclude_patterns;
+		bool exclude_regex = false;
+	} directories;
+
+	// [Files] EC_TAG_PREFS_FILES
+	struct FilesPrefs
+	{
+		bool ich_enabled = false;
+		bool aich_trust = false;
+		bool new_paused = false;
+		bool new_auto_dl_prio = false;
+		bool new_auto_ul_prio = false;
+		bool preview_prio = false;
+		bool start_next_paused = false;
+		bool resume_same_cat = false;
+		bool save_sources = false;
+		bool extract_metadata = false;
+		bool alloc_full_size = false;
+		bool check_free_space = false;
+		std::uint32_t min_free_space_mb = 0;
+		bool create_normal = false;
+	} files;
+
+	// [Servers] EC_TAG_PREFS_SERVERS
+	struct ServersPrefs
+	{
+		bool remove_dead = false;
+		std::uint32_t dead_server_retries = 0;
+		bool auto_update = false;
+		bool add_from_server = false;
+		bool add_from_client = false;
+		bool use_score_system = false;
+		bool smart_id_check = false;
+		bool safe_server_connect = false;
+		bool autoconn_static_only = false;
+		bool manual_high_prio = false;
+		std::string update_url;
+	} servers;
+
+	// [Security] EC_TAG_PREFS_SECURITY
+	struct SecurityPrefs
+	{
+		bool can_see_shares = false;
+		bool ipfilter_clients = false;
+		bool ipfilter_servers = false;
+		bool ipfilter_auto_update = false;
+		std::string ipfilter_update_url;
+		std::uint32_t ipfilter_level = 0;
+		bool ipfilter_filter_lan = false;
+		bool use_secident = false;
+		bool obfuscation_supported = false;
+		bool obfuscation_requested = false;
+		bool obfuscation_required = false;
+	} security;
+
+	// [MessageFilter] EC_TAG_PREFS_MESSAGEFILTER
+	struct MessageFilterPrefs
+	{
+		bool enabled = false;
+		bool all = false;
+		bool friends = false;
+		bool secure = false;
+		bool by_keyword = false;
+		std::string keywords;
+	} message_filter;
+
+	// [RemoteControls] EC_TAG_PREFS_REMOTECTRL. Passwords are
+	// write-only (set via PATCH, never serialized here).
+	struct RemoteControlsPrefs
+	{
+		bool webserver_enabled = false;
+		std::uint32_t webserver_port = 0;
+		bool webserver_use_gzip = false;
+		std::uint32_t webserver_refresh = 0;
+		std::string webserver_template;
+		bool webserver_guest_enabled = false;
+		bool amuleapi_enabled = false;
+		std::uint32_t amuleapi_port = 0;
+		std::string amuleapi_bind;
+	} remote_controls;
+
+	// [OnlineSignature] EC_TAG_PREFS_ONLINESIG
+	struct OnlineSignaturePrefs
+	{
+		bool enabled = false;
+	} online_signature;
+
+	// [CoreTweaks] EC_TAG_PREFS_CORETWEAKS
+	struct CoreTweaksPrefs
+	{
+		std::uint32_t max_conn_per_five = 0;
+		bool verbose = false;
+		std::uint32_t filebuffer = 0;
+		std::uint32_t ul_queue = 0;
+		std::uint32_t srv_keepalive_timeout = 0;
+		std::uint32_t kad_max_searches = 0;
+		std::uint32_t kad_reask_ms = 0;
+		std::uint32_t source_reask_ms = 0;
+	} core_tweaks;
+
+	// [Kademlia] EC_TAG_PREFS_KADEMLIA
+	struct KademliaPrefs
+	{
+		std::string update_url;
+	} kademlia;
 };
 
 struct StatusSnapshot

--- a/unittests/curl-tests/amuleapi/15-preferences-patch.sh
+++ b/unittests/curl-tests/amuleapi/15-preferences-patch.sh
@@ -4,7 +4,9 @@
 #
 # Endpoint:
 #   PATCH /api/v0/preferences
-#       body: { general?: {...}, connection?: {...} }
+#       body: { general?, connection?, directories?, files?, servers?,
+#               security?, message_filter?, remote_controls?,
+#               online_signature?, core_tweaks?, kademlia? }  (issue #437)
 #
 # Wire shape mirrors the /preferences GET response. Both sub-objects
 # optional; all fields within optional. Only fields present are
@@ -186,6 +188,49 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d 'not json' "$HOST/api/v0/preferences"
 _assert_status 400 "PATCH malformed JSON → 400"
+
+# --- 5b. Extended EC categories: presence + round-trip (issue #437). -
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
+_assert_json_eq '(.directories|type)' object '/preferences has directories object'
+_assert_json_eq '(.files|type)' object '/preferences has files object'
+_assert_json_eq '(.servers|type)' object '/preferences has servers object'
+_assert_json_eq '(.security|type)' object '/preferences has security object'
+_assert_json_eq '(.message_filter|type)' object '/preferences has message_filter object'
+_assert_json_eq '(.remote_controls|type)' object '/preferences has remote_controls object'
+_assert_json_eq '(.online_signature|type)' object '/preferences has online_signature object'
+_assert_json_eq '(.core_tweaks|type)' object '/preferences has core_tweaks object'
+_assert_json_eq '(.kademlia|type)' object '/preferences has kademlia object'
+_assert_json_eq '(.directories.shared|type)' array 'directories.shared is an array'
+_assert_json_eq '(.files.min_free_space_mb|type)' number 'files.min_free_space_mb is numeric'
+# Passwords are write-only — no password key ever appears on GET
+# (user_hash is the identity hash, deliberately not matched here).
+_assert_json_eq '[paths(scalars) as $p | select($p[-1]|tostring|test("password";"i"))] | length' \
+	0 'no password key present in GET /preferences'
+SAVED_NEW_PAUSED=$(printf '%s' "$CURL_BODY" | jq -r '.files.new_paused')
+SAVED_RETRIES=$(printf '%s' "$CURL_BODY" | jq -r '.servers.dead_server_retries')
+
+# Round-trip a bool (files) + int (servers) and confirm no stale GET.
+NEW_PAUSED_TOGGLE=$([ "$SAVED_NEW_PAUSED" = "true" ] && echo false || echo true)
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d "{\"files\":{\"new_paused\":$NEW_PAUSED_TOGGLE},\"servers\":{\"dead_server_retries\":9}}" \
+	"$HOST/api/v0/preferences"
+_assert_status 200 "PATCH files+servers categories → 200"
+_assert_json_eq '.files.new_paused' "$NEW_PAUSED_TOGGLE" 'files.new_paused toggled in response'
+_assert_json_eq '.servers.dead_server_retries' 9 'servers.dead_server_retries=9 in response'
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
+_assert_json_eq '.files.new_paused' "$NEW_PAUSED_TOGGLE" 'files.new_paused persisted (no stale GET)'
+_assert_json_eq '.servers.dead_server_retries' 9 'servers.dead_server_retries persisted'
+
+# Wrong type on a new-category field → 400.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d '{"files":{"min_free_space_mb":"lots"}}' "$HOST/api/v0/preferences"
+_assert_status 400 "PATCH files.min_free_space_mb as string → 400"
+
+# Restore the #437 fields we touched.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d "{\"files\":{\"new_paused\":$SAVED_NEW_PAUSED},\"servers\":{\"dead_server_retries\":$SAVED_RETRIES}}" \
+	"$HOST/api/v0/preferences"
+_assert_status 200 "PATCH (restore #437 fields) → 200"
 
 # --- 6. Restore pre-mutation state. --------------------------------
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1266,3 +1266,78 @@ TEST(Refresher, ClientDetailFieldsDecode)
 	ASSERT_TRUE(!it2->second.is_friend);
 	ASSERT_TRUE(it2->second.dl_up_modifier == 0.0);
 }
+
+// --- #437: extended EC preference categories decode ------------------
+//
+// Covers both boolean encodings the core serializer uses: value tags
+// (share_hidden/exclude_regex/can_see_shares -> GetInt()!=0) and bare
+// presence tags (ich_enabled/use_secident -> tag present == true), plus
+// ints, strings, and the directories.shared string array.
+TEST(Refresher, PreferencesExtendedCategoriesDecode)
+{
+	CECPacket resp(EC_OP_SET_PREFERENCES);
+
+	CECEmptyTag dir(EC_TAG_PREFS_DIRECTORIES);
+	dir.AddTag(CECTag(EC_TAG_DIRECTORIES_INCOMING, wxString::FromUTF8("/inc")));
+	dir.AddTag(CECTag(EC_TAG_DIRECTORIES_TEMP, wxString::FromUTF8("/tmp")));
+	CECTag shared(EC_TAG_DIRECTORIES_SHARED, static_cast<std::uint32_t>(2));
+	shared.AddTag(CECTag(EC_TAG_STRING, wxString::FromUTF8("/a")));
+	shared.AddTag(CECTag(EC_TAG_STRING, wxString::FromUTF8("/b")));
+	dir.AddTag(shared);
+	dir.AddTag(CECTag(EC_TAG_DIRECTORIES_SHARE_HIDDEN, true)); // value-encoded bool
+	dir.AddTag(CECTag(EC_TAG_DIRECTORIES_EXCLUDE_REGEX, true));
+	resp.AddTag(dir);
+
+	CECEmptyTag files(EC_TAG_PREFS_FILES);
+	files.AddTag(CECEmptyTag(EC_TAG_FILES_ICH_ENABLED)); // presence == true
+	files.AddTag(CECTag(EC_TAG_FILES_MIN_FREE_SPACE, static_cast<std::uint32_t>(512)));
+	resp.AddTag(files);
+
+	CECEmptyTag srv(EC_TAG_PREFS_SERVERS);
+	srv.AddTag(CECTag(EC_TAG_SERVERS_DEAD_SERVER_RETRIES, static_cast<std::uint16_t>(5)));
+	srv.AddTag(CECTag(EC_TAG_SERVERS_UPDATE_URL, wxString::FromUTF8("http://srv")));
+	resp.AddTag(srv);
+
+	CECEmptyTag sec(EC_TAG_PREFS_SECURITY);
+	sec.AddTag(CECTag(EC_TAG_SECURITY_CAN_SEE_SHARES, true)); // value-encoded bool
+	sec.AddTag(CECTag(EC_TAG_IPFILTER_LEVEL, static_cast<std::uint32_t>(100)));
+	sec.AddTag(CECEmptyTag(EC_TAG_SECURITY_USE_SECIDENT)); // presence == true
+	resp.AddTag(sec);
+
+	CECEmptyTag cw(EC_TAG_PREFS_CORETWEAKS);
+	cw.AddTag(CECTag(EC_TAG_CORETW_MAX_CONN_PER_FIVE, static_cast<std::uint32_t>(200)));
+	cw.AddTag(CECTag(EC_TAG_CORETW_KAD_REASK_MS, static_cast<std::uint32_t>(1800000)));
+	resp.AddTag(cw);
+
+	CECEmptyTag kad(EC_TAG_PREFS_KADEMLIA);
+	kad.AddTag(CECTag(EC_TAG_KADEMLIA_UPDATE_URL, wxString::FromUTF8("http://nodes")));
+	resp.AddTag(kad);
+
+	PreferencesSnapshot p;
+	std::vector<CategorySnapshot> cats;
+	ParsePreferencesFromPacket(&resp, p, cats);
+
+	ASSERT_EQUALS(std::string("/inc"), p.directories.incoming);
+	ASSERT_EQUALS(std::string("/tmp"), p.directories.temp);
+	ASSERT_EQUALS(static_cast<size_t>(2), p.directories.shared.size());
+	ASSERT_EQUALS(std::string("/a"), p.directories.shared[0]);
+	ASSERT_TRUE(p.directories.share_hidden);
+	ASSERT_TRUE(p.directories.exclude_regex);
+	ASSERT_TRUE(!p.directories.auto_rescan); // absent -> false
+
+	ASSERT_TRUE(p.files.ich_enabled);
+	ASSERT_TRUE(!p.files.aich_trust); // absent presence tag -> false
+	ASSERT_EQUALS(static_cast<std::uint32_t>(512), p.files.min_free_space_mb);
+
+	ASSERT_EQUALS(static_cast<std::uint32_t>(5), p.servers.dead_server_retries);
+	ASSERT_EQUALS(std::string("http://srv"), p.servers.update_url);
+
+	ASSERT_TRUE(p.security.can_see_shares);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(100), p.security.ipfilter_level);
+	ASSERT_TRUE(p.security.use_secident);
+	ASSERT_TRUE(!p.security.obfuscation_required); // absent -> false
+
+	ASSERT_EQUALS(static_cast<std::uint32_t>(200), p.core_tweaks.max_conn_per_five);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1800000), p.core_tweaks.kad_reask_ms);
+	ASSERT_EQUALS(std::string("http://nodes"), p.kademlia.update_url);
+}


### PR DESCRIPTION
Implements #437.

`GET/PATCH /api/v0/preferences` served only `general` (4 fields) + `connection` (14). This adds the **nine** remaining categories the daemon already serializes and applies over EC — `directories`, `files`, `servers`, `security`, `message_filter`, `remote_controls`, `online_signature`, `core_tweaks`, `kademlia` — closing the gap with the desktop Preferences tabs. Purely REST-layer plumbing: **no core/EC change**.

**How**
- `RefresherTick` widens `EC_TAG_SELECT_PREFS` to request every category (`STATISTICS` omitted — its serialize block is empty; `CATEGORIES` already has its own `/categories` endpoint).
- Per-category parsers in `Refresher.cpp` honor **both** core boolean encodings (bare presence tag vs always-present value tag) plus ints/strings and the `directories.shared` array; dispatched from `ParsePreferencesFromPacket`.
- `PreferencesSnapshot` gains nested sub-structs; the GET body and the PATCH echo now share one `WritePreferencesBody` helper (previously duplicated).
- PATCH validates + packs each category via generic `PrefTake*` helpers — every field optional, bools packed as value tags (`Apply` reads `GetInt()!=0` at `EC_DETAIL_FULL`), unknown/mis-typed field ⇒ `400`.
- **Passwords are write-only**: `webserver_password` / `webserver_guest_password` / `amuleapi_password` are accepted on PATCH (plaintext → MD5 → `EC_TAG_PASSWD_HASH` / `_AMULEAPI_PASSWD`) and **never** emitted on GET. The guest password packs into the shared `EC_TAG_WEBSERVER_GUEST` tag alongside its enable bit.

**Scope notes**
- Follows the issue's "expose everything the daemon carries over EC" — including self-affecting settings (`remote_controls.amuleapi_port`/`bind`, `directories.incoming`/`temp`). The docs flag these as foot-guns; a port/bind change only takes effect on the next amuled restart, so it won't drop the current connection.
- Out of scope per the issue: web-UI rendering (`preferences.js`), settings not yet on EC (Proxy, GeoIP, UPnP), `STATISTICS`.

**Tests / docs**
- `RefresherTest.PreferencesExtendedCategoriesDecode` — both bool encodings, ints, strings, the shared array.
- `curl 15` — presence of all 9 categories, round-trip PATCH (bool + int), no-password-leak check, wrong-type `400`.
- REST docs: full category reference, write-only-password contract, self-affecting foot-gun note.
- Verified live on a connected daemon: all 9 categories populated, PATCH round-trips, no password leak (**42/42** curl 15).