### PR TITLE
feat(prefs): default the IP filter auto-update to off

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1489,7 +1489,7 @@ void CPreferences::BuildItemList(const wxString &appdir)
 		IDC_IPFSERVERS, (new Cfg_Bool("/ExternalConnect/IpFilterServers", s_IPFilterServers, true)));
 	NewCfgItem(IDC_FILTERLAN, (new Cfg_Bool("/eMule/FilterLanIPs", s_filterLanIP, true)));
 	NewCfgItem(IDC_PARANOID, (new Cfg_Bool("/eMule/ParanoidFiltering", s_paranoidfilter, true)));
-	NewCfgItem(IDC_AUTOIPFILTER, (new Cfg_Bool("/eMule/IPFilterAutoLoad", s_IPFilterAutoLoad, true)));
+	NewCfgItem(IDC_AUTOIPFILTER, (new Cfg_Bool("/eMule/IPFilterAutoLoad", s_IPFilterAutoLoad, false)));
 	NewCfgItem(IDC_IPFILTERURL,
 		(new Cfg_Str(
 			"/eMule/IPFilterURL", s_IPFilterURL, "https://upd.emule-security.org/ipfilter.zip")));


### PR DESCRIPTION
Follow-up to #577. That PR set a working default for `IPFilterURL` so the "Auto-update ipfilter at startup" toggle would stop being a no-op — but with the toggle also defaulting on, new users would silently fetch and apply emule-security's filter at startup.

As raised by @Telemacore, that list blocks entire hosting IP ranges, which flags many VPN exit nodes — a default-on fetch would block VPN users before they ever open the preferences. This flips `IPFilterAutoLoad` to default **off**, so the behaviour is opt-in: the URL default from #577 stays in place, so ticking the box works out of the box, but nothing is fetched or applied unless the user chooses it.

Existing configs keep their stored `IPFilterAutoLoad` value; this only changes the shipped default for new configs.

One line in `src/Preferences.cpp`. Built clean (daemon); clang-format and Tier-2 clang-tidy clean.