### PR TITLE
feat(webapi): expose the core's shared-directory configuration

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -47,6 +47,8 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/shared`](#get-apiv0shared) — list shared files
 - [`GET /api/v0/shared/{hash}`](#get-apiv0sharedhash) — detail view; every list field plus shared-detail fields
 - [`POST /api/v0/shared/reload`](#post-apiv0sharedreload) — re-walk shared directories
+- [`GET /api/v0/shared/directories`](#get-apiv0shareddirectories) — the configured share roots
+- [`PUT /api/v0/shared/directories`](#put-apiv0shareddirectories) — replace the configured share roots
 - [`POST /api/v0/shared/{hash}/verify`](#post-apiv0sharedhashverify) — re-hash a shared file against its on-disk data
 - [`PATCH /api/v0/shared`](#patch-apiv0shared) — bulk change upload priority
 - [`PATCH /api/v0/shared/{hash}`](#patch-apiv0sharedhash) — change upload priority
@@ -1092,6 +1094,91 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 Returns `202 Accepted`.
 
 **Errors:** `503 ec_unavailable`.
+
+#### `GET /api/v0/shared/directories`
+
+**Auth:** `GUEST`
+
+The share roots amuled is configured with — as opposed to [`GET /shared`](#get-apiv0shared), which lists the files those roots produced. This is the *intent*: a recursive root is one entry here however many subdirectories it covers.
+
+```sh
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/shared/directories"
+```
+
+```json
+{
+  "directories": [
+    { "path": "/home/user/media", "recursive": true },
+    { "path": "/home/user/iso", "recursive": false }
+  ]
+}
+```
+
+`recursive` distinguishes the two lists amuled keeps (`shareddir-recursive.dat` vs `shareddir-explicit.dat`). The runtime union it derives from them — every expanded subdirectory — is deliberately not exposed: it is generated state, not configuration.
+
+**Errors:** `502 amuled_rejected`, `503 ec_unavailable`.
+
+#### `PUT /api/v0/shared/directories`
+
+**Auth:** `ADMIN`
+
+Replace the whole set of roots. A full replace rather than a merge, because that is exactly what amuled's operation does — making it a `PUT` keeps the semantics honest instead of hiding a read-modify-write.
+
+```sh
+curl -s -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"directories":[{"path":"/home/user/media","recursive":true}]}' \
+  "http://$HOST/api/v0/shared/directories"
+```
+
+```json
+{ "ok": true, "rejected": [] }
+```
+
+`recursive` is optional and defaults to `false`.
+
+amuled validates every path — a REST client cannot stat the core's filesystem, so a typo would otherwise become a silently dead share. Paths that pass are applied, persisted and rescanned; the rest come back in `rejected`, so **one bad entry does not discard the edit**:
+
+```json
+{ "ok": true, "rejected": [ { "path": "/typo", "reason": "not_found" } ] }
+```
+
+`reason` is `not_found` (missing, or not a directory) or `not_readable`. amuled reports these as codes and the API renders them, so its locale never leaks into your response.
+
+**Errors:** `400 bad_request` (`directories` not an array, an entry without a non-empty `path`, non-boolean `recursive`), `502 amuled_rejected`, `503 ec_unavailable`.
+
+#### `POST /api/v0/shared/directories`
+
+**Auth:** `ADMIN`
+
+Add a single root, leaving the others alone — the convenience path for scripts that would otherwise have to read the list, splice it and write it back.
+
+```sh
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"path":"/home/user/new","recursive":true}' \
+  "http://$HOST/api/v0/shared/directories"
+```
+
+Idempotent: adding a path that is already configured updates its `recursive` flag rather than failing, so "ensure this folder is shared" is safe to repeat. Same `{ok, rejected}` body as `PUT`.
+
+**Errors:** `400 bad_request` (missing/empty `path`, non-boolean `recursive`), `502 amuled_rejected`, `503 ec_unavailable`.
+
+#### `DELETE /api/v0/shared/directories`
+
+**Auth:** `ADMIN`
+
+Remove a single root. The path is a query parameter rather than a path segment because it is an absolute filesystem path.
+
+```sh
+curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/shared/directories?path=%2Fhome%2Fuser%2Fnew"
+```
+
+Removing a path that is not configured is a `404` rather than a silent success, so a typo is visible. Same `{ok, rejected}` body as `PUT`.
+
+**Errors:** `400 bad_request` (no `path` parameter), `404 not_found` (path not configured), `502 amuled_rejected`, `503 ec_unavailable`.
+
+> Concurrency: `POST` and `DELETE` are read-modify-write against amuled's whole-list operation, serialised inside amuleapi so two API clients cannot lose each other's change. Nothing can make them atomic against a *simultaneous* edit from amuleGUI — the protocol has no compare-and-set — so that case is last-write-wins.
 
 #### `POST /api/v0/shared/{hash}/verify`
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -31,6 +31,8 @@
 #include "ConstantTime.h"
 #include "Etag.h"
 #include "JsonWriter.h"
+
+#include <mutex> // serialises the shared-directory read-modify-write
 #include "Jwt.h"
 #include "PathPatterns.h"
 #include "Refresher.h" // ParseStatsTreeFromPacket / ParseGraphsFromPacket / ApplySearchFull
@@ -784,6 +786,28 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			return ErrorResponse(405, "method_not_allowed", "only POST on /shared/reload");
 		}
 		return HandleSharedReload(req);
+	}
+
+	// /shared/directories — the configured share roots, as opposed to /shared
+	// which lists the files those roots produced. Literal path, so it has to be
+	// matched before the /shared/{hash} patterns below or "directories" would be
+	// captured as a hash.
+	if (path == "/api/v0/shared/directories") {
+		if (req.method == "GET" || req.method == "HEAD") {
+			return HandleSharedDirectories(req);
+		}
+		if (req.method == "PUT") {
+			return HandleSharedDirectoriesPut(req);
+		}
+		if (req.method == "POST") {
+			return HandleSharedDirectoriesAdd(req);
+		}
+		if (req.method == "DELETE") {
+			return HandleSharedDirectoriesDelete(req);
+		}
+		return ErrorResponse(405,
+			"method_not_allowed",
+			"only GET / HEAD / PUT / POST / DELETE on /shared/directories");
 	}
 
 	if (path == "/api/v0/servers") {
@@ -7225,6 +7249,310 @@ CHttpServer::Response CApiDispatcher::HandleSharedVerify(
 	w.EndObject();
 	FinalizeJsonBody(w, r);
 	return r;
+}
+
+namespace
+{
+struct SharedDirEntry
+{
+	wxString path;
+	bool recursive = false;
+};
+
+// The core's shared-directory op is a whole-list replace, so adding or removing
+// a single root is a read-modify-write. Serialise those here: SendRecvSerialized
+// locks per roundtrip, not across the pair, so two concurrent single-entry calls
+// would otherwise read the same list and the second SET would drop the first's
+// change. (Nothing can make this atomic against a simultaneous amuleGUI edit —
+// the protocol has no compare-and-set — so that stays last-write-wins.)
+std::mutex s_sharedDirsMutex;
+
+// Read the current roots. Returns false and fills `err` when EC is unreachable
+// or refuses; the caller turns that into an HTTP error.
+bool FetchSharedDirs(CamuleapiApp &app, std::vector<SharedDirEntry> &out, std::string &err)
+{
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_GET_SHARED_DIRS));
+	const CECPacket *ec_resp = app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		err = "no reply from amuled";
+		return false;
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		err = ec_err_msg;
+		return false;
+	}
+	for (const CECTag &tag : *ec_resp) {
+		if (tag.GetTagName() != EC_TAG_SHAREDDIR) {
+			continue;
+		}
+		const CECTag *recursive_tag = tag.GetTagByName(EC_TAG_SHAREDDIR_RECURSIVE);
+		SharedDirEntry entry;
+		entry.path = tag.GetStringData();
+		entry.recursive = recursive_tag != nullptr && recursive_tag->GetInt() != 0;
+		out.push_back(entry);
+	}
+	delete ec_resp;
+	return true;
+}
+// Replace the core's roots with `dirs` and render the outcome. The core applies
+// every path that validates and reports the rest, so a single bad entry does not
+// discard the edit.
+CHttpServer::Response ApplySharedDirs(CamuleapiApp &app, const std::vector<SharedDirEntry> &dirs)
+{
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SET_SHARED_DIRS));
+	for (const SharedDirEntry &entry : dirs) {
+		CECTag dir_tag(EC_TAG_SHAREDDIR, entry.path);
+		if (entry.recursive) {
+			dir_tag.AddTag(CECTag(EC_TAG_SHAREDDIR_RECURSIVE, (uint8)1));
+		}
+		ec_req->AddTag(dir_tag);
+	}
+
+	const CECPacket *ec_resp = app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "no reply from amuled");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(502, "amuled_rejected", ec_err_msg.c_str());
+	}
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("ok");
+	w.ValueBool(true);
+	// Paths the core would not take. Empty when everything applied; the reasons
+	// are rendered here rather than shipped as text from a core whose locale is
+	// not the caller's.
+	w.Key("rejected");
+	w.BeginArray();
+	for (const CECTag &tag : *ec_resp) {
+		if (tag.GetTagName() != EC_TAG_SHAREDDIR_REJECTED) {
+			continue;
+		}
+		const CECTag *err_tag = tag.GetTagByName(EC_TAG_SHAREDDIR_ERROR);
+		w.BeginObject();
+		w.Key("path");
+		w.ValueString(tag.GetStringData());
+		w.Key("reason");
+		w.ValueString((err_tag != nullptr && err_tag->GetInt() == 2) ? "not_readable" : "not_found");
+		w.EndObject();
+	}
+	w.EndArray();
+	w.EndObject();
+	delete ec_resp;
+	FinalizeJsonBody(w, r);
+	return r;
+}
+} // namespace
+
+// The core's configured share roots: the explicit ones and the recursive ones,
+// each with the flag that says which. This is the *intent*, not the expansion —
+// a recursive root yields one entry here however many subdirectories it covers,
+// while /shared lists the files that expansion produced.
+CHttpServer::Response CApiDispatcher::HandleSharedDirectories(const CHttpServer::Request &req)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_GET_SHARED_DIRS));
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "no reply from amuled");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(502, "amuled_rejected", ec_err_msg.c_str());
+	}
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("directories");
+	w.BeginArray();
+	for (const CECTag &tag : *ec_resp) {
+		if (tag.GetTagName() != EC_TAG_SHAREDDIR) {
+			continue;
+		}
+		const CECTag *recursive_tag = tag.GetTagByName(EC_TAG_SHAREDDIR_RECURSIVE);
+		w.BeginObject();
+		w.Key("path");
+		w.ValueString(tag.GetStringData());
+		w.Key("recursive");
+		w.ValueBool(recursive_tag != nullptr && recursive_tag->GetInt() != 0);
+		w.EndObject();
+	}
+	w.EndArray();
+	w.EndObject();
+	delete ec_resp;
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+// Replace the whole set of roots. A full replace rather than add/remove verbs
+// because that is exactly what the core's EC op does — expressing it as PUT
+// keeps the API honest and avoids a read-modify-write race between two clients.
+// The core validates each path (a REST client cannot stat the core's
+// filesystem), applies the ones that pass and reports the rest, so a single bad
+// entry does not discard the whole edit.
+CHttpServer::Response CApiDispatcher::HandleSharedDirectoriesPut(const CHttpServer::Request &req)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	}
+	const auto &obj = root.get<picojson::object>();
+	const auto dirs_it = obj.find("directories");
+	if (dirs_it == obj.end() || !dirs_it->second.is<picojson::array>()) {
+		return ErrorResponse(400, "bad_request", "`directories` must be an array");
+	}
+
+	std::vector<SharedDirEntry> dirs;
+	for (const auto &entry : dirs_it->second.get<picojson::array>()) {
+		if (!entry.is<picojson::object>()) {
+			return ErrorResponse(400, "bad_request", "each directory must be an object");
+		}
+		const auto &dir = entry.get<picojson::object>();
+		const auto path_it = dir.find("path");
+		if (path_it == dir.end() || !path_it->second.is<std::string>() ||
+			path_it->second.get<std::string>().empty()) {
+			return ErrorResponse(400, "bad_request", "each directory needs a non-empty `path`");
+		}
+		SharedDirEntry parsed;
+		parsed.path = wxString::FromUTF8(path_it->second.get<std::string>().c_str());
+		const auto rec_it = dir.find("recursive");
+		if (rec_it != dir.end()) {
+			if (!rec_it->second.is<bool>()) {
+				return ErrorResponse(400, "bad_request", "`recursive` must be a boolean");
+			}
+			parsed.recursive = rec_it->second.get<bool>();
+		}
+		dirs.push_back(parsed);
+	}
+
+	// Whole-list replace: no read-modify-write, so no lock needed beyond the
+	// per-roundtrip one SendRecvSerialized already holds.
+	return ApplySharedDirs(m_app, dirs);
+}
+
+// Add one root, leaving the others alone. Idempotent: re-adding a configured
+// path just updates its recursive flag, which is friendlier to scripts than a
+// conflict. Read-modify-write, so it runs under s_sharedDirsMutex.
+CHttpServer::Response CApiDispatcher::HandleSharedDirectoriesAdd(const CHttpServer::Request &req)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	}
+	const auto &obj = root.get<picojson::object>();
+	const auto path_it = obj.find("path");
+	if (path_it == obj.end() || !path_it->second.is<std::string>() ||
+		path_it->second.get<std::string>().empty()) {
+		return ErrorResponse(400, "bad_request", "`path` must be a non-empty string");
+	}
+	bool recursive = false;
+	const auto rec_it = obj.find("recursive");
+	if (rec_it != obj.end()) {
+		if (!rec_it->second.is<bool>()) {
+			return ErrorResponse(400, "bad_request", "`recursive` must be a boolean");
+		}
+		recursive = rec_it->second.get<bool>();
+	}
+	const wxString wanted = wxString::FromUTF8(path_it->second.get<std::string>().c_str());
+
+	std::lock_guard<std::mutex> guard(s_sharedDirsMutex);
+	std::vector<SharedDirEntry> dirs;
+	std::string ec_err;
+	if (!FetchSharedDirs(m_app, dirs, ec_err)) {
+		return ErrorResponse(503, "ec_unavailable", ec_err.c_str());
+	}
+	bool found = false;
+	for (SharedDirEntry &entry : dirs) {
+		if (entry.path == wanted) {
+			entry.recursive = recursive;
+			found = true;
+			break;
+		}
+	}
+	if (!found) {
+		SharedDirEntry added;
+		added.path = wanted;
+		added.recursive = recursive;
+		dirs.push_back(added);
+	}
+	return ApplySharedDirs(m_app, dirs);
+}
+
+// Remove one root. The path arrives as a query parameter rather than a path
+// segment because it is an absolute filesystem path and would otherwise have to
+// survive being spliced into the URL path. Unknown paths are a 404 so a typo is
+// visible instead of silently succeeding.
+CHttpServer::Response CApiDispatcher::HandleSharedDirectoriesDelete(const CHttpServer::Request &req)
+{
+	auto a = AuthenticateRequestRateLimited(
+		req, m_jwt, m_revocations, m_authRateLimiter, kSessionCookieName);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	std::string query;
+	const std::size_t q = req.target.find('?');
+	if (q != std::string::npos) {
+		query = req.target.substr(q + 1);
+	}
+	const auto qmap = web_api_path::ParseQuery(query);
+	const auto path_param = qmap.find("path");
+	if (path_param == qmap.end() || path_param->second.empty()) {
+		return ErrorResponse(400, "bad_request", "`path` query parameter is required");
+	}
+	const std::string wanted_utf8 = path_param->second;
+	const wxString wanted = wxString::FromUTF8(wanted_utf8.c_str());
+
+	std::lock_guard<std::mutex> guard(s_sharedDirsMutex);
+	std::vector<SharedDirEntry> dirs;
+	std::string ec_err;
+	if (!FetchSharedDirs(m_app, dirs, ec_err)) {
+		return ErrorResponse(503, "ec_unavailable", ec_err.c_str());
+	}
+	const size_t before = dirs.size();
+	for (std::vector<SharedDirEntry>::iterator it = dirs.begin(); it != dirs.end(); ++it) {
+		if (it->path == wanted) {
+			dirs.erase(it);
+			break;
+		}
+	}
+	if (dirs.size() == before) {
+		return ErrorResponse(404, "not_found", "no such shared directory");
+	}
+	return ApplySharedDirs(m_app, dirs);
 }
 
 CHttpServer::Response CApiDispatcher::HandleSharedReload(const CHttpServer::Request &req)

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -168,6 +168,10 @@ private:
 	// roots and re-publishes whatever's there. Parameterless EC op
 	// (EC_OP_SHAREDFILES_RELOAD).
 	CHttpServer::Response HandleSharedReload(const CHttpServer::Request &);
+	CHttpServer::Response HandleSharedDirectories(const CHttpServer::Request &);
+	CHttpServer::Response HandleSharedDirectoriesPut(const CHttpServer::Request &);
+	CHttpServer::Response HandleSharedDirectoriesAdd(const CHttpServer::Request &);
+	CHttpServer::Response HandleSharedDirectoriesDelete(const CHttpServer::Request &);
 	// categories CRUD.
 	CHttpServer::Response HandleCategoryCreate(const CHttpServer::Request &);
 	CHttpServer::Response HandleCategoryUpdate(

--- a/unittests/curl-tests/amuleapi/31-shared-directories.sh
+++ b/unittests/curl-tests/amuleapi/31-shared-directories.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# amuleapi 31-shared-directories — the configured share roots.
+#
+# Endpoints:
+#   GET    /api/v0/shared/directories            → {"directories":[{path,recursive}]}
+#   PUT    /api/v0/shared/directories            → replace the whole set
+#   POST   /api/v0/shared/directories            → add one (idempotent)
+#   DELETE /api/v0/shared/directories?path=...   → remove one
+#
+# These are the roots amuled is configured with, as opposed to /shared which
+# lists the files those roots produced. A recursive root is a single entry here
+# however many subdirectories it covers.
+#
+# The write verbs really do mutate the core's configuration, so this smoke
+# snapshots the current roots up front and restores them via PUT at the end
+# (including on early exit). Everything it adds lives under a mktemp directory,
+# never the operator's real shares.
+#
+# amuled validates paths server-side — a REST client cannot stat the core's
+# filesystem — and reports refusals per path in `rejected` while still applying
+# the entries that passed. Both halves of that contract are asserted.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+GUEST_PASS=${GUEST_PASS:-guestpass}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+
+CURL_BODY_FILE=$(mktemp -t amuleapi_31_shared_dirs_body.XXXXXX)
+SCRATCH_DIR=$(mktemp -d -t amuleapi_31_shared_dirs.XXXXXX)
+ORIGINAL_DIRS=""
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 10 -o "$CURL_BODY_FILE" -w '%{http_code}' "$@") \
+		|| _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat "$CURL_BODY_FILE")
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS" \
+			"body head: $(printf '%s' "$CURL_BODY" | head -c 200)"
+	fi
+}
+
+_assert_json_eq() {
+	local expr=$1 expected=$2 label=$3
+	local actual
+	actual=$(printf '%s' "$CURL_BODY" | jq -r "$expr" 2>/dev/null) \
+		|| _fail "$label" "body was not valid JSON" "body: $CURL_BODY"
+	if [ "$actual" = "$expected" ]; then
+		_pass "$label"
+	else
+		_fail "$label" "expected $expected, got $actual" "body: $CURL_BODY"
+	fi
+}
+
+# Put the operator's configuration back exactly as we found it, whatever
+# happened in between. Registered before the first mutation.
+_restore() {
+	if [ -n "$ORIGINAL_DIRS" ]; then
+		curl -s -o /dev/null --max-time 10 -X PUT \
+			-H "Authorization: Bearer ${ADMIN_TOKEN:-}" \
+			-H "Content-Type: application/json" \
+			-d "{\"directories\":$ORIGINAL_DIRS}" \
+			"$HOST/api/v0/shared/directories" 2>/dev/null || true
+	fi
+	rm -f "$CURL_BODY_FILE"
+	rm -rf "$SCRATCH_DIR"
+}
+trap _restore EXIT
+
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+	_die "amuleapi at $HOST is not reachable."
+fi
+
+echo "amuleapi 31-shared-directories smoke @ $HOST"
+
+ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
+
+GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+HAVE_GUEST=0
+[ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
+
+# --- 1. Auth + method gates. ----------------------------------------
+_curl "$HOST/api/v0/shared/directories"
+_assert_status 401 "GET /shared/directories (no token) → 401"
+
+_curl -X PUT -H "Content-Type: application/json" \
+	-d '{"directories":[]}' "$HOST/api/v0/shared/directories"
+_assert_status 401 "PUT /shared/directories (no token) → 401"
+
+if [ "$HAVE_GUEST" = "1" ]; then
+	# Reading the roots is GUEST, matching GET /shared and GET /preferences.
+	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/shared/directories"
+	_assert_status 200 "GET /shared/directories (guest) → 200"
+
+	_curl -X PUT -H "Authorization: Bearer $GUEST_TOKEN" -H "Content-Type: application/json" \
+		-d '{"directories":[]}' "$HOST/api/v0/shared/directories"
+	_assert_status 403 "PUT /shared/directories (guest) → 403"
+
+	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" -H "Content-Type: application/json" \
+		-d "{\"path\":\"$SCRATCH_DIR\"}" "$HOST/api/v0/shared/directories"
+	_assert_status 403 "POST /shared/directories (guest) → 403"
+
+	_curl -X DELETE -H "Authorization: Bearer $GUEST_TOKEN" \
+		"$HOST/api/v0/shared/directories?path=%2Ftmp"
+	_assert_status 403 "DELETE /shared/directories (guest) → 403"
+fi
+
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_assert_status 405 "PATCH /shared/directories → 405"
+
+# --- 2. Read the current configuration (and snapshot it). -----------
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_assert_status 200 "GET /shared/directories → 200"
+_assert_json_eq '.directories | type' 'array' "directories is an array"
+ORIGINAL_DIRS=$(printf '%s' "$CURL_BODY" | jq -c '.directories')
+[ -n "$ORIGINAL_DIRS" ] || _die "could not snapshot the current shared directories"
+
+# --- 3. Body validation. --------------------------------------------
+_curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d 'not json' "$HOST/api/v0/shared/directories"
+_assert_status 400 "PUT (malformed JSON) → 400"
+
+_curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d '{}' "$HOST/api/v0/shared/directories"
+_assert_status 400 "PUT (no directories array) → 400"
+
+_curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d '{"directories":[{"path":""}]}' "$HOST/api/v0/shared/directories"
+_assert_status 400 "PUT (empty path) → 400"
+
+_curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d "{\"directories\":[{\"path\":\"$SCRATCH_DIR\",\"recursive\":\"yes\"}]}" \
+	"$HOST/api/v0/shared/directories"
+_assert_status 400 "PUT (non-boolean recursive) → 400"
+
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d '{}' "$HOST/api/v0/shared/directories"
+_assert_status 400 "POST (no path) → 400"
+
+_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_assert_status 400 "DELETE (no path parameter) → 400"
+
+# --- 4. Add a real directory, then read it back. ---------------------
+SCRATCH_ENC=$(jq -rn --arg p "$SCRATCH_DIR" '$p|@uri')
+
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d "{\"path\":\"$SCRATCH_DIR\",\"recursive\":true}" "$HOST/api/v0/shared/directories"
+_assert_status 200 "POST (add scratch dir, recursive) → 200"
+_assert_json_eq '.ok' 'true' "POST reports ok"
+_assert_json_eq '.rejected | length' '0' "POST rejected nothing"
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_assert_json_eq \
+	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '1' \
+	"added directory is listed"
+_assert_json_eq \
+	"[.directories[] | select(.path==\"$SCRATCH_DIR\")][0].recursive" 'true' \
+	"added directory kept its recursive flag"
+
+# Idempotent re-add: no duplicate, and the flag follows the new value.
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d "{\"path\":\"$SCRATCH_DIR\",\"recursive\":false}" "$HOST/api/v0/shared/directories"
+_assert_status 200 "POST (re-add same path) → 200"
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_assert_json_eq \
+	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '1' \
+	"re-add did not duplicate the entry"
+_assert_json_eq \
+	"[.directories[] | select(.path==\"$SCRATCH_DIR\")][0].recursive" 'false' \
+	"re-add updated the recursive flag"
+
+# --- 5. Server-side validation of a path the client cannot check. ----
+BOGUS="$SCRATCH_DIR/definitely-not-here"
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d "{\"path\":\"$BOGUS\"}" "$HOST/api/v0/shared/directories"
+_assert_status 200 "POST (nonexistent path) → 200 with a rejection"
+_assert_json_eq \
+	"[.rejected[] | select(.path==\"$BOGUS\")][0].reason" 'not_found' \
+	"nonexistent path rejected as not_found"
+
+# The valid entry must survive a sibling's rejection.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_assert_json_eq \
+	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '1' \
+	"rejection did not discard the valid entry"
+_assert_json_eq \
+	"[.directories[] | select(.path==\"$BOGUS\")] | length" '0' \
+	"rejected path was not stored"
+
+# --- 6. Remove it again. --------------------------------------------
+_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/shared/directories?path=$SCRATCH_ENC"
+_assert_status 200 "DELETE (configured path) → 200"
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_assert_json_eq \
+	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '0' \
+	"deleted directory is gone"
+
+_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/shared/directories?path=$SCRATCH_ENC"
+_assert_status 404 "DELETE (path not configured) → 404"
+
+# --- Summary. -------------------------------------------------------
+echo
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	exit 0
+fi
+echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"
+exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -203,6 +203,7 @@ PHASES=(
 	28-list-pagination-sort.sh
 	29-bulk-mutations.sh
 	30-shared-verify.sh
+	31-shared-directories.sh
 )
 
 # Override list from the command line if given.


### PR DESCRIPTION
Follow-up to #530, which made the core's share roots reachable over EC. amuleapi could already list the files a share produced (`/shared`) and ask the core to re-walk its roots (`/shared/reload`), but had no way to see or change which roots those were.

### Endpoints

| Verb | Purpose |
|---|---|
| `GET /api/v0/shared/directories` | the configured roots as `{path, recursive}` — **GUEST** |
| `PUT /api/v0/shared/directories` | replace the whole set — **ADMIN** |
| `POST /api/v0/shared/directories` | add one root, idempotent — **ADMIN** |
| `DELETE /api/v0/shared/directories?path=…` | remove one root — **ADMIN** |

`GET` returns the user's *intent*, not the runtime expansion: a recursive root is a single entry however many subdirectories it covers. The derived union is deliberately not exposed — it's generated state, not configuration. Read access is `GUEST` to match `GET /shared` and `GET /preferences`, both of which already expose paths.

`PUT` mirrors the core's operation one-for-one rather than hiding a read-modify-write behind a merge. `POST`/`DELETE` exist because the scripted case is a single folder, and making every client read-splice-write the whole list is how clients get it wrong. `POST` is idempotent (re-adding updates the `recursive` flag) so "ensure this is shared" repeats safely; `DELETE` 404s on an unconfigured path so a typo is visible.

### Validation

The core validates each path — a REST client can't stat the core's filesystem, so a typo would otherwise become a silently dead share. Entries that pass are applied, persisted and rescanned; the rest come back in `rejected`, and **one bad path never discards the edit**:

```json
{ "ok": true, "rejected": [ { "path": "/typo", "reason": "not_found" } ] }
```

Reasons arrive from the core as codes and are rendered here, so its locale can't leak into a response — the same approach amuleGUI uses.

### Concurrency

`POST` and `DELETE` are read-modify-write against a whole-list operation, so they hold a mutex across the read and the write: `SendRecvSerialized` locks per round-trip, not across a pair, and two concurrent adds would otherwise lose one. Nothing can make this atomic against a *simultaneous* amuleGUI edit — the protocol has no compare-and-set — so that stays last-write-wins, and the reference documents it rather than implying otherwise.

### Testing

New `31-shared-directories.sh` curl smoke, registered in `run-all.sh`. It snapshots the operator's real configuration and restores it on exit (including early exit), and works entirely under a `mktemp` directory. Covers auth/method/body guards, an add → read-back → delete round trip, idempotent re-add, and a server-side rejection landing alongside a valid entry that survives.

30/30 passing against a live amuled + amuleapi. clang-format clean across `src/`, Tier-1 and Tier-2 clang-tidy clean. No `.po` impact — the reason strings are wire values, not translatable text.
