### PR TITLE
cmake: add option to use system picojson

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -42,6 +42,7 @@ option (BUILD_WEBSERVER "compile aMule WebServer")
 option (BUILD_AMULEAPI "compile aMule REST API daemon")
 option (BUILD_WXCAS "compile aMule GUI Statistics")
 option (BUILD_TESTING "Build unit tests" OFF)
+option (USE_SYSTEM_PICOJSON "Use system-installed picojson instead of bundled copy" OFF)
 
 if (PREFIX)
 	set (CMAKE_INSTALL_PREFIX "${PREFIX}")

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -140,6 +140,7 @@ Common `-D` options (`YES` / `NO` unless noted otherwise):
 | `ENABLE_IP2COUNTRY`      | YES     | libmaxminddb country flags ([docs/IP2Country.md](IP2Country.md))         |
 | `ENABLE_CCACHE`          | AUTO    | use ccache as compiler launcher when found (`AUTO`/`ON`/`OFF`); set `OFF` for distro builds that manage ccache themselves, `ON` to hard-fail if ccache is missing |
 | `ENABLE_VERSION_CHECK`   | ON      | compile in the in-app new-version check (startup notification, the "Check for new version at startup" preference, and the About dialog's "Check for updates" button). Packagers shipping aMule via an OS package manager want `OFF`, so nothing contacts GitHub and the distro's package manager owns updates |
+| `USE_SYSTEM_PICOJSON`    | OFF     | use a system-installed `picojson.h` instead of the bundled copy           |
 
 For the full list:
 

--- a/docs/THIRDPARTY.md
+++ b/docs/THIRDPARTY.md
@@ -46,6 +46,9 @@ The vendored header is unmodified upstream 1.3.0; the
 `PICOJSON_USE_INT64` toggle is defined at use sites rather than as a
 modification to the header.
 
+The bundled copy is used by default. Distributions may configure with
+`-DUSE_SYSTEM_PICOJSON=ON` to use a system-installed `picojson.h` instead.
+
 ## muleunit
 
 Lightweight unit test framework used by the C++ test suite at

--- a/docs/THIRDPARTY.md
+++ b/docs/THIRDPARTY.md
@@ -47,7 +47,8 @@ The vendored header is unmodified upstream 1.3.0; the
 modification to the header.
 
 The bundled copy is used by default. Distributions may configure with
-`-DUSE_SYSTEM_PICOJSON=ON` to use a system-installed `picojson.h` instead.
+`-DUSE_SYSTEM_PICOJSON=ON` to use a system-installed `picojson.h` version
+1.3.0 or newer instead.
 
 ## muleunit
 

--- a/src/libwebcommon/CMakeLists.txt
+++ b/src/libwebcommon/CMakeLists.txt
@@ -16,6 +16,32 @@ add_library (webcommon STATIC
 	PathPatterns.cpp
 )
 
+add_library (picojson_header INTERFACE)
+
+if (USE_SYSTEM_PICOJSON)
+	find_path (PICOJSON_INCLUDE_DIR picojson.h)
+	if (NOT EXISTS "${PICOJSON_INCLUDE_DIR}/picojson.h")
+		message (FATAL_ERROR
+			"USE_SYSTEM_PICOJSON is ON, but picojson.h was not found")
+	endif()
+
+	message (STATUS "Using system picojson: ${PICOJSON_INCLUDE_DIR}/picojson.h")
+	target_include_directories (picojson_header INTERFACE
+		${PICOJSON_INCLUDE_DIR}
+	)
+	# webcommon's public headers expose this source directory to consumers,
+	# which also makes the bundled picojson.h visible. Select the discovered
+	# header by its full path so an implicit system directory such as
+	# /usr/include cannot lose to that transitive include path.
+	target_compile_definitions (picojson_header INTERFACE
+		AMULE_PICOJSON_HEADER="${PICOJSON_INCLUDE_DIR}/picojson.h"
+	)
+else()
+	target_include_directories (picojson_header INTERFACE
+		${CMAKE_CURRENT_SOURCE_DIR}
+	)
+endif()
+
 target_include_directories (webcommon
 	PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 )
@@ -28,4 +54,5 @@ target_include_directories (webcommon
 target_link_libraries (webcommon
 	PUBLIC wxWidgets::BASE
 	PUBLIC CRYPTOPP::CRYPTOPP
+	PRIVATE picojson_header
 )

--- a/src/libwebcommon/CMakeLists.txt
+++ b/src/libwebcommon/CMakeLists.txt
@@ -37,8 +37,8 @@ if (USE_SYSTEM_PICOJSON)
 		AMULE_PICOJSON_HEADER="${PICOJSON_INCLUDE_DIR}/picojson.h"
 	)
 else()
-	target_include_directories (picojson_header INTERFACE
-		${CMAKE_CURRENT_SOURCE_DIR}
+	target_compile_definitions (picojson_header INTERFACE
+		AMULE_PICOJSON_HEADER="${CMAKE_CURRENT_SOURCE_DIR}/picojson.h"
 	)
 endif()
 

--- a/src/libwebcommon/Jwt.cpp
+++ b/src/libwebcommon/Jwt.cpp
@@ -27,7 +27,11 @@
 #include "ConstantTime.h"
 
 #define PICOJSON_USE_INT64
-#include "picojson.h"
+#ifdef AMULE_PICOJSON_HEADER
+#include AMULE_PICOJSON_HEADER
+#else
+#include <picojson.h>
+#endif
 
 // cryptopp headers pull in deprecated implicit copy ctors + throw()
 // specs (P0806 + C++17). See CryptoPP_Inc.h for the full rationale.

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -75,7 +75,11 @@
 #endif
 
 #define PICOJSON_USE_INT64
-#include "picojson.h"
+#ifdef AMULE_PICOJSON_HEADER
+#include AMULE_PICOJSON_HEADER
+#else
+#include <picojson.h>
+#endif
 
 #include "config.h" // VERSION
 

--- a/src/webapi/CMakeLists.txt
+++ b/src/webapi/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries (amuleapi
 	PRIVATE mulecommon
 	PRIVATE mulesocket
 	PRIVATE webcommon
+	PRIVATE picojson_header
 	PRIVATE wxWidgets::NET
 	PRIVATE ${Boost_LIBRARIES}
 	# zlib powers the on-the-wire gzip encoder in HttpServer (Content-


### PR DESCRIPTION
aMule currently bundles picojson, which is useful for self-contained builds. Fedora provides picojson as a system package, and Fedora packaging guidelines require packaged system libraries to be used when available rather than carrying a bundled copy.

Currently, packaging aMule for Fedora requires a downstream patch to replace the bundled picojson header with the system-provided version. This adds an opt-in USE_SYSTEM_PICOJSON CMake option so distributions can select the system picojson.h directly without maintaining that downstream patch.

When enabled, CMake locates the system picojson.h and uses it for both webcommon and amuleapi.

The option defaults to OFF, so existing builds, including AppImage and Flatpak builds, continue using the bundled copy unchanged. No picojson source or licensing information is removed.

The new option was tested with both the bundled and system copies of picojson. The system configuration was also verified through a clean Fedora mock build using /usr/include/picojson.h.