### PR TITLE
fix(remote-gui): repaint client/source list after a Freeze/Thaw refresh on Windows

### DIFF
--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -5643,6 +5643,20 @@ void wxGenericListCtrl::Freeze()
 void wxGenericListCtrl::Thaw()
 {
 	m_mainWin->Thaw();
+
+	// wxMSW leaves rows blank after a Freeze/Thaw-wrapped repopulate: the
+	// cached visible-line range is stale and Thaw's repaint blits it without
+	// recomputing, so the exposed rows stay empty until a scroll or click
+	// forces a recompute (aMule #478, #445 -- same wxMSW blit-without-repaint
+	// family, reached here through a data refresh rather than scrolling). Once
+	// fully thawed (a nested Freeze still suppresses painting), do the work the
+	// idle handler would do when dirty -- RecalculatePositions() resets the
+	// visible-line range -- but now, then repaint. macOS/GTK recompute on their
+	// own and are unaffected.
+	if (!m_mainWin->IsFrozen()) {
+		m_mainWin->RecalculatePositions();
+		m_mainWin->RefreshAll();
+	}
 }
 
 } // namespace MuleExtern


### PR DESCRIPTION
Testing the View Files feature (#399), @ghysler hit a regression on Windows 11: after right-clicking a row in the Shared Files window, the bottom Client list goes blank a couple of seconds later — the rows are still there and the context menu works, but they're invisible until a left-click anywhere in the panel repaints them.

This is the same wxMSW family as #478 (list rows blanking on scroll/keyboard) and #445 (log view blanking), reached through a different trigger. `CGenericClientListCtrl::ShowSources()` repopulates the sources/peers list inside `Freeze()`/`Thaw()`. On wxMSW the cached visible-line range is stale after the batched insert/delete, and Thaw's repaint blits it without recomputing, so the exposed rows come up blank until a scroll or click forces a recompute. It surfaces most on a remote GUI, where the peer data arrives asynchronously over EC a few seconds after selecting a file — so the repopulate, and the blanking, lands right after the click.

The #478 fix only covered the scroll (`OnScroll`) and keyboard-nav (`MoveToItem`) paths, neither of which involves Freeze/Thaw, so this data-refresh path was never covered — and it still needs #478, since scrolling and HOME/END don't go through Thaw.

Fix it at the root, in the vendored `wxGenericListCtrl::Thaw()`: once fully thawed (a nested Freeze still suppresses painting), do the work the idle handler already does when the control is dirty — `RecalculatePositions()`, which resets the visible-line range — then `RefreshAll()`. This reuses the existing recompute/repaint primitives (the same `ResetVisibleLinesRange()` lever #478's `ScrollListTo()` relies on) rather than duplicating them, and covers every Freeze/Thaw user of these lists, not just `ShowSources`.

macOS/GTK recompute their metrics regardless and are unaffected either way.

**Test plan** — @ghysler, this is the fix for the disappearing Client list; a Windows build with it is on issue #399 (portable, GUI-only, no daemon change). To confirm:

- Connect amuleGUI to a remote amuled, open the Shared Files window.
- Select/right-click a shared file so the bottom Client list populates from the async EC response.
- The Client list should stay visible through the right-click and the refresh that follows — no rows blanking out, no need to left-click to bring them back.
- Sanity-check the same list still repaints correctly on scroll and keyboard nav (HOME/END/PgUp/PgDn), i.e. the #478 behaviour is intact.

Reasoned from the #445/#478 mechanism and validated to build on macOS; the wxMSW-specific repaint needs a Windows run to confirm, which is what the test build is for.
