### PR TITLE
perf(remote-gui): batch remote log delivery + rendering

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -719,15 +719,23 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 }
 
 // Make a Logger tag (if there are any logging messages) and add it to the response
+// Max log lines packed into a single EC stats response. Kept bounded so a
+// large first-sync backlog (a remote GUI attaching to a daemon with a big
+// accumulated logfile — issue #445) drains in a handful of polls without any
+// one poll hauling multiple MB: the log rides on the same response as the
+// live stats, and the client renders each poll's batch in one go. The wire
+// format itself imposes no such limit (ec_taglen_t is uint32 and the tag
+// count is uint32-extensible) — this is purely a per-poll responsiveness cap.
+static const int EC_LOG_LINES_PER_MESSAGE = 5000;
+
 static void AddLoggerTag(CECPacket *response, CLoggerAccess &LoggerAccess)
 {
 	if (LoggerAccess.HasString()) {
 		CECEmptyTag tag(EC_TAG_STATS_LOGGER_MESSAGE);
-		// Tag structure is fix: tag carries nothing, inside are the strings
-		// maximum of 200 log lines per message
+		// Tag structure is fix: tag carries nothing, inside are the strings.
 		int entries = 0;
 		wxString line;
-		while (entries < 200 && LoggerAccess.GetString(line)) {
+		while (entries < EC_LOG_LINES_PER_MESSAGE && LoggerAccess.GetString(line)) {
 			tag.AddTag(CECTag(EC_TAG_STRING, line));
 			entries++;
 		}

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -1285,9 +1285,14 @@ void CStatistics::UpdateStats(const CECPacket *stats)
 
 	const CECTag *LoggerTag = stats->GetTagByName(EC_TAG_STATS_LOGGER_MESSAGE);
 	if (LoggerTag) {
-		for (CECTag::const_iterator it = LoggerTag->begin(); it != LoggerTag->end(); ++it) {
-			theApp->AddRemoteLogLine(it->GetStringData());
+		// Coalesce the whole poll's log lines into a single repaint + one
+		// scroll: a remote-GUI first-sync backlog can be thousands of lines
+		// and per-line rendering froze the GUI for minutes (issue #445).
+		theApp->BeginRemoteLogBatch();
+		for (const auto &tag : *LoggerTag) {
+			theApp->AddRemoteLogLine(tag.GetStringData());
 		}
+		theApp->EndRemoteLogBatch();
 	}
 }
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -684,6 +684,16 @@ void CamuleRemoteGuiApp::AddRemoteLogLine(const wxString &line)
 	amuledlg->AddLogLine(line);
 }
 
+void CamuleRemoteGuiApp::BeginRemoteLogBatch()
+{
+	amuledlg->BeginLogBatch();
+}
+
+void CamuleRemoteGuiApp::EndRemoteLogBatch()
+{
+	amuledlg->EndLogBatch();
+}
+
 int CamuleRemoteGuiApp::InitGui(bool geometry_enabled, wxString &geom_string)
 {
 	CamuleGuiBase::InitGui(geometry_enabled, geom_string);

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -827,6 +827,10 @@ public:
 
 	void AddServerMessageLine(wxString &msg);
 	void AddRemoteLogLine(const wxString &line);
+	// Bracket a stats poll's worth of AddRemoteLogLine() calls so the log
+	// view repaints/scrolls once for the batch, not per line (issue #445).
+	void BeginRemoteLogBatch();
+	void EndRemoteLogBatch();
 
 	void SetOSFiles(wxString) { /* onlinesig is created on remote side */ }
 

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -757,16 +757,28 @@ void CamuleDlg::AddLogLine(const wxString &line)
 	// Add the message to the log-view
 	wxTextCtrl *ct = CastByID(ID_LOGVIEW, m_serverwnd, wxTextCtrl);
 	if (ct) {
-		// Bold critical log-lines
-		// Works in Windows too thanks to wxTE_RICH2 style in muuli
-		wxTextAttr style = ct->GetDefaultStyle();
-		wxFont font = style.GetFont();
-		font.SetWeight(addtostatusbar ? wxFONTWEIGHT_BOLD : wxFONTWEIGHT_NORMAL);
-		style.SetFont(font);
-		style.SetFontSize(8);
-		ct->SetDefaultStyle(style);
+		// Bold critical log-lines (works on Windows too thanks to the
+		// wxTE_RICH2 style in muuli). SetDefaultStyle() is expensive on the
+		// RichEdit control, so only touch it when the weight actually
+		// changes rather than on every line -- a remote-GUI first-sync
+		// backlog is thousands of lines (issue #445).
+		int critical = addtostatusbar ? 1 : 0;
+		if (critical != m_logLastCritical) {
+			wxTextAttr style = ct->GetDefaultStyle();
+			wxFont font = style.GetFont();
+			font.SetWeight(addtostatusbar ? wxFONTWEIGHT_BOLD : wxFONTWEIGHT_NORMAL);
+			style.SetFont(font);
+			style.SetFontSize(8);
+			ct->SetDefaultStyle(style);
+			m_logLastCritical = critical;
+		}
 		ct->AppendText(bufferline);
-		ct->ShowPosition(ct->GetLastPosition() - 1);
+		// During a batch (BeginLogBatch/EndLogBatch) the caller scrolls once
+		// at the end; a per-line ShowPosition on a large backlog forces an
+		// O(n) RichEdit reflow on every line.
+		if (!m_logBatching) {
+			ct->ShowPosition(ct->GetLastPosition() - 1);
+		}
 	}
 
 	// Set the status-bar if the event warrents it
@@ -778,6 +790,28 @@ void CamuleDlg::AddLogLine(const wxString &line)
 		text->SetLabel(bufferline.BeforeFirst('\n'));
 		text->SetToolTip(bufferline);
 		text->GetParent()->Layout();
+	}
+}
+
+void CamuleDlg::BeginLogBatch()
+{
+	// Coalesce a burst of log lines (a stats poll delivers up to
+	// EC_LOG_LINES_PER_MESSAGE at once on a first-sync backlog) into a
+	// single repaint plus one final scroll instead of per-line reflow.
+	m_logBatching = true;
+	wxTextCtrl *ct = CastByID(ID_LOGVIEW, m_serverwnd, wxTextCtrl);
+	if (ct) {
+		ct->Freeze();
+	}
+}
+
+void CamuleDlg::EndLogBatch()
+{
+	m_logBatching = false;
+	wxTextCtrl *ct = CastByID(ID_LOGVIEW, m_serverwnd, wxTextCtrl);
+	if (ct) {
+		ct->ShowPosition(ct->GetLastPosition() - 1);
+		ct->Thaw();
 	}
 }
 

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -139,6 +139,12 @@ public:
 	void AddServerMessageLine(wxString &message);
 	void ResetLog(int id);
 
+	// Bracket a burst of AddLogLine() calls so the log view is repainted
+	// and scrolled once for the whole batch instead of per line (issue
+	// #445 — a remote-GUI first-sync backlog is thousands of lines).
+	void BeginLogBatch();
+	void EndLogBatch();
+
 	void ShowUserCount(const wxString &info = "");
 	void ShowConnectionState(bool skinChanged = false);
 	void ShowTransferRate();
@@ -254,6 +260,13 @@ private:
 	DialogType m_nActiveDialog;
 	bool m_is_safe_state;
 	bool m_BlinkMessages;
+	//! True while a BeginLogBatch()/EndLogBatch() bracket is open, so
+	//! AddLogLine() defers the per-line scroll to the end of the batch.
+	bool m_logBatching = false;
+	//! Last log-line weight applied to the view's default style (1 = bold,
+	//! 0 = normal, -1 = not yet set) so SetDefaultStyle() is only touched
+	//! when the weight actually changes.
+	int m_logLastCritical = -1;
 	int m_CurrentBlinkBitmap;
 	uint32 m_last_iconizing;
 	// The "new version available" popup is shown at most once per session;


### PR DESCRIPTION
On a remote GUI first sync the daemon replays the whole logfile, and the GUI rendered it one line at a time: `CamuleDlg::AddLogLine` rebuilt the `wxTE_RICH2` default style and scrolled to the end on **every** line with no `Freeze`/`Thaw`, and the daemon throttled to **200** log lines per stats poll. For a large backlog (#445 — ~10k queue) the "aMule Log" tab took ~5 minutes to catch up with the GUI frozen throughout. (The server-info log already had a diff optimization; the app log never got one.)

Keeps the full-log-on-connect behaviour, just fast:

- **Daemon:** per-poll cap `200 → 5000` (`EC_LOG_LINES_PER_MESSAGE`), so a large backlog drains in a few polls instead of ~50. The wire format imposes no limit (`ec_taglen_t` is `uint32`, tag count is `uint32`-extensible) — the cap is purely per-poll responsiveness, since the log shares the response with live stats.
- **GUI:** batch each poll's lines into one repaint + one scroll via `CamuleDlg::BeginLogBatch()`/`EndLogBatch()` (`Freeze`/`Thaw`), and call the costly `SetDefaultStyle()` only when the bold state actually changes, not per line.

**Verification:** amuled + amulegui build clean; clang-format + clang-tidy (Tier-1 & Tier-2) clean. End-to-end speed-up to be confirmed by the reporter on his 10k queue.

Refs #445
