### PR TITLE
fix(build): gate -Wdeprecated-copy to C++ sources only

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,16 +17,20 @@ set (EC_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/libs/ec/cpp")
 #   -Wdeprecated               -> broad umbrella (C++17 constexpr
 #                                 static-member redecl, throw() spec)
 #
+# -Wdeprecated-copy is a C++-only concept (copy special members), so it's
+# gated to COMPILE_LANGUAGE:CXX; passing it to the C compiler just produces
+# "not valid for C" noise on every C translation unit.
+#
 # The pragma-wraps landed in #341 keep cryptopp and vendored wx quiet
 # under -isystem-less discovery; without those wraps this gate would
 # fire on ~230 cryptopp header hits on macOS.
 add_compile_options (
 	-Wdeprecated
 	-Wdeprecated-declarations
-	-Wdeprecated-copy
 	-Werror=deprecated
 	-Werror=deprecated-declarations
-	-Werror=deprecated-copy
+	$<$<COMPILE_LANGUAGE:CXX>:-Wdeprecated-copy>
+	$<$<COMPILE_LANGUAGE:CXX>:-Werror=deprecated-copy>
 )
 
 # Clang-only: promote -Winconsistent-missing-override to an error so a class


### PR DESCRIPTION
## Summary
- `-Wdeprecated-copy` (and its `-Werror=` companion) is a C++-only concept (P0806 copy special members), but `add_compile_options()` in `src/CMakeLists.txt` applied it to C translation units as well, producing `cc1` warnings that the flag/its `-Werror=` form are not valid for C.
- Restricts both to `$<COMPILE_LANGUAGE:CXX>` so C sources (e.g. `icon_data.c`) no longer trigger the warning, while `-Wdeprecated` and `-Wdeprecated-declarations` remain applied to both C and C++ as before.

## Test plan
- [x] Reconfigured and rebuilt; confirmed via `compile_commands.json` that `icon_data.c` no longer receives `-Wdeprecated-copy` / `-Werror=deprecated-copy`, while C++ sources still do.
- [x] Full build (`amule`, `amuled`, `amulegui`) completes cleanly with no `deprecated-copy` warnings.