### PR TITLE
feat(prefs): default the IP filter URL to emule-security's ipfilter.zip

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1490,7 +1490,9 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	NewCfgItem(IDC_FILTERLAN, (new Cfg_Bool("/eMule/FilterLanIPs", s_filterLanIP, true)));
 	NewCfgItem(IDC_PARANOID, (new Cfg_Bool("/eMule/ParanoidFiltering", s_paranoidfilter, true)));
 	NewCfgItem(IDC_AUTOIPFILTER, (new Cfg_Bool("/eMule/IPFilterAutoLoad", s_IPFilterAutoLoad, true)));
-	NewCfgItem(IDC_IPFILTERURL, (new Cfg_Str("/eMule/IPFilterURL", s_IPFilterURL, "")));
+	NewCfgItem(IDC_IPFILTERURL,
+		(new Cfg_Str(
+			"/eMule/IPFilterURL", s_IPFilterURL, "https://upd.emule-security.org/ipfilter.zip")));
 	NewCfgItem(ID_IPFILTERLEVEL, (MkCfg_Int("/eMule/FilterLevel", s_filterlevel, 127)));
 	NewCfgItem(IDC_IPFILTERSYS, (new Cfg_Bool("/eMule/IPFilterSystem", s_IPFilterSys, false)));
 


### PR DESCRIPTION
The **"Auto-update ipfilter at startup"** preference (`IPFilterAutoLoad`) ships **on by default**, but the actual update is gated on `IPFilterAutoLoad() && !IPFilterURL().IsEmpty()` — and `IPFilterURL` defaulted to `""`. So the default-on toggle has effectively been a no-op: new users get no IP filter unless they find the URL field and fill it in.

This sets the default to `https://upd.emule-security.org/ipfilter.zip`, the same host already used for the server list (`server.met`) and Kad nodes (`nodes.dat`), so the default-on toggle finally does what it says.

The startup fetch is conditional — `CHTTPDownloadThread` is created with `checkDownloadNewer=true`, sending `If-Modified-Since`, so an unchanged file returns 304 and is skipped; only an updated filter is re-fetched. Existing configs that already persisted an empty `IPFilterURL` keep their stored value; this only changes the shipped default for new configs.

Verified the URL resolves (`HTTP/2 200`, `application/zip`). Built clean (daemon); clang-format and Tier-2 clang-tidy clean.
