### PR TITLE
fix(shared-dir-watcher): don't Remove() a watch the OS already dropped (#458)

### DIFF
--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -467,8 +467,20 @@ bool CSharedDirWatcher::HandleDirRemoved(const wxString &path)
 
 #ifndef __WXOSX__
 	// Remove its per-subdir watch (macOS covers the whole tree via FSEvents).
+	// Only if wx still tracks it: when a directory vanishes the OS drops the
+	// inotify watch on its own (a cross-filesystem move is a delete, firing
+	// IN_IGNORED), so the path is no longer in the watcher's map. Calling
+	// Remove() on an untracked path trips wx's `it != m_watches.end()`
+	// assertion and aborts amuled (issue #458). A same-filesystem rename keeps
+	// the inode watch under the old key, so the guarded Remove() still cleans
+	// that up. GetWatchedPaths() reports the exact key Remove() looks up.
 	if (removed && m_watcher) {
-		m_watcher->Remove(wxFileName::DirName(path));
+		const wxFileName dir = wxFileName::DirName(path);
+		wxArrayString watched;
+		m_watcher->GetWatchedPaths(&watched);
+		if (watched.Index(dir.GetFullPath()) != wxNOT_FOUND) {
+			m_watcher->Remove(dir);
+		}
 	}
 #endif
 


### PR DESCRIPTION
`CSharedDirWatcher::HandleDirRemoved` unconditionally called `wxFileSystemWatcher::Remove()` on a directory that had just vanished. When a watched directory is deleted — or **moved to another filesystem**, which is a delete plus inotify `IN_IGNORED` — the OS drops the watch and wx removes it from its map. `Remove()` then trips wx's `it != m_watches.end()` assertion and **aborts amuled** (reported in #458: moving a staging dir to final storage → `Aborted (core dumped)`).

This guards the call with `GetWatchedPaths()`: `Remove()` runs only when wx still tracks the path. A same-filesystem rename keeps the inode watch under the old key, so the guarded `Remove()` still cleans that up; a cross-fs move / delete (where wx already dropped it) is now a no-op instead of an abort. `GetWatchedPaths()` reports the exact key `Remove()` looks up, so the check is precise.

### Version scope

The `Remove()` call was added by #289 (`846a7496e`, 2026-07-04), which is **after** the 3.0.1 tag (2026-06-24). So this crash exists only in **git/snapshot builds since then** — not in 3.0.0, 3.0.1, or the betas. (The fs-watcher feature itself shipped in 3.0.0, but without this call.)

### Test plan

- [x] clang-format (v18) clean
- [x] Linux `amuled` builds (the fix is inside `#ifndef __WXOSX__`; the local macOS build compiles it out — verified building on Ubuntu/amule-dev-vm)
- [x] Manual repro on Linux (amule-dev-vm, aarch64): a watched shared subdir listed in `shareddir.dat`, then removed. **Unfixed** build fires the exact reported assertion — `fswatchercmn.cpp:Remove:157 'it != m_watches.end()' … Path '…/share/topic/' is not watched`, via `HandleDirRemoved → wxFileSystemWatcherBase::Remove` (same frames as the report). **Fixed** build: no assertion, the removal is handled cleanly. (This VM's wx logs the assert rather than abort+coredump like the reporter's Debian build, but the assertion — the defect — is reproduced and eliminated.)

Closes #458.
