### PR TITLE
fix(shutdown): release the single-instance lock before std::_Exit

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -227,6 +227,10 @@ int CamuleRemoteGuiApp::OnExit()
 	// crash. By this point our own cleanup (timer, sockets) has run; _Exit
 	// bypasses atexit + static destructors so the buggy wx dtor never runs.
 	// Remove once the upstream wx fix lands in a release we depend on.
+	//
+	// _Exit also skips ~CamuleAppCommon, which would release the
+	// single-instance lock; drop it here so muleLockRGUI is unlinked.
+	ReleaseSingleInstance();
 	std::_Exit(0);
 
 	return wxApp::OnExit();

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -510,6 +510,11 @@ int CamuleApp::OnExit()
 	// _Exit bypasses atexit and static destructors, so the buggy wx
 	// dtor never runs and the process terminates cleanly. Remove this
 	// once the upstream wx fix lands in a release we depend on.
+	//
+	// It also bypasses ~CamuleAppCommon, which would otherwise release the
+	// single-instance lock; drop it here so muleLock is unlinked rather than
+	// left dangling for the next run.
+	ReleaseSingleInstance();
 	std::_Exit(0);
 
 	// Return 0 for successful program termination

--- a/src/amule.h
+++ b/src/amule.h
@@ -151,6 +151,11 @@ protected:
 
 	bool InitCommon(int argc, wxChar **argv);
 	void RefreshSingleInstanceChecker();
+	// Drop the single-instance lock (and unlink its file). OnExit() calls
+	// std::_Exit() to dodge the wxWebSession teardown crash, which bypasses
+	// ~CamuleAppCommon — so this must be called explicitly before the exit,
+	// or the muleLock / muleLockRGUI file lingers between runs.
+	void ReleaseSingleInstance();
 	bool CheckMuleDirectory(const wxString &desc,
 		const class CPath &directory,
 		const wxString &alternative,

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -134,6 +134,15 @@ void CamuleAppCommon::RefreshSingleInstanceChecker()
 	m_singleInstance->Acquire("muleLock", thePrefs::GetConfigDir());
 }
 
+void CamuleAppCommon::ReleaseSingleInstance()
+{
+	// ~InstanceLock() -> Release() unlinks the lock file and drops the
+	// fcntl lock. Needed because OnExit() terminates via std::_Exit(),
+	// which skips ~CamuleAppCommon and so would leave the file behind.
+	delete m_singleInstance;
+	m_singleInstance = nullptr;
+}
+
 void CamuleAppCommon::AddLinksFromFile()
 {
 	const wxString fullPath = thePrefs::GetConfigDir() + "ED2KLinks";


### PR DESCRIPTION
`OnExit()` terminates via `std::_Exit()` to skip wx's `WebRequestModule` teardown — the `wxWebSession` destructor dereferences freed state and crashes on quit (amule-org/amule#18). But `std::_Exit()` also bypasses `~CamuleAppCommon`, which is what would delete the `InstanceLock` and unlink its lock file. So **`muleLock` (and `muleLockRGUI` for amulegui) was left on disk after every clean exit, on every platform.**

**Fix:** add `CamuleAppCommon::ReleaseSingleInstance()` and call it immediately before `std::_Exit()` in both `CamuleApp::OnExit` and `CamuleRemoteGuiApp::OnExit`. The kernel drops the `fcntl` lock on exit regardless; this removes the stale *file*.

**Scope/impact.** The leftover file was **functionally harmless**. `InstanceLock` keys on the kernel `fcntl` lock, not the file's presence, so a stale `muleLock` never blocked startup (which is why users see "No other instances are running" and it proceeds). This is a cleanup fix — it removes an artifact that confuses users inspecting the config dir, not a lock-correctness bug.

**Verification.** Built monolithic + amulegui + amuled. Ran the fixed amuled with a throwaway config: it acquired `muleLock`, exited through the normal `OnExit` path, and `muleLock` was removed — versus current master, where it persists. clang-format v18 and clang-tidy Tier-1 + Tier-2 both clean.
