### PR TITLE
fix(gui): render the log views with wxStyledTextCtrl (Scintilla)

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -220,6 +220,9 @@ endif()
 
 if (NEED_LIB_MULEAPPGUI)
 	set (wx_NEED_GUI TRUE)
+	# The log/server-info panes use wxStyledTextCtrl (Scintilla) for fast,
+	# full-history scrolling; only the GUI lib pulls it in.
+	set (wx_NEED_STC TRUE)
 endif()
 
 if (NEED_LIB_MULESOCKET)

--- a/cmake/wx.cmake
+++ b/cmake/wx.cmake
@@ -50,6 +50,11 @@ if (wx_NEED_NET)
 	list (APPEND _amule_wx_targets NET)
 endif()
 
+if (wx_NEED_STC)
+	list (APPEND _amule_wx_components stc)
+	list (APPEND _amule_wx_targets STC)
+endif()
+
 if (wx_NEED_ADV)
 	list (APPEND _amule_wx_targets ADV)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -854,6 +854,7 @@ if (NEED_LIB_MULEAPPGUI)
 		MuleVirtualListCtrl.cpp
 		MuleNotebook.cpp
 		MuleTextCtrl.cpp
+		MuleLogCtrl.cpp
 	)
 
 

--- a/src/MuleLogCtrl.cpp
+++ b/src/MuleLogCtrl.cpp
@@ -1,0 +1,162 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "MuleLogCtrl.h"
+
+#include <wx/settings.h>
+
+CMuleLogCtrl::CMuleLogCtrl(wxWindow *parent,
+	wxWindowID id,
+	const wxPoint &pos,
+	const wxSize &size,
+	long style,
+	const wxString &name)
+: wxStyledTextCtrl(parent, id, pos, size, style, name)
+, m_inBatch(false)
+, m_batchTailing(false)
+, m_scrollPending(false)
+{
+	// Store text as UTF-8 so AppendText()'s wxString conversion and the byte
+	// positions used for styling agree (GetLength() is a byte count).
+	SetCodePage(wxSTC_CP_UTF8);
+
+	// Look like a plain log pane, not a code editor: no line-number / symbol /
+	// fold margins.
+	for (int margin = 0; margin < 3; ++margin) {
+		SetMarginWidth(margin, 0);
+	}
+	// Word-wrap long lines (as the old wxTE_RICH2 pane did) and drop the
+	// horizontal scrollbar entirely. The h-scrollbar is not just cosmetic: on
+	// the macOS and Windows Scintilla backends it is drawn inside the client
+	// area but its height is NOT subtracted from LinesOnScreen(), so
+	// ScrollToEnd() leaves the last line or two hidden behind it -- the log
+	// looked stuck a few lines short of the bottom (issue #547). GTK draws it
+	// outside the client area, which is why Linux was unaffected. With wrapping
+	// on there is no horizontal scrollbar at all.
+	SetWrapMode(wxSTC_WRAP_WORD);
+	SetUseHorizontalScrollBar(false);
+
+	// Theme-aware colours (matches the old wxTE_RICH2, which used the system
+	// window colours -- so dark themes keep working).
+	StyleSetForeground(wxSTC_STYLE_DEFAULT, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+	StyleSetBackground(wxSTC_STYLE_DEFAULT, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+	wxFont guiFont = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+	StyleSetFont(wxSTC_STYLE_DEFAULT, guiFont);
+	// Propagate the default style to all styles, then make critical lines bold.
+	StyleClearAll();
+	StyleSetBold(Style_Critical, true);
+
+	SetReadOnly(true);
+}
+
+bool CMuleLogCtrl::AtBottom()
+{
+	// Compare in *display* lines: GetFirstVisibleLine()/LinesOnScreen() count
+	// wrapped rows, while GetLineCount() counts document lines, so with wrapping
+	// on the two must be reconciled. The total display-line count is the first
+	// display row of the last doc line plus how many rows it wraps to. Generous
+	// by one so "sitting at the end" always re-tails on append.
+	const int lastDoc = GetLineCount() - 1;
+	const int displayLines = VisibleFromDocLine(lastDoc) + WrapCount(lastDoc);
+	return GetFirstVisibleLine() + LinesOnScreen() >= displayLines - 1;
+}
+
+void CMuleLogCtrl::ScrollToBottom()
+{
+	if (!IsShownOnScreen()) {
+		// The control's notebook page is hidden (e.g. the first-sync backlog
+		// arrives while another tab is in front on launch), so it has no
+		// laid-out geometry and ScrollToEnd() lands on a stale extent -- the log
+		// then sits a few lines short once shown. Defer to NotifyShown()
+		// (issue #547).
+		m_scrollPending = true;
+		return;
+	}
+	ScrollToEnd();
+}
+
+void CMuleLogCtrl::OnInternalIdle()
+{
+	wxStyledTextCtrl::OnInternalIdle();
+
+	// Apply a tail-scroll that was deferred while the control was hidden, now
+	// that its page/sub-tab is on screen and has real geometry. IsShownOnScreen()
+	// is only evaluated while a scroll is actually pending, so the common
+	// idle path stays a single bool test.
+	if (m_scrollPending && IsShownOnScreen()) {
+		m_scrollPending = false;
+		ScrollToEnd();
+	}
+}
+
+void CMuleLogCtrl::AppendLogLine(const wxString &line, bool critical)
+{
+	const bool tail = m_inBatch ? false : AtBottom();
+
+	if (!m_inBatch) {
+		SetReadOnly(false);
+	}
+
+	const int start = GetLength();
+	AppendText(line);
+	// Style the bytes just appended (StartStyling/SetStyling work on the style
+	// buffer, not the text, so read-only state is irrelevant here).
+	StartStyling(start);
+	SetStyling(GetLength() - start, critical ? Style_Critical : Style_Normal);
+
+	if (!m_inBatch) {
+		SetReadOnly(true);
+		if (tail) {
+			ScrollToBottom();
+		}
+	}
+}
+
+void CMuleLogCtrl::ClearLog()
+{
+	SetReadOnly(false);
+	ClearAll();
+	SetReadOnly(true);
+}
+
+void CMuleLogCtrl::BeginBatch()
+{
+	// No Freeze()/Thaw(): Scintilla does not auto-scroll on append, so lines
+	// added below the fold cause no repaint until the single ScrollToBottom() in
+	// EndBatch(). Freezing would only leave the scroll extent stale at Thaw.
+	m_batchTailing = AtBottom();
+	m_inBatch = true;
+	SetReadOnly(false);
+}
+
+void CMuleLogCtrl::EndBatch()
+{
+	SetReadOnly(true);
+	m_inBatch = false;
+	if (m_batchTailing) {
+		ScrollToBottom();
+	}
+}
+
+// File_checked_for_headers

--- a/src/MuleLogCtrl.h
+++ b/src/MuleLogCtrl.h
@@ -1,0 +1,88 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef MULELOGCTRL_H
+#define MULELOGCTRL_H
+
+#include <wx/stc/stc.h>
+
+// A read-only, append-only log view backed by wxStyledTextCtrl (Scintilla).
+//
+// Replaces the wxTE_RICH2 log panes (aMule Log, aMuleGUI Log, server info).
+// RichEdit holds the whole document and reflows O(n) on scroll, so the tens of
+// thousands of lines a remote-GUI first sync can dump made scrolling crawl and
+// left the view mispainted (only the tail visible until a manual scroll) --
+// issues #445, #547. Scintilla renders only the visible lines, so scroll and
+// full-history retention stay O(visible) at any size, and unlike a virtual
+// list it keeps character-level selection and find.
+class CMuleLogCtrl : public wxStyledTextCtrl
+{
+public:
+	CMuleLogCtrl(wxWindow *parent,
+		wxWindowID id = wxID_ANY,
+		const wxPoint &pos = wxDefaultPosition,
+		const wxSize &size = wxDefaultSize,
+		long style = 0,
+		const wxString &name = "CMuleLogCtrl");
+
+	// Append one already-newline-terminated line. `critical` renders it bold
+	// (errors/warnings). Auto-scrolls to the end only when the view was already
+	// at the bottom, so a user who scrolled up to read history is left in place.
+	void AppendLogLine(const wxString &line, bool critical = false);
+
+	// Remove all text.
+	void ClearLog();
+
+	// Bracket a burst of AppendLogLine() calls (one stats poll's backlog): the
+	// control is left writable for the whole run, and the single tail-scroll is
+	// deferred to EndBatch(), decided by whether the view was at the bottom when
+	// the batch began.
+	void BeginBatch();
+	void EndBatch();
+
+	// A tail-scroll requested while the control was hidden (its notebook page or
+	// sub-tab was not selected) cannot be applied reliably, so it is deferred
+	// and performed here on the first idle once the control is actually on
+	// screen. Overriding at this level means every log/info pane inherits it.
+	void OnInternalIdle() override;
+
+private:
+	bool AtBottom();
+	void ScrollToBottom();
+
+	// Scintilla style ids: 0 is the default text style, 1 adds bold.
+	enum
+	{
+		Style_Normal = 0,
+		Style_Critical = 1
+	};
+
+	bool m_inBatch;
+	bool m_batchTailing;
+	// A tail-scroll was requested while the control was hidden; performed by
+	// NotifyShown() once the page is visible.
+	bool m_scrollPending;
+};
+
+#endif // MULELOGCTRL_H

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -58,6 +58,7 @@
 #include "KadDlg.h"           // Needed for CKadDlg
 #include "Logger.h"
 #include "MuleTextCtrl.h" // Needed for CMuleTextCtrl (fast-links placeholder)
+#include "MuleLogCtrl.h"  // Needed for CMuleLogCtrl (the log/server-info panes)
 #include "MuleTrayIcon.h"
 #include "muuli_wdr.h"   // Needed for ID_BUTTON*
 #include "Preferences.h" // Needed for CPreferences
@@ -719,10 +720,10 @@ void CamuleDlg::OnBnConnect(wxCommandEvent &WXUNUSED(evt))
 
 void CamuleDlg::ResetLog(int id)
 {
-	wxTextCtrl *ct = CastByID(id, m_serverwnd, wxTextCtrl);
+	CMuleLogCtrl *ct = CastByID(id, m_serverwnd, CMuleLogCtrl);
 	wxCHECK_RET(ct, "Resetting unknown log");
 
-	ct->Clear();
+	ct->ClearLog();
 
 	if (id == ID_LOGVIEW) {
 		// Also clear the log line
@@ -736,7 +737,7 @@ void CamuleDlg::AddLogLine(const wxString &line)
 {
 	// The "aMule Log" tab: the daemon/core log (over EC in amulegui, or this
 	// process's own log in the monolithic build).
-	AddLogLineToView(line, ID_LOGVIEW, m_logLastCritical);
+	AddLogLineToView(line, ID_LOGVIEW);
 }
 
 void CamuleDlg::AddGuiLogLine(const wxString &line)
@@ -744,43 +745,25 @@ void CamuleDlg::AddGuiLogLine(const wxString &line)
 #ifdef CLIENT_GUI
 	// amulegui: the GUI client's own messages go to the separate "aMuleGUI Log"
 	// tab, keeping "aMule Log" for the daemon log.
-	AddLogLineToView(line, ID_GUILOGVIEW, m_guiLogLastCritical);
+	AddLogLineToView(line, ID_GUILOGVIEW);
 #else
 	// Monolithic: there is a single log tab.
 	AddLogLine(line);
 #endif
 }
 
-void CamuleDlg::AddLogLineToView(const wxString &line, int viewId, int &lastCritical)
+void CamuleDlg::AddLogLineToView(const wxString &line, int viewId)
 {
 	bool addtostatusbar = line[0] == '!';
 	wxString bufferline = line.Mid(1);
 
-	// Add the message to the log-view
-	wxTextCtrl *ct = CastByID(viewId, m_serverwnd, wxTextCtrl);
+	// Add the message to the log-view. CMuleLogCtrl (Scintilla) renders only the
+	// visible lines, so a large first-sync backlog no longer reflows per line or
+	// mispaints the tail the way the old wxTE_RICH2 control did (issues #445,
+	// #547). Critical lines are shown bold.
+	CMuleLogCtrl *ct = CastByID(viewId, m_serverwnd, CMuleLogCtrl);
 	if (ct) {
-		// Bold critical log-lines (works on Windows too thanks to the
-		// wxTE_RICH2 style in muuli). SetDefaultStyle() is expensive on the
-		// RichEdit control, so only touch it when the weight actually
-		// changes rather than on every line -- a remote-GUI first-sync
-		// backlog is thousands of lines (issue #445).
-		int critical = addtostatusbar ? 1 : 0;
-		if (critical != lastCritical) {
-			wxTextAttr style = ct->GetDefaultStyle();
-			wxFont font = style.GetFont();
-			font.SetWeight(addtostatusbar ? wxFONTWEIGHT_BOLD : wxFONTWEIGHT_NORMAL);
-			style.SetFont(font);
-			style.SetFontSize(8);
-			ct->SetDefaultStyle(style);
-			lastCritical = critical;
-		}
-		ct->AppendText(bufferline);
-		// During a batch (BeginLogBatch/EndLogBatch) the caller scrolls once
-		// at the end; a per-line ShowPosition on a large backlog forces an
-		// O(n) RichEdit reflow on every line.
-		if (!m_logBatching) {
-			ct->ShowPosition(ct->GetLastPosition() - 1);
-		}
+		ct->AppendLogLine(bufferline, addtostatusbar);
 	}
 
 	// Set the status-bar if the event warrents it
@@ -797,39 +780,32 @@ void CamuleDlg::AddLogLineToView(const wxString &line, int viewId, int &lastCrit
 
 void CamuleDlg::BeginLogBatch()
 {
-	// Coalesce a poll's worth of log lines into a single scroll-to-end
-	// (EndLogBatch) instead of one per line, which forced an O(n) RichEdit
-	// reflow on every line of a first-sync backlog (issue #445).
-	//
-	// Deliberately NO Freeze()/Thaw() here: appending to a *frozen*
-	// wxTE_RICH2 control on Windows leaves its line/scroll metrics stale, so
-	// after Thaw the view renders blank with the newest line pinned to the top
-	// until a manual scroll forces a recompute. That's the regression #451
-	// introduced and #471's Thaw-before-scroll tweak didn't cure (the append
-	// itself happened while frozen). Appending live keeps the metrics correct;
-	// suppressing only the per-line ShowPosition still removes the reflow cost.
-	m_logBatching = true;
+	// A stats poll can carry a large first-sync backlog; bracket the burst so
+	// the log view freezes once and tail-scrolls once instead of per line (see
+	// CMuleLogCtrl::BeginBatch/EndBatch).
+	CMuleLogCtrl *ct = CastByID(ID_LOGVIEW, m_serverwnd, CMuleLogCtrl);
+	if (ct) {
+		ct->BeginBatch();
+	}
 }
 
 void CamuleDlg::EndLogBatch()
 {
-	m_logBatching = false;
-	wxTextCtrl *ct = CastByID(ID_LOGVIEW, m_serverwnd, wxTextCtrl);
+	CMuleLogCtrl *ct = CastByID(ID_LOGVIEW, m_serverwnd, CMuleLogCtrl);
 	if (ct) {
-		ct->ShowPosition(ct->GetLastPosition() - 1);
+		ct->EndBatch();
 	}
 }
 
 void CamuleDlg::AddServerMessageLine(wxString &message)
 {
-	wxTextCtrl *cv = CastByID(ID_SERVERINFO, m_serverwnd, wxTextCtrl);
+	CMuleLogCtrl *cv = CastByID(ID_SERVERINFO, m_serverwnd, CMuleLogCtrl);
 	if (cv) {
 		if (message.Length() > 500) {
-			cv->AppendText(message.Left(500) + "\n");
+			cv->AppendLogLine(message.Left(500) + "\n");
 		} else {
-			cv->AppendText(message + "\n");
+			cv->AppendLogLine(message + "\n");
 		}
-		cv->ShowPosition(cv->GetLastPosition() - 1);
 	}
 }
 

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -266,19 +266,10 @@ private:
 	DialogType m_nActiveDialog;
 	bool m_is_safe_state;
 	bool m_BlinkMessages;
-	//! True while a BeginLogBatch()/EndLogBatch() bracket is open, so
-	//! AddLogLine() defers the per-line scroll to the end of the batch.
-	bool m_logBatching = false;
-	//! Last log-line weight applied to the view's default style (1 = bold,
-	//! 0 = normal, -1 = not yet set) so SetDefaultStyle() is only touched
-	//! when the weight actually changes.
-	int m_logLastCritical = -1;
-	//! Same, tracked separately for the amulegui-only "aMuleGUI Log" view.
-	int m_guiLogLastCritical = -1;
 
-	//! Shared append logic for both log views. viewId is the text-control ID
-	//! and lastCritical the matching per-view bold-state cache.
-	void AddLogLineToView(const wxString &line, int viewId, int &lastCritical);
+	//! Shared append logic for both log views (ID_LOGVIEW / ID_GUILOGVIEW).
+	//! Lines starting with '!' are critical (bold + status bar).
+	void AddLogLineToView(const wxString &line, int viewId);
 	int m_CurrentBlinkBitmap;
 	uint32 m_last_iconizing;
 	// The "new version available" popup is shown at most once per session;

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -67,6 +67,7 @@
 #include "FriendListCtrl.h"
 #include "FileDetailListCtrl.h"
 #include "MuleGifCtrl.h"
+#include "MuleLogCtrl.h"
 #include "ChatSelector.h"
 #include "DirectoryTreeCtrl.h"	// Needed for CDirectoryTreeCtrl
 #include "KadDlg.h"
@@ -2320,7 +2321,7 @@ wxSizer *ServerInfoLog( wxWindow *parent, bool call_fit, bool set_sizer )
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
-    CMuleTextCtrl *item2 = new CMuleTextCtrl( parent, ID_SERVERINFO, "", wxDefaultPosition, wxSize(200, 100), wxTE_MULTILINE|wxTE_READONLY|wxVSCROLL );
+    CMuleLogCtrl *item2 = new CMuleLogCtrl( parent, ID_SERVERINFO, wxDefaultPosition, wxSize(200, 100) );
     item0->Add( item2, wxSizerFlags(1).Expand().Border(wxALL, 5) );
     wxButton *item3 = new wxButton( parent, ID_BTN_RESET_SERVER, _("Clear"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->SetToolTip( _("Click this button to reset the log.") );
@@ -2339,7 +2340,7 @@ wxSizer *aMuleLog( wxWindow *parent, bool call_fit, bool set_sizer )
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
-    CMuleTextCtrl *item2 = new CMuleTextCtrl( parent, ID_LOGVIEW, "", wxDefaultPosition, wxSize(200, 100), wxTE_MULTILINE|wxTE_READONLY|wxVSCROLL|wxTE_RICH2 );
+    CMuleLogCtrl *item2 = new CMuleLogCtrl( parent, ID_LOGVIEW, wxDefaultPosition, wxSize(200, 100) );
     item0->Add( item2, wxSizerFlags(1).Expand().Border(wxALL, 5) );
     wxButton *item3 = new wxButton( parent, ID_BTN_RESET, _("Clear"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->SetToolTip( _("Click this button to reset the log.") );
@@ -2361,7 +2362,7 @@ wxSizer *aMuleGuiLog( wxWindow *parent, bool call_fit, bool set_sizer )
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
-    CMuleTextCtrl *item2 = new CMuleTextCtrl( parent, ID_GUILOGVIEW, "", wxDefaultPosition, wxSize(200, 100), wxTE_MULTILINE|wxTE_READONLY|wxVSCROLL|wxTE_RICH2 );
+    CMuleLogCtrl *item2 = new CMuleLogCtrl( parent, ID_GUILOGVIEW, wxDefaultPosition, wxSize(200, 100) );
     item0->Add( item2, wxSizerFlags(1).Expand().Border(wxALL, 5) );
     wxButton *item3 = new wxButton( parent, ID_BTN_RESET_GUILOG, _("Clear"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->SetToolTip( _("Click this button to reset the log.") );


### PR DESCRIPTION
The amuleGUI log panes used a `wxTE_RICH2` (RichEdit) control, which holds the entire document and reflows O(n) on scroll. A remote-GUI first sync can deliver tens of thousands of daemon-log lines at once, so scrolling the "aMule Log" tab crawled, and the view mispainted — only the tail was visible until a manual one-line scroll (#547, follow-up to the #445 / #451 / #471 / #477 RichEdit repaint saga).

## What changed

- New `CMuleLogCtrl` backed by **`wxStyledTextCtrl` (Scintilla)** replaces the three log/info panes: **aMule Log**, **aMuleGUI Log**, and **server info**. Scintilla renders only the visible lines, so scrolling and full-history retention stay O(visible) at any size, and — unlike a virtual list — it keeps character-level selection and find. Lines word-wrap as the old pane did; critical lines are bold via per-line Scintilla styles.
- The view tail-scrolls after new content **only when it was already at the bottom**, so scrolling up to read history isn't disturbed. When lines arrive while a pane is hidden — its notebook page *or sub-tab* isn't selected (e.g. the first-sync backlog before the Networks tab is opened, or the aMuleGUI Log / server info sub-tabs before you switch to them) — the control has no laid-out geometry and can't be scrolled reliably, so the tail-scroll is deferred and applied on the first idle once the pane is on screen. This lives in the base `CMuleLogCtrl`, so **all three panes share it**.
- This **removes the whole RichEdit workaround stack** — the per-poll append batching and the `Freeze`/`Thaw` lineage from #451/#471/#477 — none of which Scintilla needs.
- `wxStyledTextCtrl` (the `stc` component) ships with the wxWidgets packages every platform already builds against (verified: Ubuntu `libwxgtk3.2-dev`, Homebrew `wxwidgets`, MSYS2 `wxwidgets3.2`, and the AppImage/flatpak source builds have `wxUSE_STC` on by default). **No new dependency**; `stc` is requested only for the GUI library that owns the log views, and the Windows packaging bundles its DLL automatically via the existing `GET_RUNTIME_DEPENDENCIES` install step.

## Test plan

Verified on all three GUI platforms against a live remote daemon with a large multi-day log (~16k lines):

**macOS** (Cocoa, wx 3.3)
- [x] First-sync backlog loads fast; scrolling the full history is instant (was crawling before).
- [x] Backlog arriving while on the Networks tab → lands exactly at the bottom, then follows live lines.
- [x] Backlog arriving while on another tab, then switching to Networks → lands exactly at the bottom (deferred-scroll path).
- [x] aMuleGUI Log and server-info panes also land at the bottom when first opened (deferral is in the base control).
- [x] Scroll up to read history → stays put as new lines arrive; switching tabs and back does not yank to the bottom.
- [x] Critical (error/warning) lines render bold; normal lines normal.
- [x] Text selection / copy works.

**Linux** (GTK3, wx 3.2)
- [x] Same scenarios as above; scroll-to-bottom correct in both visible and hidden-during-load cases.

**Windows** (wxMSW, wx 3.2)
- [x] Same scenarios; hidden-during-load deferred scroll lands at the bottom (matches macOS/GTK).
- [x] Portable bundles `wxmsw32u_stc_*.dll` and launches cleanly.

Lint: `clang-format` clean; clang-tidy Tier-1 and Tier-2 diff checks both clean.
