### PR TITLE
fix(ec): report a browse's terminal status even after the client is reaped

### DIFF
--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -2058,7 +2058,12 @@ uint16 CUpDownClient::GetBrowseBarValue() const
 
 void CUpDownClient::UpdateBrowseBar()
 {
+	// Mirror both the bar value and the lifecycle status into the search list,
+	// keyed by the routing ID. The status is what lets the EC PROGRESS reply
+	// report a terminal "failed" (vs "finished") after this client — which is
+	// transient, especially a browse that fails on disconnect — has been reaped.
 	theApp->searchlist->SetBrowseBar(GetBrowseRoutingId(), GetBrowseBarValue());
+	theApp->searchlist->SetBrowseStatusById(GetBrowseRoutingId(), static_cast<uint8>(m_browseStatus));
 }
 
 void CUpDownClient::MarkBrowse(EBrowseStatus s)

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -443,24 +443,6 @@ CUpDownClient *CClientList::FindClientByECID(uint32 ecid) const
 	return NULL;
 }
 
-CUpDownClient *CClientList::FindClientByBrowseSearchId(uint32 browseSearchId) const
-{
-	// Reverse map from an EC-allocated browse ("View Files") search ID to the
-	// client it was pinned on, so the SEARCH_PROGRESS poll can report the
-	// browse's lifecycle. Browses are rare and few, so a linear scan is cheap.
-	if (browseSearchId == 0) {
-		return nullptr;
-	}
-	for (const auto &entry : m_clientList) {
-		CUpDownClient *client = entry.second.GetClient();
-		if (client && client->GetBrowseSearchId() == browseSearchId) {
-			return client;
-		}
-	}
-
-	return nullptr;
-}
-
 bool CClientList::IsIPAlreadyKnown(uint32_t ip)
 {
 	// Find all items with the specified ip

--- a/src/ClientList.h
+++ b/src/ClientList.h
@@ -173,12 +173,6 @@ public:
 	 */
 	CUpDownClient *FindClientByECID(uint32 ecid) const;
 
-	/**
-	 * Finds the client a browse ("View Files") search ID was pinned on, or NULL.
-	 * Used by the EC SEARCH_PROGRESS poll to report the browse's lifecycle.
-	 */
-	CUpDownClient *FindClientByBrowseSearchId(uint32 browseSearchId) const;
-
 	//! The list-type used to store clients IPs and ban time information
 	typedef std::map<uint32, uint64> ClientMap;
 

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2618,20 +2618,25 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 			s_ecSearches.Touch(want);
 			sid = want;
 			// A browse ("View Files") ID is not a CSearchList search: report its
-			// lifecycle from the peer's client (browsing / finished / failed)
-			// plus the running result count, so amuleGUI's tab marker and hit
-			// count update. EC_TAG_SEARCH_BROWSE_STATUS is the discriminator the
-			// GUI branches on before the normal progress decode.
-			if (CUpDownClient *browseClient =
-					theApp->clientlist->FindClientByBrowseSearchId(sid)) {
-				// Bar value (0..100 running, 0xffff done/failed) so amuleGUI
-				// drives the browse tab's gauge via the same UpdateSearchProgress
-				// path as a search. Kept first for consistency with the search
-				// reply (GetFirstTagSafe).
-				response->AddTag(CECTag(EC_TAG_SEARCH_STATUS,
-					theApp->searchlist->GetSearchBarStatusById(sid)));
-				response->AddTag(CECTag(EC_TAG_SEARCH_BROWSE_STATUS,
-					static_cast<uint8>(browseClient->GetBrowseStatus())));
+			// lifecycle from the persisted browse state (browsing / finished /
+			// failed) + bar, keyed by search ID, plus the running result count so
+			// amuleGUI's tab marker and hit count update. Reading the persisted
+			// state — rather than the browsing client, which is transient and, for
+			// a browse that fails on disconnect, reaped before the next poll —
+			// means the terminal "failed" still reaches amuleGUI so its tab marker
+			// flips instead of sticking at "browsing".
+			// EC_TAG_SEARCH_BROWSE_STATUS is the discriminator the GUI branches on
+			// before the normal progress decode.
+			if (theApp->searchlist->HasBrowseStatus(sid)) {
+				const uint8 browseStatus = theApp->searchlist->GetBrowseStatusById(sid);
+				// Bar value (0..100 running, 0xffff done/failed) so amuleGUI drives
+				// the browse tab's gauge via the same UpdateSearchProgress path as
+				// a search. Kept first for consistency with the search reply
+				// (GetFirstTagSafe).
+				const uint16 bar =
+					static_cast<uint16>(theApp->searchlist->GetSearchBarStatusById(sid));
+				response->AddTag(CECTag(EC_TAG_SEARCH_STATUS, bar));
+				response->AddTag(CECTag(EC_TAG_SEARCH_BROWSE_STATUS, browseStatus));
 				response->AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(sid)));
 				response->AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT,
 					static_cast<uint32>(
@@ -2641,8 +2646,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 				// existing SEARCH_PROGRESS handling with no special-casing:
 				// browsing -> RUNNING, finished/failed -> FINISHED. Percent is the
 				// dir-based bar value (0..100), snapped to 100 once terminal.
-				const bool browsing = browseClient->GetBrowseStatus() == BROWSE_IN_PROGRESS;
-				const uint16 bar = browseClient->GetBrowseBarValue();
+				const bool browsing = browseStatus == BROWSE_IN_PROGRESS;
 				response->AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE,
 					static_cast<uint8>(
 						browsing ? CSearchList::SEARCH_LIFECYCLE_RUNNING

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -295,6 +295,7 @@ void CSearchList::RemoveResults(wxUIntPtr searchID)
 	m_finishedKadSearches.erase(static_cast<uint32_t>(searchID));
 	m_searchStartTimes.erase(static_cast<uint32_t>(searchID));
 	m_browseBar.erase(searchID);
+	m_browseStatus.erase(searchID);
 
 	ResultMap::iterator it = m_results.find(searchID);
 	if (it != m_results.end()) {

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -163,6 +163,22 @@ public:
 	// GetSearchBarStatusById consults this first, so both the monolithic bar and
 	// the EC PROGRESS reply render the browse percent through the same path.
 	void SetBrowseBar(wxUIntPtr searchID, uint16 value) { m_browseBar[searchID] = value; }
+	// The browse lifecycle (EBrowseStatus: browsing / finished / failed) recorded
+	// by search ID alongside the bar, so the EC PROGRESS reply can report a
+	// browse's terminal state even after the browsing client has been reaped
+	// (0xffff in m_browseBar can't tell "finished" from "failed"). Set from
+	// CUpDownClient::UpdateBrowseBar; pruned in RemoveResults, so it's bounded by
+	// the same LRU ring that caps m_browseBar and every ed2k/Kad search bucket.
+	void SetBrowseStatusById(wxUIntPtr searchID, uint8 status) { m_browseStatus[searchID] = status; }
+	bool HasBrowseStatus(wxUIntPtr searchID) const
+	{
+		return m_browseStatus.find(searchID) != m_browseStatus.end();
+	}
+	uint8 GetBrowseStatusById(wxUIntPtr searchID) const
+	{
+		std::map<wxUIntPtr, uint8>::const_iterator it = m_browseStatus.find(searchID);
+		return it != m_browseStatus.end() ? it->second : 0 /* BROWSE_NONE */;
+	}
 	// Echoes m_searchType for the current/last search; meaningful only
 	// when state is RUNNING or FINISHED. Returns LocalSearch by default.
 	SearchType GetSearchLifecycleKind() const { return m_searchType; }
@@ -354,6 +370,10 @@ private:
 	//! the browsing client (0..100 percent, or 0xffff finished/failed). Read by
 	//! GetSearchBarStatusById. Pruned in RemoveResults.
 	std::map<wxUIntPtr, uint16> m_browseBar;
+	//! Browse lifecycle (EBrowseStatus) by search ID, kept in lockstep with
+	//! m_browseBar so a browse's terminal state survives the client's teardown.
+	//! Pruned in RemoveResults.
+	std::map<wxUIntPtr, uint8> m_browseStatus;
 
 	//! ED2K-side counterpart of m_KadSearchFinished, covering both local
 	//! and global searches. Cleared to false in StartNewSearch when an


### PR DESCRIPTION
Follow-up to #520.

A "View Files" browse that failed — peer denied, connect failed, or dropped mid-list — left amuleGUI's tab stuck at `(N...)` instead of flipping to `(Failed)`, even though the daemon logged `Failed to retrieve shared files from user '…'`.

### Root cause

The daemon read the browse lifecycle **live from the browsing `CUpDownClient`**, but that client is transient: a browse that fails on disconnect drops its friend link and, being transfer-less, gets reaped before amuleGUI's next ~3s `SEARCH_PROGRESS` poll. `FindClientByBrowseSearchId` then returns null, the reply omits `EC_TAG_SEARCH_BROWSE_STATUS`, and amuleGUI's consumer updates only the gauge — never the tab marker. (Monolithic was unaffected: its `Notify_Browse_Status` fires synchronously while the client is still alive.)

### Fix

Persist the browse status by search ID alongside the bar value that already survives, and report progress from that persisted state rather than the transient client:

- `CSearchList` gains `m_browseStatus` (searchID → `EBrowseStatus`), set from `CUpDownClient::UpdateBrowseBar` in lockstep with `m_browseBar` and pruned on the same `RemoveResults` line — so it's bounded by the same 20-slot EC search ring (`AllocateBrowseSearchId` registers there), no new policy.
- The EC `SEARCH_PROGRESS` reply reports the browse lifecycle from the persisted maps, so the terminal `failed`/`finished` reaches amuleGUI on the next poll and the marker flips.
- `FindClientByBrowseSearchId` had this as its only caller and is removed.

### Scope

Daemon-side only — the amuleGUI consumer already handled `EC_TAG_SEARCH_BROWSE_STATUS` correctly; it just never received it after the client was gone. amuleapi/amuleweb are unaffected (they map the browse's lifecycle to `FINISHED` either way).

### Testing

- Validated live: browsing a peer that denies / times out now flips the tab to `(Failed)`.
- Builds clean across monolithic, amulegui, amuled and amuleapi (both `#ifdef` branches); clang-format + Tier-2 clang-tidy clean.
