### PR TITLE
test(amuleapi): make shared-file rename smoke idempotent (curl 17)

### DIFF
--- a/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
+++ b/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
@@ -122,7 +122,8 @@ fi
 TEST_HASH=$(printf '%s' "$CURL_BODY" | jq -r '.shared[0].hash')
 SAVED_PRIORITY=$(printf '%s' "$CURL_BODY" | jq -r '.shared[0].priority')
 SAVED_AUTO=$(printf '%s' "$CURL_BODY" | jq -r '.shared[0].priority_auto')
-echo "    info: saved hash=$TEST_HASH priority=$SAVED_PRIORITY priority_auto=$SAVED_AUTO"
+SAVED_NAME=$(printf '%s' "$CURL_BODY" | jq -r '.shared[0].name')
+echo "    info: saved hash=$TEST_HASH priority=$SAVED_PRIORITY priority_auto=$SAVED_AUTO name=$SAVED_NAME"
 
 # --- 1. Auth + admin gate. -----------------------------------------
 _curl -X PATCH -H "Content-Type: application/json" \
@@ -210,10 +211,24 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 _assert_status 400 "PATCH rating out of range → 400"
 
 # --- 3d. PATCH name (rename; issue #420). -------------------------
+# Rename to a name guaranteed different from the current one (renaming a
+# file to its existing name is a no-op amuled rejects with non-200),
+# verify it lands, then restore the original. This suite runs against a
+# PERSISTENT daemon, so it must leave the real shared file exactly as it
+# found it — an earlier version renamed to a fixed name and never
+# restored, which both clobbered a real share and made the next run fail
+# on the no-op rename. `jq` builds the body so odd characters in the
+# real filename are escaped correctly.
+RENAME_TO="amuleapi-test-rename.dat"
+if [ "$SAVED_NAME" = "$RENAME_TO" ]; then
+	RENAME_TO="amuleapi-test-rename-b.dat"
+fi
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
-	-d '{"name":"renamed-by-test.dat"}' "$HOST/api/v0/shared/$TEST_HASH"
+	-d "$(jq -nc --arg n "$RENAME_TO" '{name: $n}')" "$HOST/api/v0/shared/$TEST_HASH"
 _assert_status 200 "PATCH name (rename) → 200"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/$TEST_HASH"
+_assert_json_eq '.name' "$RENAME_TO" 'IMMEDIATE GET /shared/{hash} shows the renamed file (no stale)'
 
 # Path separators rejected (directory-traversal guard).
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -226,6 +241,12 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"name":""}' "$HOST/api/v0/shared/$TEST_HASH"
 _assert_status 400 "PATCH empty name → 400"
+
+# Restore the original name so the real shared file is left untouched.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d "$(jq -nc --arg n "$SAVED_NAME" '{name: $n}')" "$HOST/api/v0/shared/$TEST_HASH"
+_assert_status 200 "PATCH name (restore original) → 200"
 
 # --- 4. Error paths. ----------------------------------------------
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \


### PR DESCRIPTION
`17-shared-priority-patch.sh` renamed the first shared file to a fixed `renamed-by-test.dat` and never restored the original name. Against the **persistent** daemon the suite targets, that (a) clobbered a real shared file and (b) made the *next* run fail — renaming a file to its existing name is a no-op amuled rejects with non-200, so the second run's `PATCH name (rename) -> 200` bounced.

Fix: capture the original name alongside the saved priority, rename to a name **guaranteed different** from it (verifying the change lands with an immediate GET), run the traversal/empty-name negative checks, then **restore the original name**. `jq` builds the request body so odd characters in a real filename are escaped. The shared file is now left exactly as it was found.

Verified live against a connected daemon: **42/42** (previously 41/42 — the rename assertion failed on a persistent daemon that a prior run had already renamed).
