### PR TITLE
fix(gui): keep the log tail-scroll at the true bottom with wrapping

### DIFF
--- a/src/MuleLogCtrl.cpp
+++ b/src/MuleLogCtrl.cpp
@@ -36,6 +36,7 @@ CMuleLogCtrl::CMuleLogCtrl(wxWindow *parent,
 , m_inBatch(false)
 , m_batchTailing(false)
 , m_scrollPending(false)
+, m_lastAutoScrollLine(-1)
 {
 	// Store text as UTF-8 so AppendText()'s wxString conversion and the byte
 	// positions used for styling agree (GetLength() is a byte count).
@@ -46,14 +47,10 @@ CMuleLogCtrl::CMuleLogCtrl(wxWindow *parent,
 	for (int margin = 0; margin < 3; ++margin) {
 		SetMarginWidth(margin, 0);
 	}
-	// Word-wrap long lines (as the old wxTE_RICH2 pane did) and drop the
-	// horizontal scrollbar entirely. The h-scrollbar is not just cosmetic: on
-	// the macOS and Windows Scintilla backends it is drawn inside the client
-	// area but its height is NOT subtracted from LinesOnScreen(), so
-	// ScrollToEnd() leaves the last line or two hidden behind it -- the log
-	// looked stuck a few lines short of the bottom (issue #547). GTK draws it
-	// outside the client area, which is why Linux was unaffected. With wrapping
-	// on there is no horizontal scrollbar at all.
+	// Word-wrap long lines, as the old wxTE_RICH2 pane did, so nothing is clipped
+	// off the right edge; with wrapping on there is no horizontal scrollbar to
+	// show. (Wrapping is why AtBottom() and the tail-scroll reason in display
+	// lines rather than document lines.)
 	SetWrapMode(wxSTC_WRAP_WORD);
 	SetUseHorizontalScrollBar(false);
 
@@ -84,30 +81,53 @@ bool CMuleLogCtrl::AtBottom()
 
 void CMuleLogCtrl::ScrollToBottom()
 {
+	// Request only -- OnInternalIdle() is the sole scroller. Keeping every scroll
+	// in one place stops the batch/live tail-scroll from racing the idle
+	// re-scroll loop: that loop tells a manual scroll from an append by watching
+	// the first-visible line, and a direct ScrollToEnd() here would move it and
+	// be misread as the user scrolling -- which aborted the catch-up mid-load, so
+	// switching to the log while it was still replaying landed short (issue #547,
+	// @ghysler). Deferring also naturally waits until the pane is on screen.
 	if (!IsShownOnScreen()) {
-		// The control's notebook page is hidden (e.g. the first-sync backlog
-		// arrives while another tab is in front on launch), so it has no
-		// laid-out geometry and ScrollToEnd() lands on a stale extent -- the log
-		// then sits a few lines short once shown. Defer to NotifyShown()
-		// (issue #547).
-		m_scrollPending = true;
-		return;
+		// No reliable first-visible baseline while hidden; let the first scroll
+		// after the pane appears run unconditionally.
+		m_lastAutoScrollLine = -1;
 	}
-	ScrollToEnd();
+	m_scrollPending = true;
 }
 
 void CMuleLogCtrl::OnInternalIdle()
 {
 	wxStyledTextCtrl::OnInternalIdle();
 
-	// Apply a tail-scroll that was deferred while the control was hidden, now
-	// that its page/sub-tab is on screen and has real geometry. IsShownOnScreen()
-	// is only evaluated while a scroll is actually pending, so the common
-	// idle path stays a single bool test.
-	if (m_scrollPending && IsShownOnScreen()) {
-		m_scrollPending = false;
-		ScrollToEnd();
+	// Sole scroller for every tail-scroll (live line, batch, or deferred while
+	// hidden). IsShownOnScreen() is only evaluated while a scroll is pending, so
+	// the common idle path stays a single bool test; a scroll requested while the
+	// pane was hidden simply waits here until it is shown.
+	if (!m_scrollPending || !IsShownOnScreen()) {
+		return;
 	}
+
+	// With word-wrap on, Scintilla lays out wrapped lines incrementally over
+	// several idles, so a single ScrollToEnd() the moment the pane appears (or
+	// while the log is still replaying) lands short -- against a display-line
+	// count that does not yet include the still-unwrapped tail (issue #547,
+	// reported by @ghysler with wrapped lines on a narrow window). Re-scroll each
+	// idle until the position stops moving (wrap has settled at the true bottom).
+	// Appends do not move the first-visible line, so if it has moved away from
+	// where our last auto-scroll left it the user scrolled -- bail and reset, so
+	// a manual scroll is never fought and a later return to the bottom re-tails.
+	if (m_lastAutoScrollLine != -1 && GetFirstVisibleLine() != m_lastAutoScrollLine) {
+		m_scrollPending = false;
+		m_lastAutoScrollLine = -1;
+		return;
+	}
+	ScrollToEnd();
+	const int firstVisible = GetFirstVisibleLine();
+	if (firstVisible == m_lastAutoScrollLine) {
+		m_scrollPending = false; // stable: layout settled at the bottom
+	}
+	m_lastAutoScrollLine = firstVisible;
 }
 
 void CMuleLogCtrl::AppendLogLine(const wxString &line, bool critical)
@@ -143,8 +163,9 @@ void CMuleLogCtrl::ClearLog()
 void CMuleLogCtrl::BeginBatch()
 {
 	// No Freeze()/Thaw(): Scintilla does not auto-scroll on append, so lines
-	// added below the fold cause no repaint until the single ScrollToBottom() in
-	// EndBatch(). Freezing would only leave the scroll extent stale at Thaw.
+	// added below the fold cause no repaint until the tail-scroll (requested by
+	// EndBatch(), applied on the next idle). Freezing would only leave the scroll
+	// extent stale at Thaw.
 	m_batchTailing = AtBottom();
 	m_inBatch = true;
 	SetReadOnly(false);

--- a/src/MuleLogCtrl.h
+++ b/src/MuleLogCtrl.h
@@ -61,10 +61,11 @@ public:
 	void BeginBatch();
 	void EndBatch();
 
-	// A tail-scroll requested while the control was hidden (its notebook page or
-	// sub-tab was not selected) cannot be applied reliably, so it is deferred
-	// and performed here on the first idle once the control is actually on
-	// screen. Overriding at this level means every log/info pane inherits it.
+	// Sole scroller for every tail-scroll. ScrollToBottom() only flags one as
+	// pending; this applies it -- waiting until the pane is on screen (a hidden
+	// control cannot be scrolled reliably), and re-applying across idles until
+	// the layout (which Scintilla wraps incrementally) settles at the true
+	// bottom. Overriding at this level means every log/info pane inherits it.
 	void OnInternalIdle() override;
 
 private:
@@ -80,9 +81,13 @@ private:
 
 	bool m_inBatch;
 	bool m_batchTailing;
-	// A tail-scroll was requested while the control was hidden; performed by
-	// NotifyShown() once the page is visible.
+	// A tail-scroll has been requested; OnInternalIdle() applies it (deferring
+	// while the pane is hidden, and re-applying until the layout settles).
 	bool m_scrollPending;
+	// First-visible line left by the last auto-scroll while m_scrollPending is
+	// being resolved, so the idle loop can tell when the (possibly wrapping)
+	// layout has settled and when the user has scrolled away. -1 = none yet.
+	int m_lastAutoScrollLine;
 };
 
 #endif // MULELOGCTRL_H

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -781,8 +781,8 @@ void CamuleDlg::AddLogLineToView(const wxString &line, int viewId)
 void CamuleDlg::BeginLogBatch()
 {
 	// A stats poll can carry a large first-sync backlog; bracket the burst so
-	// the log view freezes once and tail-scrolls once instead of per line (see
-	// CMuleLogCtrl::BeginBatch/EndBatch).
+	// the log view is written and tail-scrolled once for the whole batch rather
+	// than per line (see CMuleLogCtrl::BeginBatch/EndBatch).
 	CMuleLogCtrl *ct = CastByID(ID_LOGVIEW, m_serverwnd, CMuleLogCtrl);
 	if (ct) {
 		ct->BeginBatch();


### PR DESCRIPTION
Follow-up to #548, which moved the amuleGUI log panes to `wxStyledTextCtrl` (Scintilla). This fixes the auto-scroll-to-bottom landing short when log lines wrap.

## Background

With word-wrap on, Scintilla lays out wrapped lines **incrementally** over several idle cycles (wrapping tens of thousands of lines is expensive, so it doesn't block). The tail-scroll ran once, before that layout finished, so it computed against a display-line count that didn't yet include the still-unwrapped tail and stopped short. It only reproduced when lines actually wrap — @ghysler pinned it to window width (short at 1280px where his lines wrap two-up, correct at 2560px where they don't).

A first attempt (re-scroll on idle until the position settles) fixed the *switch-in-after-load* case but not *switch-in-mid-load*: while the log was still replaying, each poll's batch also scrolled directly, and the idle loop — which watches the scroll position to tell a manual scroll from an append — misread the batch's own scroll as a manual scroll and gave up, so the final one-shot scroll landed at ~90%.

## Fix

Make `OnInternalIdle()` the **sole scroller**: `ScrollToBottom()` only sets a pending flag, and the idle loop re-applies `ScrollToEnd()` until the first-visible line stops moving (wrap settled at the true bottom), bailing only when the view moves on its own (a genuine manual scroll). Since appends never move the first-visible line, the loop follows the growing log through the whole replay. It lives in the base `CMuleLogCtrl`, so all three panes (aMule Log, aMuleGUI Log, server info) share it.

Also corrects a few comments from #548 that the rework left inaccurate (comment-only).

## Test plan

Verified against a live remote daemon with a large multi-day log (~16k lines), on a narrow window so lines wrap:

- [x] Switch to Networks **after** load finishes → lands at the bottom
- [x] Switch to Networks **mid-load** (watching the replay) → lands at the bottom
- [x] Scroll up to read history → stays put; returning to the bottom re-tails
- [x] aMuleGUI Log and server-info panes behave the same

Lint: `clang-format` clean; clang-tidy Tier-1 + Tier-2 diff checks both clean.
