### PR TITLE
feat(prefs): raise the default free-disk-space floor to 500 MB

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1361,7 +1361,7 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	NewCfgItem(IDC_ICH, (new Cfg_Bool("/eMule/ICH", s_ICH, true)));
 	NewCfgItem(IDC_AICHTRUST, (new Cfg_Bool("/eMule/AICHTrust", s_AICHTrustEveryHash, false)));
 	NewCfgItem(IDC_CHECKDISKSPACE, (new Cfg_Bool("/eMule/CheckDiskspace", s_checkDiskspace, true)));
-	NewCfgItem(IDC_MINDISKSPACE, (MkCfg_Int("/eMule/MinFreeDiskSpace", s_uMinFreeDiskSpace, 1)));
+	NewCfgItem(IDC_MINDISKSPACE, (MkCfg_Int("/eMule/MinFreeDiskSpace", s_uMinFreeDiskSpace, 500)));
 	NewCfgItem(IDC_ADDNEWFILESPAUSED,
 		(new Cfg_Bool("/eMule/AddNewFilesPaused", s_addnewfilespaused, false)));
 	NewCfgItem(IDC_PREVIEWPRIO, (new Cfg_Bool("/eMule/PreviewPrio", s_bpreviewprio, false)));


### PR DESCRIPTION
`MinFreeDiskSpace` defaulted to **1 MB**. The disk-space check is on by default (`CheckDiskspace` = true), so a fresh install would let downloads fill the disk down to ~1 MB above what the current write needs before pausing — almost no cushion.

This raises the default to **500 MB**, a sensible safety margin. Only the shipped default changes; existing configs keep their stored `MinFreeDiskSpace`. A hard `PARTSIZE` (~9.28 MB) minimum is always enforced independently of this setting, and the value stays user-adjustable (UI range 1–1,000,000 MB).

Built clean (daemon); clang-format and Tier-2 clang-tidy clean.
