### PR TITLE
fix(amulegui): restore the Kad Info log tab; track log tabs by identity

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -332,13 +332,15 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 	wxNotebook *logs_notebook = CastChild(ID_SRVLOG_NOTEBOOK, wxNotebook);
 	wxNotebook *networks_notebook = CastChild(ID_NETNOTEBOOK, wxNotebook);
 
-	wxASSERT(logs_notebook->GetPageCount() == 4);
 	wxASSERT(networks_notebook->GetPageCount() == 2);
 
-	for (uint32 i = 0; i < logs_notebook->GetPageCount(); ++i) {
-		m_logpages[i].page = logs_notebook->GetPage(i);
-		m_logpages[i].name = logs_notebook->GetPageText(i);
-	}
+	// Capture the network-conditional log tabs by the control each hosts, not
+	// by index -- amulegui's tab layout differs from the monolithic build, and
+	// an index-based scheme silently dropped Kad Info when the "aMuleGUI Log"
+	// tab was added. DoNetworkRearrange() shows/hides these by identity.
+	m_logServerInfo = CaptureLogPage(logs_notebook, ID_SERVERINFO);
+	m_logED2KInfo = CaptureLogPage(logs_notebook, ID_ED2KINFO);
+	m_logKadInfo = CaptureLogPage(logs_notebook, ID_KADINFO);
 
 	for (uint32 i = 0; i < networks_notebook->GetPageCount(); ++i) {
 		m_networkpages[i].page = networks_notebook->GetPage(i);
@@ -1806,6 +1808,27 @@ void CamuleDlg::OnExit(wxCommandEvent &WXUNUSED(evt))
 	Close(true);
 }
 
+PageType CamuleDlg::CaptureLogPage(wxNotebook *notebook, wxWindowID ctrlId)
+{
+	PageType result{ nullptr, wxString() };
+	// The control lives inside its notebook page (a direct child of the
+	// notebook); walk up from the control to that page.
+	wxWindow *win = notebook->FindWindow(ctrlId);
+	wxASSERT(win);
+	if (!win) {
+		return result;
+	}
+	while (win->GetParent() && win->GetParent() != notebook) {
+		win = win->GetParent();
+	}
+	result.page = win;
+	const int idx = notebook->FindPage(win);
+	if (idx != wxNOT_FOUND) {
+		result.name = notebook->GetPageText(idx);
+	}
+	return result;
+}
+
 void CamuleDlg::DoNetworkRearrange()
 {
 #if !defined(__WXOSX_COCOA__)
@@ -1819,8 +1842,14 @@ void CamuleDlg::DoNetworkRearrange()
 	// set the log windows
 	wxNotebook *logs_notebook = CastChild(ID_SRVLOG_NOTEBOOK, wxNotebook);
 
-	while (logs_notebook->GetPageCount() > 1) {
-		logs_notebook->RemovePage(logs_notebook->GetPageCount() - 1);
+	// Detach the network-conditional tabs by identity (never by index -- the
+	// always-on tabs "aMule Log" and, in amulegui, "aMuleGUI Log" must be left
+	// in place), then re-add the ones whose network is enabled.
+	for (const PageType *p : { &m_logServerInfo, &m_logED2KInfo, &m_logKadInfo }) {
+		const int idx = logs_notebook->FindPage(p->page);
+		if (idx != wxNOT_FOUND) {
+			logs_notebook->RemovePage(idx);
+		}
 	}
 
 	if (thePrefs::GetNetworkED2K()) {
@@ -1829,12 +1858,12 @@ void CamuleDlg::DoNetworkRearrange()
 		// the EC_OP_GET_SERVERINFO / EC_OP_CLEAR_SERVERINFO polling
 		// in CamuleRemoteGuiApp now mirrors the server_msg buffer, so
 		// the tab is shown unconditionally as in the monolithic build.
-		logs_notebook->AddPage(m_logpages[1].page, m_logpages[1].name);
-		logs_notebook->AddPage(m_logpages[2].page, m_logpages[2].name);
+		logs_notebook->AddPage(m_logServerInfo.page, m_logServerInfo.name);
+		logs_notebook->AddPage(m_logED2KInfo.page, m_logED2KInfo.name);
 	}
 
 	if (thePrefs::GetNetworkKademlia()) {
-		logs_notebook->AddPage(m_logpages[3].page, m_logpages[3].name);
+		logs_notebook->AddPage(m_logKadInfo.page, m_logKadInfo.name);
 	}
 
 	// Set the main window.

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -44,6 +44,7 @@
 
 class wxTimerEvent;
 class wxTextCtrl;
+class wxNotebook;
 class CVersionCheck;
 
 class CIP2Country;
@@ -318,8 +319,21 @@ private:
 	WX_DECLARE_STRING_HASH_MAP(wxZipEntry *, ZipCatalog);
 	ZipCatalog cat;
 
-	PageType m_logpages[4];
+	// Network-conditional log tabs (Server Info / ED2K Info / Kad Info),
+	// captured by the control each page hosts rather than by notebook index:
+	// the tab layout differs between the monolithic build and amulegui (which
+	// adds an "aMuleGUI Log" tab), and index-based tracking silently broke Kad
+	// Info when that tab was inserted. DoNetworkRearrange() shows/hides these by
+	// identity; the always-on tabs (aMule Log, aMuleGUI Log) are left alone.
+	PageType m_logServerInfo;
+	PageType m_logED2KInfo;
+	PageType m_logKadInfo;
 	PageType m_networkpages[2];
+
+	// Finds the notebook page hosting the control ctrlId and captures its
+	// window + tab label. Used to track the network-conditional log tabs by
+	// identity instead of position.
+	PageType CaptureLogPage(wxNotebook *notebook, wxWindowID ctrlId);
 
 	bool LoadGUIPrefs(bool override_pos, bool override_size);
 	bool SaveGUIPrefs();


### PR DESCRIPTION
Fixes a regression from #508 (reported there by @danim7): in amulegui the **Kad Info** log tab disappeared.

## Cause

#508 added an "aMuleGUI Log" tab to the remote GUI's log notebook by inserting it at index 1. But `CamuleDlg` tracked the network-conditional log tabs (Server Info / ED2K Info / Kad Info) **by position** in a fixed `m_logpages[4]` array, so the extra tab shifted everything:

- `wxASSERT(logs_notebook->GetPageCount() == 4)` fired in debug builds (now 5 pages);
- the capture loop wrote `m_logpages[4]` past the end of the 4-element array, corrupting the adjacent `m_networkpages`;
- `DoNetworkRearrange()` kept page 0 and re-added `m_logpages[1..3]` — which after the insert are aMuleGUI Log / Server Info / ED2K Info — so **Kad Info (index 4) was never re-added**.

## Fix

Track the network-conditional tabs **by identity instead of index**: capture each page via the control it hosts (`ID_SERVERINFO` / `ID_ED2KINFO` / `ID_KADINFO`) and add/remove those specific pages with `FindPage()`.

This is index- and build-independent — the always-on tabs (aMule Log, and aMuleGUI Log in the remote GUI) are simply left in place, so the monolithic and amulegui layouts share one code path, and it won't break again if a tab is added or reordered. Removes the fragile count assert and the fixed-size array (and with it the out-of-bounds write).

## Testing

- Builds clean on macOS (amulegui + monolithic amule); clang-format v18, Tier-1 + Tier-2 clang-tidy pass. No new strings.
- amulegui: all five tabs present (**Kad Info restored**), and toggling ED2K/Kad in preferences shows/hides Server Info/ED2K Info/Kad Info correctly while aMule Log + aMuleGUI Log stay put.
- monolithic aMule: unchanged — four tabs, same network-toggle behavior.
