### PR TITLE
feat(ec): relay incoming chat messages to amulegui (read-only)

### DIFF
--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -2688,7 +2688,33 @@ bool CUpDownClient::ShouldReceiveCryptUDPPackets() const
 
 void CUpDownClient::ProcessCaptchaRequest(CMemFile *WXUNUSED(data)) {}
 void CUpDownClient::ProcessCaptchaReqRes(uint8 WXUNUSED(nStatus)) {}
-void CUpDownClient::ProcessChatMessage(const wxString WXUNUSED(message)) {}
+
+// On a headless daemon this was historically a no-op (chat was a GUI-only
+// feature). To relay incoming friend/chat messages to a connected amulegui
+// (read-only), run the non-interactive part here: apply the message filter,
+// then fire the notify — which on the daemon routes to the EC chat relay
+// (MuleNotify::ChatProcessMsg -> ExternalConn::QueueChatMessage). The advanced
+// spam-filter captcha is an interactive flow (captcha image + chat-window
+// session state) a headless core can't drive, so it's intentionally skipped;
+// the message filter above still applies.
+//
+// By-value to match the single header signature — the non-daemon impl
+// reassigns `message` (captcha path), so the parameter can't be const-ref.
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void CUpDownClient::ProcessChatMessage(wxString message)
+{
+	if (IsMessageFiltered(message)) {
+		AddLogLineC(CFormat(_("Message filtered from '%s' (IP:%s)")) % GetUserName() % GetFullIP());
+		return;
+	}
+	wxString logMsg = CFormat(_("New message from '%s' (IP:%s)")) % GetUserName() % GetFullIP();
+	if (thePrefs::ShowMessagesInLog()) {
+		logMsg += ": " + message;
+	}
+	AddLogLineC(logMsg);
+	IncMessagesReceived();
+	Notify_ChatProcessMsg(GUI_ID(GetIP(), GetUserPort()), GetUserName() + "|" + message);
+}
 
 #else
 
@@ -2921,6 +2947,10 @@ void CUpDownClient::ProcessChatMessage(wxString message)
 	Notify_ChatProcessMsg(GUI_ID(GetIP(), GetUserPort()), GetUserName() + "|" + message);
 }
 
+#endif // AMULE_DAEMON
+
+// Prefs-based and GUI-free, so it's shared by both builds — the daemon's
+// read-only chat relay applies the same message filter the monolithic GUI does.
 bool CUpDownClient::IsMessageFiltered(const wxString &message)
 {
 	bool filtered = false;
@@ -2939,8 +2969,6 @@ bool CUpDownClient::IsMessageFiltered(const wxString &message)
 	}
 	return filtered;
 }
-
-#endif
 
 void CUpDownClient::SendSharedDirectories()
 {

--- a/src/ChatWnd.cpp
+++ b/src/ChatWnd.cpp
@@ -216,6 +216,16 @@ void CChatWnd::SendMessage(const wxString &message, const wxString &client_name,
 
 void CChatWnd::CheckNewButtonsState()
 {
+#ifdef CLIENT_GUI
+	// amulegui is receive-only: sending a chat message isn't wired over EC
+	// (CChatSelector::SendMessage is compiled out under CLIENT_GUI), so the
+	// compose box and Send button stay permanently disabled. Close still
+	// tracks whether there's an open session to close.
+	const bool hasSession = chatselector->GetPageCount() > 0;
+	GetParent()->FindWindow(IDC_CSEND)->Enable(false);
+	GetParent()->FindWindow(IDC_CMESSAGE)->Enable(false);
+	GetParent()->FindWindow(IDC_CCLOSE)->Enable(hasSession);
+#else
 	switch (chatselector->GetPageCount()) {
 	case 0:
 		GetParent()->FindWindow(IDC_CSEND)->Enable(false);
@@ -234,6 +244,7 @@ void CChatWnd::CheckNewButtonsState()
 		wxASSERT(GetParent()->FindWindow(IDC_CMESSAGE)->IsEnabled());
 		break;
 	}
+#endif
 }
 
 bool CChatWnd::IsIdValid(uint64 id)

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -230,6 +230,23 @@ public:
 
 	void ResetLog() { m_LoggerAccess.Reset(); }
 
+	// True once this connection advertised EC_TAG_CAN_CHAT — used by
+	// ExternalConn::QueueChatMessage to fan an incoming peer message out only
+	// to clients that asked for the chat relay.
+	bool ChatActive() const { return m_chatActive; }
+
+	// Append one incoming peer chat message to THIS connection's own queue
+	// (per-client, like the partial-update valuemaps — each EC client drains
+	// its own copy). Bounded so a slow-polling client can't grow it without
+	// limit; oldest dropped first.
+	void QueueChatMessage(uint64 sender_id, const wxString &message)
+	{
+		m_chatQueue.emplace_back(sender_id, message);
+		while (m_chatQueue.size() > MAX_CHAT_MESSAGES) {
+			m_chatQueue.pop_front();
+		}
+	}
+
 private:
 	ECNotifier *m_ec_notifier;
 
@@ -286,6 +303,16 @@ private:
 	// single-search path runs verbatim (the `0xffffffff` sentinel bucket,
 	// wipe-on-start, parameterless stop) so old clients keep working.
 	bool m_multiSearchActive;
+	// Set when the client advertised EC_TAG_CAN_CHAT: it wants incoming peer
+	// chat messages relayed over EC and polls EC_OP_GET_CHAT_MESSAGES. The
+	// daemon always supports this, so the flag just mirrors the client tag.
+	bool m_chatActive;
+	// This connection's own queue of incoming peer chat messages, drained on
+	// EC_OP_GET_CHAT_MESSAGES. Per-client (not global) so several GUIs each
+	// get their own independent copy — like the partial-update valuemaps.
+	// <sender GUI_ID, "name|message">.
+	std::list<std::pair<uint64, wxString>> m_chatQueue;
+	static const size_t MAX_CHAT_MESSAGES = 100;
 	// Set of file ECIDs sent in the previous response for each EC
 	// request path. Diffed against the current snapshot to compute the
 	// removal list emitted to partial-update-capable clients. Tracked
@@ -328,6 +355,7 @@ CECServerSocket::CECServerSocket(ECNotifier *notifier)
 , m_lastEcGenSeenPart(0)
 , m_partialUpdateActive(false)
 , m_multiSearchActive(false)
+, m_chatActive(false)
 {
 	wxASSERT(theApp->ECServerHandler);
 	theApp->ECServerHandler->AddSocket(this);
@@ -509,6 +537,19 @@ void ExternalConn::ResetAllLogs()
 	}
 }
 
+void ExternalConn::QueueChatMessage(uint64 sender_id, const wxString &message)
+{
+	// Fan the incoming peer message out to every connected EC client that
+	// asked for the chat relay. Each keeps its own queue (per-client, like
+	// the partial-update valuemaps), so multiple GUIs get independent copies
+	// and one draining its queue doesn't steal messages from another.
+	for (CECServerSocket *s : socket_list) {
+		if (s->ChatActive()) {
+			s->QueueChatMessage(sender_id, message);
+		}
+	}
+}
+
 CExternalConnListener::CExternalConnListener(const amuleIPV4Address &adr, int flags, ExternalConn *conn)
 : CLibSocketServer(adr, flags, thePrefs::GetECNetworkInterface())
 , m_conn(conn)
@@ -649,6 +690,14 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					// single-search sentinel path — see the search handlers.
 					m_multiSearchActive = true;
 				}
+				if (request->GetTagByName(EC_TAG_CAN_CHAT)) {
+					// Client (amulegui) wants incoming peer chat messages
+					// relayed over EC. The daemon always supports this, so
+					// echo the capability in AUTH_OK; the client then polls
+					// EC_OP_GET_CHAT_MESSAGES. Old clients omit the tag and
+					// simply never poll — see the client-side login packet.
+					m_chatActive = true;
+				}
 				m_haveNotificationSupport = request->GetTagByName(EC_TAG_CAN_NOTIFY) != NULL;
 				AddDebugLogLineN(logEC,
 					CFormat("Client capabilities: ZLIB: %s  UTF8 numbers: %s  Push "
@@ -702,6 +751,11 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					// off its bulk "missing == deleted" fallback and
 					// expects explicit `EC_TAG_FILE_REMOVED` markers.
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_UPDATE));
+				}
+				if (m_chatActive) {
+					// Confirm chat relay so the client starts polling
+					// EC_OP_GET_CHAT_MESSAGES for incoming peer messages.
+					response->AddTag(CECEmptyTag(EC_TAG_CAN_CHAT));
 				}
 				if (m_multiSearchActive) {
 					// Confirm multi-search mode so the client addresses
@@ -2688,6 +2742,20 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		theApp->GetServerLog(true);
 		response = new CECPacket(EC_OP_NOOP);
 		break;
+	case EC_OP_GET_CHAT_MESSAGES: {
+		// Drain buffered incoming peer chat messages for a polling EC
+		// client (amulegui). Each EC_TAG_CHAT carries the "name|message"
+		// string, with the sender's GUI_ID as an EC_TAG_CHAT_CLIENT_ID
+		// child — the format CChatWnd::ProcessMessage already expects.
+		response = new CECPacket(EC_OP_CHAT_MESSAGES);
+		for (const auto &msg : m_chatQueue) {
+			CECTag chatTag(EC_TAG_CHAT, msg.second);
+			chatTag.AddTag(CECTag(EC_TAG_CHAT_CLIENT_ID, msg.first));
+			response->AddTag(chatTag);
+		}
+		m_chatQueue.clear();
+		break;
+	}
 	//
 	// Statistics
 	//

--- a/src/ExternalConn.h
+++ b/src/ExternalConn.h
@@ -29,6 +29,9 @@
 
 #include <ec/cpp/ECSpecialTags.h>
 
+#include <list>    // for std::list (chat message buffer)
+#include <utility> // for std::pair (chat message buffer)
+
 #include "amuleIPV4Address.h" // for amuleIPV4Address
 #include "RLE.h"              // for RLE
 #include "DownloadQueue.h"
@@ -108,6 +111,15 @@ public:
 	void RemoveSocket(CECServerSocket *s);
 	void KillAllSockets();
 	void ResetAllLogs();
+
+	// Read-only chat bridge for EC clients (amulegui): incoming peer chat
+	// messages are dropped on a headless daemon (no chat window), so relay
+	// them to any connected EC client that asked for the chat feed. Fans the
+	// message out to each chat-capable CECServerSocket's own per-client queue,
+	// which the client drains via EC_OP_GET_CHAT_MESSAGES. The pair carried is
+	// <sender GUI_ID, "name|message"> — the same encoding the built-in GUI's
+	// CChatWnd::ProcessMessage already parses.
+	void QueueChatMessage(uint64 sender_id, const wxString &message);
 };
 
 class ECUpdateMsgSource

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -694,8 +694,20 @@ void ChatConnResult(bool NOT_ON_DAEMON(success), uint64 NOT_ON_DAEMON(id), wxStr
 #endif
 }
 
-void ChatProcessMsg(uint64 NOT_ON_DAEMON(sender), wxString NOT_ON_DAEMON(message))
+// MuleNotify stores the notify args by value (CMuleNotifier DeepCopy), so a
+// `const wxString &` param would dangle — keep it by value like every other
+// notify handler. (NOLINT must sit on the line directly above the signature.)
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void ChatProcessMsg(uint64 sender, wxString message)
 {
+	// Relay the incoming peer message to any polling EC client (amulegui):
+	// the daemon has no chat window of its own, and even a monolithic aMule
+	// with EC enabled should surface friend messages on a connected remote
+	// GUI. Buffered here and drained via EC_OP_GET_CHAT_MESSAGES; the
+	// built-in GUI below still handles its own local display.
+	if (theApp->ECServerHandler) {
+		theApp->ECServerHandler->QueueChatMessage(sender, message);
+	}
 #ifndef AMULE_DAEMON
 	if (theApp->amuledlg->m_chatwnd) {
 		theApp->amuledlg->m_chatwnd->ProcessMessage(sender, message);

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -344,6 +344,17 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 			}
 			statgraphs->DoRequery();
 		}
+		// Incoming friend/chat messages are relayed by the daemon over EC
+		// (amulegui is receive-only). Poll unconditionally — like stats
+		// above, and unlike the per-tab data — so a message that arrives
+		// while the user is on another tab still triggers the new-message
+		// blink in CChatWnd::ProcessMessage. Cheap: an empty reply when
+		// nothing is pending. Gated on the daemon supporting the relay;
+		// old daemons never echo EC_TAG_CAN_CHAT and we never poll.
+		if (m_connect->ServerSupportsChat()) {
+			CECPacket chat_req(EC_OP_GET_CHAT_MESSAGES);
+			m_connect->SendRequest(&m_chatmsg_handler, &chat_req);
+		}
 		// Back to the roots
 		request_step = 0;
 		break;
@@ -465,6 +476,10 @@ bool CamuleRemoteGuiApp::OnInit()
 	// once); advertise the multi-search capability. An old daemon won't echo
 	// it and amulegui stays single-search (ServerSupportsMultiSearch()).
 	m_connect->SetCanMultiSearch(true);
+	// amulegui shows incoming friend/chat messages read-only; ask the daemon
+	// to relay them (polled via EC_OP_GET_CHAT_MESSAGES). An old daemon won't
+	// echo the capability and amulegui simply never polls (ServerSupportsChat()).
+	m_connect->SetCanChat(true);
 	// The ForceZLIB override is read from the connection dialog
 	// (see ShowConnectionDialog) so the user's checkbox choice in this
 	// session overrides the persisted /EC/ForceZLIB value.
@@ -591,6 +606,7 @@ void CamuleRemoteGuiApp::ResetEcConnect()
 	wxConfig::Get()->Read("/EC/ZLIB", &enableZLIB, 1);
 	m_connect->SetCapabilities(enableZLIB != 0, true, false);
 	m_connect->SetCanMultiSearch(true);
+	m_connect->SetCanChat(true);
 }
 
 void CamuleRemoteGuiApp::OnECConnection(wxEvent &event)
@@ -995,6 +1011,29 @@ void CServerInfoHandlerRem::HandlePacket(const CECPacket *packet)
 		if (!line.IsEmpty()) {
 			theApp->AddServerMessageLine(line);
 		}
+	}
+}
+
+void CChatMsgHandlerRem::HandlePacket(const CECPacket *packet)
+{
+	// amuled answers EC_OP_GET_CHAT_MESSAGES with one EC_TAG_CHAT tag per
+	// buffered incoming message (empty reply if none). Feed each through the
+	// same CChatWnd::ProcessMessage the monolithic GUI uses — that both opens
+	// / updates the sender's chat tab and fires the new-message blink when the
+	// chat window isn't the visible one.
+	if (!theApp->amuledlg || !theApp->amuledlg->m_chatwnd) {
+		return;
+	}
+	for (const CECTag &tag : *packet) {
+		if (tag.GetTagName() != EC_TAG_CHAT) {
+			continue;
+		}
+		uint64 sender = 0;
+		const CECTag *idTag = tag.GetTagByName(EC_TAG_CHAT_CLIENT_ID);
+		if (idTag) {
+			sender = idTag->GetInt();
+		}
+		theApp->amuledlg->m_chatwnd->ProcessMessage(sender, tag.GetStringData());
 	}
 }
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -715,6 +715,18 @@ public:
 	virtual void HandlePacket(const CECPacket *);
 };
 
+// Polls the daemon for incoming peer chat/friend messages relayed over EC
+// (EC_OP_GET_CHAT_MESSAGES -> EC_OP_CHAT_MESSAGES). amulegui can't send
+// chat (the compose box and Send button are disabled), but surfaces received
+// messages read-only through the same CChatWnd::ProcessMessage path the
+// monolithic GUI uses. Each EC_TAG_CHAT tag carries the "name|message" text
+// with the sender GUI_ID in an EC_TAG_CHAT_CLIENT_ID child.
+class CChatMsgHandlerRem : public CECPacketHandlerBase
+{
+public:
+	virtual void HandlePacket(const CECPacket *);
+};
+
 class CStatTreeRem : public CECPacketHandlerBase
 {
 	virtual void HandlePacket(const CECPacket *);
@@ -830,6 +842,7 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 
 	CStatsUpdaterRem m_stats_updater;
 	CServerInfoHandlerRem m_serverinfo_handler;
+	CChatMsgHandlerRem m_chatmsg_handler;
 
 public:
 	void Startup();

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -155,6 +155,10 @@ EC_OP_SHARED_FILE_SEARCH_KAD_NOTES  0x59
 
 EC_OP_VERIFY_LOCAL_DATA             0x5A
 
+EC_OP_GET_CHAT_MESSAGES             0x5B
+
+EC_OP_CHAT_MESSAGES                 0x5C
+
 [/Section]
 
 [Section Content]
@@ -184,6 +188,7 @@ EC_TAG_CAN_PARTIAL_UPDATE                 0x0012
 EC_TAG_FILE_REMOVED                       0x0013
 EC_TAG_PREFER_NO_ZLIB                     0x0014
 EC_TAG_CAN_MULTI_SEARCH                   0x0015
+EC_TAG_CAN_CHAT                           0x0016
 
 
 EC_TAG_CLIENT_NAME                        0x0100
@@ -377,6 +382,9 @@ EC_TAG_FRIEND                             0x0800
 	EC_TAG_FRIEND_REMOVE                      0x0807
 	EC_TAG_FRIEND_FRIENDSLOT                  0x0808
 	EC_TAG_FRIEND_SHARED                      0x0809
+
+EC_TAG_CHAT                               0x0900
+	EC_TAG_CHAT_CLIENT_ID                     0x0901
 
 EC_TAG_SELECT_PREFS                       0x1000
 

--- a/src/libs/ec/cpp/ECCodes.h
+++ b/src/libs/ec/cpp/ECCodes.h
@@ -128,7 +128,9 @@ enum ECOpCodes
 	EC_OP_FRIEND = 0x57,
 	EC_OP_VERSION_CHECK = 0x58,
 	EC_OP_SHARED_FILE_SEARCH_KAD_NOTES = 0x59,
-	EC_OP_VERIFY_LOCAL_DATA = 0x5A
+	EC_OP_VERIFY_LOCAL_DATA = 0x5A,
+	EC_OP_GET_CHAT_MESSAGES = 0x5B,
+	EC_OP_CHAT_MESSAGES = 0x5C
 };
 
 enum ECTagNames
@@ -155,6 +157,7 @@ enum ECTagNames
 	EC_TAG_FILE_REMOVED = 0x0013,
 	EC_TAG_PREFER_NO_ZLIB = 0x0014,
 	EC_TAG_CAN_MULTI_SEARCH = 0x0015,
+	EC_TAG_CAN_CHAT = 0x0016,
 	EC_TAG_CLIENT_NAME = 0x0100,
 	EC_TAG_CLIENT_VERSION = 0x0101,
 	EC_TAG_CLIENT_MOD = 0x0102,
@@ -339,6 +342,8 @@ enum ECTagNames
 	EC_TAG_FRIEND_REMOVE = 0x0807,
 	EC_TAG_FRIEND_FRIENDSLOT = 0x0808,
 	EC_TAG_FRIEND_SHARED = 0x0809,
+	EC_TAG_CHAT = 0x0900,
+	EC_TAG_CHAT_CLIENT_ID = 0x0901,
 	EC_TAG_SELECT_PREFS = 0x1000,
 	EC_TAG_PREFS_CATEGORIES = 0x1100,
 	EC_TAG_CATEGORY = 0x1101,
@@ -771,6 +776,12 @@ wxString GetDebugNameECOpCodes(uint8 arg)
 		return "EC_OP_VERSION_CHECK";
 	case 0x59:
 		return "EC_OP_SHARED_FILE_SEARCH_KAD_NOTES";
+	case 0x5A:
+		return "EC_OP_VERIFY_LOCAL_DATA";
+	case 0x5B:
+		return "EC_OP_GET_CHAT_MESSAGES";
+	case 0x5C:
+		return "EC_OP_CHAT_MESSAGES";
 	default:
 		return CFormat("unknown %d 0x%x") % arg % arg;
 	}
@@ -823,6 +834,8 @@ wxString GetDebugNameECTagNames(uint16 arg)
 		return "EC_TAG_PREFER_NO_ZLIB";
 	case 0x0015:
 		return "EC_TAG_CAN_MULTI_SEARCH";
+	case 0x0016:
+		return "EC_TAG_CAN_CHAT";
 	case 0x0100:
 		return "EC_TAG_CLIENT_NAME";
 	case 0x0101:
@@ -1191,6 +1204,10 @@ wxString GetDebugNameECTagNames(uint16 arg)
 		return "EC_TAG_FRIEND_FRIENDSLOT";
 	case 0x0809:
 		return "EC_TAG_FRIEND_SHARED";
+	case 0x0900:
+		return "EC_TAG_CHAT";
+	case 0x0901:
+		return "EC_TAG_CHAT_CLIENT_ID";
 	case 0x1000:
 		return "EC_TAG_SELECT_PREFS";
 	case 0x1100:

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -58,7 +58,8 @@ CECLoginPacket::CECLoginPacket(const wxString &client,
 	bool canUTF8numbers,
 	bool canNotify,
 	bool preferNoZlib,
-	bool canMultiSearch)
+	bool canMultiSearch,
+	bool canChat)
 : CECPacket(EC_OP_AUTH_REQ)
 {
 	AddTag(CECTag(EC_TAG_CLIENT_NAME, client));
@@ -108,6 +109,11 @@ CECLoginPacket::CECLoginPacket(const wxString &client,
 	// unknown tag and the client stays single-search.
 	if (canMultiSearch)
 		AddTag(CECEmptyTag(EC_TAG_CAN_MULTI_SEARCH));
+	// Client wants incoming peer chat messages relayed over EC (amulegui
+	// surfaces them read-only). Only advertised by clients with a chat
+	// window; old servers ignore the unknown tag and never relay.
+	if (canChat)
+		AddTag(CECEmptyTag(EC_TAG_CAN_CHAT));
 }
 
 CECAuthPacket::CECAuthPacket(const wxString &pass)
@@ -145,6 +151,8 @@ m_req_fifo_thr(20)
 , m_serverPartialUpdate(false)
 , m_canMultiSearch(false)
 , m_serverMultiSearch(false)
+, m_canChat(false)
+, m_serverChat(false)
 {
 }
 
@@ -219,7 +227,8 @@ bool CRemoteConnect::ConnectToCore(const wxString &host,
 			m_canUTF8numbers,
 			m_canNotify,
 			m_preferNoZlib,
-			m_canMultiSearch);
+			m_canMultiSearch,
+			m_canChat);
 
 		CSmartPtr<const CECPacket> getSalt(SendRecvPacket(&login_req));
 		m_ec_state = EC_REQ_SENT;
@@ -266,7 +275,8 @@ void CRemoteConnect::OnConnect()
 			m_canUTF8numbers,
 			m_canNotify,
 			m_preferNoZlib,
-			m_canMultiSearch);
+			m_canMultiSearch,
+			m_canChat);
 		CECSocket::SendPacket(&login_req);
 
 		m_ec_state = EC_REQ_SENT;
@@ -448,6 +458,12 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 			// the client stays on the single-search sentinel path.
 			if (reply->GetTagByName(EC_TAG_CAN_MULTI_SEARCH)) {
 				m_serverMultiSearch = true;
+			}
+			// Server confirmed chat relay: it will buffer incoming peer
+			// messages and hand them out via EC_OP_GET_CHAT_MESSAGES. Old
+			// daemons omit the echo and the client never polls for chat.
+			if (reply->GetTagByName(EC_TAG_CAN_CHAT)) {
+				m_serverChat = true;
 			}
 		} else {
 			m_ec_state = EC_FAIL;

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -64,7 +64,8 @@ public:
 		bool canUTF8numbers = true,
 		bool canNotify = false,
 		bool preferNoZlib = false,
-		bool canMultiSearch = false);
+		bool canMultiSearch = false,
+		bool canChat = false);
 };
 
 class CECAuthPacket : public CECPacket
@@ -141,6 +142,15 @@ private:
 	// Old daemons don't echo it; the client then stays single-search.
 	bool m_serverMultiSearch;
 
+	// Client opts into chat relay (advertise `EC_TAG_CAN_CHAT`). Off by
+	// default; a client with a chat window sets it via SetCanChat(). Read
+	// when building the login packet.
+	bool m_canChat;
+	// Set when the server echoed `EC_TAG_CAN_CHAT` in AUTH_OK, confirming it
+	// buffers incoming peer messages for polling via EC_OP_GET_CHAT_MESSAGES.
+	// Old daemons don't echo it; the client then never polls for chat.
+	bool m_serverChat;
+
 	void WriteDoneAndQueueEmpty();
 
 public:
@@ -160,9 +170,15 @@ public:
 	// should set this; otherwise it stays single-search.
 	void SetCanMultiSearch(bool can) noexcept { m_canMultiSearch = can; }
 
+	// Opt into chat relay. Call BEFORE ConnectToCore(). Only a client with a
+	// chat window (amulegui) should set this; others never poll for messages.
+	void SetCanChat(bool can) noexcept { m_canChat = can; }
+
 	bool ServerSupportsPartialUpdate() const { return m_serverPartialUpdate; }
 
 	bool ServerSupportsMultiSearch() const { return m_serverMultiSearch; }
+
+	bool ServerSupportsChat() const { return m_serverChat; }
 
 	bool ConnectToCore(const wxString &host,
 		int port,


### PR DESCRIPTION
## Summary

amulegui can manage the friends list but has never been able to exchange messages. Two gaps: the chat send path is compiled out under `CLIENT_GUI`, and a headless daemon dropped incoming peer messages entirely — `CUpDownClient::ProcessChatMessage` was a no-op stub under `AMULE_DAEMON`, so it never filtered, never fired the GUI notify, and no EC code carried a message.

This wires up **read-only** chat in the remote GUI: incoming friend/chat messages now appear in amulegui's Messages tabs (with the new-message blink), while sending stays disabled.

## What changed

**Daemon** now processes incoming chat headlessly, purely to relay it: a real `ProcessChatMessage` under `AMULE_DAEMON` applies the message filter and fires `Notify_ChatProcessMsg` (the interactive spam-captcha stays GUI-only — a headless core can't drive it). `IsMessageFiltered` moves out of the GUI-only block since it's prefs-based and GUI-free. The notify routes to a per-connection chat queue on each chat-capable `CECServerSocket` (per-client, like the partial-update valuemaps, so multiple GUIs get independent copies), drained on `EC_OP_GET_CHAT_MESSAGES`.

**EC protocol:** new `EC_OP_GET_CHAT_MESSAGES` / `EC_OP_CHAT_MESSAGES`, `EC_TAG_CHAT` (+ `EC_TAG_CHAT_CLIENT_ID` child), and an `EC_TAG_CAN_CHAT` capability negotiated in `AUTH_OK` (old daemons/clients simply never relay/poll). Abstract + hand-maintained `ECCodes.h`.

**amulegui** advertises `EC_TAG_CAN_CHAT`, polls unconditionally (so the new-message blink fires from any tab), feeds messages through the existing `CChatWnd::ProcessMessage` path, and disables the Send button + compose box.

## Not included

Sending from amulegui — that needs a client->daemon send op and interactive captcha handling; out of scope here.

## Testing

Built amuled + amulegui on macOS + Linux. Verified end-to-end against a live HighID daemon: an incoming peer message flows daemon -> EC -> amulegui and appears read-only in a Messages tab. clang-format (v18) and diff-scoped clang-tidy (`.clang-tidy-new-code`) both clean.
