### PR TITLE
feat(amuleapi): add POST /shared/{hash}/verify (Verify Local Data)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -47,6 +47,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/shared`](#get-apiv0shared) — list shared files
 - [`GET /api/v0/shared/{hash}`](#get-apiv0sharedhash) — detail view; every list field plus shared-detail fields
 - [`POST /api/v0/shared/reload`](#post-apiv0sharedreload) — re-walk shared directories
+- [`POST /api/v0/shared/{hash}/verify`](#post-apiv0sharedhashverify) — re-hash a shared file against its on-disk data
 - [`PATCH /api/v0/shared`](#patch-apiv0shared) — bulk change upload priority
 - [`PATCH /api/v0/shared/{hash}`](#patch-apiv0sharedhash) — change upload priority
 
@@ -1092,6 +1093,34 @@ Returns `202 Accepted`.
 
 **Errors:** `503 ec_unavailable`.
 
+#### `POST /api/v0/shared/{hash}/verify`
+
+**Auth:** `ADMIN`
+
+Equivalent to the desktop client's "Verify Local Data" — amuled re-hashes the file's on-disk data against the MD4 (and, where a hashset is available, AICH) hashes it has stored, reporting any blocks that no longer match.
+
+```sh
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/shared/$HASH/verify"
+```
+
+```json
+{ "ok": true }
+```
+
+Returns `202 Accepted`. amuled queues the hashing task and answers immediately, so the response confirms only that the re-hash was **scheduled** — it never carries the outcome, and a large file may take minutes to finish.
+
+**Reading the result.** The verdict is emitted as an amule log line when the task completes, so read it back from [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `log` SSE channel:
+
+- `Verify Local Data (MD4 & AICH): Result OK for <path>`
+- `Verify Local Data (MD4 & AICH): ERRORS FOUND! <path> Failed blocks: MD4: 3,7 AICH: 5: (0,2)`
+
+Like all daemon log output these lines are gettext-translated at the daemon's locale and carry no correlation id tying them to a specific request, so treat them as human-readable output rather than a machine-parseable contract.
+
+**Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported`, `503 ec_unavailable`.
+
+Only completed files can be verified. A file still downloading is rejected with `409 partfile_unsupported`: the hashing task skips partfiles outright, so accepting one would promise a report that never arrives. A download that has *finished* but is still listed under `/downloads` is a valid target.
+
 #### `PATCH /api/v0/shared`
 
 **Auth:** `ADMIN`
@@ -1823,6 +1852,7 @@ Every error code emitted by `/api/v0/*`, sorted by what triggered it. The matchi
 | `invalid_credentials` | 401 | `/auth/login` password didn't match any role. |
 | `forbidden` | 403 | Authenticated as `guest` but the endpoint requires `admin`. |
 | `not_found` | 404 | Resource doesn't exist (unknown hash, ECID, graph name). |
+| `partfile_unsupported` | 409 | Verify Local Data requested on a file that is still an incomplete partfile. |
 | `rate_limited` | 429 | Per-IP failure bucket full. `Retry-After: <seconds>` accompanies the response. |
 | `login_disabled` | 503 | `/auth/login` reached but no admin AND no guest password configured. |
 | `ec_unavailable` | 503 | EC connection not ready yet (cold start, transient amuled restart). |

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -873,6 +873,22 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleKadBootstrap(req);
 	}
 
+	// re-hash one shared file against its on-disk data. Matched before the
+	// single-segment `/shared/{hash}` pattern below purely for locality —
+	// the two can't collide, this one carries an extra path segment.
+	{
+		static const auto shared_verify = web_api_path::ParsePattern("/api/v0/shared/{hash}/verify");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(shared_verify, path_segs, caps)) {
+			if (req.method != "POST") {
+				return ErrorResponse(
+					405, "method_not_allowed", "only POST on /shared/{hash}/verify");
+			}
+			return HandleSharedVerify(req, caps["hash"]);
+		}
+	}
+
 	// shared file priority PATCH. `{hash}` is the lowercase 32-char hex
 	// MD4 hash.
 	{
@@ -7136,6 +7152,79 @@ CHttpServer::Response CApiDispatcher::HandleSharedBulkPatch(const CHttpServer::R
 	}
 	(void)RefresherTick(m_app, m_state);
 	return BulkResultsResponse(results, 200);
+}
+
+CHttpServer::Response CApiDispatcher::HandleSharedVerify(
+	const CHttpServer::Request &req, const std::string &key)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
+	webapi::FileSnapshot s;
+	std::string needle = key;
+	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+		return std::tolower(c);
+	});
+	if (!m_state.FindShared(needle, s)) {
+		return ErrorResponse(404, "not_found", "no shared file with that hash");
+	}
+
+	// Partfiles have no verify implementation: the hashing task bails out on
+	// IsPartFile(), and amuled's EC handler answers NOOP either way, so a
+	// caller would be told the re-hash was accepted and then never see a
+	// report. Reject up front instead. Same "genuinely incomplete" test the
+	// `path` field uses (#417): a download that has completed but is still
+	// listed keeps is_downloading set, yet is a knownfile by then and so is
+	// a legitimate verify target.
+	if (s.is_downloading && s.download.status != "completed") {
+		return ErrorResponse(
+			409, "partfile_unsupported", "verify local data is not supported on a partfile");
+	}
+
+	CMD4Hash file_hash;
+	if (!HashFromHex(s.hash, file_hash)) {
+		return ErrorResponse(500, "internal_error", "failed to decode file hash");
+	}
+
+	auto ec_req = std::make_unique<CECPacket>(EC_OP_VERIFY_LOCAL_DATA);
+	ec_req->AddTag(CECTag(EC_TAG_KNOWNFILE, file_hash));
+
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for VERIFY_LOCAL_DATA");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+	}
+	delete ec_resp;
+
+	// 202, not 200: amuled queues a CVerifyLocalDataTask and answers NOOP
+	// immediately, so the re-hash is still in flight here. The verdict is
+	// only ever reported as an amule log line (CVerifyLocalDataTask::
+	// PrintReport -> "Verify Local Data (...): Result OK" / "ERRORS
+	// FOUND!"), which clients read back through /logs/amule or the SSE log
+	// channel. No RefresherTick: nothing observable has changed yet.
+	CHttpServer::Response r;
+	r.status = 202;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("ok");
+	w.ValueBool(true);
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
 }
 
 CHttpServer::Response CApiDispatcher::HandleSharedReload(const CHttpServer::Request &req)

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -149,6 +149,10 @@ private:
 	CHttpServer::Response HandleSharedPatch(const CHttpServer::Request &, const std::string &key);
 	// bulk shared-priority PATCH over a `hashes` array (#358).
 	CHttpServer::Response HandleSharedBulkPatch(const CHttpServer::Request &);
+	// re-hash a shared file against its on-disk data (EC_OP_VERIFY_LOCAL_DATA).
+	// `key` = 32-char MD4 hash. amuled schedules the hashing task and answers
+	// immediately, so this is accepted rather than completed.
+	CHttpServer::Response HandleSharedVerify(const CHttpServer::Request &, const std::string &key);
 
 	// Static-frontend fallthrough. Resolves `url_path` under
 	// ServerCfg().static_root, returns the file with a content-type

--- a/unittests/curl-tests/amuleapi/30-shared-verify.sh
+++ b/unittests/curl-tests/amuleapi/30-shared-verify.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# amuleapi 30-shared-verify — POST /shared/{hash}/verify.
+#
+# Endpoint:
+#   POST /api/v0/shared/{hash}/verify   → 202 {"ok":true}
+#
+# Re-hashes a shared file against its on-disk data (EC_OP_VERIFY_LOCAL_DATA).
+# amuled queues a CVerifyLocalDataTask and answers immediately, so the call
+# is accepted (202), never completed (200) — the verdict is only ever emitted
+# as an amule log line ("Verify Local Data (...): Result OK" / "ERRORS
+# FOUND!"), which a client reads back through /logs/amule or the SSE log
+# channel. There is therefore nothing to assert about the outcome here; the
+# contract under test is the accept path and its guards.
+#
+# Partfiles are rejected with 409 partfile_unsupported: the hashing task
+# bails out on IsPartFile(), so accepting one would promise a report that
+# never arrives.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+GUEST_PASS=${GUEST_PASS:-guestpass}
+AMULE_SHARED_DIR=${AMULE_SHARED_DIR:-}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+
+CURL_BODY_FILE=$(mktemp -t amuleapi_30_shared_verify_body.XXXXXX)
+trap 'rm -f "$CURL_BODY_FILE"' EXIT
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 10 -o "$CURL_BODY_FILE" -w '%{http_code}' "$@") \
+		|| _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat "$CURL_BODY_FILE")
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS" \
+			"body head: $(printf '%s' "$CURL_BODY" | head -c 200)"
+	fi
+}
+
+_assert_json_eq() {
+	local expr=$1 expected=$2 label=$3
+	local actual
+	actual=$(printf '%s' "$CURL_BODY" | jq -r "$expr" 2>/dev/null) \
+		|| _fail "$label" "body was not valid JSON" "body: $CURL_BODY"
+	if [ "$actual" = "$expected" ]; then
+		_pass "$label"
+	else
+		_fail "$label" "expected $expected, got $actual" "body: $CURL_BODY"
+	fi
+}
+
+if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+	_die "amuleapi at $HOST is not reachable."
+fi
+
+echo "amuleapi 30-shared-verify smoke @ $HOST"
+
+ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
+
+GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+HAVE_GUEST=0
+[ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
+
+sleep 4
+
+# Verify only applies to completed knownfiles, so the fixture path is the
+# same one 17-shared-priority-patch uses: plant a real file in a directory
+# amuled shares and let it hash in. Reused across runs once it exists.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared"
+COUNT=$(printf '%s' "$CURL_BODY" | jq '.shared | length')
+
+if [ "$COUNT" = "0" ]; then
+	[ -n "$AMULE_SHARED_DIR" ] \
+		|| _die "set AMULE_SHARED_DIR to a directory amuled shares so the smoke can plant a fixture"
+	FIXTURE="$AMULE_SHARED_DIR/amuleapi-regtest-shared.dat"
+	if [ ! -f "$FIXTURE" ]; then
+		head -c 1048576 /dev/urandom > "$FIXTURE" \
+			|| _die "cannot write fixture to AMULE_SHARED_DIR=$AMULE_SHARED_DIR"
+	fi
+	echo "    info: planted fixture $FIXTURE; reloading shares"
+	curl -s -o /dev/null -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/shared/reload"
+	for _ in $(seq 1 30); do
+		sleep 1
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared"
+		COUNT=$(printf '%s' "$CURL_BODY" | jq '.shared | length')
+		[ "$COUNT" != "0" ] && break
+	done
+	[ "$COUNT" != "0" ] \
+		|| _die "fixture planted in $AMULE_SHARED_DIR but never appeared in /shared after reload"
+fi
+
+# Pick a completed entry — a shared partfile is rejected by design, so it
+# can't stand in for the happy path. The list object carries no partfile
+# flag; the detail object's `path` reads "[PartFile]" exactly while a file
+# is genuinely incomplete (#417), so classify through that. The same sweep
+# picks up a partfile for the 409 guard below, when the library has one.
+TEST_HASH=""
+PART_HASH=""
+for h in $(printf '%s' "$CURL_BODY" | jq -r '.shared[].hash' | head -20); do
+	P=$(curl -s --max-time 10 -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/shared/$h" | jq -r '.path')
+	if [ "$P" = "[PartFile]" ]; then
+		[ -z "$PART_HASH" ] && PART_HASH=$h
+	else
+		[ -z "$TEST_HASH" ] && TEST_HASH=$h
+	fi
+	[ -n "$TEST_HASH" ] && [ -n "$PART_HASH" ] && break
+done
+[ -n "$TEST_HASH" ] || _die "no completed (non-partfile) shared file available to verify"
+echo "    info: verifying hash=$TEST_HASH"
+
+# --- 1. Auth + admin gate. -----------------------------------------
+_curl -X POST "$HOST/api/v0/shared/$TEST_HASH/verify"
+_assert_status 401 "POST /shared/{hash}/verify (no token) → 401"
+
+if [ "$HAVE_GUEST" = "1" ]; then
+	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" \
+		"$HOST/api/v0/shared/$TEST_HASH/verify"
+	_assert_status 403 "POST /shared/{hash}/verify (guest) → 403"
+fi
+
+# --- 2. Happy path: accepted, not completed. -----------------------
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/shared/$TEST_HASH/verify"
+_assert_status 202 "POST /shared/{hash}/verify → 202"
+_assert_json_eq '.ok' true "verify response .ok == true"
+
+# Uppercase hash resolves the same file (lookup lowercases the capture).
+UPPER_HASH=$(printf '%s' "$TEST_HASH" | tr 'a-f' 'A-F')
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/shared/$UPPER_HASH/verify"
+_assert_status 202 "POST /shared/{HASH}/verify (uppercase) → 202"
+
+# --- 3. Unknown hash → 404. ----------------------------------------
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/shared/00000000000000000000000000000000/verify"
+_assert_status 404 "POST /shared/{unknown}/verify → 404"
+_assert_json_eq '.error.code' not_found "unknown hash → error.code=not_found"
+
+# --- 4. Method gate. -----------------------------------------------
+_curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/shared/$TEST_HASH/verify"
+_assert_status 405 "GET /shared/{hash}/verify → 405"
+
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" -d '{}' \
+	"$HOST/api/v0/shared/$TEST_HASH/verify"
+_assert_status 405 "PATCH /shared/{hash}/verify → 405"
+
+# --- 5. Partfile guard (only when the library has one). ------------
+# A partfile shows up in /shared once ≥1 part has completed. Classified in
+# the sweep above. Skipped rather than forced, since planting a
+# half-finished download isn't reproducible in a smoke run.
+if [ -n "$PART_HASH" ]; then
+	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/shared/$PART_HASH/verify"
+	_assert_status 409 "POST /shared/{partfile}/verify → 409"
+	_assert_json_eq '.error.code' partfile_unsupported \
+		"partfile → error.code=partfile_unsupported"
+else
+	echo "    info: no shared partfile present; skipping the 409 guard check"
+fi
+
+# --- Summary. -----------------------------------------------------
+echo
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	exit 0
+fi
+echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"
+exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -202,6 +202,7 @@ PHASES=(
 	27-static-frontend.sh
 	28-list-pagination-sort.sh
 	29-bulk-mutations.sh
+	30-shared-verify.sh
 )
 
 # Override list from the command line if given.


### PR DESCRIPTION
Exposes the Verify Local Data action over the REST API, following #491 which added it for the desktop clients. Reuses the `EC_OP_VERIFY_LOCAL_DATA` opcode as-is — no core changes.

`POST /api/v0/shared/{hash}/verify` (ADMIN) → `202 {"ok": true}`

**Up front: Verify Local Data has no mechanism to return its result to UI or EC clients.** `CVerifyLocalDataTask` has no `OnExit()`, emits no notification, raises no EC event, and changes no observable file state. It collects `m_corruptedMD4` / `m_corruptedAICH` and nothing consumes them beyond formatting them into a single log line in `PrintReport()`. That limitation is the same for the monolithic GUI and amulegui as it is here — it isn't something this PR introduces or works around.

So this endpoint can only honestly answer `202` (the re-hash was *scheduled*) and point clients at the log. amuled queues the task and replies immediately; a large file may take minutes. The verdict then appears as:

- `Verify Local Data (MD4 & AICH): Result OK for <path>`
- `Verify Local Data (MD4 & AICH): ERRORS FOUND! <path> Failed blocks: MD4: 3,7 …`

which clients read back through `/logs/amule` or the `log` SSE channel. The reference documents exactly that, and flags it for what it is: the lines are gettext-translated and carry no correlation id tying them to a request, so they are human-readable output, not a machine-parseable contract. A structured result needs a core change (task notification → EC event → typed SSE event); better as a follow-up than a parallel path bolted onto this endpoint.

**Partfile guard.** Incomplete partfiles are rejected with `409 partfile_unsupported` — the hashing task skips partfiles outright, so accepting one would promise a report that never arrives. The guard reuses the same "genuinely incomplete" test as the `path` field, so a download that has finished but is still listed under `/downloads` remains a valid target.

**Verification.** Ran live against a real amuled; all 11 assertions pass, including the 409 guard (the node had an actual partfile, so that path was genuinely exercised rather than skipped):

```
PASS  POST /shared/{hash}/verify (no token) → 401
PASS  POST /shared/{hash}/verify (guest) → 403
PASS  POST /shared/{hash}/verify → 202
PASS  verify response .ok == true
PASS  POST /shared/{HASH}/verify (uppercase) → 202
PASS  POST /shared/{unknown}/verify → 404
PASS  unknown hash → error.code=not_found
PASS  GET /shared/{hash}/verify → 405
PASS  PATCH /shared/{hash}/verify → 405
PASS  POST /shared/{partfile}/verify → 409
PASS  partfile → error.code=partfile_unsupported
```

Reporting confirmed end to end as well — after the 202 the daemon logged `Verify Local Data (MD4 & AICH): Result OK for …`, readable back through `GET /api/v0/logs/amule`.

clang-format (v18, whole-file) and the clang-tidy Tier-1 + Tier-2 diff checks are both clean.
