### PR TITLE
fix(remote-gui): don't blank the log view on each new line (Windows) (#445)

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -771,8 +771,13 @@ void CamuleDlg::EndLogBatch()
 	m_logBatching = false;
 	wxTextCtrl *ct = CastByID(ID_LOGVIEW, m_serverwnd, wxTextCtrl);
 	if (ct) {
-		ct->ShowPosition(ct->GetLastPosition() - 1);
+		// Thaw first, THEN scroll: on Windows, ShowPosition() on a still-frozen
+		// wxTE_RICH2 control doesn't lay out the visible region, so after Thaw
+		// the log view comes back blank (only the last line pinned at the top)
+		// until a manual scroll forces a repaint (issue #445). Scrolling the
+		// live control avoids that; macOS/GTK are unaffected either way.
 		ct->Thaw();
+		ct->ShowPosition(ct->GetLastPosition() - 1);
 	}
 }
 


### PR DESCRIPTION
Follow-up to #451. On Windows the "aMule Log" view goes blank on every new line, and only redraws after a manual scroll up (reported in #445).

The per-poll log batching in #451 scrolls the log text ctrl in `EndLogBatch()` **while it is still frozen**, then thaws. On Windows, `ShowPosition()` on a frozen `wxTE_RICH2` control doesn't lay out the visible region, so after `Thaw()` the view comes back blank — only the last line pinned at the top — until a manual scroll forces a repaint. Since every stats poll carrying new daemon log lines runs through this path, the log window blanks on each new line.

Fix: `Thaw()` first, then `ShowPosition()`, so the scroll runs on a live control. The batching win is preserved (`Freeze()` still spans the appends), and macOS/GTK — which tolerate scroll-while-frozen — are unaffected either way.

Client-side only, GUI rendering — no daemon or EC protocol change.
