### PR TITLE
fix(cmake): detect libatomic with a link probe instead of find_library (#453)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,15 +297,21 @@ endif()
 # require libatomic unconditionally on 32-bit builds.
 set (LIBATOMIC "")
 if (CMAKE_SIZEOF_VOID_P EQUAL 4)
-	# Accept either the unversioned `libatomic.so` (Debian / Fedora /
-	# Arch ship it via the -dev / -devel package) or the versioned-only
-	# `libatomic.so.1` (openSUSE ships only the latter -- there's no
-	# separate -devel package). Listing the unversioned name first keeps
-	# the canonical path preferred when both are present.
-	find_library (LIBATOMIC_LIBRARY NAMES atomic libatomic.so.1)
-	if (LIBATOMIC_LIBRARY)
+	# Probe with a compiler-driven LINK test, not find_library. With GCC,
+	# libatomic ships inside the compiler's own runtime dir (e.g.
+	# .../lib/gcc14/) which is not on find_library's filesystem search
+	# path, so find_library false-fails even though `-latomic` links fine
+	# -- the GCC driver resolves its internal libatomic (MacPorts, #453).
+	# check_library_exists links a probe with `-latomic` through the
+	# compiler driver, so it succeeds wherever the flag actually links:
+	# GCC's internal copy, or a system libatomic (Clang / distro -dev
+	# packages, versioned or not). This replaces the earlier find_library
+	# lookup that only searched standard library paths.
+	include (CheckLibraryExists)
+	check_library_exists (atomic __atomic_load_8 "" HAVE_LIBATOMIC)
+	if (HAVE_LIBATOMIC)
 		set (LIBATOMIC atomic)
-		message (STATUS "32-bit target: linking libatomic for std::atomic<int64_t> (${LIBATOMIC_LIBRARY})")
+		message (STATUS "32-bit target: linking libatomic for std::atomic<int64_t>")
 	else()
 		message (FATAL_ERROR
 			"32-bit target detected (sizeof(void*) == 4). aMule's "


### PR DESCRIPTION
On 32-bit targets the download-bandwidth throttler holds its byte budget as `std::atomic<int64_t>`, whose ops expand to `__atomic_*_8` library calls that live in **libatomic**. The availability check used `find_library(atomic)`, which only searches standard filesystem paths. With **GCC**, libatomic ships inside the compiler's own runtime dir (e.g. `.../lib/gcc14/`), which isn't on that path — so `find_library` false-fails and configure aborts with the "libatomic was not found" `FATAL_ERROR`, even though `-latomic` links fine because the GCC driver resolves its internal copy. Reported on MacPorts in #453.

This replaces `find_library` with `check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMIC)`, which links a probe with `-latomic` **through the compiler driver**. It succeeds wherever the flag actually links — GCC's internal libatomic, or a system libatomic (Clang / distro `-dev` packages, versioned or not) — and only errors when the flag genuinely can't link. The 32-bit "require libatomic" decision and the `FATAL_ERROR` guidance are unchanged; only the availability probe changes.

## Test plan

- [x] `check_library_exists` probe executes cleanly (verified standalone)
- [x] 64-bit configure unaffected — the block is `CMAKE_SIZEOF_VOID_P EQUAL 4`-gated
- [ ] @barracuda156 confirms configure now succeeds on the 32-bit GCC / MacPorts target (the reporting toolchain)

Closes #453.
