### PR TITLE
fix(ec): don't reload the shared files on an A4AF source swap

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2535,7 +2535,6 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		break;
 	}
 	case EC_OP_CLIENT_SWAP_TO_ANOTHER_FILE: {
-		theApp->sharedfiles->Reload();
 		uint32 idClient = request->GetTagByNameSafe(EC_TAG_CLIENT)->GetInt();
 		CUpDownClient *client = theApp->clientlist->FindClientByECID(idClient);
 		CMD4Hash idFile = request->GetTagByNameSafe(EC_TAG_PARTFILE)->GetMD4Data();


### PR DESCRIPTION
amuleGUI's **"Swap to this file"** on an A4AF source sends `EC_OP_CLIENT_SWAP_TO_ANOTHER_FILE`, whose daemon handler called `theApp->sharedfiles->Reload()` before performing the swap — a full re-scan (and re-hash of any new files) of every shared directory on each swap.

The reload is spurious: the swap only reads the client list (`FindClientByECID`) and the download queue (`GetFileByID`), neither of which depends on the shared-file list. The **monolithic** GUI's equivalent action (`GenericClientListCtrl`, "Swap to this file") makes the identical `SwapToAnotherFile(true, false, false, file)` call with no reload — so this over-reload only ever affected remote-GUI (amuleGUI/amuleweb) clients, and monolithic is the reference for correct behavior.

The line has been present since 2010; it is just more noticeable now with larger shared collections. Removing it makes the EC path match monolithic.

Built clean (daemon); clang-format and Tier-2 clang-tidy clean.
