### PR TITLE
fix(gui): make the search Stop button track and stop the selected tab

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -186,13 +186,20 @@ wxUIntPtr CSearchDlg::GetVisibleSearchId()
 
 void CSearchDlg::ApplyProgressToBar(uint32 status)
 {
-	if (status == 0xffff || status == 0xfffe) {
+	const bool finished = (status == 0xffff || status == 0xfffe);
+	if (finished) {
 		// Finished (ed2k or Kad): reset the bar.
 		m_progressbar->SetValue(0);
 	} else {
 		// Running: real global percent, or the Kad cosmetic ramp.
 		UpdateProgress(status);
 	}
+	// Keep Stop in step with the visible tab's lifecycle — live while the search
+	// runs, greyed once it finishes. Both callers feed this the visible tab's
+	// status (RefreshVisibleTabProgress on monolithic, UpdateSearchProgress on
+	// the remote GUI), so Stop follows the selected tab rather than the most-
+	// recently-started search.
+	FindWindow(IDC_CANCELS)->Enable(!finished);
 }
 
 #ifndef CLIENT_GUI
@@ -563,7 +570,16 @@ void CSearchDlg::SetBrowseStatus(wxUIntPtr searchID, uint32 status)
 
 void CSearchDlg::OnBnClickedStop(wxCommandEvent &WXUNUSED(evt))
 {
-	theApp->searchlist->StopSearch();
+	// Stop only the selected tab's search. The parameterless StopSearch() acts
+	// on the scalar most-recently-started search (m_currentSearch), so with
+	// several searches open it would stop the wrong tab whenever the visible one
+	// is not the newest. Address the daemon/core by the visible tab's own id.
+	wxUIntPtr sid = GetVisibleSearchId();
+	if (sid) {
+		theApp->searchlist->StopSearchById(sid);
+	} else {
+		theApp->searchlist->StopSearch();
+	}
 	ResetControls();
 }
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -654,8 +654,10 @@ public:
 
 	// Multi-search: stop one search by ID; andClose also frees its results
 	// on the daemon (tab close). Falls back to a parameterless stop on a
-	// legacy daemon.
-	void StopSearchById(wxUIntPtr searchID, bool andClose);
+	// legacy daemon. andClose defaults to false so the shared search dialog
+	// can stop the selected tab without closing it (CSearchList's single-arg
+	// overload matches the same call).
+	void StopSearchById(wxUIntPtr searchID, bool andClose = false);
 
 	// Multi-search: remap the optimistic local tab ID to the daemon-allocated
 	// ID once the START reply echoes the correlation token.


### PR DESCRIPTION
Addresses the Stop-button half of #571, and fixes the same bug in the monolithic GUI.

Both problems stem from the Stop button acting on the scalar most-recently-started search (`m_currentSearch`) rather than the selected tab:

- **It stopped the wrong search.** `OnBnClickedStop` called the parameterless `StopSearch()`, which targets `m_currentSearch` — the newest search, not the visible tab. With several searches open, stopping while viewing an older tab killed the wrong one. It now stops the selected tab by id via `StopSearchById(GetVisibleSearchId())`. (`CSearchList::StopSearchById` already does the right per-id thing; the remote `andClose` now defaults to `false` so the shared handler compiles for both builds.)
- **The greyed state didn't follow the visible tab.** amuleGUI never tied Stop to the search lifecycle at all, and the monolithic GUI only greyed it on ed2k completion (via `ResetControls`/`LocalSearchEnd`) — not on Kad completion or per visible tab. Both are now driven from the shared `ApplyProgressToBar`, already fed the visible tab's status: enabled while the selected search runs, greyed once it finishes.

So the Stop button now both reflects and acts on the selected tab, consistently across the monolithic and remote GUIs. Verified by building both `amule` and `amulegui`.

The other half of #571 — the always-greyed "More" button, which needs new EC plumbing — will follow in a separate PR.
