### PR TITLE
fix(amuleapi): serialize EC roundtrips on a dedicated worker with a bounded queue

### DIFF
--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -423,6 +423,12 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 		return dispatcher->PreflightEvents(req);
 	};
 
+	// Start the EC worker before the HTTP server accepts and before the
+	// refresher loop below — both are producers into it. The EC connection
+	// is already up (ConnectAndRun logged in before calling TextShell), so
+	// from here the worker thread is the sole user of the socket.
+	m_ec_service.Start([this](const CECPacket *r) { return SendRecvMsg_v2(r); });
+
 	m_http = std::unique_ptr<CHttpServer>(new CHttpServer());
 	if (!m_http->Start(bind, port, handler, streaming_resolver, streaming_handler, streaming_preflight)) {
 		Show(CFormat("amuleapi: HTTP server failed to start: %s\n") %
@@ -537,8 +543,12 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 
 const CECPacket *CamuleapiApp::SendRecvSerialized(const CECPacket *request)
 {
-	std::lock_guard<std::mutex> lock(m_ec_mtx);
-	return SendRecvMsg_v2(request);
+	// Route every roundtrip through the EC worker (sole socket owner,
+	// bounded FIFO queue). Block for the reply; the worker fulfils the
+	// future, or returns nullptr on backpressure (queue full while a
+	// roundtrip is stalled) or EC failure — both of which every caller
+	// already maps to 503. The wait is bounded by the EC read timeout.
+	return m_ec_service.Submit(request).get();
 }
 
 bool CamuleapiApp::IsServerPartialUpdateActive()
@@ -573,6 +583,12 @@ int CamuleapiApp::OnExit()
 		m_http->Stop();
 		m_http.reset();
 	}
+	// HTTP is fully stopped, so no handler can submit anymore. Stop the EC
+	// worker (joins — bounded by the read timeout if a roundtrip is in
+	// flight) before the base tears down m_ECClient, which the worker uses.
+	// Any refresher-loop submit already returned: TextShell's loop exited
+	// before OnExit runs.
+	m_ec_service.Stop();
 	m_dispatcher.reset();
 	m_jwt.reset();
 	return CaMuleExternalConnector::OnExit();

--- a/src/webapi/App.h
+++ b/src/webapi/App.h
@@ -30,6 +30,7 @@
 #include "ExternalConnector.h"
 
 #include "AmuleApiConfig.h"
+#include "EcService.h"
 #include "EventBus.h"
 #include "EventDiff.h"
 #include "State.h"
@@ -154,6 +155,11 @@ private:
 
 	CAmuleApiConfig m_apiConfig;
 	webapi::CState m_state;
+	// All EC roundtrips run on this service's single worker thread (bounded
+	// FIFO queue). Sole owner of the EC socket after login, so it also
+	// serialises m_ECClient — the reason m_ec_mtx below is now only needed
+	// for the immutable-after-login version accessor.
+	webapi::CEcService m_ec_service;
 	std::mutex m_ec_mtx; // serializes m_ECClient
 	std::unique_ptr<CJwt> m_jwt;
 	std::unique_ptr<CApiDispatcher> m_dispatcher;

--- a/src/webapi/EcService.h
+++ b/src/webapi/EcService.h
@@ -1,0 +1,175 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+//
+
+#ifndef WEBAPI_ECSERVICE_H
+#define WEBAPI_ECSERVICE_H
+
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <future>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+class CECPacket;
+
+namespace webapi
+{
+
+// Serialises all EC roundtrips onto a single dedicated worker thread with a
+// bounded FIFO queue.
+//
+// Why: amuleapi's one EC connection is a strictly serial request/reply
+// protocol, and the HTTP request handlers now run on a worker pool (many
+// threads). Letting each pool thread do its own blocking roundtrip meant a
+// stalled amuled could park an unbounded number of pool threads on the EC
+// mutex until the read timeout fired — starving non-EC requests. It also
+// left the single socket reachable from several threads, which is how a
+// framing desync becomes possible.
+//
+// This service fixes both: exactly one thread ever touches the socket
+// (no desync), and the queue is bounded (backpressure). When the queue is
+// full — i.e. a roundtrip is stalled and callers are piling up behind it —
+// further submissions return `nullptr` immediately, which every caller
+// already treats as `503 ec_unavailable`. So a stalled EC lane sheds load
+// instead of exhausting the handler pool.
+//
+// Lifetime contract: `Submit` borrows the request pointer; callers block on
+// the returned future until completion (the per-roundtrip duration is bounded
+// by the EC read timeout), so the caller's stack-owned request outlives the
+// worker's use of it. The result pointer follows the pre-existing
+// SendRecvSerialized contract — the caller owns and deletes it.
+class CEcService
+{
+public:
+	// Runs one EC roundtrip (send request, block for reply); returns the
+	// reply packet (caller-owned) or nullptr on EC failure. Bound to
+	// CaMuleExternalConnector::SendRecvMsg_v2.
+	using Roundtrip = std::function<const CECPacket *(const CECPacket *)>;
+
+	explicit CEcService(std::size_t max_depth = 8)
+	: m_max_depth(max_depth)
+	{
+	}
+
+	~CEcService() { Stop(); }
+
+	CEcService(const CEcService &) = delete;
+	CEcService &operator=(const CEcService &) = delete;
+
+	// Start the worker. Call once, after the EC connection is established
+	// and before any producer (refresher loop / HTTP handlers) can submit.
+	void Start(Roundtrip roundtrip)
+	{
+		m_roundtrip = std::move(roundtrip);
+		m_worker = std::thread([this] { WorkerLoop(); });
+	}
+
+	// Enqueue a roundtrip and return a future for its reply. Returns a
+	// ready future holding nullptr if the queue is full (backpressure) or
+	// the service is stopping — callers map nullptr to 503.
+	std::future<const CECPacket *> Submit(const CECPacket *request)
+	{
+		std::promise<const CECPacket *> prom;
+		std::future<const CECPacket *> fut = prom.get_future();
+		{
+			std::lock_guard<std::mutex> lk(m_mu);
+			if (m_stop || m_queue.size() >= m_max_depth) {
+				prom.set_value(nullptr);
+				return fut;
+			}
+			m_queue.push_back(Job{ request, std::move(prom) });
+		}
+		m_cv.notify_one();
+		return fut;
+	}
+
+	// Stop the worker. Idempotent. Fulfils any queued (not-yet-started)
+	// jobs with nullptr so their callers unblock, then joins — bounded by
+	// the EC read timeout if a roundtrip is in flight.
+	void Stop()
+	{
+		{
+			std::lock_guard<std::mutex> lk(m_mu);
+			if (m_stop) {
+				return;
+			}
+			m_stop = true;
+			while (!m_queue.empty()) {
+				m_queue.front().prom.set_value(nullptr);
+				m_queue.pop_front();
+			}
+		}
+		m_cv.notify_all();
+		if (m_worker.joinable()) {
+			m_worker.join();
+		}
+	}
+
+private:
+	struct Job
+	{
+		const CECPacket *request;
+		std::promise<const CECPacket *> prom;
+	};
+
+	void WorkerLoop()
+	{
+		for (;;) {
+			Job job;
+			{
+				std::unique_lock<std::mutex> lk(m_mu);
+				m_cv.wait(lk, [this] { return m_stop || !m_queue.empty(); });
+				// Stop drains the queue under the lock, so a wake with an
+				// empty queue means we're shutting down.
+				if (m_queue.empty()) {
+					return;
+				}
+				job = std::move(m_queue.front());
+				m_queue.pop_front();
+			}
+			const CECPacket *resp = nullptr;
+			try {
+				resp = m_roundtrip(job.request);
+			} catch (...) {
+				resp = nullptr;
+			}
+			job.prom.set_value(resp);
+		}
+	}
+
+	Roundtrip m_roundtrip;
+	std::deque<Job> m_queue;
+	std::mutex m_mu;
+	std::condition_variable m_cv;
+	std::thread m_worker;
+	bool m_stop = false;
+	const std::size_t m_max_depth;
+};
+
+} // namespace webapi
+
+#endif // WEBAPI_ECSERVICE_H


### PR DESCRIPTION
## Problem

After moving request handlers onto a worker pool (#489), up to 16 pool threads can each attempt a blocking EC roundtrip. They are already serialized correctly — `m_ec_mtx` guards every `m_ECClient` access, so only one thread is ever in the socket and there is no concurrency desync. The remaining gap is **load, not correctness**: while one roundtrip is stalled (bounded to #486's timeout), every other EC caller parks on `m_ec_mtx`, so a single stuck EC lane can tie up the whole handler pool and starve non-EC requests for the duration of the stall.

## Fix

Introduce `CEcService`: one dedicated worker thread drains a **bounded FIFO queue** of roundtrips. `SendRecvSerialized` now submits to it and blocks on the returned future.

- **Backpressure (the point of this PR)** — the queue is bounded (depth 8). When it is full (a roundtrip is stalled and callers are piling up behind it), further submissions return `nullptr` immediately, which every caller already maps to `503 ec_unavailable`. A stalled EC lane sheds load instead of exhausting the handler pool, so non-EC requests keep flowing.
- **Single-owner socket** — as a structural consequence, exactly one thread touches the EC socket. This is a cleaner invariant than a mutex around many threads, but it is not new safety: `m_ec_mtx` already prevented concurrent access, and the stall/reuse hazard is handled by #486 (timeout → drop the connection). This PR does not add desync protection on top of those.

The worker starts in `TextShell` (after login, before the HTTP server accepts and before the refresher loop) and stops in `OnExit` after the HTTP server is fully drained, before the base tears down `m_ECClient`.

## Validation

Combined with #486 + #489 (they touch disjoint files), on the relay-freeze rig:
- **Backpressure** — 16 concurrent EC requests during a freeze → **7 returned instant `503`** (~0.4 ms, rejected beyond the cap), 9 blocked (1 in-worker + 8-deep queue). Cap respected exactly.
- **Isolation** — `GET /` stayed **200 @ ~7 ms** throughout the stall.
- **Normal operation** — every endpoint (status, downloads, servers, stats/tree, preferences, search) works through the worker.
- **Clean shutdown** — SIGTERM → exits in 2 s (worker `Stop`/join).
- Builds clean (macOS); clang-format + Tier-2 clang-tidy clean.

## Scope

Third of three composing PRs for the amuleapi single-client-wedge class:
- **#486** bounds how long any one roundtrip can stall (so the queue drains and the shutdown join stay bounded).
- **#489** runs handlers off the io_context thread (the concurrent submitters this backpressure protects against).
- **this** bounds the EC lane so a stall can never exhaust the handler pool.
