### PR TITLE
fix(gui): silence deprecated enum-enum bitwise OR in CReconnectDialog

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -148,7 +148,7 @@ public:
 		top->Add(m_label, 0, wxALL, 15);
 		top->Add(new wxButton(this, wxID_CANCEL, _("Abort and exit")),
 			0,
-			wxALIGN_CENTER | wxLEFT | wxRIGHT | wxBOTTOM,
+			static_cast<int>(wxALIGN_CENTER) | wxLEFT | wxRIGHT | wxBOTTOM,
 			15);
 		SetAttempt(1);
 		SetSizerAndFit(top);


### PR DESCRIPTION
## Summary
- `wxALIGN_CENTER` (a `wxAlignment` value) OR'd with `wxLEFT | wxRIGHT | wxBOTTOM` (`wxDirection` values) mixes two different unscoped enum types in a bitwise operation, which C++20 deprecates and GCC/Clang warn on (`-Wdeprecated-enum-enum-conversion`).
- Cast the first operand to `int`, so the chain becomes `int | enum` (never deprecated) instead of `enum | enum`. This matches the existing pattern already used for the same class of sizer flags elsewhere in the codebase (`FirstRunWizard.cpp`, `amule.cpp`).

## Test plan
- [x] Recompiled `amule-remote-gui.cpp` standalone with the project's deprecation-as-error flags; confirmed the warning at line 151 no longer appears.