### PR TITLE
fix(i18n): replace non-ASCII dashes/arrows in strings that mojibake on Windows

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -2364,11 +2364,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/ar.po
+++ b/po/ar.po
@@ -2395,11 +2395,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/ast.po
+++ b/po/ast.po
@@ -2445,11 +2445,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/bg.po
+++ b/po/bg.po
@@ -2389,11 +2389,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/bn.po
+++ b/po/bn.po
@@ -2363,11 +2363,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/ca.po
+++ b/po/ca.po
@@ -2436,11 +2436,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/cs.po
+++ b/po/cs.po
@@ -2423,11 +2423,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/da.po
+++ b/po/da.po
@@ -2400,11 +2400,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/de.po
+++ b/po/de.po
@@ -2441,11 +2441,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/el.po
+++ b/po/el.po
@@ -2454,11 +2454,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -2364,11 +2364,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/es.po
+++ b/po/es.po
@@ -2444,12 +2444,12 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "GeoLite2-Country.mmdb migrado a %s"
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
-msgstr "IP2Country: Se ha seleccionado MaxMind como fuente GeoIP, pero no se ha configurado ninguna clave de licencia. Abra Preferencias → IP2Country, pegue su clave de licencia gratuita de MaxMind y haga clic en «Actualizar ahora»."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgstr "IP2Country: Se ha seleccionado MaxMind como fuente GeoIP, pero no se ha configurado ninguna clave de licencia. Abra Preferencias -> IP2Country, pegue su clave de licencia gratuita de MaxMind y haga clic en «Actualizar ahora»."
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
-msgstr "IP2Country: Se ha seleccionado una URL personalizada como fuente GeoIP, pero no se ha configurado ninguna URL. Abra Preferencias → IP2Country e introduzca una URL que apunte a un archivo .mmdb (o .gz / .tar.gz que contenga uno)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgstr "IP2Country: Se ha seleccionado una URL personalizada como fuente GeoIP, pero no se ha configurado ninguna URL. Abra Preferencias -> IP2Country e introduzca una URL que apunte a un archivo .mmdb (o .gz / .tar.gz que contenga uno)."
 
 #: src/IP2Country.cpp:116
 msgid "IP2Country: failed to resolve a GeoIP download URL."

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -2437,11 +2437,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/eu.po
+++ b/po/eu.po
@@ -2438,11 +2438,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/fi.po
+++ b/po/fi.po
@@ -2438,11 +2438,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/fr.po
+++ b/po/fr.po
@@ -2444,12 +2444,12 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Le fichier GeoLite2-Country.mmdb existant a été migré vers %s"
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
-msgstr "IP2COuntry : MaxMind a été sélectionné en tant que source de GeoIP mais aucune clef de licence n'a été configurée. Ouvrez Préférences → IP2Country, collez votre clef de licence MaxMind gratuit et cliquez sur « Mettre à jour maintenant »."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgstr "IP2COuntry : MaxMind a été sélectionné en tant que source de GeoIP mais aucune clef de licence n'a été configurée. Ouvrez Préférences -> IP2Country, collez votre clef de licence MaxMind gratuit et cliquez sur « Mettre à jour maintenant »."
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
-msgstr "IP2Country : un lien (URL) personnalisé est sélectionné comme source de GeoIP, mais aucun lien n'est configuré. Ouvrez Préférences → IP2Country et fournissez un lien qui pointe vers un mmdb (ou bien un .gz / .tar.gz qui en contiendrait un)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgstr "IP2Country : un lien (URL) personnalisé est sélectionné comme source de GeoIP, mais aucun lien n'est configuré. Ouvrez Préférences -> IP2Country et fournissez un lien qui pointe vers un mmdb (ou bien un .gz / .tar.gz qui en contiendrait un)."
 
 #: src/IP2Country.cpp:116
 msgid "IP2Country: failed to resolve a GeoIP download URL."

--- a/po/gl.po
+++ b/po/gl.po
@@ -2454,11 +2454,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/he.po
+++ b/po/he.po
@@ -2407,11 +2407,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/hr.po
+++ b/po/hr.po
@@ -2407,11 +2407,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/hu.po
+++ b/po/hu.po
@@ -2428,12 +2428,12 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Létező GeoLite2-Country.mmdb migrálva %s helyre"
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
-msgstr "IP2Country: MaxMind van kiválasztva GeoIP forrásként, de nincs megadva licenckulcs. Nyissa meg a Beállítások → IP2Country pontot, illessze be az ingyenes MaxMind licenckulcsát, és kattintson a „Frissítés most” gombra."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgstr "IP2Country: MaxMind van kiválasztva GeoIP forrásként, de nincs megadva licenckulcs. Nyissa meg a Beállítások -> IP2Country pontot, illessze be az ingyenes MaxMind licenckulcsát, és kattintson a „Frissítés most” gombra."
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
-msgstr "IP2Country: Egyéni URL van kiválasztva GeoIP forrásnak, de nincs URL konfigurálva. Nyissa meg a Beállítások → IP2Country pontot, és adjon meg egy URL-t, amely egy .mmdb (vagy egy olyat tartalmazó .gz / .tar.gz) fájlra mutat."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgstr "IP2Country: Egyéni URL van kiválasztva GeoIP forrásnak, de nincs URL konfigurálva. Nyissa meg a Beállítások -> IP2Country pontot, és adjon meg egy URL-t, amely egy .mmdb (vagy egy olyat tartalmazó .gz / .tar.gz) fájlra mutat."
 
 #: src/IP2Country.cpp:116
 msgid "IP2Country: failed to resolve a GeoIP download URL."

--- a/po/it.po
+++ b/po/it.po
@@ -2449,12 +2449,12 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Migrato il file GeoLite2-Country.mmdb esistente in %s"
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
-msgstr "IP2Country: MaxMind selezionato come sorgente GeoIP ma nessuna License Key configurata. Apri Preferenze → IP2Country, incolla la tua License Key MaxMind gratuita e clicca su 'Aggiorna ora'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgstr "IP2Country: MaxMind selezionato come sorgente GeoIP ma nessuna License Key configurata. Apri Preferenze -> IP2Country, incolla la tua License Key MaxMind gratuita e clicca su 'Aggiorna ora'."
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
-msgstr "IP2Country: URL personalizzato selezionato come sorgente GeoIP ma nessun URL configurato. Apri Preferenze → IP2Country e fornisci un URL che punti a un .mmdb (o un .gz / .tar.gz che ne contenga uno)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgstr "IP2Country: URL personalizzato selezionato come sorgente GeoIP ma nessun URL configurato. Apri Preferenze -> IP2Country e fornisci un URL che punti a un .mmdb (o un .gz / .tar.gz che ne contenga uno)."
 
 #: src/IP2Country.cpp:116
 msgid "IP2Country: failed to resolve a GeoIP download URL."

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -2444,11 +2444,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/ja.po
+++ b/po/ja.po
@@ -2437,11 +2437,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -2456,11 +2456,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/lt.po
+++ b/po/lt.po
@@ -2462,11 +2462,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/lv.po
+++ b/po/lv.po
@@ -2375,11 +2375,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/nl.po
+++ b/po/nl.po
@@ -2440,11 +2440,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/nn.po
+++ b/po/nn.po
@@ -2451,11 +2451,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/pl.po
+++ b/po/pl.po
@@ -2447,11 +2447,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2445,12 +2445,12 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Arquivo GeoLite2-Country.mmdb existente migrado para %s"
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
-msgstr "IP2Country: MaxMind selecionado como fonte de GeoIP, mas não existe chave de licensa configurada. Abra Preferências → IP2Country, e cole sua chave de licensa grátis e clique \"Atualizar agora\"."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgstr "IP2Country: MaxMind selecionado como fonte de GeoIP, mas não existe chave de licensa configurada. Abra Preferências -> IP2Country, e cole sua chave de licensa grátis e clique \"Atualizar agora\"."
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
-msgstr "IP2Country: URL Customizada foi selecionada como fonte de GeoIP, mas não existe URL configurada. Abra Preferências → IP2Country, e forneça uma URL que aponte para um arquivo .nmdb (ou .gz / .tar.gz contendo um)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgstr "IP2Country: URL Customizada foi selecionada como fonte de GeoIP, mas não existe URL configurada. Abra Preferências -> IP2Country, e forneça uma URL que aponte para um arquivo .nmdb (ou .gz / .tar.gz contendo um)."
 
 #: src/IP2Country.cpp:116
 msgid "IP2Country: failed to resolve a GeoIP download URL."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -2444,11 +2444,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/ro.po
+++ b/po/ro.po
@@ -2442,11 +2442,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/ru.po
+++ b/po/ru.po
@@ -2459,11 +2459,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/sl.po
+++ b/po/sl.po
@@ -2457,11 +2457,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/sq.po
+++ b/po/sq.po
@@ -2445,11 +2445,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/sv.po
+++ b/po/sv.po
@@ -2436,11 +2436,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/ta.po
+++ b/po/ta.po
@@ -2363,11 +2363,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/tr.po
+++ b/po/tr.po
@@ -2437,12 +2437,12 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Mevcut GeoLite2-Country.mmdb dosyası %s unsuruna taşındı"
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
-msgstr "IP2Country: MaxMind GeoIP kaynağı olarak seçilmiştir fakat hiçbir Lisans Anahtarı yapılandırılmamıştır. Ayarlar → IP2Country menülerine gidin, ücretsiz MaxMind Lisans Anahtarınızı yapıştırın ve 'Şimdi güncelle' düğmesine tıklayın."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgstr "IP2Country: MaxMind GeoIP kaynağı olarak seçilmiştir fakat hiçbir Lisans Anahtarı yapılandırılmamıştır. Ayarlar -> IP2Country menülerine gidin, ücretsiz MaxMind Lisans Anahtarınızı yapıştırın ve 'Şimdi güncelle' düğmesine tıklayın."
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
-msgstr "IP2Country: kişiselleştirilmiş bir URL (bağlantı) GeoIP kaynağı olarak seçilmiştir fakat hiçbir URL yapılandırılmamıştır. Ayarlar → IP2Country menülerine gidin ve bir .mmdb dosyasına (veya onu içeren bir .gz / .tar.gz dosyasına) işaret eden bir URL girin."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgstr "IP2Country: kişiselleştirilmiş bir URL (bağlantı) GeoIP kaynağı olarak seçilmiştir fakat hiçbir URL yapılandırılmamıştır. Ayarlar -> IP2Country menülerine gidin ve bir .mmdb dosyasına (veya onu içeren bir .gz / .tar.gz dosyasına) işaret eden bir URL girin."
 
 #: src/IP2Country.cpp:116
 msgid "IP2Country: failed to resolve a GeoIP download URL."

--- a/po/uk.po
+++ b/po/uk.po
@@ -2457,11 +2457,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2441,12 +2441,12 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "已将现有的 GeoLite2-Country.mmdb 迁移至 %s"
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
-msgstr "IP2Country：已选择 MaxMind 作为 GeoIP 源，但未配置许可证密钥。请打开偏好设置 → IP2Country，粘贴您的免费 MaxMind 许可证密钥，然后点击“立即更新”。"
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgstr "IP2Country：已选择 MaxMind 作为 GeoIP 源，但未配置许可证密钥。请打开偏好设置 -> IP2Country，粘贴您的免费 MaxMind 许可证密钥，然后点击“立即更新”。"
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
-msgstr "IP2Country：已选择自定义 URL 作为 GeoIP 源，但未配置 URL。请打开偏好设置 → IP2Country，并提供指向 .mmdb 文件（或包含该文件的.gz/.tar.gz 压缩包）的 URL。"
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgstr "IP2Country：已选择自定义 URL 作为 GeoIP 源，但未配置 URL。请打开偏好设置 -> IP2Country，并提供指向 .mmdb 文件（或包含该文件的.gz/.tar.gz 压缩包）的 URL。"
 
 #: src/IP2Country.cpp:116
 msgid "IP2Country: failed to resolve a GeoIP download URL."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2434,11 +2434,11 @@ msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
 #: src/IP2Country.cpp:106
-msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences → IP2Country, paste your free MaxMind License Key and click 'Update now'."
+msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
 #: src/IP2Country.cpp:111
-msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences → IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
+msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
 #: src/IP2Country.cpp:116

--- a/scripts/update-po.sh
+++ b/scripts/update-po.sh
@@ -87,6 +87,15 @@ sed -e "1,5 s/^# Copyright (C) YEAR /# Copyright (C) ${YEAR} /" po/amule.pot > p
 	&& mv po/amule.pot.tmp po/amule.pot
 die 32 "failed to substitute copyright year in po/amule.pot"
 
+# xgettext stamps "charset=CHARSET" whenever every extracted msgid is ASCII
+# (it only infers UTF-8 once it sees a non-ASCII byte). An all-ASCII template
+# is legitimate, but "CHARSET" is not a portable encoding name -- msgcat and
+# the catalog-sync check reject it. Pin the header to UTF-8, which is correct
+# for ASCII and already matches every .po.
+sed -e "s/charset=CHARSET/charset=UTF-8/" po/amule.pot > po/amule.pot.tmp \
+	&& mv po/amule.pot.tmp po/amule.pot
+die 33 "failed to normalise charset in po/amule.pot"
+
 echo "Merging po/amule.pot into each .po file ..."
 # Write via --output-file + mv rather than --update: msgmerge --update
 # treats the .po as up-to-date when only the pot's wrap differs from

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -657,7 +657,7 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				if (request->GetTagByName(EC_TAG_PREFER_NO_ZLIB)) {
 					SetLocalPeer(true);
 					AddDebugLogLineN(logEC,
-						CFormat("EC peer %s asked to skip ZLIB (loopback/LAN hint) — "
+						CFormat("EC peer %s asked to skip ZLIB (loopback/LAN hint) - "
 							"bypassing for small/medium packets") %
 							GetPeer());
 				}

--- a/src/IP2Country.cpp
+++ b/src/IP2Country.cpp
@@ -104,12 +104,12 @@ void CIP2Country::StartDownload(int monthOffset)
 		switch (thePrefs::GetGeoIPSource()) {
 		case CPreferences::GeoIPSourceMaxMind:
 			msg = _("IP2Country: MaxMind selected as the GeoIP source but no License Key "
-				"configured. Open Preferences → IP2Country, paste your free MaxMind "
+				"configured. Open Preferences -> IP2Country, paste your free MaxMind "
 				"License Key and click 'Update now'.");
 			break;
 		case CPreferences::GeoIPSourceCustom:
 			msg = _("IP2Country: Custom URL selected as the GeoIP source but no URL "
-				"configured. Open Preferences → IP2Country and supply a URL that "
+				"configured. Open Preferences -> IP2Country and supply a URL that "
 				"points to an .mmdb (or .gz / .tar.gz containing one).");
 			break;
 		default:

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -1080,7 +1080,7 @@ private:
 				// exiting." the EC layer prints next.
 				wxString msg =
 					CFormat(wxT("amule: synchronous socket read made no progress for %d "
-						    "ms (peer %s) — stalled or desynced peer; dropping the "
+						    "ms (peer %s) - stalled or desynced peer; dropping the "
 						    "connection.")) %
 					m_syncReadTimeoutMs % m_IP;
 				fprintf(stderr, "%s\n", (const char *)unicode2char(msg));

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -2102,7 +2102,7 @@ void PrefsUnifiedDlg::UpdateGeoIPStatus()
 		const wxString &last = thePrefs::GetGeoIPStatusLastResult();
 		if (!last.IsEmpty()) {
 			if (!line.IsEmpty()) {
-				line += " — ";
+				line += " - ";
 			}
 			line += last;
 		}

--- a/src/ProtocolHandlerManager.cpp
+++ b/src/ProtocolHandlerManager.cpp
@@ -172,7 +172,7 @@ void ProtocolHandler_QueueSchemeLink(const wxString &url)
 	// the literals CMagnetED2KConverter / the eD2k parser expect.
 	wxString decoded = wxURI::Unescape(url);
 	const wxString &cfgDir = thePrefs::GetConfigDir();
-	AMULE_URL_LOG(wxT("queue: '%s' → '%s'"), url, decoded);
+	AMULE_URL_LOG(wxT("queue: '%s' -> '%s'"), url, decoded);
 
 	wxTextFile ed2kFile(cfgDir + wxT("ED2KLinks"));
 	if (!ed2kFile.Exists()) {

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -733,7 +733,7 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, bool bForceRepr
 		theApp->mediaProbeThread->QueueProbe(pFile->GetFileHash(), fullPath, ffprobePath);
 	} else {
 		AddDebugLogLineN(logMediaProbe,
-			CFormat(wxT("MediaProbe: dropped %s — probe thread not ready")) %
+			CFormat(wxT("MediaProbe: dropped %s - probe thread not ready")) %
 				pFile->GetFileName());
 	}
 }


### PR DESCRIPTION
The IP2Country preferences panel showed mojibake on Windows where an em-dash separator should be. Root cause: a narrow `char` string literal containing a UTF-8 em-dash (`U+2014`) is decoded via the system codepage — not UTF-8 — when handed to `wxString` on Windows, so it renders as garbage. (macOS/Linux UTF-8 locales mask it, which is why it only shows on Windows.)

A whole-tree scan found the same pattern (em-dashes and arrows, `U+2192`) in six literals:

- `PrefsUnifiedDlg.cpp` — the IP2Country panel separator (the reported case)
- `IP2Country.cpp` ×2 — GeoIP hint messages (`_()`)
- `ExternalConn.cpp`, `SharedFileList.cpp`, `LibSocketAsio.cpp`, `ProtocolHandlerManager.cpp` — log strings

All replaced with ASCII (`-`, `->`). Comments are left alone — they never reach `wxString`.

**Catalogs.** The two GeoIP hints are `_()` msgids, so the arrow is replaced in the msgid **and** msgstr of every catalog, scoped to those entries, so no translation is lost or fuzzied.

**Template charset.** Those two were the only non-ASCII msgids in the tree, so with them ASCII-ised `xgettext` can no longer infer the template's charset and emits the `CHARSET` placeholder — which `msgcat` and the catalog-sync check reject as non-portable. `update-po.sh` now pins `po/amule.pot` to `UTF-8` (correct for an all-ASCII template, and what every `.po` already declares). Verified with the exact CI sync check: regen reproduces the committed catalogs with zero drift, `.pot` stays `UTF-8`, and the two entries stay non-fuzzy. Line-ref (`#:`) churn from regen is intentionally not committed — the sync check strips it and master already carries stale refs.

Note: catalog text loads from the `.mo` as UTF-8 and renders fine on Windows; translated strings were never the bug, and the msgstr edits are for consistency. Not touched: the webapi `std::string`/`std::cerr` sites (JSON is UTF-8-correct; stderr is a daemon diagnostic).
