### PR TITLE
fix(gui): keep the macOS status bar clear of the rounded window corners

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -146,7 +146,15 @@ wxSizer *muleDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item17->SetToolTip( _("Currently connected server.") );
     item17->SetName( "connLabel" );
     item6->Add( item17, wxSizerFlags().Center().Border(wxRIGHT, 5) );
+#if defined(__WXMAC__)
+    // macOS rounds the frame's bottom corners, clipping content that sits flush
+    // against the edge. Inset the status row -- a wider left margin for the
+    // leading icon, a slimmer bottom margin -- so nothing is cut off.
+    item6->PrependSpacer(16);
+    item0->Add( item6, wxSizerFlags().Expand().CenterVertical().Border(wxRIGHT|wxBOTTOM, 6) );
+#else
     item0->Add( item6, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT, 5) );
+#endif
     if (set_sizer)
     {
         parent->SetSizer( item0 );


### PR DESCRIPTION
On macOS the main window's bottom corners are rounded, which clipped the bottom status bar where its content sat flush against the window edge — most visibly the trailing connection label ("Kad: …") at the bottom-right, and the info icon at the bottom-left.

The status row is now inset on macOS only (`#if defined(__WXMAC__)`): a left spacer plus right/bottom margins so the leading icon and trailing text clear the corner curve. Other platforms keep the current 5px-left layout, so there is no wasted space on Linux or Windows.

The change is a layout-only tweak in `muuli_wdr.cpp`; it applies to both the monolithic `aMule` and the remote `amuleGUI`, which share the status bar. No new strings and no behavior change off macOS.
