### PR TITLE
refactor: unify ProcessChatMessage, guard only the GUI captcha block

### DIFF
--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -2689,33 +2689,6 @@ bool CUpDownClient::ShouldReceiveCryptUDPPackets() const
 void CUpDownClient::ProcessCaptchaRequest(CMemFile *WXUNUSED(data)) {}
 void CUpDownClient::ProcessCaptchaReqRes(uint8 WXUNUSED(nStatus)) {}
 
-// On a headless daemon this was historically a no-op (chat was a GUI-only
-// feature). To relay incoming friend/chat messages to a connected amulegui
-// (read-only), run the non-interactive part here: apply the message filter,
-// then fire the notify — which on the daemon routes to the EC chat relay
-// (MuleNotify::ChatProcessMsg -> ExternalConn::QueueChatMessage). The advanced
-// spam-filter captcha is an interactive flow (captcha image + chat-window
-// session state) a headless core can't drive, so it's intentionally skipped;
-// the message filter above still applies.
-//
-// By-value to match the single header signature — the non-daemon impl
-// reassigns `message` (captcha path), so the parameter can't be const-ref.
-// NOLINTNEXTLINE(performance-unnecessary-value-param)
-void CUpDownClient::ProcessChatMessage(wxString message)
-{
-	if (IsMessageFiltered(message)) {
-		AddLogLineC(CFormat(_("Message filtered from '%s' (IP:%s)")) % GetUserName() % GetFullIP());
-		return;
-	}
-	wxString logMsg = CFormat(_("New message from '%s' (IP:%s)")) % GetUserName() % GetFullIP();
-	if (thePrefs::ShowMessagesInLog()) {
-		logMsg += ": " + message;
-	}
-	AddLogLineC(logMsg);
-	IncMessagesReceived();
-	Notify_ChatProcessMsg(GUI_ID(GetIP(), GetUserPort()), GetUserName() + "|" + message);
-}
-
 #else
 
 void CUpDownClient::ProcessCaptchaRequest(CMemFile *data)
@@ -2788,6 +2761,15 @@ void CUpDownClient::ProcessCaptchaReqRes(uint8 nStatus)
 	}
 }
 
+#endif // AMULE_DAEMON
+
+// Shared by both builds. The advanced spam filter (captcha + URL heuristic) is
+// GUI-only — CCaptchaGenerator lives in the monolithic target and the spam path
+// touches the chat window — so it is compiled out on the daemon, which relays
+// incoming messages to amulegui with the message filter alone.
+// By-value to match the header signature: the non-daemon path reassigns
+// `message` (captcha), so the parameter can't be const-ref.
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void CUpDownClient::ProcessChatMessage(wxString message)
 {
 	if (IsMessageFiltered(message)) {
@@ -2795,6 +2777,7 @@ void CUpDownClient::ProcessChatMessage(wxString message)
 		return;
 	}
 
+#ifndef AMULE_DAEMON
 	// advanced spamfilter check
 	if (thePrefs::IsChatCaptchaEnabled() && !IsFriend()) {
 		// captcha checks outrank any further checks - if the captcha has been solved, we assume it's
@@ -2936,6 +2919,7 @@ void CUpDownClient::ProcessChatMessage(wxString message)
 			return;
 		}
 	}
+#endif // AMULE_DAEMON
 
 	wxString logMsg = CFormat(_("New message from '%s' (IP:%s)")) % GetUserName() % GetFullIP();
 	if (thePrefs::ShowMessagesInLog()) {
@@ -2946,8 +2930,6 @@ void CUpDownClient::ProcessChatMessage(wxString message)
 
 	Notify_ChatProcessMsg(GUI_ID(GetIP(), GetUserPort()), GetUserName() + "|" + message);
 }
-
-#endif // AMULE_DAEMON
 
 // Prefs-based and GUI-free, so it's shared by both builds — the daemon's
 // read-only chat relay applies the same message filter the monolithic GUI does.


### PR DESCRIPTION
## Summary

Follow-up cleanup to #517. That PR split `ProcessChatMessage` into a daemon definition and a GUI definition under `#ifdef AMULE_DAEMON`, duplicating the message-filter entry and the `log + IncMessagesReceived + Notify_ChatProcessMsg` tail across both.

This collapses them into a single definition and guards only the genuinely GUI-only part — the advanced spam filter (captcha challenge + URL heuristic), which depends on `CCaptchaGenerator` (compiled only into the monolithic target, pulls `wxImage`) and touches the chat window. On the daemon that block compiles out and the function falls through to the shared notify tail: identical behaviour, one copy of the shared logic. The daemon captcha stubs are unchanged.

No functional change (-18 lines net).

## Testing

Built `amuled`, monolithic `amule` (the build that actually compiles the `#ifndef` captcha block), and `amulegui` — all clean. clang-format (v18) and diff-scoped clang-tidy (`.clang-tidy-new-code`) both clean.
