### PR TITLE
fix(crypto): use unsigned char, not CryptoPP::byte, to build on Crypto++ 5.6.4

### DIFF
--- a/src/SHA.cpp
+++ b/src/SHA.cpp
@@ -43,7 +43,11 @@ void CSHA::GetHash(SHA1Digest *pHash) const
 
 void CSHA::Add(const void *pData, uint32 nLength)
 {
-	m_sha.Update((const CryptoPP::byte *)pData, nLength);
+	// Crypto++'s byte is always `unsigned char`; spell it that way rather
+	// than CryptoPP::byte, which only exists from Crypto++ 5.6.5+ (issue
+	// #449 — build failure on 5.6.4). unsigned char* binds to the byte*
+	// API parameter on every Crypto++ version.
+	m_sha.Update(static_cast<const unsigned char *>(pData), nLength);
 }
 
 void CSHA::Finish()

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -1951,8 +1951,9 @@ CSession *CScriptWebServer::CheckLoggedin(ThreadData &Data)
 		static CryptoPP::AutoSeededRandomPool s_sessionPool;
 		do {
 			uint64_t fresh = 0;
-			s_sessionPool.GenerateBlock(
-				reinterpret_cast<CryptoPP::byte *>(&fresh), sizeof(fresh));
+			// unsigned char* (== Crypto++'s byte) binds on every Crypto++
+			// version; CryptoPP::byte only exists from 5.6.5+ (issue #449).
+			s_sessionPool.GenerateBlock(reinterpret_cast<unsigned char *>(&fresh), sizeof(fresh));
 			Data.SessionID = fresh;
 			// Loop on 0 (which means "no session" elsewhere in this
 			// file) or on the astronomically unlikely collision with


### PR DESCRIPTION
`CryptoPP::byte` (the namespaced typedef) only exists from Crypto++ **5.6.5+**; on **5.6.4** (Ubuntu 20.04's `libcrypto++-dev`) it doesn't name a type, so the build fails (#449):

```
error: 'byte' in namespace 'CryptoPP' does not name a type
```

Crypto++'s `byte` is always `unsigned char`, and the API parameters (`HashTransformation::Update(const byte*)`, `RandomNumberGenerator::GenerateBlock(byte*)`) are therefore `unsigned char*`. Spelling the cast as `unsigned char*` binds on **every** Crypto++ version (5.6.4 → 8.x) with no version macros — and stays correct on Crypto++ 6.0+ under C++17, where the global `byte` is removed to avoid the `std::byte` clash (so the naive `byte*` workaround the reporter found would break *there* instead).

Two sites: `SHA.cpp` (core) and `webserver/WebServer.cpp`.

**Verification:** reproduced the break **and** the fix against Crypto++ 5.6.4 in an Ubuntu 20.04 container; still builds clean on modern Crypto++ (macOS); clang-format + clang-tidy (Tier-1 & Tier-2) clean.

Refs #449
