### PR TITLE
i18n: add Latvian to the language picker

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -5258,6 +5258,10 @@ msgstr ""
 msgid "Korean"
 msgstr ""
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -5323,6 +5323,10 @@ msgstr ""
 msgid "Korean"
 msgstr "الكوريه"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "الليتوانيه"

--- a/po/ast.po
+++ b/po/ast.po
@@ -5396,6 +5396,10 @@ msgstr "Xaponés"
 msgid "Korean"
 msgstr "Coreanu"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituanu"

--- a/po/bg.po
+++ b/po/bg.po
@@ -5304,6 +5304,10 @@ msgstr "японски"
 msgid "Korean"
 msgstr "корейски"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "литовски"

--- a/po/bn.po
+++ b/po/bn.po
@@ -5257,6 +5257,10 @@ msgstr ""
 msgid "Korean"
 msgstr ""
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -5373,6 +5373,10 @@ msgstr "Japonès"
 msgid "Korean"
 msgstr "Coreà"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituà"

--- a/po/cs.po
+++ b/po/cs.po
@@ -5375,6 +5375,10 @@ msgstr "Japonština"
 msgid "Korean"
 msgstr "Korejština"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litevština"

--- a/po/da.po
+++ b/po/da.po
@@ -5334,6 +5334,10 @@ msgstr ""
 msgid "Korean"
 msgstr "Korean"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lithuanian"

--- a/po/de.po
+++ b/po/de.po
@@ -5368,6 +5368,10 @@ msgstr "Japanisch"
 msgid "Korean"
 msgstr "Koreanisch"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litauisch"

--- a/po/el.po
+++ b/po/el.po
@@ -5409,6 +5409,10 @@ msgstr "Γιαπωνέζικα"
 msgid "Korean"
 msgstr "Κορεάτικα"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Λιθουανικά"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -5258,6 +5258,10 @@ msgstr ""
 msgid "Korean"
 msgstr ""
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -5385,6 +5385,10 @@ msgstr "Japonés"
 msgid "Korean"
 msgstr "Coreano"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituano"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -5374,6 +5374,10 @@ msgstr "Jaapani"
 msgid "Korean"
 msgstr "Korea"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Leedu"

--- a/po/eu.po
+++ b/po/eu.po
@@ -5374,6 +5374,10 @@ msgstr "Japoniera"
 msgid "Korean"
 msgstr "Koreera"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituaniera"

--- a/po/fi.po
+++ b/po/fi.po
@@ -5374,6 +5374,10 @@ msgstr "Japani"
 msgid "Korean"
 msgstr "Korea"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Liettua"

--- a/po/fr.po
+++ b/po/fr.po
@@ -5357,6 +5357,10 @@ msgstr "Japonais"
 msgid "Korean"
 msgstr "Coréen"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituanien"

--- a/po/gl.po
+++ b/po/gl.po
@@ -5382,6 +5382,10 @@ msgstr "Xaponés"
 msgid "Korean"
 msgstr "Coreano"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituano"

--- a/po/he.po
+++ b/po/he.po
@@ -5344,6 +5344,10 @@ msgstr "יפנית"
 msgid "Korean"
 msgstr "קוראינית"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "ליטאית"

--- a/po/hr.po
+++ b/po/hr.po
@@ -5350,6 +5350,10 @@ msgstr "Japanski"
 msgid "Korean"
 msgstr "Korejski"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litavski"

--- a/po/hu.po
+++ b/po/hu.po
@@ -5355,6 +5355,10 @@ msgstr "Japán"
 msgid "Korean"
 msgstr "Koreai"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litván"

--- a/po/it.po
+++ b/po/it.po
@@ -5362,6 +5362,10 @@ msgstr "Giapponese"
 msgid "Korean"
 msgstr "Coreano"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituano"

--- a/po/ja.po
+++ b/po/ja.po
@@ -5376,6 +5376,10 @@ msgstr "日本語"
 msgid "Korean"
 msgstr "韓国語"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "リトアニア語"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -5405,6 +5405,10 @@ msgstr ""
 msgid "Korean"
 msgstr "한국어"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -5421,6 +5421,10 @@ msgstr "Japonų"
 msgid "Korean"
 msgstr "Korėjiečių"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lietuvių"

--- a/po/lv.po
+++ b/po/lv.po
@@ -5279,6 +5279,10 @@ msgstr "Japāņu"
 msgid "Korean"
 msgstr "Korejiešu"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lietuviešu"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5378,6 +5378,10 @@ msgstr "Japans"
 msgid "Korean"
 msgstr "Koreaans"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litouws"

--- a/po/nn.po
+++ b/po/nn.po
@@ -5401,6 +5401,10 @@ msgstr "Japansk"
 msgid "Korean"
 msgstr "Koreansk"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litauisk"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5400,6 +5400,10 @@ msgstr "Japoński"
 msgid "Korean"
 msgstr "Koreański"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litewski"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5358,6 +5358,10 @@ msgstr "Japonês"
 msgid "Korean"
 msgstr "Coreano"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituânia"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -5381,6 +5381,10 @@ msgstr "Japonês"
 msgid "Korean"
 msgstr "Coreano"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituano"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5386,6 +5386,10 @@ msgstr "Japoneză"
 msgid "Korean"
 msgstr "Koreană"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituaniană"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5423,6 +5423,10 @@ msgstr "Японский"
 msgid "Korean"
 msgstr "Корейский"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Литовский"

--- a/po/sl.po
+++ b/po/sl.po
@@ -5415,6 +5415,10 @@ msgstr "Japonsko"
 msgid "Korean"
 msgstr "Korejsko"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litvansko"

--- a/po/sq.po
+++ b/po/sq.po
@@ -5393,6 +5393,10 @@ msgstr "Japonisht"
 msgid "Korean"
 msgstr "Koreane"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Lituane"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5371,6 +5371,10 @@ msgstr "Japanska"
 msgid "Korean"
 msgstr "Koreanska"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litauisk"

--- a/po/ta.po
+++ b/po/ta.po
@@ -5257,6 +5257,10 @@ msgstr ""
 msgid "Korean"
 msgstr ""
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -5371,6 +5371,10 @@ msgstr "Japonca"
 msgid "Korean"
 msgstr "Korece"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Litvanyaca"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5421,6 +5421,10 @@ msgstr "Японська"
 msgid "Korean"
 msgstr "Корейська"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "Литовська"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5352,6 +5352,10 @@ msgstr "日语"
 msgid "Korean"
 msgstr "韩语"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "立陶宛语"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5359,6 +5359,10 @@ msgstr "日語"
 msgid "Korean"
 msgstr "韓語"
 
+#: src/Preferences.cpp:697
+msgid "Latvian"
+msgstr ""
+
 #: src/Preferences.cpp:698
 msgid "Lithuanian"
 msgstr "立陶宛語"

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -694,6 +694,7 @@ static LangInfo aMuleLanguages[] = {
 	{ wxLANGUAGE_ITALIAN, false, "", wxTRANSLATE("Italian") },
 	{ wxLANGUAGE_JAPANESE, false, "", wxTRANSLATE("Japanese") },
 	{ wxLANGUAGE_KOREAN, false, "", wxTRANSLATE("Korean") },
+	{ wxLANGUAGE_LATVIAN, false, "", wxTRANSLATE("Latvian") },
 	{ wxLANGUAGE_LITHUANIAN, false, "", wxTRANSLATE("Lithuanian") },
 	{ wxLANGUAGE_NORWEGIAN_NYNORSK, false, "", wxTRANSLATE("Norwegian (Nynorsk)") },
 	{ wxLANGUAGE_POLISH, false, "", wxTRANSLATE("Polish") },


### PR DESCRIPTION
The `lv` (Latvian) catalog ships (~31% translated, ~567 strings, and active on Weblate) but was **unreachable** from the GUI: the language picker iterates the hardcoded `aMuleLanguages[]` table in `Preferences.cpp`, which had no `wxLANGUAGE_LATVIAN` entry — so users could not select Latvian despite the translation existing.

This adds the table entry (between Korean and Lithuanian) and the `Latvian` string to the po catalogs.

The catalogs were edited surgically — the new entry is inserted in `msgmerge`'s canonical position — so the diff is limited to the added string rather than a whole-tree `#:`-reference reflow. Verified locally to be CI-equivalent to a full `update-po.sh` regen (no drift after normalization).

Note: `bn` (Bengali, 0% — untouched stub) and `ta` (Tamil, ~1%) remain shipped-but-unlisted for now; only Latvian has enough coverage to be worth surfacing.