### PR TITLE
build: measure and report ccache usage in compile.sh

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -97,8 +97,23 @@ cmake_configure () {
 
 cmake_build() {
 	echo Running the CMake build with "${OPT_J} parallel jobs"
-	cmake --build build -j"${OPT_J}" "$@"
 
+	local HAVE_CCACHE=0
+	if command -v ccache > /dev/null 2>&1; then
+		HAVE_CCACHE=1
+		ccache -z > /dev/null
+	fi
+
+	cmake --build build -j"${OPT_J}" "$@"
+	local BUILD_STATUS=$?
+
+	if [[ ${HAVE_CCACHE} == 1 ]]; then
+		echo
+		echo "ccache statistics for this build:"
+		ccache -s
+	fi
+
+	(exit "${BUILD_STATUS}")
 	die 3 "CMake build failed"
 }
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -21,15 +21,21 @@ usage() {
 	echo "  --help       Display this help message"
 	echo "  -j<n>"
 	echo "  --jobs<n>    Run <n> jobs in parallel"
+	echo "  -c"
+	echo "  --measure-cache"
+	echo "               Build against an empty, isolated ccache directory"
+	echo "               and print its size at the end, to measure this"
+	echo "               project's own ccache footprint. Skips running tests."
 }
 
 OPT_DEBUG=Release
 OPT_J=1
+OPT_MEASURE_CACHE=0
 
 # Setup parse options
 # -o "j:" means short flag 'j' requires an argument
 # --long "jobs:" means long flag 'jobs' requires an argument
-if ! PARAMS=$(getopt -o "dhj:" -l "debug,jobs:,help" -n "$0" -- "$@"); then
+if ! PARAMS=$(getopt -o "dhj:c" -l "debug,jobs:,help,measure-cache" -n "$0" -- "$@"); then
 	# If getopt fails (invalid flag), exit
 	usage
 	false; die 10
@@ -58,6 +64,10 @@ while true; do
 			usage
 			false; die 12
 		fi
+		;;
+	-c | --measure-cache )
+		OPT_MEASURE_CACHE=1
+		shift
 		;;
 	-- )
 		shift
@@ -133,8 +143,22 @@ die 12 \
 	$'\n' \
 	"This script must be run in '${GIT_ROOT}'"
 
+if [[ ${OPT_MEASURE_CACHE} == 1 ]]; then
+	CCACHE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/amule-ccache-measure.XXXXXX")
+	die 23 "Error creating scratch ccache directory"
+	export CCACHE_DIR
+	trap 'rm -rf "${CCACHE_DIR}"' EXIT
+fi
+
 cmake_configure
 cmake_build "$@"
-cmake_test
+
+if [[ ${OPT_MEASURE_CACHE} == 1 ]]; then
+	echo
+	echo "This project's ccache footprint (empty cache, full build):"
+	du -sh "${CCACHE_DIR}"
+else
+	cmake_test
+fi
 
 exit 0


### PR DESCRIPTION
## Summary
- Print ccache hit/miss statistics after each `scripts/compile.sh` build (counters are zeroed before the build so the report reflects this run, not lifetime totals).
- Add a `-c`/`--measure-cache` option that builds against an empty, isolated `CCACHE_DIR` and reports its size at the end, to measure this project's own ccache footprint independent of whatever else shares the machine's cache. Skips running tests since the goal is just to size the cache.

## Test plan
- [x] `bash -n scripts/compile.sh`
- [x] `./scripts/compile.sh -j$(nproc)` — confirmed ccache stats print after the build
- [x] `./scripts/compile.sh --help` — confirmed new option documented
- [x] `./scripts/compile.sh -c -j$(nproc)` — confirmed isolated-cache footprint printed, tests skipped, scratch dir cleaned up afterward