### PR TITLE
fix(amule): mark CamuleApp overrides + guard against inconsistent-missing-override (#488)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,19 @@ add_compile_options (
 	-Werror=deprecated-copy
 )
 
+# Clang-only: promote -Winconsistent-missing-override to an error so a class
+# that marks some of its virtual overrides `override` but not others fails the
+# build at the PR that introduces the mismatch -- instead of emitting hundreds
+# of warnings across every TU that includes the header (a single header,
+# amule.h, produced 800+; issue #488). GCC has no equivalent for the
+# "some marked, some not" case (only the whole-tree -Wsuggest-override), so this
+# is gated to Clang/AppleClang; the Clang-based CI jobs (macOS, mingw-w64) catch
+# any regression. The warning is on by default under Clang, so only the
+# promotion to error is needed here.
+add_compile_options (
+	$<$<CXX_COMPILER_ID:Clang,AppleClang>:-Werror=inconsistent-missing-override>
+)
+
 # Embed every PNG under src/icons/ as a static byte-array table in a
 # generated C TU (see src/icons/embed_icons.py for the format).
 # CamuleArtProvider then exposes the entries to wxArtProvider at

--- a/src/amule.h
+++ b/src/amule.h
@@ -242,10 +242,10 @@ public:
 	CamuleApp();
 	virtual ~CamuleApp();
 
-	virtual bool OnInit();
-	int OnExit();
+	bool OnInit() override;
+	int OnExit() override;
 #if wxUSE_ON_FATAL_EXCEPTION
-	void OnFatalException();
+	void OnFatalException() override;
 #endif
 	bool ReinitializeNetwork(wxString *msg);
 
@@ -391,8 +391,11 @@ protected:
 	 * release builds and otherwise routes here through wxApp's
 	 * default dialog.
 	 */
-	virtual void OnAssertFailure(
-		const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg);
+	void OnAssertFailure(const wxChar *file,
+		int line,
+		const wxChar *func,
+		const wxChar *cond,
+		const wxChar *msg) override;
 
 	void OnUDPDnsDone(CMuleInternalEvent &evt);
 	void OnSourceDnsDone(CMuleInternalEvent &evt);
@@ -460,7 +463,7 @@ public:
 #endif
 
 private:
-	virtual void OnUnhandledException();
+	void OnUnhandledException() override;
 
 #ifdef ENABLE_VERSION_CHECK
 	void CheckNewVersion(uint32 result);


### PR DESCRIPTION
Fixes the batch of `-Winconsistent-missing-override` warnings in #488.

`CamuleApp` already marks some of its `wxApp` overrides `override` (e.g. `EnableIP2Country`, `GetIP2Country`), so newer Clang flags the ones that don't — and since `amule.h` is included in almost every translation unit, it fires 800+ times (830 reproduced locally; louder still on the fussier Clang in Ubuntu 26.10).

**Two commits:**

1. **Mark the 5 remaining `wxApp` overrides** in `CamuleApp` with `override` (dropping the redundant `virtual`), matching the class's existing style: `OnInit`, `OnExit`, `OnFatalException`, `OnAssertFailure`, `OnUnhandledException`. `amule.h` was the *only* source with this warning tree-wide, so this takes it 830 → 0.
2. **Promote `-Winconsistent-missing-override` to an error on Clang**, mirroring the existing `-Werror=deprecated*` gate, so the whole class of warning can't silently recur. Clang-only via a generator expression (GCC has no "some-marked-some-not" variant — only the whole-tree `-Wsuggest-override` — so an unconditional `-Werror=` would break the GCC/Ubuntu build); the Clang CI jobs (macOS, mingw-w64) catch any regression. Verified the build stays green, and that un-marking a single override makes it fail as intended.

Scope is deliberately just these compiler warnings; the broader tree-wide `modernize-use-override` sweep + enabling the clang-tidy check is left for a separate one-shot PR (as the `.clang-tidy-new-code` comment already anticipates).
