### PR TITLE
fix(gui): make View Files switch to an open browse tab and browse each selected peer

### DIFF
--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -36,6 +36,7 @@
 #include "AddFriend.h"          // Needed for CAddFriend
 #include "ChatWnd.h"            // Needed for CChatWnd
 #include "Friend.h"             // Needed for CFriend
+#include "SearchDlg.h"          // Needed for CSearchDlg (View Files browse tab)
 #include "muuli_wdr.h"
 #include "SafeFile.h"
 #include "FriendList.h" // Needed for the friends list
@@ -222,7 +223,16 @@ void CFriendListCtrl::OnViewFiles(wxCommandEvent &WXUNUSED(event))
 
 	while (index != -1) {
 		CFriend *cur_friend = reinterpret_cast<CFriend *>(GetItemData(index));
-		theApp->friendlist->RequestSharedFileList(cur_friend);
+		// If this friend's listing is already open in the Search panel, switch
+		// to that tab instead of re-requesting -- a second request would
+		// duplicate the results in the existing tab. The browse tab is keyed by
+		// the linked client's ECID (0 when the friend isn't currently linked).
+		const CClientRef &linked = cur_friend->GetLinkedClient();
+		const uint32 ecid = linked.IsLinked() ? linked.ECID() : 0;
+		if (!(theApp->amuledlg && theApp->amuledlg->m_searchwnd &&
+			    theApp->amuledlg->m_searchwnd->ActivateBrowseTabIfOpen(ecid))) {
+			theApp->friendlist->RequestSharedFileList(cur_friend);
+		}
 		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 	}
 }

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -29,6 +29,7 @@
 #include <common/Format.h> // Needed for CFormat
 #include "amule.h"         // Needed for theApp
 #include "amuleDlg.h"      // Needed for CamuleDlg
+#include "SearchDlg.h"     // Needed for CSearchDlg (View Files browse tab)
 #include "BarShader.h"     // Needed for CBarShader
 #include "BitVector.h"
 #include "ClientDetailDialog.h" // Needed for CClientDetailDialog
@@ -552,8 +553,16 @@ void CGenericClientListCtrl::OnViewFiles(wxCommandEvent &WXUNUSED(event))
 {
 	ItemList sources = ::GetSelectedItems(this);
 
-	if (sources.size() == 1) {
-		sources.front()->GetSource().RequestSharedFileList();
+	// Browse each selected peer, opening one result tab per peer. If a peer's
+	// listing is already open in the Search panel, switch to that tab instead
+	// of re-requesting -- a second request would duplicate the results in the
+	// existing tab. Only once the tab is closed does a fresh request go out.
+	for (ClientCtrlItem_Struct *source : sources) {
+		CClientRef &client = source->GetSource();
+		if (!(theApp->amuledlg && theApp->amuledlg->m_searchwnd &&
+			    theApp->amuledlg->m_searchwnd->ActivateBrowseTabIfOpen(client.ECID()))) {
+			client.RequestSharedFileList();
+		}
 	}
 }
 

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -489,15 +489,37 @@ wxUIntPtr CSearchDlg::AllocateOptimisticId()
 	return 0x40000000u | (s_optimisticIdCounter & 0x3fffffffu);
 }
 
-CSearchListCtrl *CSearchDlg::GetBrowseList(uint32 ecid)
+CSearchListCtrl *CSearchDlg::GetBrowseList(uint32 ecid, int *outPage)
 {
 	for (size_t i = 0; i < m_notebook->GetPageCount(); ++i) {
 		CSearchListCtrl *page = dynamic_cast<CSearchListCtrl *>(m_notebook->GetPage(i));
 		if (page && page->GetBrowseEcid() == ecid) {
+			if (outPage) {
+				*outPage = static_cast<int>(i);
+			}
 			return page;
 		}
 	}
 	return nullptr;
+}
+
+bool CSearchDlg::ActivateBrowseTabIfOpen(uint32 peerEcid)
+{
+	// ecid 0 is "no live client" (e.g. an unlinked friend): nothing to match.
+	if (peerEcid == 0) {
+		return false;
+	}
+	int page = -1;
+	if (GetBrowseList(peerEcid, &page) && page >= 0) {
+		m_notebook->SetSelection(static_cast<size_t>(page));
+		// The request came from another panel (Friends / Transfers); bring the
+		// Search panel forward so the already-open tab is actually revealed.
+		if (theApp->amuledlg) {
+			theApp->amuledlg->ShowSearchWindow();
+		}
+		return true;
+	}
+	return false;
 }
 
 void CSearchDlg::EnsureBrowseTab(uint32 peerEcid, const wxString &userName, wxUIntPtr searchID)

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -138,6 +138,14 @@ public:
 	// routing ID is rekeyed to searchID. Shared by monolithic and amuleGUI.
 	void EnsureBrowseTab(uint32 peerEcid, const wxString &userName, wxUIntPtr searchID);
 
+	// "View Files": if a browse tab for this peer's ECID is already open, bring
+	// the Search panel forward, select that tab, and return true. Lets the
+	// request sites skip re-browsing a peer whose listing is still on screen --
+	// which would otherwise fire a redundant request and duplicate the results
+	// in the existing tab. Returns false (and does nothing) for ecid 0 or when
+	// no such tab is open. Shared by monolithic and amuleGUI.
+	bool ActivateBrowseTabIfOpen(uint32 peerEcid);
+
 	// Remote GUI: allocate a fresh optimistic placeholder tab ID in the reserved
 	// high sub-range (bit 30, bottom half) the daemon's allocators never produce.
 	wxUIntPtr AllocateOptimisticId();
@@ -203,7 +211,8 @@ private:
 	void ApplyProgressToBar(uint32 status);
 
 	// Find an open "View Files" tab by the browsed peer's ECID (NULL if none).
-	CSearchListCtrl *GetBrowseList(uint32 ecid);
+	// When found and outPage is non-null, outPage receives the tab's page index.
+	CSearchListCtrl *GetBrowseList(uint32 ecid, int *outPage = nullptr);
 
 	// Monotonic counter behind search/browse tab IDs. On the remote GUI both a
 	// new search and a browse draw their optimistic placeholder from it via


### PR DESCRIPTION
Three issues with **View Files** (browse a peer's shared files, #520), affecting both the monolithic client and amuleGUI:

1. **Re-requesting a peer whose result tab was still open didn't switch to it** — the request just fired again and left you on the current panel.
2. **It duplicated the listing** — the second response appended another copy of the file list into the existing tab.
3. **Selecting several clients and choosing View Files did nothing** — the client handler bailed unless exactly one was selected, whereas the same action on several friends already opened a tab per friend. Inconsistent.

## Fix

A new `CSearchDlg::ActivateBrowseTabIfOpen(ecid)` — if a browse tab keyed by the peer's client-ECID is already open, it brings the Search panel forward, selects that tab, and reports that it handled the request. Both the Friends and Clients "View Files" handlers call it before requesting:

- An already-open peer **switches to its tab instead of re-browsing** — no redundant request, no duplicated results. Only once the tab is closed does a fresh request go out (fixes 1 + 2).
- Both handlers now **loop over the whole selection**, so multi-select opens one tab per peer, consistently across Friends and Clients (fixes 3).

Works in both builds: in amuleGUI the browse tab is created optimistically at request time (`SendBrowseRequest -> EnsureBrowseTab`), so the ECID lookup matches there too.

## Testing

Builds clean on macOS (monolithic + amuleGUI); clang-format and clang-tidy (Tier-1 + Tier-2) clean on the diff. Verified live: re-View-Files on an open peer switches to its tab with no duplication; multi-selecting two peers opens both tabs.
