### PR TITLE
fix(gui): erase virtual-list rows freed by a shrink

### DIFF
--- a/src/MuleVirtualListCtrl.cpp
+++ b/src/MuleVirtualListCtrl.cpp
@@ -114,14 +114,18 @@ void CMuleVirtualListCtrl::RefreshFromRow(long fromRow)
 		top = 0;
 	}
 	long first = fromRow < top ? top : fromRow;
-	long last = top + GetCountPerPage() + 1;
+	// Clamp into range: after an erase, fromRow can equal the old (larger) count
+	// and land past the last row. RefreshAfter() bails out when its start row is
+	// beyond the visible range, so an out-of-range first would skip the repaint.
 	const long maxRow = static_cast<long>(m_items.size()) - 1;
-	if (last > maxRow) {
-		last = maxRow;
+	if (first > maxRow) {
+		first = maxRow;
 	}
-	if (last >= first) {
-		RefreshItems(first, last);
-	}
+	// Repaint from `first` down to the bottom of the client area, not just to the
+	// last item: on an erase the rows freed below the shrunken count must be
+	// cleared too, or stale, non-clickable rows linger at the bottom until a full
+	// repaint (panel switch) forces one (aMule #399).
+	RefreshAfter(first);
 }
 
 long CMuleVirtualListCtrl::InsertPos(wxUIntPtr data)

--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -5612,6 +5612,11 @@ void wxGenericListCtrl::RefreshItems(long itemFrom, long itemTo)
 	m_mainWin->RefreshLines(itemFrom, itemTo);
 }
 
+void wxGenericListCtrl::RefreshAfter(long itemFrom)
+{
+	m_mainWin->RefreshAfter(itemFrom);
+}
+
 // Generic wxListCtrl is more or less a container for two other
 // windows which drawings are done upon. These are namely
 // 'm_headerWin' and 'm_mainWin'.

--- a/src/extern/wxWidgets/listctrl.h
+++ b/src/extern/wxWidgets/listctrl.h
@@ -188,6 +188,9 @@ public:
 	virtual void Thaw();
 	// Force the deferred (idle-time) layout recompute now; see the definition.
 	void EnsureLayout();
+	// Invalidate from itemFrom down to the bottom of the client area (past the
+	// last item), so rows freed by a shrink get erased rather than left stale.
+	void RefreshAfter(long itemFrom);
 	virtual void OnDrawItem(
 		int item, wxDC *dc, const wxRect &rect, const wxRect &rectHL, bool highlighted);
 


### PR DESCRIPTION
When rows are removed from a virtual list (clients, downloads, shared files), the leftover rows below the new count stayed painted on screen — stale, non-clickable rows that only cleared on a full repaint (e.g. switching panels).

**Root cause**

`CMuleVirtualListCtrl::RefreshFromRow()` clamped its repaint range to the new (smaller) item count after an erase, so the strip below the last surviving row was never invalidated. `OnPaint` only clears the update region, so those pixels kept their old content.

**Fix**

Repaint from the first shifted row down to the bottom of the client area instead of stopping at the last item, via a new `wxGenericListCtrl::RefreshAfter()` forwarder to the existing `wxListMainWindow::RefreshAfter()`. `OnPaint` clears the whole update region first, so the freed tail is redrawn as background.

Because the fix lives in the shared `RefreshFromRow()` path, one change covers all three `CMuleVirtualListCtrl` lists. It surfaced on the shared-file peers list in #399 (client rows lingering after peers disconnect), but the same repaint gap existed on the download and shared-files lists.

**Testing**

- amulegui peers list: disconnecting clients now clear immediately instead of leaving stale rows until a panel switch.
- @ghysler is verifying the fixed x64 build, the configuration where it was originally reported.
