### PR TITLE
Remove unnecessary GuiEvents dependency from amulecmd

### DIFF
--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -1425,8 +1425,12 @@ int CamulecmdApp::OnRun()
 	return 0;
 }
 
+// Stub functions needed by the linker in ASIO builds
 namespace MuleNotify
 {
+void HandleNotification(const class CMuleNotiferBase &);
+void HandleNotificationAlways(const class CMuleNotiferBase &);
+
 void HandleNotification(const class CMuleNotiferBase &) {}
 void HandleNotificationAlways(const class CMuleNotiferBase &) {}
 } // namespace MuleNotify

--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -1425,18 +1425,6 @@ int CamulecmdApp::OnRun()
 	return 0;
 }
 
-// Stub functions needed by the linker in ASIO builds
-#include "GuiEvents.h"
-
-// MULE_EVT_NOTIFY is declared in GuiEvents.h and referenced by the header-inline
-// CMuleGUIEvent (its ctor and Clone()) that this console binary pulls in, but amulecmd
-// links no TU that defines it: GuiEvents.cpp lives in muleappcore and WebInterface.cpp
-// in the webserver, neither of which amulecmd links. Non-LTO builds dead-strip the
-// unused inline copies before the symbol is demanded; LTO keeps the CMuleGUIEvent vtable
-// and the reference survives to the final link, so the definition must live here. Same
-// per-binary event-definition pattern as MULE_EVT_LOGLINE in LoggerConsole.cpp.
-wxDEFINE_EVENT(MULE_EVT_NOTIFY, wxEvent);
-
 namespace MuleNotify
 {
 void HandleNotification(const class CMuleNotiferBase &) {}


### PR DESCRIPTION
Current master works around a GCC 16 LTO link failure in amulecmd by including
GuiEvents.h in TextClient.cpp and defining MULE_EVT_NOTIFY locally.

amulecmd does not use GUI notification events, so this dependency is unnecessary.
Removing the GuiEvents.h include also makes the local
wxDEFINE_EVENT(MULE_EVT_NOTIFY, wxEvent) workaround unnecessary.

This keeps amulecmd independent of the GUI event machinery rather than providing
a local definition for an event it does not use.

Verified on Fedora Rawhide with GCC 16.1.1 and LTO enabled:

- amulecmd builds successfully
- amule builds successfully
- amuled builds successfully
- amuleweb builds successfully
- 24/24 configured tests pass

The patch only removes the unused GuiEvents dependency and the corresponding
local event-definition workaround.
