### PR TITLE
fix(gui): re-theme Scintilla log views on system appearance change

### DIFF
--- a/src/MuleLogCtrl.cpp
+++ b/src/MuleLogCtrl.cpp
@@ -26,6 +26,26 @@
 
 #include <wx/settings.h>
 
+#include <cstdlib> // std::abs
+
+namespace
+{
+// Perceived brightness (ITU-R BT.601 luma), 0 (black) .. 255 (white).
+int Luminance(const wxColour &c)
+{
+	return (c.Red() * 299 + c.Green() * 587 + c.Blue() * 114) / 1000;
+}
+
+// Whether two colours are far enough apart in brightness for text painted in
+// one over the other to be legible. The threshold is deliberately generous: a
+// false "too close" only forgoes the theme's exact foreground for a guaranteed-
+// readable black/white, which is always preferable to invisible text.
+bool Contrasts(const wxColour &a, const wxColour &b)
+{
+	return std::abs(Luminance(a) - Luminance(b)) >= 64;
+}
+} // namespace
+
 CMuleLogCtrl::CMuleLogCtrl(wxWindow *parent,
 	wxWindowID id,
 	const wxPoint &pos,
@@ -55,16 +75,43 @@ CMuleLogCtrl::CMuleLogCtrl(wxWindow *parent,
 	SetUseHorizontalScrollBar(false);
 
 	// Theme-aware colours (matches the old wxTE_RICH2, which used the system
-	// window colours -- so dark themes keep working).
-	StyleSetForeground(wxSTC_STYLE_DEFAULT, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-	StyleSetBackground(wxSTC_STYLE_DEFAULT, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
-	wxFont guiFont = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
-	StyleSetFont(wxSTC_STYLE_DEFAULT, guiFont);
-	// Propagate the default style to all styles, then make critical lines bold.
-	StyleClearAll();
-	StyleSetBold(Style_Critical, true);
+	// window colours -- so dark themes keep working). Scintilla does not follow
+	// the system appearance on its own, so re-apply on every theme change.
+	SetupStyles();
+	Bind(wxEVT_SYS_COLOUR_CHANGED, &CMuleLogCtrl::OnSysColourChanged, this);
 
 	SetReadOnly(true);
+}
+
+void CMuleLogCtrl::SetupStyles()
+{
+	wxColour fg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+	const wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+
+	// On macOS the window/text system colours are appearance-aware and resolved
+	// to RGB at call time; in some configurations (seen with a self-built wx 3.3
+	// on macOS -- issue #569) they come back with too little contrast, which
+	// paints the whole log invisible. Windows/GTK return static, well-contrasted
+	// values and are unaffected. When the pair is unreadable, keep the theme's
+	// background but force a legible foreground from its brightness.
+	if (!Contrasts(fg, bg)) {
+		fg = Luminance(bg) < 128 ? *wxWHITE : *wxBLACK;
+	}
+
+	StyleSetForeground(wxSTC_STYLE_DEFAULT, fg);
+	StyleSetBackground(wxSTC_STYLE_DEFAULT, bg);
+	StyleSetFont(wxSTC_STYLE_DEFAULT, wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
+	// Propagate the default style to all styles, then make critical lines bold.
+	// This also re-themes existing text on a live appearance change: the style
+	// bytes (Style_Normal / Style_Critical) are kept, only their colours change.
+	StyleClearAll();
+	StyleSetBold(Style_Critical, true);
+}
+
+void CMuleLogCtrl::OnSysColourChanged(wxSysColourChangedEvent &event)
+{
+	SetupStyles();
+	event.Skip();
 }
 
 bool CMuleLogCtrl::AtBottom()

--- a/src/MuleLogCtrl.h
+++ b/src/MuleLogCtrl.h
@@ -72,6 +72,19 @@ private:
 	bool AtBottom();
 	void ScrollToBottom();
 
+	// Paint the default text/background colours and font from the current system
+	// theme. Native wxTextCtrl (the pre-Scintilla log widget) tracked the theme
+	// automatically; Scintilla does not, so we set the colours by hand -- here,
+	// and again on every theme change (see OnSysColourChanged). Guards against a
+	// foreground/background that come back with too little contrast to read (on
+	// macOS the window/text system colours are appearance-aware and can resolve
+	// near-identical, painting the log invisible -- issue #569).
+	void SetupStyles();
+
+	// Re-theme on a live light/dark switch (Scintilla snapshots colours; it will
+	// not follow the appearance on its own).
+	void OnSysColourChanged(wxSysColourChangedEvent &event);
+
 	// Scintilla style ids: 0 is the default text style, 1 adds bold.
 	enum
 	{


### PR DESCRIPTION
The log views were migrated to `wxStyledTextCtrl` (Scintilla) in #548. Scintilla paints its colours from the system theme once, in the constructor, and — unlike the native `wxTextCtrl` it replaced — does not follow the platform appearance on its own. A live light↔dark switch therefore left the three log panes (aMule Log, aMuleGUI Log, Server Info) stuck in the previous theme's colours while the rest of the UI re-themed. This re-applies the styles on `wxEVT_SYS_COLOUR_CHANGED` so the panes track the appearance. Verified on macOS — the panes now re-theme live.

It also adds a contrast guard: on macOS the window/text system colours are appearance-aware and resolved to RGB at call time, and on some wx builds they resolve with too little contrast to read, painting the log invisible (reported in #569 with a self-built wxWidgets 3.3.3). When the two come back near-identical the fix keeps the theme's background and forces a legible foreground chosen from its brightness. Windows/GTK return static, well-contrasted colours, so that branch never triggers there and their rendering is unchanged.
