### PR TITLE
fix(logger): reopen the EC log stream to clear sticky EOF on wx 3.3

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -358,16 +358,20 @@ bool CLoggerAccess::HasString()
 			// wxFFileInputStream wraps a stdio FILE* whose EOF flag is
 			// sticky: once GetC() returns wxEOF, subsequent reads keep
 			// returning wxEOF even when amuled has appended more lines
-			// to the logfile in the meantime. Re-seek to the current
-			// position; this calls fseek() which clears the FILE*'s
-			// EOF indicator and resets the wxInputStream error state,
-			// so the next poll picks up newly appended log lines.
-			// Without this, EC clients (amuleGUI, amuleweb) display
-			// the log content captured at connection time and never
-			// see anything emitted afterwards (#215).
+			// to the logfile in the meantime. The amule-project/amule#215
+			// fix re-seeked to the current position to clear it, but wx 3.3
+			// short-circuits a seek to the current offset (no fseek is
+			// issued), so EOF is never cleared and EC clients (amuleGUI,
+			// amuleweb) stop seeing new lines after the batch captured at
+			// connect time. Reopen the stream instead: a fresh
+			// wxFFileInputStream has no EOF set, and seeking back to where we
+			// left off resumes at the first newly appended byte -- independent
+			// of seek-clears-EOF semantics (amule-project/amule#215, wx 3.3).
 			wxFileOffset pos = m_logfile->TellI();
 			if (pos != wxInvalidOffset) {
-				m_logfile->SeekI(pos);
+				delete m_logfile;
+				m_logfile = new wxFFileInputStream(theLogger.GetLogfileName());
+				m_logfile->SeekI(pos, wxFromStart);
 			}
 			break;
 		}


### PR DESCRIPTION
On wxWidgets 3.3, amulegui/amuleweb stop receiving new core-log lines after connecting: the log tab shows the backlog captured at connect time, then never updates.

`CLoggerAccess` tails the daemon logfile via a `wxFFileInputStream`. Once `GetC()` hits `wxEOF`, stdio's EOF flag is sticky, so later reads keep returning EOF even after amuled appends more lines. The amule-project/amule#215 fix cleared it by re-seeking to the current position — but wx 3.3 short-circuits a seek to the current offset (it issues no `fseek`), so EOF is never cleared and the incremental path dies. Verified in isolation: read a file to EOF, append bytes, re-seek to the same position, re-read → 0 bytes; even `SeekI(pos, wxFromStart)` fails, only an actual position change clears it.

Fix: reopen the stream rather than relying on seek-clears-EOF. A fresh `wxFFileInputStream` has no EOF set; seeking back to the saved offset resumes at the first newly appended byte. The seek is an `fseek` to an absolute offset, so this stays O(1) — one `open()`/`fseek()` per poll, flat regardless of logfile size (measured ~46 µs/cycle from 69 KB to 72 MB logs). Daemon-side only, so every EC client benefits.

Tested on macOS (wx 3.3.3): amulegui now shows incremental core-log lines live.
