### PR TITLE
fix(ec): drop comments the ECCodes generator cannot parse

### DIFF
--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -159,8 +159,6 @@ EC_OP_GET_CHAT_MESSAGES             0x5B
 
 EC_OP_CHAT_MESSAGES                 0x5C
 
-# Shared-directory configuration. GET returns the daemon's explicit and
-# recursive roots; SET replaces both lists, persists them and rescans.
 EC_OP_GET_SHARED_DIRS               0x5D
 
 EC_OP_SET_SHARED_DIRS               0x5E
@@ -196,8 +194,6 @@ EC_TAG_PREFER_NO_ZLIB                     0x0014
 EC_TAG_CAN_MULTI_SEARCH                   0x0015
 EC_TAG_CAN_CHAT                           0x0016
 
-# Client can read/write the daemon's shared-directory configuration
-# (EC_OP_GET/SET_SHARED_DIRS). Echoed by daemons that implement it.
 EC_TAG_CAN_SHAREDDIRS_CONFIG              0x0017
 
 
@@ -588,16 +584,8 @@ EC_TAG_SELECT_PREFS                       0x1000
 		EC_TAG_IP2COUNTRY_LAST_RESULT             0x1F0B
 		EC_TAG_IP2COUNTRY_UPDATE_NOW              0x1F0C
 
-	# Shared-directory configuration (EC_OP_GET/SET_SHARED_DIRS). One
-	# EC_TAG_SHAREDDIR per configured root, its string value being the
-	# path; the RECURSIVE subtag marks a root whose whole subtree is
-	# shared (shareddir-recursive.dat) versus a plain explicit root
-	# (shareddir-explicit.dat). The runtime union (shareddir.dat) is
-	# derived by the daemon and never travels on the wire.
 	EC_TAG_SHAREDDIR                          0x2000
 		EC_TAG_SHAREDDIR_RECURSIVE                0x2001
-	# SET reply: one REJECTED tag per path the daemon refused, its
-	# string value being the path, with the reason in the ERROR subtag.
 	EC_TAG_SHAREDDIR_REJECTED                 0x2002
 		EC_TAG_SHAREDDIR_ERROR                    0x2003
 [/Section]


### PR DESCRIPTION
The Flatpak job regenerates `ECCodes.h` from `ECCodes.abstract` rather than using the committed header, and #530's comments in that file made the generated header unparseable — `invalid preprocessing directive #=` and a truncated `ECOpCodes` enum — failing every Flatpak build on master ([run](https://github.com/amule-org/amule/actions/runs/29743590866)).

Two separate ways those comments broke it:

- The generator only treats a line as a comment when it matches `^#`, i.e. with **no leading whitespace**. The comments inside the tag section were indented to line up with the entries, so they fell through to the data path, lost their leading tab, and had every word turned into a field.
- It also flattens the file into a CMake list by replacing newlines with `;` (`abstracts/CMakeLists.txt`), so a **semicolon inside a comment** splits the line and the fragment after it no longer starts with `#`. That's where the mangled `ECOpCodes` entry came from.

Documentation for these codes already lives in the hand-maintained `ECCodes.h`, so the fix is simply to keep the abstract to entries.

Verified by generating a header from the abstract before and after: master's produces **8 mangled lines and 11 compile errors**, this produces **none**, with all seven new codes present and correct.
