### PR TITLE
feat(ec+amuleapi): search-result grouping + download-under-name (#431)

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -413,11 +413,12 @@ Emitted per new result that appears in the results map between refresher ticks.
   "rating": 0,
   "status": "new",
   "type": "videos",
-  "media": { "length_s": 5400, "bitrate": 1500, "codec": "h264", "artist": "", "album": "", "title": "" }
+  "media": { "length_s": 5400, "bitrate": 1500, "codec": "h264", "artist": "", "album": "", "title": "" },
+  "children": []
 }
 ```
 
-Key results by `hash`. The payload is byte-for-byte identical to a `/search/results` array entry (including `status` and `type` — see [REFERENCE.md](REFERENCE.md#get-apiv0searchresults)); `sources` is the nested `{total, complete}` object, and `media` — the audio/video metadata object — is present only for locally-known/probed hits and omitted otherwise, same as the REST endpoint. amuled wipes its searchlist on every new `POST /search`, so subscribers must treat each search as a fresh result space — clear prior results when you start a new query.
+Key results by `hash`. The payload is byte-for-byte identical to a `/search/results` array entry (including `status`, `type`, and the `children[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchresults)); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present only for locally-known/probed hits and omitted otherwise, and `children` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire this event — children are folded into their parent's `children[]`, never emitted as their own `search_result_added`. amuled wipes its searchlist on every new `POST /search`, so subscribers must treat each search as a fresh result space — clear prior results when you start a new query.
 
 #### `search_progress`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1603,7 +1603,11 @@ This endpoint does NOT busy-wait — it returns whatever amuled has in its resul
       "rating":       0,
       "status":       "new",
       "type":         "videos",
-      "media":        { "length_s": 5400, "bitrate": 1500, "codec": "h264", "artist": "", "album": "", "title": "" }
+      "media":        { "length_s": 5400, "bitrate": 1500, "codec": "h264", "artist": "", "album": "", "title": "" },
+      "children": [
+        { "ecid": 621, "name": "example-distribution-26.04.iso", "hash": "8b54a3c2...", "sources": { "total": 40, "complete": 22 } },
+        { "ecid": 622, "name": "example_distro_2604_amd64.iso",  "hash": "8b54a3c2...", "sources": { "total": 10, "complete":  3 } }
+      ]
     }
   ],
   "progress": {
@@ -1615,6 +1619,8 @@ This endpoint does NOT busy-wait — it returns whatever amuled has in its resul
 ```
 
 Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints) — **present only** for a hit that is already known/probed locally, and **omitted entirely** for remote hits with no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list.
+
+`children` (issue #431) is the result-grouping tree: amuled collapses hits that are the **same file** (same ed2k hash **and** size) but advertised under **different filenames** into one parent row, and `children[]` holds the alternative names. Each child carries the parent's `hash` (that's why they group), its own `sources`, and a distinct `ecid` — pass that `ecid` to [`POST /search/results/{hash}/download`](#post-apiv0searchresultshashdownload) to download the file **under that chosen filename**. `children` is always present and is an empty array for a hit seen under a single name. The top-level `results[]` contains parents only — a child never appears as its own top-level entry.
 
 The `progress` object carries the same `state` / `kind` / `percent` fields as the [`search_progress`](EVENTS.md#search_progress) SSE event, so REST pollers and stream consumers interpret progress identically. (The event additionally carries a `results` count, since — unlike this response — it has no `results` array beside it.)
 
@@ -1642,7 +1648,7 @@ Cancels the in-flight search; cached results stay.
 
 Promote a search result into the transfer queue. Equivalent to clicking "Download" on a desktop search row.
 
-**Body:** `{ "category": 0 }` (optional).
+**Body:** `{ "category": 0, "ecid": 621 }` — both optional. `category` is the download category (default `0`). `ecid` (issue #431) selects one grouped **child** by its `results[].children[].ecid`, so the file downloads **under that child's filename**; omit it to download the parent (the aggregated/highest-source name). Since grouped children share the parent's hash, `{hash}` alone can't disambiguate them — `ecid` is how you pick a specific advertised name.
 
 **Response:** `202 Accepted` → `{ "ok": true, "hash": "...", "category": 0 }`.
 

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1485,6 +1485,15 @@ static CECPacket *Get_EC_Response_Search_Results(
 	const bool tombstone_path =
 		partial_update_active && detail_level == EC_DETAIL_UPDATE && queryitems.empty();
 
+	// Result grouping (issue #431): a caller that wants the same-hash/
+	// same-size-but-different-filename children (the expandable tree the
+	// GUI shows) opts in by adding an empty `EC_TAG_SEARCH_PARENT` flag
+	// to the request. Without it this path stays parents-only, so
+	// amulecmd `search` and amuleweb are unchanged. Children carry their
+	// parent's ECID via `EC_TAG_SEARCH_PARENT` in CEC_SearchFile_Tag, so
+	// the client can rebuild the tree.
+	const bool want_children = request->GetTagByName(EC_TAG_SEARCH_PARENT) != nullptr;
+
 	std::set<uint32> current_ids;
 
 	const CSearchResultList &list = theApp->searchlist->GetSearchResults(0xffffffff);
@@ -1498,6 +1507,14 @@ static CECPacket *Get_EC_Response_Search_Results(
 			current_ids.insert(sf->ECID());
 		}
 		response->AddTag(CEC_SearchFile_Tag(sf, detail_level));
+		if (want_children && sf->HasChildren()) {
+			for (CSearchFile *sfc : sf->GetChildren()) {
+				if (tombstone_path) {
+					current_ids.insert(sfc->ECID());
+				}
+				response->AddTag(CEC_SearchFile_Tag(sfc, detail_level));
+			}
+		}
 	}
 
 	if (tombstone_path) {
@@ -1550,9 +1567,23 @@ static CECPacket *Get_EC_Response_Search_Results_Download(const CECPacket *reque
 	CECPacket *response = new CECPacket(EC_OP_STRINGS);
 	for (CECPacket::const_iterator it = request->begin(); it != request->end(); ++it) {
 		const CECTag &tag = *it;
-		CMD4Hash hash = tag.GetMD4Data();
-		uint8 category = tag.GetFirstTagSafe()->GetInt();
-		theApp->searchlist->AddFileToDownloadByHash(hash, category);
+		// Read the category by name (both amulegui and amuleapi send it as
+		// EC_TAG_PARTFILE_CAT) rather than "first child", so an optional
+		// EC_TAG_SEARCHFILE selector below can ride alongside it.
+		uint8 category = 0;
+		if (const CECTag *catTag = tag.GetTagByName(EC_TAG_PARTFILE_CAT)) {
+			category = catTag->GetInt();
+		}
+		// Issue #431: an optional EC_TAG_SEARCHFILE child carries a search
+		// result's ECID, selecting one specific same-hash/different-name
+		// grouped result so it downloads under that chosen filename.
+		// Without it, download the first result matching the hash (the
+		// parent) — the unchanged behaviour.
+		if (const CECTag *ecidTag = tag.GetTagByName(EC_TAG_SEARCHFILE)) {
+			theApp->searchlist->AddFileToDownloadByEcid(ecidTag->GetInt(), category);
+		} else {
+			theApp->searchlist->AddFileToDownloadByHash(tag.GetMD4Data(), category);
+		}
 	}
 	return response;
 }

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -767,6 +767,29 @@ void CSearchList::AddFileToDownloadByHash(const CMD4Hash &hash, uint8 cat)
 	}
 }
 
+void CSearchList::AddFileToDownloadByEcid(uint32 ecid, uint8 cat)
+{
+	// Match against parents and their same-hash/different-name children
+	// (issue #431 grouping); downloading the specific CSearchFile lands
+	// the partfile under that result's own filename.
+	for (auto &entry : m_results) {
+		for (CSearchFile *sf : entry.second) {
+			if (sf->ECID() == ecid) {
+				CoreNotify_Search_Add_Download(sf, cat);
+				return;
+			}
+			if (sf->HasChildren()) {
+				for (CSearchFile *child : sf->GetChildren()) {
+					if (child->ECID() == ecid) {
+						CoreNotify_Search_Add_Download(child, cat);
+						return;
+					}
+				}
+			}
+		}
+	}
+}
+
 bool CSearchList::IsKadSearch(uint32_t searchID) const
 {
 	return Kademlia::CSearchManager::IsKadSearch(searchID);

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -147,6 +147,14 @@ public:
 	void AddFileToDownloadByHash(const CMD4Hash &hash, uint8 category = 0);
 
 	/**
+	 * Start downloading the specific search result identified by its EC
+	 * ECID — used to pick one same-hash/different-name grouped child so
+	 * the partfile lands under that chosen filename (issue #431).
+	 * Searches parents and their children; a no-op if the ecid is gone.
+	 */
+	void AddFileToDownloadByEcid(uint32 ecid, uint8 category = 0);
+
+	/**
 	 * Processes a list of shared files from a client.
 	 *
 	 * @param packet The raw packet received from the client.

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -4458,6 +4458,32 @@ void WriteSearchObject(CJsonWriter &w, const webapi::SearchResult &r)
 		w.ValueString(wxString::FromUTF8(r.media.title.c_str()));
 		w.EndObject();
 	}
+	// Result grouping (issue #431): the same-hash/same-size hit's
+	// alternative filenames. Always emitted (empty array when the hit was
+	// seen under a single name) so clients can render the expandable tree
+	// without a presence check. Each child shares the parent's `hash`; the
+	// distinct `ecid` selects it for download-under-that-name (see
+	// POST /search/results/{hash}/download).
+	w.Key("children");
+	w.BeginArray();
+	for (const auto &c : r.children) {
+		w.BeginObject();
+		w.Key("ecid");
+		w.ValueInt(static_cast<int64_t>(c.ecid));
+		w.Key("name");
+		w.ValueString(wxString::FromUTF8(c.name.c_str()));
+		w.Key("hash");
+		w.ValueString(wxString::FromUTF8(c.hash.c_str()));
+		w.Key("sources");
+		w.BeginObject();
+		w.Key("total");
+		w.ValueInt(static_cast<int64_t>(c.source_count));
+		w.Key("complete");
+		w.ValueInt(static_cast<int64_t>(c.complete_source_count));
+		w.EndObject();
+		w.EndObject();
+	}
+	w.EndArray();
 	w.EndObject();
 }
 
@@ -7364,12 +7390,17 @@ CHttpServer::Response CApiDispatcher::HandleSearchDownload(
 		return ErrorResponse(400, "bad_request", "`{hash}` must be a 32-char hex MD4");
 	}
 
-	// Optional body: {"category": uint8}. amulegui's
+	// Optional body: {"category": uint8, "ecid": uint32}. amulegui's
 	// CDownQueueRem::AddSearchToDownload defaults to category 0
 	// when none is supplied; we mirror that. The body itself is
 	// optional — clients that don't care about category POST with
-	// no body and get the default download path.
+	// no body and get the default download path. `ecid` (issue #431)
+	// selects one same-hash/different-name grouped child (from a result's
+	// `children[].ecid`) so it downloads under that chosen filename;
+	// omitted => the parent (first result matching the hash).
 	std::uint8_t category = 0;
+	bool has_ecid = false;
+	std::uint32_t ecid = 0;
 	if (!req.body.empty()) {
 		picojson::value root;
 		std::string parse_err;
@@ -7389,14 +7420,32 @@ CHttpServer::Response CApiDispatcher::HandleSearchDownload(
 			}
 			category = static_cast<std::uint8_t>(v);
 		}
+		const auto eit = obj.find("ecid");
+		if (eit != obj.end()) {
+			if (!eit->second.is<double>()) {
+				return ErrorResponse(
+					400, "bad_request", "`ecid` must be a non-negative integer");
+			}
+			const double v = eit->second.get<double>();
+			if (v < 0 || v > 4294967295.0) {
+				return ErrorResponse(400, "bad_request", "`ecid` out of range");
+			}
+			ecid = static_cast<std::uint32_t>(v);
+			has_ecid = true;
+		}
 	}
 
 	// amuled accepts the result hash as the partfile-tag's int
 	// payload (matches amule-remote-gui.cpp:2230). amuled looks up
-	// the hash in its searchlist; if not present, returns FAILED.
+	// the hash in its searchlist; if not present, returns FAILED. When
+	// an `ecid` selector is supplied, it rides as an EC_TAG_SEARCHFILE
+	// child and amuled downloads that specific grouped result instead.
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_DOWNLOAD_SEARCH_RESULT));
 	CECTag hash_tag(EC_TAG_PARTFILE, file_hash);
 	hash_tag.AddTag(CECTag(EC_TAG_PARTFILE_CAT, category));
+	if (has_ecid) {
+		hash_tag.AddTag(CECTag(EC_TAG_SEARCHFILE, ecid));
+	}
 	ec_req->AddTag(hash_tag);
 
 	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -550,6 +550,26 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 							<< EscJson(m.album) << "\",\"title\":\""
 							<< EscJson(m.title) << "\"}";
 					}
+					// Result grouping (issue #431) — same shape as
+					// WriteSearchObject's children[]; always present
+					// (empty array when the hit had a single name).
+					payload << ",\"children\":[";
+					{
+						bool first = true;
+						for (const auto &c : kv.second.children) {
+							if (!first)
+								payload << ",";
+							first = false;
+							payload << "{\"ecid\":" << c.ecid << ",\"name\":\""
+								<< EscJson(c.name) << "\",\"hash\":\""
+								<< EscJson(c.hash)
+								<< "\",\"sources\":{\"total\":"
+								<< c.source_count
+								<< ",\"complete\":" << c.complete_source_count
+								<< "}}";
+						}
+					}
+					payload << "]";
 					payload << "}";
 					bus.Publish("search_result_added", payload.str());
 				}

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1868,6 +1868,16 @@ void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult
 				r.complete_source_count = v;
 		}
 		r.already_have = sf->AlreadyHave();
+		// Grouping (issue #431): a child hit carries its parent's ECID in
+		// EC_TAG_SEARCH_PARENT. Recorded here; folded into the parent's
+		// children[] in the second pass below.
+		{
+			std::uint32_t v = 0;
+			if (sf->AssignIfExist(EC_TAG_SEARCH_PARENT, v)) {
+				r.parent_ecid = v;
+				r.has_parent = true;
+			}
+		}
 		{
 			std::uint8_t v = 0;
 			if (sf->AssignIfExist(EC_TAG_KNOWNFILE_RATING, v))
@@ -1912,6 +1922,33 @@ void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult
 			r.has_media = true;
 		}
 		cache.emplace(r.ecid, std::move(r));
+	}
+
+	// Second pass (issue #431): fold each child into its parent's
+	// children[] and drop it from the top-level set, so the API serves
+	// one parent row per hash+size with the alternative filenames nested.
+	// A child whose parent isn't in the set (shouldn't happen — the core
+	// emits the parent before its children) is left as a top-level row so
+	// nothing is silently lost.
+	std::vector<std::uint32_t> folded;
+	for (auto &kv : cache) {
+		SearchResult &child = kv.second;
+		if (!child.has_parent)
+			continue;
+		auto pit = cache.find(child.parent_ecid);
+		if (pit == cache.end())
+			continue;
+		SearchResult::Child c;
+		c.ecid = child.ecid;
+		c.name = child.name;
+		c.hash = child.hash;
+		c.source_count = child.source_count;
+		c.complete_source_count = child.complete_source_count;
+		pit->second.children.push_back(std::move(c));
+		folded.push_back(kv.first);
+	}
+	for (std::uint32_t ecid : folded) {
+		cache.erase(ecid);
 	}
 }
 

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -173,6 +173,12 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		std::uint32_t lifecycle_state = 0;
 		{
 			std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_RESULTS, EC_DETAIL_FULL));
+			// Opt into result grouping (issue #431): the empty
+			// EC_TAG_SEARCH_PARENT flag tells the FULL responder to also
+			// emit each same-hash/different-name child so /search/results
+			// can nest them. Other EC clients that don't send it keep the
+			// flat parents-only list.
+			req->AddTag(CECEmptyTag(EC_TAG_SEARCH_PARENT));
 			const CECPacket *resp = app.SendRecvSerialized(req.get());
 			if (!resp)
 				return false;

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -507,6 +507,24 @@ struct SearchResult
 		std::string album;
 		std::string title;
 	} media;
+
+	// Result grouping (issue #431): same-hash/same-size hits advertised
+	// under different filenames. `parent_ecid`/`has_parent` are set on a
+	// child during decode; the refresher then folds children into their
+	// parent's `children` list and drops them from the top-level set, so
+	// the API emits one parent row per hash+size with the alternative
+	// names nested. `children` is empty for a hit seen under one name.
+	std::uint32_t parent_ecid = 0;
+	bool has_parent = false;
+	struct Child
+	{
+		std::uint32_t ecid = 0;
+		std::string name;
+		std::string hash; // same as the parent's (that's why they group)
+		std::uint32_t source_count = 0;
+		std::uint32_t complete_source_count = 0;
+	};
+	std::vector<Child> children;
 };
 
 // Refresher-tracked lifecycle of the currently-active (or last-finished)

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -201,6 +201,15 @@ if [ -n "$RESULT_HASH" ]; then
 	# known/probed, absent otherwise — both are valid.
 	_assert_json_eq '.results[0].media | type | test("^(object|null)$")' \
 		true '/search/results[0].media is an object or absent'
+	# Result grouping (issue #431): every result carries a children[]
+	# array (empty when the hit was seen under a single name). No result
+	# is itself a child (children are folded into their parent), and each
+	# child object has ecid + name + hash + sources.
+	_assert_json_eq '.results[0].children | type' array '/search/results[0].children is an array'
+	_assert_json_eq '[.results[].children[]?] | all(has("ecid") and has("name") and has("hash") and has("sources"))' \
+		true 'every child has ecid/name/hash/sources'
+	_assert_json_eq '[.results[].children[]?.hash | length] | all(. == 32)' \
+		true 'every child hash is 32-char hex (shared with its parent)'
 
 	# progress envelope. `progress` exists on every GET /search/results
 	# response (even before any POST /search). `state` is canonical
@@ -259,6 +268,14 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-d '{"category":300}' \
 	"$HOST/api/v0/search/results/baadbaadbaadbaadbaadbaadbaadbaad/download"
 _assert_status 400 "POST download (category out of range) → 400"
+
+# Download-under-name selector (issue #431): `ecid` must be a
+# non-negative integer.
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"ecid":"notnum"}' \
+	"$HOST/api/v0/search/results/baadbaadbaadbaadbaadbaadbaadbaad/download"
+_assert_status 400 "POST download (ecid wrong type) → 400"
 
 # Unknown hash that's well-formed (32 hex chars) → amuled rejection.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1140,6 +1140,50 @@ TEST(Refresher, SearchResultMediaDecode)
 	ASSERT_TRUE(!it2->second.has_media);
 }
 
+// --- #431: result grouping folds same-hash/diff-name children --------
+//
+// A parent plus two children (each carrying EC_TAG_SEARCH_PARENT) must
+// collapse to a single top-level result with the two alternative names
+// nested in children[]; the child ECIDs must not remain top-level.
+TEST(Refresher, SearchResultGroupingFoldsChildren)
+{
+	std::map<std::uint32_t, SearchResult> cache;
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+
+	CECTag parent(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(100));
+	parent.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("best.mkv")));
+	parent.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(123)));
+	parent.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(30)));
+	resp.AddTag(parent);
+
+	CECTag c1(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(101));
+	c1.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("alt.name.mkv")));
+	c1.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(123)));
+	c1.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(10)));
+	c1.AddTag(CECTag(EC_TAG_SEARCH_PARENT, static_cast<std::uint32_t>(100)));
+	resp.AddTag(c1);
+
+	CECTag c2(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(102));
+	c2.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("third.mkv")));
+	c2.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(123)));
+	c2.AddTag(CECTag(EC_TAG_SEARCH_PARENT, static_cast<std::uint32_t>(100)));
+	resp.AddTag(c2);
+
+	ApplySearchFull(&resp, cache);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), cache.size());
+	const auto it = cache.find(100);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_TRUE(cache.find(101) == cache.end());
+	ASSERT_TRUE(cache.find(102) == cache.end());
+	ASSERT_EQUALS(static_cast<size_t>(2), it->second.children.size());
+	// map iterates ecid-ascending, so 101 folds before 102.
+	ASSERT_EQUALS(std::string("alt.name.mkv"), it->second.children[0].name);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(101), it->second.children[0].ecid);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(10), it->second.children[0].source_count);
+	ASSERT_EQUALS(std::string("third.mkv"), it->second.children[1].name);
+}
+
 // --- #359: peer software_version must be locale-independent ----------
 //
 // The daemon formats the version string with gettext, so an unidentified


### PR DESCRIPTION
Implements #431.

Collapse hits that are the **same file** (same ed2k hash **and** size) but advertised under **different filenames** into one expandable parent row, end to end, and let a chosen alternative name be downloaded.

**Phase 1 — expose grouping**
- **Core** (`ExternalConn.cpp`): the `EC_DETAIL_FULL` search responder now descends into `GetChildren()` and emits each child **only when the caller opts in** with an empty `EC_TAG_SEARCH_PARENT` flag on the request. amulecmd/amuleweb don't send it, so their flat parents-only list is unchanged; the INC_UPDATE (amulegui) path already emitted children. Children carry their parent's ECID via `EC_TAG_SEARCH_PARENT` (already stamped by `CEC_SearchFile_Tag`). This is the least-disruptive of the issue's two options — no other EC client sees a change.
- **webapi**: the refresher sends the flag; `ApplySearchFull` reads `EC_TAG_SEARCH_PARENT` and folds children into the parent's `children[]` (name/hash/ecid/sources), dropping them from the top-level set; `WriteSearchObject` + the `search_result_added` SSE emit `children[]` (always present, empty for a single-name hit). `results[]` stays parents-only.

**Phase 2 — download under a chosen name**
- Grouped children share the parent's hash, so hash alone can't disambiguate. `POST /search/results/{hash}/download` takes an optional `ecid` (a child's ECID from `children[].ecid`) that rides as an `EC_TAG_SEARCHFILE` selector; `CSearchList::AddFileToDownloadByEcid` resolves it across parents + children and downloads that specific result, so the partfile lands under the chosen filename. Omitted => the parent (unchanged). The download responder now reads the category **by name** (`EC_TAG_PARTFILE_CAT`) so the selector can ride alongside it.

**Out of scope:** the web-UI rendering of the tree (`static/js/views/search.js`) — a follow-up.

**Tests / docs**
- `RefresherTest.SearchResultGroupingFoldsChildren` — parent + 2 children collapse to one row with nested `children[]`; child ECIDs not top-level.
- curl `19-search.sh` — every result has `children[]`, each child has `ecid`/`name`/`hash`/`sources`; download `ecid` wrong-type => `400`.
- REST (`REFERENCE.md`) + SSE (`EVENTS.md`) docs: `children[]` shape + the download `ecid` selector.
- Verified live on a connected daemon (search "euphoria": **3 grouped parents / 6 children**; download `202`, `ecid`-type `400`).
