### PR TITLE
fix(ec): keep amulegui optimistic tab ids disjoint from daemon search ids

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1516,12 +1516,19 @@ constexpr std::size_t kMaxEcSearches = 20;
 class CEcSearchRegistry
 {
 public:
-	// Allocate a fresh bottom-half ed2k search ID (& 0x7fffffff), disjoint
-	// from Kad's top-half IDs (>= 0x80000000) and never 0 (our "none").
+	// Allocate a fresh ed2k search ID in the LOW quarter (& 0x3fffffff), never 0
+	// (our "none"). This keeps ed2k IDs provably disjoint from the two other id
+	// spaces they share the wire with: Kad's top-half IDs (>= 0x80000000) and
+	// the remote GUI's optimistic placeholder tab IDs, which reserve the
+	// 0x40000000-0x7fffffff sub-range (see CSearchDlg::StartNewSearch). Without
+	// that separation a placeholder could numerically equal a live ed2k ID and
+	// the GUI's tab-rekey would hit the wrong tab. IDs are ephemeral (a 20-entry
+	// LRU ring), so the wrap back to 1 after ~1.07e9 searches only ever reuses
+	// IDs whose search was evicted long before — no live collision.
 	uint32 AllocateEd2kId()
 	{
 		do {
-			m_nextEd2kId = (m_nextEd2kId + 1) & 0x7fffffff;
+			m_nextEd2kId = (m_nextEd2kId + 1) & 0x3fffffff;
 		} while (m_nextEd2kId == 0);
 		return m_nextEd2kId;
 	}

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -679,6 +679,21 @@ void CSearchDlg::StartNewSearch()
 	}
 
 	uint32 real_id = m_nSearchID;
+#ifdef CLIENT_GUI
+	// Remote GUI only: real_id here is an OPTIMISTIC placeholder tab id. The tab
+	// is created immediately (for instant feedback) and rekeyed to the daemon's
+	// real search id when the START reply arrives (RemapSearch). The daemon
+	// allocates ed2k ids sequentially from the low end and Kad ids from the top
+	// half (0x80000000+), so a plain low placeholder can numerically equal an
+	// earlier tab's daemon id once the two counters drift apart — and then
+	// RekeySearch would match (and rekey) the WRONG tab, routing results to the
+	// wrong tab and eventually corrupting the tab map (searches stop working).
+	// Reserve a high sub-range (bit 30) that the daemon's allocators never
+	// produce, so the placeholder can never collide with any daemon id. This
+	// applies to every search type — the placeholder is what collides, not the
+	// eventual (ed2k or Kad) daemon id. Still bottom-half, so clear of Kad ids.
+	real_id = 0x40000000u | (m_nSearchID & 0x3fffffffu);
+#endif
 	wxString error = theApp->searchlist->StartNewSearch(&real_id, search_type, params);
 	if (!error.IsEmpty()) {
 		// Search failed / Remote in progress


### PR DESCRIPTION
## Problem

amulegui could route search results to the **wrong tab**, and after enough searches new searches would silently **stop working** until amulegui was restarted. Both were intermittent and state-dependent.

## Root cause

amulegui creates a result tab immediately on search using an **optimistic placeholder id**, then rekeys it to the daemon-allocated search id when the `EC_OP_SEARCH_START` reply arrives (`RemapSearch` → `RekeySearch`). The placeholder and the daemon's ed2k ids were both plain sequential **bottom-half integers sharing one range**. Once the two counters drift apart — another EC client searching, a reconnect, etc. — a later search's placeholder can numerically equal an **earlier tab's daemon id**. `RekeySearch(placeholder)` then matches the **wrong tab** (two tabs momentarily carry the same id), scrambling the tab→id map: results land in the wrong tab, and once the map is corrupt some search's results can no longer route ("search never starts").

Reproduces deterministically by offsetting the counters: do N searches, close amulegui, reopen (fresh local counter; daemon counter now N) — the search at index N+1 collides. Kad searches are affected too: the *placeholder* is what collides (with an earlier ed2k daemon id); the eventual Kad top-half id is irrelevant.

## Fix

Partition the shared 32-bit search-id space into three **provably-disjoint** ranges:

- **daemon ed2k ids** → low quarter `[1, 0x3fffffff]` (`AllocateEd2kId` now masks `& 0x3fffffff`)
- **amulegui optimistic placeholder ids** → `[0x40000000, 0x7fffffff]` (bit 30 set)
- **Kad ids** → top half `[0x80000000, …]`

A placeholder can then never numerically equal any daemon id, so `RekeySearch` always matches exactly the tab that owns it. Applies to all search types.

ed2k ids are ephemeral (a 20-entry LRU ring), so the ed2k counter wrapping back to `1` after ~1.07 B searches only ever reuses ids whose search was evicted long before — no live collision from the narrower range.

## Scope

amulegui + daemon. The monolithic build uses the id directly (no remap) and is unaffected. amulecmd and amuleapi address searches by the daemon id with no placeholder/rekey step — they just consume whatever id the daemon returns.

Regression from #511 (multi-search).
