### PR TITLE
fix(webapi): include <algorithm> for std::find in EventDiff.cpp

### DIFF
--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -26,6 +26,7 @@
 
 #include "EventBus.h"
 
+#include <algorithm>
 #include <atomic>
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
The multi-search prune loop (#511) uses `std::find`, which compiled on clang and older libstdc++ via a transitive include but breaks on GCC 14.2 (the Linux/Docker packaging build) now that `<algorithm>` is no longer leaked through other standard headers. Include it explicitly.

Build-break hotfix for master.