### PR TITLE
fix(aich): stop the post-hashing AICH sync from pruning a just-hashed file

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -452,8 +452,12 @@ void CSharedFileList::FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborte
 				"Found %i known shared file", "Found %i known shared files", GetCount())) %
 			GetCount());
 
-		// Make sure the AICH-hashes are up to date.
-		CThreadScheduler::AddTask(new CAICHSyncTask());
+		// Make sure the AICH-hashes are up to date. This is the startup sync
+		// run once the shared/known list is authoritative, so it opts into the
+		// orphan-prune (drop known2_64.met entries no longer owned by any known
+		// file). Post-hashing syncs deliberately do not prune -- see
+		// CAICHSyncTask's ctor doc.
+		CThreadScheduler::AddTask(new CAICHSyncTask(true));
 	} else {
 		// New files, AICH thread will be run at the end of the hashing thread.
 		AddLogLineN(CFormat(wxPLURAL("Found %i known shared file, %i unknown",

--- a/src/ThreadTasks.cpp
+++ b/src/ThreadTasks.cpp
@@ -250,7 +250,11 @@ void CHashingTask::OnLastTask()
 		// explicitly save the list of hashed files here.
 		theApp->knownfiles->Save();
 
-		// Make sure the AICH-hashes are up to date.
+		// Make sure the AICH-hashes are up to date. No orphan-prune here: this
+		// runs right after hashing (including a just-completed download) and
+		// races the main-thread SafeAddKFile that registers those files, so
+		// pruning could delete a hashset we just wrote. Only the startup sync
+		// prunes -- see CAICHSyncTask's ctor doc.
 		CThreadScheduler::AddTask(new CAICHSyncTask());
 	}
 }
@@ -258,8 +262,9 @@ void CHashingTask::OnLastTask()
 ////////////////////////////////////////////////////////////
 // CAICHSyncTask
 
-CAICHSyncTask::CAICHSyncTask()
+CAICHSyncTask::CAICHSyncTask(bool pruneOrphans)
 : CThreadTask("AICH Synchronizing", "", ETP_Low)
+, m_pruneOrphans(pruneOrphans)
 {
 }
 
@@ -278,8 +283,17 @@ void CAICHSyncTask::Entry()
 	// record was TTL-evicted by CKnownFileList::PruneDuplicates) from
 	// known2_64.met during the read walk. Empty set disables the prune
 	// (defensive: never wipe everything before knownfiles is loaded).
+	//
+	// Only the startup sync collects it: a post-hashing sync (scheduled by
+	// CHashingTask::OnLastTask) runs on a worker thread that can outrun the
+	// main-thread CamuleApp::OnFinishedHashing -> CKnownFileList::SafeAddKFile
+	// that registers the file it just hashed. That file's freshly-written
+	// hashset would then be absent from liveRoots and pruned as an orphan,
+	// leaving a newly completed download unable to load its AICH set until the
+	// next restart re-hashes it. Leaving liveRoots empty keeps the prune off on
+	// those runs; startup only prunes once the known-file list is authoritative.
 	std::unordered_set<CAICHHash> liveRoots;
-	if (theApp->knownfiles) {
+	if (m_pruneOrphans && theApp->knownfiles) {
 		theApp->knownfiles->CollectLiveAICHRoots(liveRoots);
 	}
 

--- a/src/ThreadTasks.h
+++ b/src/ThreadTasks.h
@@ -133,7 +133,15 @@ private:
 class CAICHSyncTask : public CThreadTask
 {
 public:
-	CAICHSyncTask();
+	/**
+	 * @param pruneOrphans  Rewrite known2_64.met dropping hashsets no longer
+	 *   referenced by any known file. Only safe when the known-file list is
+	 *   authoritative (startup); a post-hashing sync races the main-thread
+	 *   registration of the file it just hashed and would prune its own
+	 *   freshly-written hashset. Defaults to false so only the startup sync
+	 *   opts in.
+	 */
+	explicit CAICHSyncTask(bool pruneOrphans = false);
 
 protected:
 	/** See CThreadTask::Entry */
@@ -141,6 +149,9 @@ protected:
 
 	/** Converts old known2.met files to known2_64.met files. */
 	bool ConvertToKnown2ToKnown264();
+
+private:
+	bool m_pruneOrphans;
 };
 
 /**


### PR DESCRIPTION
Completing a download (or otherwise hashing a new file) can leave it unable to load its AICH hashset: **Verify Local Data checks MD4 only**, `LoadHashSet()` fails, and a restart re-hashes the file. Reported in #524 with a clear log trace.

**Root cause — a race between the AICH orphan-prune and known-file registration.** `CAICHSyncTask` rewrites `known2_64.met`, dropping every hashset whose root hash isn't in the live-roots snapshot (`CKnownFileList::CollectLiveAICHRoots`). That prune is scheduled from two places:

- the **startup** sync (`CSharedFileList`, once the shared/known list is loaded), and
- `CHashingTask::OnLastTask`, right after a file is hashed.

The post-hashing schedule runs on a worker thread that can outrun the main-thread `CamuleApp::OnFinishedHashing -> CKnownFileList::SafeAddKFile` that registers the file it just hashed. When it does, that file's freshly-written hashset is absent from `liveRoots` and gets pruned as an "orphan" — exactly the `known2_64.met orphan prune: dropped 1` in the reporter's log, immediately after `Successfully saved eMuleAC Hashset ... Masterhash written`. The file then can't load its AICH set until a later restart re-hashes it.

The orphan-prune was added in `29717617a` as a **startup** cleanup for hashsets whose `known.met` record was TTL-evicted by `PruneDuplicates`; the `OnLastTask` sync predates it (2006) and only ever meant to keep AICH hashes up to date. This gates the destructive prune behind an explicit `CAICHSyncTask(pruneOrphans)` flag, opted into **only** by the startup sync where the known-file list is authoritative. Post-hashing syncs still run `CheckAICHHashes`, just without the prune.

Regression is present in 3.0.0 and 3.0.1 (the prune shipped before those tags).

**Testing:** builds clean on macOS (monolithic + daemon); clang-format and clang-tidy (Tier-1 + Tier-2) clean on the diff. The trigger is a thread-timing race that needs a busy main thread (real downloads/network); it did not reproduce in a quiescent sandbox daemon, where the single-worker scheduler hashes then syncs sequentially and the idle main thread always registers first — so I've asked the reporter to confirm against their live setup.
