### PR TITLE
fix(upnp): raise libupnp content-length limit for large router SCPD

### DIFF
--- a/src/UPnPBase.cpp
+++ b/src/UPnPBase.cpp
@@ -777,6 +777,25 @@ CUPnPControlPoint::CUPnPControlPoint(unsigned short udpPort)
 	msg << "bound to " << ipAddress << ":" << port << ".";
 	AddDebugLogLineN(logUPnP, msg);
 	msg.str("");
+
+	// Raise the SDK's incoming content-length ceiling above libupnp's
+	// 16 KB default (DEFAULT_SOAP_CONTENT_LENGTH). Some gateways serve an
+	// SCPD/description XML slightly larger than that, which makes the
+	// blocking UpnpDownloadXmlDoc in Subscribe() fail with
+	// UPNP_E_OUTOF_BOUNDS ("Error getting SCPD Document") — the service
+	// never registers, so no port mapping happens and the user is stuck on
+	// a LowID (observed on ZTE and Sagemcom routers). 1 MB clears any real
+	// router descriptor while still bounding what a hostile LAN device can
+	// push into a blocking fetch. Must run after UpnpInit2 succeeds: the
+	// call is a no-op (UPNP_E_FINISH) until the SDK is initialised.
+	ret = UpnpSetMaxContentLength(1024 * 1024);
+	if (ret != UPNP_E_SUCCESS) {
+		msg << "warning(UpnpSetMaxContentLength): could not raise content-length limit, error code "
+		    << ret << "; keeping libupnp default.";
+		AddDebugLogLineN(logUPnP, msg);
+		msg.str("");
+	}
+
 	ret = UpnpRegisterClient(static_cast<Upnp_FunPtr>(&CUPnPControlPoint::Callback),
 		&m_UPnPClientHandle,
 		&m_UPnPClientHandle);


### PR DESCRIPTION
## Problem

Some routers fail UPnP port mapping in aMule, leaving the user on a LowID. The debug log shows `Error getting SCPD Document from http://<gw>/…SCPD.xml`. Reported on ZTE and Sagemcom gateways in amule-project/amule#349.

Root cause (diagnosed by @darkcamper): libupnp only processes incoming SOAP/description bodies up to `DEFAULT_SOAP_CONTENT_LENGTH` = 16 KB by default. When a gateway's SCPD XML is a little larger, the blocking `UpnpDownloadXmlDoc` call in `CUPnPControlPoint::Subscribe` returns `UPNP_E_OUTOF_BOUNDS`, the service is never registered, and no port mapping happens.

## Fix

Call `UpnpSetMaxContentLength(1024 * 1024)` once, right after `UpnpInit2` succeeds. The limit is a global SDK setting; the call is a documented no-op (`UPNP_E_FINISH`) until the SDK is initialised, so placement matters.

1 MB comfortably clears any realistic router descriptor (they are tens of KB at worst) while still bounding what a device on the LAN can feed into a blocking fetch — so we don't pass `0` (unlimited). A failed raise is treated as non-fatal: we log a warning and keep libupnp's default.

## Verification

- `UpnpSetMaxContentLength` stores the argument verbatim with no cap or validation (checked pupnp 1.6.x–1.14.x); the only failure mode is being called before `UpnpInit2`, which the placement avoids.
- Builds clean (`amuled`, macOS), no new warnings; clang-format and Tier-2 clang-tidy clean on the diff.
