### PR TITLE
fix(locale): promote LC_CTYPE to UTF-8 for accented paths on bare-locale daemons

### DIFF
--- a/src/libs/common/LocaleInit.cpp
+++ b/src/libs/common/LocaleInit.cpp
@@ -25,8 +25,80 @@
 
 #include <clocale>
 
+#ifndef __WXMSW__
+#include <cstdlib>
+#include <cstring>
+#include <langinfo.h>
+
+namespace
+{
+// True when `s` names the C / POSIX locale (or is empty / unset), i.e. a
+// locale with no useful character encoding for filesystem paths.
+bool IsCLocaleName(const char *s)
+{
+	return s == nullptr || s[0] == '\0' || std::strcmp(s, "C") == 0 || std::strcmp(s, "POSIX") == 0;
+}
+
+// True when the current LC_CTYPE codeset is a bare ASCII one, meaning the
+// process cannot represent accented / UTF-8 filesystem paths.
+bool CtypeCodesetIsAscii()
+{
+	const char *codeset = nl_langinfo(CODESET);
+	return codeset != nullptr && (std::strcmp(codeset, "ANSI_X3.4-1968") == 0 ||  // glibc C/POSIX
+					     std::strcmp(codeset, "US-ASCII") == 0 || // BSD/macOS C
+					     std::strcmp(codeset, "ASCII") == 0);
+}
+} // namespace
+#endif
+
 void aMuleInitLocale()
 {
 	std::setlocale(LC_ALL, "");
+
+#ifndef __WXMSW__
+	// A headless daemon in a bare container (systemd / Docker) frequently has
+	// no LANG / LC_* exported, so the call above leaves LC_CTYPE at POSIX/C.
+	// Its ASCII codeset cannot represent accented / UTF-8 filesystem paths, so
+	// wxConvFileName fails to open them — an accented shared folder silently
+	// becomes invisible to the file scan (verified on glibc: `LC_ALL=C` finds
+	// 0 files in an accented dir where UTF-8 finds them).
+	//
+	// Promote just the character type to UTF-8. The guard is the codeset
+	// itself, so a real locale is never overridden (a deliberate UTF-8 or even
+	// latin1 locale never reports ASCII here) and musl — whose C locale is
+	// already UTF-8 — never triggers it. Windows is exempt: it uses wide-char
+	// filesystem APIs, so CPath never routes a path through a narrow-locale
+	// conversion.
+	if (CtypeCodesetIsAscii()) {
+		// Pick a UTF-8 ctype the C library actually has: C.UTF-8 is portable
+		// (glibc >= 2.35, musl, most runtimes), en_US.UTF-8 the common
+		// fallback. If neither exists we stay on C — no worse than before.
+		const char *utf8 = nullptr;
+		if (std::setlocale(LC_CTYPE, "C.UTF-8") != nullptr) {
+			utf8 = "C.UTF-8";
+		} else if (std::setlocale(LC_CTYPE, "en_US.UTF-8") != nullptr) {
+			utf8 = "en_US.UTF-8";
+		}
+		if (utf8 != nullptr) {
+			// Export it, not just setlocale() it: later re-resolution of the
+			// locale (wx sets up wxConvFileName from the environment during
+			// app init) would otherwise fall back to C and undo the promotion.
+			// LC_ALL outranks LC_CTYPE, so drop a C-valued LC_ALL that would
+			// keep forcing the process back to ASCII.
+			if (IsCLocaleName(std::getenv("LC_ALL"))) {
+				unsetenv("LC_ALL");
+			}
+			setenv("LC_CTYPE", utf8, 1);
+			// Dropping LC_ALL above also stops forcing LC_NUMERIC to C for any
+			// child process (media probe, spawned amuleweb/amuleapi): its
+			// numeric category would then resolve from LANG and could inherit a
+			// comma decimal separator. Pin LC_NUMERIC=C in the environment too
+			// so children keep parsing "1.5", matching the in-process setting
+			// below.
+			setenv("LC_NUMERIC", "C", 1);
+		}
+	}
+#endif
+
 	std::setlocale(LC_NUMERIC, "C");
 }


### PR DESCRIPTION
A headless **amuled** without `LANG` / `LC_*` (systemd, Docker) runs under **POSIX/C**, whose ASCII codeset can't represent accented UTF-8 paths → `wxConvFileName` fails to open them → **an accented shared directory silently becomes invisible to the file scan**. Reproduced on ARM64 glibc: `LC_ALL=C` finds **0** files in `Música/` where a UTF-8 locale finds them. Exposed by the remote shared-folder config (#530, which is all about configuring a headless core), but it affects all of amuled's non-ASCII file handling — same root as #40.

**Fix** — in the shared `aMuleInitLocale()`: when the resolved codeset is bare ASCII, promote `LC_CTYPE` to UTF-8 (`C.UTF-8`, falling back to `en_US.UTF-8`) and **export** it, so the promotion survives wx re-resolving the locale from the environment during app init (a plain `setlocale()` alone gets undone there). It also pins `LC_NUMERIC=C` in the environment so child processes (media probe, spawned amuleweb/amuleapi) keep C decimal parsing after a C-valued `LC_ALL` is dropped.

**Bounded blast radius:** the whole block is a **no-op unless the process is already in a C/POSIX locale** — a deliberate UTF-8 or latin1 locale never reports ASCII, and musl (already UTF-8 in its C locale) never triggers it. Windows is exempt (wide-char filesystem APIs). It runs once at init (thread-safe); degrades gracefully to a no-op if no UTF-8 locale exists; leaves `LC_MESSAGES` untouched; and the codebase's explicit `LC_CTYPE=C` scopes (UPnP, wxFileConfig) self-restore and are unaffected.

**Verified** on real Linux with the built binary — the accented folder is found under a bare environment, an explicit `LC_ALL=C`, and healthy UTF-8 locales alike, with no change for a real locale (`it_IT.UTF-8`). clang-format v18 and clang-tidy Tier-1 + Tier-2 clean.
