### PR TITLE
fix(amulegui): initialize CEConnectDlg *dialog to fix x64 launch crash

### DIFF
--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -866,7 +866,11 @@ public:
 
 	class CRemoteConnect *m_connect;
 
-	CEConnectDlg *dialog;
+	// Must be null before the first ShowConnectionDialog(), which lazily
+	// creates it (if (!dialog) ...) and reuses it across retries. Left
+	// uninitialized it is read as garbage on the startup path -- harmless on
+	// Clang/ARM (landed null) but a segfault on GCC/x64.
+	CEConnectDlg *dialog = nullptr;
 
 	bool CopyTextToClipboard(wxString strText);
 


### PR DESCRIPTION
## Summary

amuleGUI crashes on launch with an access violation (`0xc0000005`) on Windows **x64**. Root cause is an **uninitialized `CEConnectDlg *dialog` member** read on the startup path. One-line fix: initialize it to `nullptr`. Reported by @ghysler in #399.

## Details

`2b9517504` (pre-3.0.1) reworked `CamuleRemoteGuiApp::ShowConnectionDialog()` to keep the connection dialog alive across retries via a lazily-created member:

```cpp
if (!dialog) {
    dialog = new CEConnectDlg;
}
```

But the `dialog` member is never initialized — no constructor, and `OnInit()` doesn't set it before the first call. So the very first `ShowConnectionDialog()` reads indeterminate garbage in `if (!dialog)`. Being UB, the outcome is build/platform-dependent:

- **Clang/ARM64:** garbage landed null → the `new` runs → works. (Every build we tested was this.)
- **GCC/x64:** garbage non-null → the `new` is skipped → `dialog->ShowModal()` dereferences a garbage pointer → segfault on launch.

gdb backtrace on the CI x64 build (fault RVA matches the reported offset):

```
#0  CamuleRemoteGuiApp::ShowConnectionDialog()
#1  CamuleRemoteGuiApp::OnInit()
```

The bug predates the 3.0.1 tag; it only surfaced now because it's latent UB that this x64 build happens to trip.

## Fix

Initialize the member at its declaration: `CEConnectDlg *dialog = nullptr;`.

## Testing

Reproduced the crash with the CI x64 build under gdb; a rebuilt x64 amuleGUI with the fix launches past the connection dialog. ARM64 was never affected.
