### PR TITLE
build(cmake): fail loudly when the readline library is found but its headers are missing

### DIFF
--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -143,4 +143,22 @@ if (HAVE_STDIO_H)
 	endif()
 endif()
 
+# A usable readline needs BOTH the library and a header. The function check
+# above can be satisfied by a bare runtime library with no -dev headers
+# installed, or by libedit's readline() compatibility symbol (whose header is
+# <editline/readline.h>, not the <readline.h> / <readline/readline.h> the code
+# includes). In that case config.h would carry HAVE_LIBREADLINE without a
+# header macro, and ExternalConnector.cpp -- which gates its rl_* code on
+# HAVE_LIBREADLINE alone -- would use the readline symbols undeclared and fail
+# deep in the build with a confusing "rl_* undeclared" error. Fail early and
+# loudly instead, pointing at the missing development headers.
+if (HAVE_LIBREADLINE AND NOT HAVE_READLINE_H AND NOT HAVE_READLINE_READLINE_H)
+	message (FATAL_ERROR
+		"The readline library was found but its development headers were not "
+		"(neither <readline/readline.h> nor <readline.h>). Install the readline "
+		"development package and re-run cmake -- e.g. Alpine: 'apk add "
+		"readline-dev'; Debian/Ubuntu: 'apt install libreadline-dev'; Fedora: "
+		"'dnf install readline-devel'; macOS (Homebrew): 'brew install readline'.")
+endif()
+
 find_package_handle_standard_args (readline DEFAULT_MSG READLINE_LIBRARIES)


### PR DESCRIPTION
## Summary

Fixes the confusing Alpine build failure reported in #481:

```
error: 'rl_compentry_func_t' does not name a type
error: 'readline' was not declared in this scope
error: 'rl_line_buffer' was not declared in this scope
...
```

## Root cause

`cmake/FindReadline.cmake` sets `HAVE_LIBREADLINE` from a `check_function_exists(readline)` that links `readline` / `edit` / `editline`. That succeeds not only with GNU readline but also with **libedit** (which exports a `readline()` compatibility symbol), or with a bare `libreadline.so` runtime and no `-dev` headers installed. The header probes, however, look only for `<readline.h>` / `<readline/readline.h>`.

So on a box with the library but not the matching development headers — Alpine with `libedit-dev` but no `readline-dev` is the common trigger — `config.h` ends up with `HAVE_LIBREADLINE` but **no** header macro. `src/ExternalConnector.cpp` gates its `rl_*` block on `HAVE_LIBREADLINE` alone while including the header under `HAVE_READLINE_READLINE_H` / `HAVE_READLINE_H`, so the `rl_*` symbols are used undeclared and the build dies deep in compilation.

## Fix

Require a usable header, not just the library. When the library is found but neither header is, stop at **configure time** with a message naming the missing package, instead of a confusing mid-build error:

```
The readline library was found but its development headers were not
(neither <readline/readline.h> nor <readline.h>). Install the readline
development package and re-run cmake -- e.g. Alpine: 'apk add readline-dev';
Debian/Ubuntu: 'apt install libreadline-dev'; Fedora: 'dnf install readline-devel';
macOS (Homebrew): 'brew install readline'.
```

## Validation

- **Alpine repro** (`libedit-dev`, no `readline-dev`): configure now stops with the message above; after `apk add readline-dev` → `HAVE_LIBREADLINE=1`, header found, `Configuring done`.
- **macOS** (readline header present): unaffected — no fatal, `amulecmd` builds.

Refs #481
