### PR TITLE
fix(search): don't report a global ed2k search as 100% before its sweep starts

### DIFF
--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -475,6 +475,15 @@ uint32 CSearchList::GetSearchProgress() const
 		return 0xffff;
 
 	case GlobalSearch:
+		// The sweep is not armed until the connected server answers the local
+		// part (OP_SEARCHRESULT -> LocalSearchEnd) and the first timer tick
+		// attaches the observer. Until then m_serverQueue is detached and empty,
+		// so GetRemaining() is a stale 0 that would read as 100% ("done") the
+		// instant a search starts. IsActive() is true only during the actual
+		// sweep, so report 0 (just-started) before it begins.
+		if (!m_serverQueue.IsActive()) {
+			return 0;
+		}
 		return 100 - (m_serverQueue.GetRemaining() * 100) / theApp->serverlist->GetServerCount();
 
 	default:


### PR DESCRIPTION
A global ed2k search shows a full ("done") progress bar the moment it starts and keeps it until the global UDP sweep begins — so a search whose connected server is slow to answer looks like it never ran. This affects every client: monolithic, amulegui, amuleapi and amuleweb.

## Cause

`CSearchList::GetSearchProgress()` computes the global percentage as `100 - remaining*100/serverCount`, where `remaining` is the size of `m_serverQueue`. That queue is only populated once the sweep is armed: the connected server must answer the local part (`OP_SEARCHRESULT` → `LocalSearchEnd()`), which starts the 750 ms sweep timer, whose first tick attaches the queue observer. In the window between pressing Search and that first tick the observer is detached and the queue is empty, so `remaining` is a stale `0` and the formula yields `100`.

Every client ultimately reads this value: the monolithic GUI in-process, and amulegui / amuleapi / amuleweb over EC — the daemon fills `EC_TAG_SEARCH_STATUS` and `EC_TAG_SEARCH_LIFECYCLE_PERCENT` from `GetSearchBarStatusById` / `GetSearchLifecyclePercentById`, which route a running global ed2k search back through the same `GetSearchProgress()`.

It was latent until #511, which added a periodic search-progress poll on both sides (the monolithic `RefreshVisibleTabProgress()` GUI-timer tick, and the amulegui `EC_OP_SEARCH_PROGRESS` poll). Before that the bar was push-only — updated from inside the sweep — so it stayed at 0 until the first real tick. The polls now sample `GetSearchProgress()` continuously, surfacing the empty-queue value as a full bar the instant a search starts.

## Fix

Return 0 while the sweep hasn't begun. `m_serverQueue.IsActive()` is true only while the observer is attached — i.e. during the actual sweep — so it cleanly separates "just started, waiting on the server" from "sweeping". Harmless during the sweep and after (completion pushes `0xffff` directly), and it removes a latent divide-by-zero when the server count is 0.

Because the fix is at the single shared source, it corrects all four clients at once; for the EC clients it lands in the daemon (`amuled`), which is what computes the value they display. A slow-server global search now honestly shows an in-progress bar instead of a misleading full one. This does not change the pre-existing behaviour of the sweep waiting on the connected server's reply — it just stops the bar from lying while it waits.
