### PR TITLE
Fix alcc: preserve Unicode characters in ed2k links

### DIFF
--- a/src/utils/aLinkCreator/src/ed2khash.cpp
+++ b/src/utils/aLinkCreator/src/ed2khash.cpp
@@ -219,13 +219,13 @@ wxString Ed2kHash::GetED2KLink(const bool addPartHashes, const wxArrayString *ar
 	return ed2kLink;
 }
 
-/// Strip all non-alphanumeric characters of a filename string
 wxString Ed2kHash::CleanFilename(const wxString &filename)
 {
 	wxString name(filename);
-
-	wxRegEx toStrip("[^[:alnum:]_.-]");
-	toStrip.Replace(&name, "_");
+    // Only replace characters that break ed2k link parsing
+    name.Replace("|", "_");
+    name.Replace("/", "_");
+    name.Replace("\\", "_");
 
 	return (name);
 }

--- a/src/utils/aLinkCreator/src/ed2khash.cpp
+++ b/src/utils/aLinkCreator/src/ed2khash.cpp
@@ -222,12 +222,16 @@ wxString Ed2kHash::GetED2KLink(const bool addPartHashes, const wxArrayString *ar
 wxString Ed2kHash::CleanFilename(const wxString &filename)
 {
 	wxString name(filename);
-    // Only replace characters that break ed2k link parsing
-    name.Replace("|", "_");
-    name.Replace("/", "_");
-    name.Replace("\\", "_");
-
-	return (name);
+	// Replace only what breaks ed2k link parsing: the field separator,
+	// the end-of-link marker, path separators, and control characters.
+	// Printable Unicode is preserved (files are keyed by hash + size).
+	for (size_t i = 0; i < name.length(); ++i) {
+		const wxUniChar ch = name[i];
+		if (ch == '|' || ch == '/' || ch == '\\' || ch < 0x20 || ch == 0x7f) {
+			name[i] = '_';
+		}
+	}
+	return name;
 }
 
 /// Get Ed2k Array of hashes


### PR DESCRIPTION
The `CleanFilename()` function in alcc used a regular expression `[^[:alnum:]_.-]` to replace every character not in the set of alphanumerics, dot, underscore, and hyphen with an underscore. This stripped all non‑ASCII characters (e.g., Chinese, Japanese, Cyrillic) from filenames, turning them into a series of underscores in the generated ed2k:// links, making them unreadable.

This commit rewrites `CleanFilename()` to replace only the three characters that actually break the ed2k link format: `|` (field separator), `/` (end‑of‑link marker), and `\` (path separator on Windows). All other characters, including Unicode, are left untouched.

As a result, `alcc` now produces fully readable ed2k links with the original filenames, while still preventing malformed links. The link integrity is maintained because the ed2k protocol identifies files by their hash and size, not by the filename string. This change has been tested with filenames containing Chinese characters under a UTF‑8 locale (LANG=zh_CN.UTF‑8) on Debian GNU/Linux.
