### PR TITLE
i18n: remove Italian (Swiss) from the language picker

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -5250,10 +5250,6 @@ msgstr ""
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr ""
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -5315,10 +5315,6 @@ msgstr "الهنغاريه"
 msgid "Italian"
 msgstr "الايطاليه"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr ""
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""

--- a/po/ast.po
+++ b/po/ast.po
@@ -5388,10 +5388,6 @@ msgstr "Húngaru"
 msgid "Italian"
 msgstr "Italianu"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italianu (Suizu)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Xaponés"

--- a/po/bg.po
+++ b/po/bg.po
@@ -5296,10 +5296,6 @@ msgstr "унгарски"
 msgid "Italian"
 msgstr "Италиански"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Италиански (швейцарски)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "японски"

--- a/po/bn.po
+++ b/po/bn.po
@@ -5249,10 +5249,6 @@ msgstr ""
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr ""
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -5365,10 +5365,6 @@ msgstr "Hongarès"
 msgid "Italian"
 msgstr "Italià"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italià (Suïssa)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonès"

--- a/po/cs.po
+++ b/po/cs.po
@@ -5367,10 +5367,6 @@ msgstr "Maďarština"
 msgid "Italian"
 msgstr "Italština"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italština (švýcarská)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonština"

--- a/po/da.po
+++ b/po/da.po
@@ -5326,10 +5326,6 @@ msgstr ""
 msgid "Italian"
 msgstr "Italian"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr ""
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -5360,10 +5360,6 @@ msgstr "Ungarisch"
 msgid "Italian"
 msgstr "Italienisch"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italienisch (Schweiz)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japanisch"

--- a/po/el.po
+++ b/po/el.po
@@ -5401,10 +5401,6 @@ msgstr "Ουγγαρέζικα"
 msgid "Italian"
 msgstr "Ιταλικά"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Ιταλικά (Ελβετίας)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Γιαπωνέζικα"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -5250,10 +5250,6 @@ msgstr ""
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr ""
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -5377,10 +5377,6 @@ msgstr "Húngaro"
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italiano (suizo)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonés"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -5366,10 +5366,6 @@ msgstr "Ungari"
 msgid "Italian"
 msgstr "Itaalia"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Itaalia (Shveits)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Jaapani"

--- a/po/eu.po
+++ b/po/eu.po
@@ -5366,10 +5366,6 @@ msgstr "Hungariera"
 msgid "Italian"
 msgstr "Italiera"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italiera (Suitzarra)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japoniera"

--- a/po/fi.po
+++ b/po/fi.po
@@ -5366,10 +5366,6 @@ msgstr "Unkari"
 msgid "Italian"
 msgstr "Italia"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italia (Sveitsi)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japani"

--- a/po/fr.po
+++ b/po/fr.po
@@ -5349,10 +5349,6 @@ msgstr "Hongrois"
 msgid "Italian"
 msgstr "Italien"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italien (Suisse)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonais"

--- a/po/gl.po
+++ b/po/gl.po
@@ -5374,10 +5374,6 @@ msgstr "Húngaro"
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italiano (Suizo)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Xaponés"

--- a/po/he.po
+++ b/po/he.po
@@ -5336,10 +5336,6 @@ msgstr "הונגרית"
 msgid "Italian"
 msgstr "איטלקית"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "איטלקית (שוויצרית)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "יפנית"

--- a/po/hr.po
+++ b/po/hr.po
@@ -5342,10 +5342,6 @@ msgstr "Mađarski"
 msgid "Italian"
 msgstr "Talijanski"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Talijanski (Švicarska)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japanski"

--- a/po/hu.po
+++ b/po/hu.po
@@ -5347,10 +5347,6 @@ msgstr "Magyar"
 msgid "Italian"
 msgstr "Olasz"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Olasz (Svájci)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japán"

--- a/po/it.po
+++ b/po/it.po
@@ -5354,10 +5354,6 @@ msgstr "Ungherese"
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italiano (Svizzera)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Giapponese"

--- a/po/ja.po
+++ b/po/ja.po
@@ -5368,10 +5368,6 @@ msgstr "ハンガリー語"
 msgid "Italian"
 msgstr "イタリア語"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "イタリア語（スイス）"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "日本語"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -5397,10 +5397,6 @@ msgstr "헝가리어"
 msgid "Italian"
 msgstr "이탈리아어"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "이탈리아어(스위스)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -5413,10 +5413,6 @@ msgstr "Vengrų"
 msgid "Italian"
 msgstr "Italų"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italų (Šveicarijos)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonų"

--- a/po/lv.po
+++ b/po/lv.po
@@ -5271,10 +5271,6 @@ msgstr "Ungāru"
 msgid "Italian"
 msgstr "Itāļu"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Itāļu (Šveices)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japāņu"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5370,10 +5370,6 @@ msgstr "Hongaars"
 msgid "Italian"
 msgstr "Italiaans"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italiaans (Zwitsers)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japans"

--- a/po/nn.po
+++ b/po/nn.po
@@ -5393,10 +5393,6 @@ msgstr "Ungarsk"
 msgid "Italian"
 msgstr "Italiensk"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italiensk (sveitsisk)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japansk"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5392,10 +5392,6 @@ msgstr "Węgierski"
 msgid "Italian"
 msgstr "Włoski"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Włoski (Szwajcarski)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japoński"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5350,10 +5350,6 @@ msgstr "Hungria"
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italiano (Suíço)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonês"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -5373,10 +5373,6 @@ msgstr "Húngaro"
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italiano (Suíço)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonês"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5378,10 +5378,6 @@ msgstr "Maghiară"
 msgid "Italian"
 msgstr "Italiană"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italian (elvețian)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japoneză"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5415,10 +5415,6 @@ msgstr "Венгерский"
 msgid "Italian"
 msgstr "Итальянский"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Итальянский (Швеция)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Японский"

--- a/po/sl.po
+++ b/po/sl.po
@@ -5407,10 +5407,6 @@ msgstr "Madžarsko"
 msgid "Italian"
 msgstr "Italijansko"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italijansko (Švica)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonsko"

--- a/po/sq.po
+++ b/po/sq.po
@@ -5385,10 +5385,6 @@ msgstr "Hungarisht"
 msgid "Italian"
 msgstr "Italiane"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italiane (Zvic)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonisht"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5363,10 +5363,6 @@ msgstr "Ungerska"
 msgid "Italian"
 msgstr "Italienska"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Italienska (Schweiz)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japanska"

--- a/po/ta.po
+++ b/po/ta.po
@@ -5249,10 +5249,6 @@ msgstr ""
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr ""
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -5363,10 +5363,6 @@ msgstr "Macarca"
 msgid "Italian"
 msgstr "İtalyanca"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "İtalyanca (İsviçre)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonca"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5413,10 +5413,6 @@ msgstr "Угорська"
 msgid "Italian"
 msgstr "Італійська"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "Італійська (Швейцарія)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Японська"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5344,10 +5344,6 @@ msgstr "匈牙利语"
 msgid "Italian"
 msgstr "意大利语"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "意大利语（瑞士）"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "日语"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5351,10 +5351,6 @@ msgstr "匈牙利語"
 msgid "Italian"
 msgstr "義大利語"
 
-#: src/Preferences.cpp:695
-msgid "Italian (Swiss)"
-msgstr "意大利語 (瑞士)"
-
 #: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "日語"

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -692,7 +692,6 @@ static LangInfo aMuleLanguages[] = {
 	{ wxLANGUAGE_HEBREW, false, "", wxTRANSLATE("Hebrew") },
 	{ wxLANGUAGE_HUNGARIAN, false, "", wxTRANSLATE("Hungarian") },
 	{ wxLANGUAGE_ITALIAN, false, "", wxTRANSLATE("Italian") },
-	{ wxLANGUAGE_ITALIAN_SWISS, false, "", wxTRANSLATE("Italian (Swiss)") },
 	{ wxLANGUAGE_JAPANESE, false, "", wxTRANSLATE("Japanese") },
 	{ wxLANGUAGE_KOREAN, false, "", wxTRANSLATE("Korean") },
 	{ wxLANGUAGE_LITHUANIAN, false, "", wxTRANSLATE("Lithuanian") },


### PR DESCRIPTION
The `it_CH` catalog was dropped in #552, but the language picker in **Preferences → General** still showed **Italian (Swiss)**.

The picker is not built from the shipped catalogs — it iterates the hardcoded `aMuleLanguages[]` table in `Preferences.cpp`, which still listed `wxLANGUAGE_ITALIAN_SWISS`. Removing the catalog could not hide it: `UpdateChoice()`'s probe marks an entry available when wxLocale reports `PACKAGE` loaded, and wxLocale falls back `it_CH → it`, so `it.mo` kept satisfying the check and the entry stayed visible.

This removes the table entry (the picker-side twin of the catalog drop) and drops the now-unused `Italian (Swiss)` string from the po catalogs.

Catalogs were edited surgically so the diff is limited to the removed entry; the stale `#:` source-line references (which CI already normalizes away) are left untouched to avoid a whole-tree reflow.