### PR TITLE
fix(upnp): classify IGD devices/services regardless of UPnP version

### DIFF
--- a/src/UPnPBase.cpp
+++ b/src/UPnPBase.cpp
@@ -182,6 +182,26 @@ static bool IsWANRelatedDeviceType(const std::string &type)
 	return false;
 }
 
+// Case-insensitive match of a device/service type URN against a
+// fully-versioned reference URN, ignoring the trailing ":<version>"
+// component. IGD:2 gateways advertise their embedded devices and services
+// with a ":2" suffix (e.g. "urn:schemas-upnp-org:service:WANIPConnection:2"),
+// so classifying by an exact ":1" string would skip them even though
+// libupnp's version-tolerant M-SEARCH still reaches the device. We keep the
+// fully-versioned constants — they double as the M-SEARCH target, which must
+// carry a version — and strip the tail only for classification, prefix-
+// matching on the reference through its final ':'. The trailing ':' is
+// retained in the prefix so "WANIPConnection:" cannot match, e.g.,
+// "WANIPConnectionFoo:1".
+static bool TypeMatchesIgnoringVersion(const std::string &type, const std::string &reference)
+{
+	std::string::size_type lastColon = reference.find_last_of(':');
+	if (lastColon == std::string::npos) {
+		return stdStringIsEqualCI(type, reference);
+	}
+	return stdStringStartsWithCI(type, reference.substr(0, lastColon + 1));
+}
+
 static std::string ProcessErrorMessage(
 	const std::string &message, int errorCode, const DOMString errorString, IXML_Document *doc)
 {
@@ -491,8 +511,8 @@ CUPnPService::CUPnPService(
 	    << "\n        absEventSubURL: " << m_absEventSubURL;
 	AddDebugLogLineN(logUPnP, msg);
 
-	if (m_serviceType == UPnP::Service::WAN_IP_Connection ||
-		m_serviceType == UPnP::Service::WAN_PPP_Connection) {
+	if (UPnP::TypeMatchesIgnoringVersion(m_serviceType, UPnP::Service::WAN_IP_Connection) ||
+		UPnP::TypeMatchesIgnoringVersion(m_serviceType, UPnP::Service::WAN_PPP_Connection)) {
 #if 0
 	    m_serviceType == UPnP::Service::WAN_PPP_Connection ||
 	    m_serviceType == UPnP::Service::WAN_Common_Interface_Config ||
@@ -1171,7 +1191,8 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 			// Extract the deviceType
 			std::string devType(IXML::Element::GetChildValueByTag(rootDevice, "deviceType"));
 			// Only add device if it is an InternetGatewayDevice
-			if (stdStringIsEqualCI(devType, UPnP::Device::IGW)) {
+			// (any version — IGD:2 advertises its root as ":2").
+			if (UPnP::TypeMatchesIgnoringVersion(devType, UPnP::Device::IGW)) {
 				// This condition can be used to auto-detect
 				// the UPnP device we are interested in.
 				// Obs.: Don't block the entry here on this
@@ -1245,7 +1266,7 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 			std::transform(devType.begin(), devType.end(), devType.begin(), tolower);
 		}
 
-		if (stdStringIsEqualCI(devType, UPnP::Device::IGW)) {
+		if (UPnP::TypeMatchesIgnoringVersion(devType, UPnP::Device::IGW)) {
 #if UPNP_VERSION >= 10800
 			const char *deviceID = UpnpDiscovery_get_DeviceID_cstr(dab_event);
 			upnpCP->RemoveRootDevice(deviceID);


### PR DESCRIPTION
## Problem

aMule's UPnP gateway detection and WAN-service classification compare type URNs against hardcoded `:1` strings:

- root device: `stdStringIsEqualCI(devType, UPnP::Device::IGW)` where `IGW = "...InternetGatewayDevice:1"`
- WAN service: `m_serviceType == UPnP::Service::WAN_IP_Connection` (`"...WANIPConnection:1"`)

An **IGD:2** gateway advertises its root device as `InternetGatewayDevice:2` and its connection service as `WANIPConnection:2`. Those exact `== :1` comparisons never match, so the root device is never registered and the WAN service is never subscribed — no port mapping, LowID — even though libupnp's version-tolerant M-SEARCH reaches the device fine.

Prompted by @Stoatwblr's observation in #47 that the module only looks for v1 URNs.

## Fix

Add `TypeMatchesIgnoringVersion()` — a case-insensitive match that strips the trailing `:<version>` from the reference URN and prefix-matches through its final `:` — and use it at the three classification sites (root-device detect, byebye removal, WAN-service detect).

The fully-versioned constants are deliberately **kept**: `UPnP::Device::IGW` also doubles as the `UpnpSearchAsync` M-SEARCH target, which must carry a version and — per the UPnP Device Architecture backward-compat rule (a device responds to searches for its type at all versions ≤ its own) — already reaches v2 gateways. Only the post-`description.xml` classification is made version-agnostic, mirroring the existing version-agnostic `IsWANRelatedDeviceType()` download pre-filter.

## Scope / caveats

- This is a **general robustness fix for IGD:2-only gateways**. Many real "v2" routers dual-advertise a parallel v1 tree, which is why aMule already works with most of them; this helps the strict-v2-only case.
