### PR TITLE
docs(api): link POST/DELETE shared/directories and document DELETE path encoding

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -49,6 +49,8 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`POST /api/v0/shared/reload`](#post-apiv0sharedreload) — re-walk shared directories
 - [`GET /api/v0/shared/directories`](#get-apiv0shareddirectories) — the configured share roots
 - [`PUT /api/v0/shared/directories`](#put-apiv0shareddirectories) — replace the configured share roots
+- [`POST /api/v0/shared/directories`](#post-apiv0shareddirectories) — add one share root
+- [`DELETE /api/v0/shared/directories`](#delete-apiv0shareddirectories) — remove one share root
 - [`POST /api/v0/shared/{hash}/verify`](#post-apiv0sharedhashverify) — re-hash a shared file against its on-disk data
 - [`PATCH /api/v0/shared`](#patch-apiv0shared) — bulk change upload priority
 - [`PATCH /api/v0/shared/{hash}`](#patch-apiv0sharedhash) — change upload priority
@@ -1169,12 +1171,19 @@ Idempotent: adding a path that is already configured updates its `recursive` fla
 
 Remove a single root. The path is a query parameter rather than a path segment because it is an absolute filesystem path.
 
+Pass the **exact** `path` string returned by `GET /shared/directories`, percent-encoded — the match is byte-for-byte, so a differing separator or drive-letter case will not match. This is what makes Windows roots work: percent-encoding carries the backslashes, the `C:` colon, and any spaces through unchanged.
+
 ```sh
+# POSIX root: /home/user/new
 curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/shared/directories?path=%2Fhome%2Fuser%2Fnew"
+
+# Windows root: C:\Users\bob\My Shares
+curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/shared/directories?path=C%3A%5CUsers%5Cbob%5CMy%20Shares"
 ```
 
-Removing a path that is not configured is a `404` rather than a silent success, so a typo is visible. Same `{ok, rejected}` body as `PUT`.
+Removing a path that is not configured is a `404` rather than a silent success, so a typo — or a path that does not byte-match what `GET` returned — is visible. Same `{ok, rejected}` body as `PUT`.
 
 **Errors:** `400 bad_request` (no `path` parameter), `404 not_found` (path not configured), `502 amuled_rejected`, `503 ec_unavailable`.
 


### PR DESCRIPTION
Follow-up to #531, tightening the reference docs for the shared-directories endpoints — no code change.

Two fixes:

- **Index was incomplete.** The endpoint summary listed only `GET` and `PUT /shared/directories`. The `POST` and `DELETE` sections were fully written in the body but had no link from the index, so they were only findable by scrolling. Added the two missing entries.

- **DELETE encoding was underspecified.** `DELETE` takes the path as a query parameter, and the docs didn't state two things a client needs: the value must be the **exact** string `GET` returned (the daemon matches it byte-for-byte), and it must be percent-encoded. Added that note plus a **Windows example** (`C:\Users\bob\My Shares` → `path=C%3A%5CUsers%5Cbob%5CMy%20Shares`) next to the existing POSIX one, so the backslash / drive-letter-colon / space encoding is shown rather than left to the reader to work out.

The byte-for-byte match is the existing behaviour (`Api.cpp`, `it->path == wanted`), not a change — the docs just now describe it.

While here I audited the whole reference: every documented endpoint is now linked from the index, and all in-page anchors resolve. The server `ip:port` aliases stay folded into their `{ecid}` index lines (annotated "ECID or `ip:port`"), matching the existing convention.
