### PR TITLE
Bind aMule's external-connection (EC) socket to its own network interface (#330)

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -498,6 +498,12 @@ void ExternalConn::ResetAllLogs()
 	}
 }
 
+CExternalConnListener::CExternalConnListener(const amuleIPV4Address &adr, int flags, ExternalConn *conn)
+: CLibSocketServer(adr, flags, thePrefs::GetECNetworkInterface())
+, m_conn(conn)
+{
+}
+
 void CExternalConnListener::OnAccept()
 {
 	CECServerSocket *sock = new CECServerSocket(m_conn->m_ec_notifier);

--- a/src/ExternalConn.h
+++ b/src/ExternalConn.h
@@ -81,11 +81,10 @@ class ExternalConn;
 class CExternalConnListener : public CLibSocketServer
 {
 public:
-	CExternalConnListener(const amuleIPV4Address &adr, int flags, ExternalConn *conn)
-	: CLibSocketServer(adr, flags)
-	, m_conn(conn)
-	{
-	}
+	// Defined in ExternalConn.cpp: the EC listener binds to its own
+	// interface (thePrefs::GetECNetworkInterface(), empty = any), decoupled
+	// from the global P2P interface pin — see issue #330.
+	CExternalConnListener(const amuleIPV4Address &adr, int flags, ExternalConn *conn);
 	void OnAccept();
 
 private:

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -173,6 +173,11 @@ class CLibSocketServer
 {
 public:
 	CLibSocketServer(const amuleIPV4Address &adr, int flags);
+	// Bind the acceptor to a specific network interface (empty = any),
+	// independent of the global bind-to-interface pin set via
+	// SetSocketBindInterface(). Used by the EC listener so external-control
+	// traffic can live on a different interface than ed2k/Kad.
+	CLibSocketServer(const amuleIPV4Address &adr, int flags, const wxString &bindInterface);
 	virtual ~CLibSocketServer();
 	// Accepts an incoming connection request, and creates a new CLibSocket object which represents the
 	// server-side of the connection.

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -1361,11 +1361,16 @@ class CAsioSocketServerImpl : public ip::tcp::acceptor,
 			      public std::enable_shared_from_this<CAsioSocketServerImpl>
 {
 public:
-	CAsioSocketServerImpl(const amuleIPV4Address &adr, CLibSocketServer *libSocketServer)
+	CAsioSocketServerImpl(const amuleIPV4Address &adr,
+		CLibSocketServer *libSocketServer,
+		bool bindInterfaceOverride = false,
+		const wxString &bindInterface = wxEmptyString)
 	: ip::tcp::acceptor(s_io_service)
 	, m_libSocketServer(libSocketServer)
 	, m_strand(s_io_service)
 	, m_address(adr)
+	, m_bindInterfaceOverride(bindInterfaceOverride)
+	, m_bindInterface(bindInterface)
 	{
 		m_ok = false;
 		m_socketAvailable = false;
@@ -1381,7 +1386,12 @@ public:
 		try {
 			open(m_address.GetEndpoint().protocol());
 			SetCloexecOnSocket(native_handle());
-			SetBoundInterface(native_handle(), s_bindToInterface, false);
+			// When an explicit per-server interface is set (EC listener), use
+			// it verbatim — empty means "any", NOT a fall-back to the global
+			// P2P pin. Otherwise inherit the global bind-to-interface setting.
+			SetBoundInterface(native_handle(),
+				m_bindInterfaceOverride ? m_bindInterface : s_bindToInterface,
+				false);
 			set_option(ip::tcp::acceptor::reuse_address(true));
 			bind(m_address.GetEndpoint());
 			listen();
@@ -1498,6 +1508,12 @@ private:
 	// shared-from-this contract needs make_shared to complete before any
 	// async ops start).
 	amuleIPV4Address m_address;
+	// Per-server egress interface override. When m_bindInterfaceOverride is
+	// true, m_bindInterface is used verbatim (empty = any) instead of the
+	// process-global s_bindToInterface. Lets the EC listener bind to a
+	// different interface than ed2k/Kad.
+	bool m_bindInterfaceOverride;
+	wxString m_bindInterface;
 };
 
 CLibSocketServer::CLibSocketServer(const amuleIPV4Address &adr, int /* flags */)
@@ -1506,6 +1522,15 @@ CLibSocketServer::CLibSocketServer(const amuleIPV4Address &adr, int /* flags */)
 	// async_accept callbacks. Init() runs the bind/listen/StartAccept
 	// sequence after the managing shared_ptr is in place.
 	m_aServer = std::make_shared<CAsioSocketServerImpl>(adr, this);
+	m_aServer->Init();
+}
+
+CLibSocketServer::CLibSocketServer(
+	const amuleIPV4Address &adr, int /* flags */, const wxString &bindInterface)
+{
+	// As above, but with an explicit per-server egress interface (empty = any)
+	// that overrides the process-global bind-to-interface pin.
+	m_aServer = std::make_shared<CAsioSocketServerImpl>(adr, this, true, bindInterface);
 	m_aServer->Init();
 }
 

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -194,6 +194,7 @@ bool CPreferences::s_showCatTabInfos;
 AllCategoryFilter CPreferences::s_allcatFilter;
 bool CPreferences::s_AcceptExternalConnections;
 wxString CPreferences::s_ECAddr;
+wxString CPreferences::s_ECNetworkInterface;
 uint32 CPreferences::s_ECPort;
 wxString CPreferences::s_ECPassword;
 bool CPreferences::s_TransmitOnlyUploadingClients;
@@ -1405,6 +1406,8 @@ void CPreferences::BuildItemList(const wxString &appdir)
 		(new Cfg_Bool(
 			"/ExternalConnect/AcceptExternalConnections", s_AcceptExternalConnections, false)));
 	NewCfgItem(IDC_EXT_CONN_IP, (new Cfg_Str("/ExternalConnect/ECAddress", s_ECAddr, "")));
+	NewCfgItem(IDC_EC_INTERFACE,
+		(new Cfg_Str("/ExternalConnect/ECNetworkInterface", s_ECNetworkInterface, "")));
 	NewCfgItem(IDC_EXT_CONN_TCP_PORT, (MkCfg_Int("/ExternalConnect/ECPort", s_ECPort, 4712)));
 	NewCfgItem(IDC_EXT_CONN_PASSWD,
 		(new Cfg_Str_Encrypted("/ExternalConnect/ECPassword", s_ECPassword, "")));

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -576,6 +576,8 @@ public:
 	static bool AcceptExternalConnections() { return s_AcceptExternalConnections; }
 	static void EnableExternalConnections(bool val) { s_AcceptExternalConnections = val; }
 	static const wxString &GetECAddress() { return s_ECAddr; }
+	static const wxString &GetECNetworkInterface() { return s_ECNetworkInterface; }
+	static void SetECNetworkInterface(const wxString &val) { s_ECNetworkInterface = val; }
 	static uint32 ECPort() { return s_ECPort; }
 	static void SetECPort(uint32 val) { s_ECPort = val; }
 	static const wxString &ECPassword() { return s_ECPassword; }
@@ -1048,6 +1050,7 @@ protected:
 	// Kry - external connections
 	static bool s_AcceptExternalConnections;
 	static wxString s_ECAddr;
+	static wxString s_ECNetworkInterface;
 	static uint32 s_ECPort;
 	static wxString s_ECPassword;
 	static bool s_TransmitOnlyUploadingClients;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -596,6 +596,10 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	if (wxComboBox *ifaceBox = CastChild(IDC_INTERFACE, wxComboBox)) {
 		ifaceBox->Append(DetectNetworkInterfaces());
 	}
+	// Same for the EC-listener's own interface selector (Remote Controls tab).
+	if (wxComboBox *ecIfaceBox = CastChild(IDC_EC_INTERFACE, wxComboBox)) {
+		ecIfaceBox->Append(DetectNetworkInterfaces());
+	}
 #endif
 
 	// Connect the Cfgs with their widgets
@@ -831,6 +835,8 @@ bool PrefsUnifiedDlg::TransferToWindow()
 		IDC_EXT_CONN_ACCEPT,
 		IDC_EXT_CONN_IP,
 		IDC_EXT_CONN_IPTEXT,
+		IDC_EC_INTERFACE,
+		IDC_EC_INTERFACETEXT,
 		IDC_EXT_CONN_TCP_PORT,
 		IDC_EXT_CONN_TCPPORTTEXT,
 		IDC_EXT_CONN_PASSWD,
@@ -1061,7 +1067,7 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 		restart_needed = true;
 		restart_needed_msg += _("- External connect acceptance changed.\n");
 	}
-	if (CfgChanged(IDC_EXT_CONN_IP)) {
+	if (CfgChanged(IDC_EXT_CONN_IP) || CfgChanged(IDC_EC_INTERFACE)) {
 		restart_needed = true;
 		restart_needed_msg += _("- External connect interface changed.\n");
 	}

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1994,6 +1994,21 @@ wxSizer *PreferencesRemoteControlsTab( wxWindow *parent, bool call_fit, bool set
     CMuleTextCtrl *item6 = new CMuleTextCtrl( parent, IDC_EXT_CONN_IP, "", wxDefaultPosition, wxDefaultSize, 0 );
     item6->SetToolTip( _("Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface.") );
     item4->Add( item6, wxSizerFlags(1).Expand().CenterVertical().Border(wxLEFT, 5) );
+
+    wxStaticText *item6b = new wxStaticText( parent, IDC_EC_INTERFACETEXT, _("Bind to network interface (empty for any):"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
+    item4->Add( item6b, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT, 5) );
+#ifdef CLIENT_GUI
+    // Hidden in the remote GUI (the whole EC-listener config group is), so a
+    // plain text field is enough — no point populating a drop-down of the
+    // wrong host's interfaces. See PrefsUnifiedDlg amuledOnlyPrefs[].
+    wxTextCtrl *item6c = new wxTextCtrl( parent, IDC_EC_INTERFACE, "", wxDefaultPosition, wxDefaultSize, 0 );
+#else
+    // Editable combo filled at runtime with the machine's interfaces
+    // (PrefsUnifiedDlg); stays editable so a currently-down interface can be
+    // typed in. Binds only aMule's external-connection (EC) socket.
+    wxComboBox *item6c = new wxComboBox( parent, IDC_EC_INTERFACE, "", wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_DROPDOWN );
+#endif
+    item4->Add( item6c, wxSizerFlags(1).Expand().CenterVertical().Border(wxLEFT, 5) );
     item1->Add( item4, wxSizerFlags().Expand().CenterVertical() );
     wxFlexGridSizer *item7 = new wxFlexGridSizer( 2, 0, 0 );
     item7->AddGrowableCol( 0 );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -263,6 +263,11 @@ wxSizer *PreferencesGeneralTab(wxWindow *parent, bool call_fit = TRUE, bool set_
 // of the current range). Its label IDC_INTERFACETEXT lives in the 10355+
 // orphan-label band below.
 #define IDC_INTERFACE 10410
+// EC-listener bind-to-interface control + its label (Remote Controls tab).
+// Separate from the P2P IDC_INTERFACE above so external-connection traffic can
+// bind to its own interface (issue #330).
+#define IDC_EC_INTERFACE 10474
+#define IDC_EC_INTERFACETEXT 10475
 #define ID_TEXT 10140
 #define IDC_MAXSOURCEPERFILE 10141
 #define IDC_MAXCON 10142


### PR DESCRIPTION
Closes #330.

PR #281 added an interface bind (`IP_UNICAST_IF` / `IP_BOUND_IF`) that pins **all** of aMule's sockets — including the EC listener — to one interface. That prevents running ed2k/Kad over a VPN tunnel while keeping the external-control port on the LAN.

This decouples the EC listener. A new daemon-side setting, `/ExternalConnect/ECNetworkInterface` (empty = any), binds only aMule's EC acceptor, independent of the global P2P interface pin. It sits beside the existing `ECAddress` IP bind — the EC control channel now has both its own IP and its own interface.

- The socket layer gains a per-server interface override; only the EC listener uses it. ed2k/Kad TCP + UDP, outbound connections and HTTP are untouched and keep following the global setting.
- A "Bind to network interface" selector is added to the Connection → Remote Controls page (reusing the existing P2P label). Like the other EC-listener settings it is daemon-only: hidden in the remote GUI and not carried over EC (you cannot reconfigure the EC listener through the EC channel you are on). Restart-needed, consistent with the EC port/address.

No new translatable strings. Builds clean on macOS (monolithic, remote GUI, daemon). Verified at runtime: with the EC interface pinned, a loopback EC connection is refused while the pinned-interface IP connects, and the ed2k listen socket stays bound to all interfaces.
