### PR TITLE
feat(web-ui): add a column picker and persist sort + columns per table

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -209,7 +209,7 @@ b { font-weight: 600; }
 }
 .spacer { flex: 1 1 auto; }
 .toolbar { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
-.server-toolbars { --srv-field: 190px; display: flex; flex-direction: column; gap: 10px; margin-bottom: 16px; }
+.server-toolbars { --srv-field: 190px; display: flex; flex-direction: column; gap: 10px; margin-bottom: 12px; }
 .server-toolbars .input-sm { width: var(--srv-field); max-width: 100%; }
 /* URL input spans the two add-server inputs combined (2 fields + the .toolbar gap). */
 .server-toolbars .input-url { width: calc(var(--srv-field) * 2 + 6px); max-width: 100%; }
@@ -237,6 +237,26 @@ b { font-weight: 600; }
 .btn-icon { padding: 6px; }
 .btn-sm { padding: 4px 8px; font-size: 13px; }
 .btn-sm .icon { width: 15px; height: 15px; }
+
+/* Column picker: a <details> whose summary is a small icon button and whose
+   body is an absolutely-positioned checkbox menu. Native <details> owns
+   open/close so there's no outside-click handler. */
+.col-picker { position: relative; display: inline-flex; }
+.col-picker > summary { list-style: none; cursor: pointer; }
+.col-picker > summary::-webkit-details-marker { display: none; }
+.col-picker-menu {
+  position: absolute; right: 0; top: calc(100% + 4px); z-index: 20;
+  min-width: 160px; max-height: 60vh; overflow-y: auto; padding: 6px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius); box-shadow: var(--shadow);
+  display: flex; flex-direction: column; gap: 2px;
+}
+.col-picker-item {
+  display: flex; align-items: center; gap: 8px; padding: 4px 6px;
+  border-radius: var(--radius); cursor: pointer; white-space: nowrap; font-size: 13px;
+}
+.col-picker-item:hover { background: var(--surface-2); }
+.col-picker-item input { margin: 0; }
 
 /* Language picker: globe icon + native <select>, blended into the ghost toolbar. */
 .lang-select { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; }
@@ -742,6 +762,8 @@ table.data.virtual td .name-cell .badge { flex-shrink: 0; }
     position: static; width: auto; height: auto; margin: 0;
     clip: auto; overflow: visible;
   }
+  /* roomier tap targets in the column picker on touch screens */
+  .col-picker-item { min-height: 40px; padding: 8px 10px; font-size: 14px; }
 }
 @media (max-width: 600px) {
   .view { padding: 10px; }

--- a/src/webapi/static/i18n/en.json
+++ b/src/webapi/static/i18n/en.json
@@ -180,6 +180,7 @@
   "search_sources": "Sources",
   "search_stop": "Stop",
   "search_title_complete_total": "complete / total",
+  "table_columns": "Columns",
   "search_toast_enter_search_terms": "Enter search terms",
   "search_toast_no_results_selected": "No results selected",
   "search_toast_search_started": "Search started",

--- a/src/webapi/static/i18n/es.json
+++ b/src/webapi/static/i18n/es.json
@@ -180,6 +180,7 @@
   "search_sources": "Fuentes",
   "search_stop": "Detener",
   "search_title_complete_total": "completas / total",
+  "table_columns": "Columnas",
   "search_toast_enter_search_terms": "Introduce términos de búsqueda",
   "search_toast_no_results_selected": "No hay resultados seleccionados",
   "search_toast_search_started": "Búsqueda iniciada",

--- a/src/webapi/static/js/store.js
+++ b/src/webapi/static/js/store.js
@@ -1,6 +1,12 @@
-// Minimal pub/sub state container. Keys are domain names ("downloads",
-// "status", …); values are whatever the data layer or a view puts there.
-// Views subscribe to a key and re-render when it changes.
+// App state, two flavours:
+//   - `store`: a minimal in-memory pub/sub container (lost on reload). Keys are
+//     domain names ("downloads", "status", …); views subscribe to a key and
+//     re-render when it changes.
+//   - loadPref/savePref: persistent prefs backed by localStorage, JSON
+//     round-trip under an "amule."-prefixed key (matching theme.js / i18n.js).
+//     Every access is guarded so a disabled / full / private-mode localStorage
+//     degrades to the caller's fallback instead of throwing.
+//     ponytail: JSON get/set only; no TTL/versioning until something needs it.
 
 const state = new Map();
 const subs = new Map(); // key -> Set<fn>
@@ -23,3 +29,18 @@ export const store = {
     return () => { const s = subs.get(key); if (s) s.delete(fn); };
   },
 };
+
+export function loadPref(key, fallback) {
+  try {
+    const v = localStorage.getItem("amule." + key);
+    return v == null ? fallback : JSON.parse(v);
+  } catch (_) {
+    return fallback;
+  }
+}
+
+export function savePref(key, val) {
+  try {
+    localStorage.setItem("amule." + key, JSON.stringify(val));
+  } catch (_) {}
+}

--- a/src/webapi/static/js/table.js
+++ b/src/webapi/static/js/table.js
@@ -11,6 +11,8 @@
 
 import { html, useRef, useState, useEffect } from "./dom.js";
 import { Icon } from "./icons.js";
+import { loadPref, savePref } from "./store.js";
+import { t } from "./i18n.js";
 
 // Fixed row height: the scroll math assumes every row is exactly this tall, and
 // each <tr> is pinned to it inline. Must fit the tallest cell content (input-sm
@@ -44,6 +46,58 @@ export function textMatcher(query) {
 }
 
 const colClass = (c) => [c.num ? "num" : "", c.cls || ""].filter(Boolean).join(" ");
+
+// Per-table UI prefs (sort direction + hidden columns) persisted as one object
+// under "amule.table.<storageKey>". `defaults` = { sortKey, sortDir, hidden:[] }.
+// Stored prefs are spread over the defaults so a column added as default-hidden
+// later stays hidden only for users who never opened the picker (their stored
+// object has no entry for it → the default wins), while everyone else keeps
+// their explicit choice. Returns the current sort plus toggles the view wires
+// to VirtualTable.onSort and the ColumnPicker.
+export function useTablePrefs(storageKey, defaults) {
+  const [prefs, setPrefs] = useState(() => ({
+    sortKey: defaults.sortKey,
+    sortDir: defaults.sortDir,
+    hidden: defaults.hidden || [],
+    ...loadPref("table." + storageKey, {}),
+  }));
+  useEffect(() => { savePref("table." + storageKey, prefs); }, [prefs]);
+
+  const toggleSort = (key) =>
+    setPrefs((p) => (p.sortKey === key
+      ? { ...p, sortDir: -p.sortDir }
+      : { ...p, sortKey: key, sortDir: 1 }));
+  const toggleCol = (key) =>
+    setPrefs((p) => {
+      const h = new Set(p.hidden);
+      h.has(key) ? h.delete(key) : h.add(key);
+      return { ...p, hidden: [...h] };
+    });
+
+  return { sortKey: prefs.sortKey, sortDir: prefs.sortDir,
+           hidden: new Set(prefs.hidden), toggleSort, toggleCol };
+}
+
+// Dropdown of checkboxes to show/hide a table's toggleable columns. Native
+// <details> so the browser owns open/close (no outside-click handler). Columns
+// without a `key`, or flagged `always`, are fixed and never listed.
+export function ColumnPicker({ columns, hidden, onToggle }) {
+  const toggleable = columns.filter((c) => c.key && !c.always);
+  return html`
+    <details class="col-picker">
+      <summary class="btn btn-sm btn-icon" title=${t("table_columns")}>
+        <${Icon} name="menu" />
+      </summary>
+      <div class="col-picker-menu">
+        ${toggleable.map((c) => html`
+          <label class="col-picker-item">
+            <input type="checkbox" checked=${!hidden.has(c.key)}
+                   onChange=${() => onToggle(c.key)} />
+            <span>${c.label}</span>
+          </label>`)}
+      </div>
+    </details>`;
+}
 
 export function VirtualTable({
   columns, rows, rowKey, rowClass, sortKey, sortDir, onSort, empty, onRowClick,

--- a/src/webapi/static/js/views/clients.js
+++ b/src/webapi/static/js/views/clients.js
@@ -8,7 +8,7 @@ import { api } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
 import { Badge, Placeholder, Tabs } from "../components.js";
-import { VirtualTable, sortRows, textMatcher } from "../table.js";
+import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes, formatSpeed } from "../format.js";
 import { Icon } from "../icons.js";
 import { t } from "../i18n.js";
@@ -31,7 +31,7 @@ const bytesOf = (c, k) => formatBytes((c.xfer || {})[k]);
 // flags column has no key → stays non-sortable).
 const COLS = [
   { cls: "peer-flags", width: "60px", show: ALL, cell: (c) => peerFlags(c) },
-  { key: "name", th: "downloads_peer_col_name", width: "170px", show: ALL, sortable: true,
+  { key: "name", always: true, th: "downloads_peer_col_name", width: "170px", show: ALL, sortable: true,
     sortVal: (c) => (c.client_name || "").toLowerCase(),
     cell: (c) => html`<span title=${c.client_name}>${c.client_name || "—"}</span>` },
   { key: "software", th: "downloads_peer_col_software", width: "140px", show: ALL, sortable: true,
@@ -72,19 +72,15 @@ export default function ClientsPanel() {
   const [filter, setFilter] = useState("all"); // direction tab: all / downloads / uploads
   const [ident, setIdent] = useState("identified");
   const [q, setQ] = useState("");
-  const [sortKey, setSortKey] = useState(null); // null → default sort (busiest first)
-  const [sortDir, setSortDir] = useState(1);
+  // sortKey null → default sort (busiest first).
+  const { sortKey, sortDir, hidden, toggleSort, toggleCol } =
+    useTablePrefs("clients", { sortKey: null, sortDir: 1, hidden: [] });
 
   useEffect(() => {
     data.register({ key: "clients", eventPrefix: "client", id: "client_ecid",
       list: () => api.get("clients").then((r) => r.clients || []) });
     data.ensure("clients");
   }, []);
-
-  const toggleSort = (key) => {
-    if (sortKey === key) setSortDir(-sortDir);
-    else { setSortKey(key); setSortDir(1); }
-  };
 
   const nDown = clients.filter(isDown).length;
   const nUp = clients.filter(isUp).length;
@@ -104,6 +100,7 @@ export default function ClientsPanel() {
 
   const columns = COLS.filter((col) => col.show.includes(filter))
     .map((col) => ({ ...col, label: col.th ? t(col.th) : "" }));
+  const shown = columns.filter((c) => !c.key || !hidden.has(c.key));
 
   // Sort by the chosen column when set (and visible in this tab); otherwise keep
   // the default "busiest peers first" order (combined dl+ul speed, descending).
@@ -129,8 +126,10 @@ export default function ClientsPanel() {
           </select>
           <span>${t("downloads_peer_filter")}:</span>
           <input class="input input-sm" type="text" value=${q} onInput=${(e) => setQ(e.target.value)} />
+          <div class="spacer"></div>
+          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
         </div>
-        <${VirtualTable} columns=${columns} rows=${list} rowKey=${(c) => c.client_ecid}
+        <${VirtualTable} columns=${shown} rows=${list} rowKey=${(c) => c.client_ecid}
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
                          empty=${html`<${Placeholder} kind="info">${t("downloads_peer_empty")}<//>`} />
       </div>

--- a/src/webapi/static/js/views/downloads.js
+++ b/src/webapi/static/js/views/downloads.js
@@ -7,7 +7,7 @@ import { api, bulkFailures } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
 import { ProgressBar, Badge, Placeholder, Tabs, toast, confirmDialog } from "../components.js";
-import { VirtualTable, sortRows, textMatcher } from "../table.js";
+import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes, formatSpeed } from "../format.js";
 import { Icon } from "../icons.js";
 import { t, tn, terr } from "../i18n.js";
@@ -24,8 +24,8 @@ export default function Downloads({ isGuest }) {
   const downloads = useStore("downloads") || [];
   const [categories, setCategories] = useState([]);
   const [selection, setSelection] = useState(() => new Set());
-  const [sortKey, setSortKey] = useState("name");
-  const [sortDir, setSortDir] = useState(1);
+  const { sortKey, sortDir, hidden, toggleSort, toggleCol } =
+    useTablePrefs("downloads", { sortKey: "name", sortDir: 1, hidden: [] });
   const [filterStatus, setFilterStatus] = useState("all");
   const [filterCategory, setFilterCategory] = useState("all");
   const [filterText, setFilterText] = useState("");
@@ -69,10 +69,6 @@ export default function Downloads({ isGuest }) {
     return c ? c.name : String(idx);
   };
 
-  const toggleSort = (key) => {
-    if (sortKey === key) setSortDir(-sortDir);
-    else { setSortKey(key); setSortDir(1); }
-  };
   const toggleRow = (hash, checked) => {
     const next = new Set(selection);
     if (checked) next.add(hash); else next.delete(hash);
@@ -151,10 +147,10 @@ export default function Downloads({ isGuest }) {
   }, [filterStatus, filterCategory, filterText]);
 
   const columns = [
-    { label: html`<input type="checkbox" title=${t("downloads_select_all")} checked=${allSelected}
+    { always: true, label: html`<input type="checkbox" title=${t("downloads_select_all")} checked=${allSelected}
                          onChange=${(e) => toggleAll(e.target.checked)} />`, width: "40px",
       cell: (d) => html`<input type="checkbox" checked=${selection.has(d.hash)} onChange=${(e) => toggleRow(d.hash, e.target.checked)} />` },
-    { key: "name", label: t("downloads_name"), cls: "name", sortable: true,
+    { key: "name", always: true, label: t("downloads_name"), cls: "name", sortable: true,
       sortVal: (d) => (d.name || "").toLowerCase(),
       cell: (d) => html`<span title=${d.name}>${d.name}</span>` },
     { key: "size", label: t("downloads_size"), num: true, width: "110px", sortable: true,
@@ -189,7 +185,7 @@ export default function Downloads({ isGuest }) {
               <option value=${0}>${t("downloads_category_none")}</option>
               ${categories.filter((c) => c.index !== 0).map((c) => html`<option value=${c.index}>${c.name || ("#" + c.index)}</option>`)}
             </select>` },
-    { label: t("downloads_actions"), cls: "row-actions admin-only", width: "130px", cell: (d) => {
+    { key: "actions", label: t("downloads_actions"), cls: "row-actions admin-only", width: "130px", cell: (d) => {
         const inactive = d.status === "paused" || d.status === "stopped";
         const canStop = d.status !== "stopped" && d.status !== "completed" && d.status !== "completing";
         return html`
@@ -207,6 +203,7 @@ export default function Downloads({ isGuest }) {
   ];
 
   list = sortRows(list, columns, sortKey, sortDir);
+  const shown = columns.filter((c) => !c.key || !hidden.has(c.key));
   const rowClass = (d) =>
     (selection.has(d.hash) ? "row-selected " : "") + (d.hash === detailHash ? "row-active" : "");
 
@@ -272,10 +269,11 @@ export default function Downloads({ isGuest }) {
           </select>
           <span>${t("downloads_filter")}:</span>
           <input class="input input-sm" type="text" value=${filterText} onInput=${(e) => setFilterText(e.target.value)} />
+          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
         </div>
       </div>
 
-        <${VirtualTable} columns=${columns} rows=${list} rowKey=${(d) => d.hash} rowClass=${rowClass}
+        <${VirtualTable} columns=${shown} rows=${list} rowKey=${(d) => d.hash} rowClass=${rowClass}
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort} onRowClick=${onRowClick}
                          maxHeight="none"
                          empty=${html`<${Placeholder} kind="info">${t("downloads_empty")}<//>`} />

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -12,7 +12,7 @@ import { data } from "../events.js";
 import { store } from "../store.js";
 import { html, useState, useEffect, useRef } from "../dom.js";
 import { Badge, Placeholder, Tabs, toast } from "../components.js";
-import { VirtualTable, sortRows, textMatcher } from "../table.js";
+import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes } from "../format.js";
 import { Icon } from "../icons.js";
 import { t, tn, terr } from "../i18n.js";
@@ -44,8 +44,10 @@ export default function Search({ isGuest }) {
   const [results, setResults] = useState([]);
   const [filter, setFilter] = useState("");
   const [selection, setSelection] = useState(() => new Set());
-  const [sortKey, setSortKey] = useState("sources");
-  const [sortDir, setSortDir] = useState(-1);
+  // Sort + hidden columns persist per-table via useTablePrefs.
+  const { sortKey, sortDir, hidden, toggleSort, toggleCol } = useTablePrefs("search", {
+    sortKey: "sources", sortDir: -1, hidden: [],
+  });
   const [progress, setProgress] = useState("");
   const [searching, setSearching] = useState(false);
   const [categories, setCategories] = useState([]);
@@ -186,10 +188,6 @@ export default function Search({ isGuest }) {
   };
   const toggleAll = (checked) =>
     setSelection(checked ? new Set(list.map((r) => r.hash)) : new Set());
-  const toggleSort = (key) => {
-    if (sortKey === key) setSortDir(-sortDir);
-    else { setSortKey(key); setSortDir(1); }
-  };
 
   const match = textMatcher(filter);
   const filtered = filter ? results.filter((r) => match(r.name)) : results;
@@ -216,10 +214,10 @@ export default function Search({ isGuest }) {
     </select>`;
 
   const columns = [
-    { label: html`<input type="checkbox" title=${t("search_select_all")} checked=${allSelected}
+    { always: true, label: html`<input type="checkbox" title=${t("search_select_all")} checked=${allSelected}
                          onChange=${(e) => toggleAll(e.target.checked)} />`, width: "40px",
       cell: (r) => html`<input type="checkbox" checked=${selection.has(r.hash)} onChange=${(e) => toggleRow(r.hash, e.target.checked)} />` },
-    { key: "name", label: t("search_name"), cls: "name", sortable: true,
+    { key: "name", always: true, label: t("search_name"), cls: "name", sortable: true,
       sortVal: (r) => (r.name || "").toLowerCase(),
       // flex cell so a long name ellipsizes without hiding the "already have" badge
       cell: (r) => html`<div class="name-cell" title=${r.name}><span class="name-text">${r.name}</span>${r.already_have ? html`<${Badge} title=${t("search_already_have_title")}>${t("search_badge_have")}<//>` : null}</div>` },
@@ -230,7 +228,7 @@ export default function Search({ isGuest }) {
       cell: (r) => { const src = r.sources || {}; return html`<span title=${t("search_title_complete_total")}>${(src.complete || 0) + " / " + (src.total || 0)}</span>`; } },
     { key: "rating", label: t("search_rating"), num: true, width: "90px", sortable: true,
       sortVal: (r) => r.rating || 0, cell: (r) => r.rating || 0 },
-    { label: t("search_actions"), cls: "row-actions admin-only", width: "180px",
+    { key: "actions", label: t("search_actions"), cls: "row-actions admin-only", width: "180px",
       cell: (r) => html`
         <select class="input input-sm" value=${catFor(r.hash)}
                 onChange=${(e) => setRowCat({ ...rowCat, [r.hash]: Number(e.target.value) })}>
@@ -242,6 +240,9 @@ export default function Search({ isGuest }) {
   ];
 
   const list = sortRows(filtered, columns, sortKey, sortDir);
+  // sortRows keeps the full column set (it looks columns up by key); only the
+  // VirtualTable is fed the visible subset.
+  const shown = columns.filter((c) => !c.key || !hidden.has(c.key));
   const rowClass = (r) => selection.has(r.hash) ? "row-selected" : "";
 
   return html`
@@ -287,9 +288,10 @@ export default function Search({ isGuest }) {
           <div class="spacer"></div>
           <span>${t("search_filter")}:</span>
           <input class="input input-sm" type="text" value=${filter} onInput=${(e) => setFilter(e.target.value)} />
+          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
         </div>
 
-        <${VirtualTable} columns=${columns} rows=${list} rowKey=${(r) => r.hash} rowClass=${rowClass}
+        <${VirtualTable} columns=${shown} rows=${list} rowKey=${(r) => r.hash} rowClass=${rowClass}
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
                          empty=${html`<${Placeholder} kind="info">${t("search_empty")}<//>`} />
       </div>

--- a/src/webapi/static/js/views/servers.js
+++ b/src/webapi/static/js/views/servers.js
@@ -6,7 +6,7 @@ import { api } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
 import { Badge, Placeholder, toast, confirmDialog } from "../components.js";
-import { VirtualTable, sortRows } from "../table.js";
+import { VirtualTable, sortRows, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatInt } from "../format.js";
 import { Icon } from "../icons.js";
 import { t, terr } from "../i18n.js";
@@ -15,8 +15,8 @@ export function ServersPanel({ isGuest }) {
   const servers = useStore("servers") || [];
   const status = useStore("status");
   const ed2k = status && status.ed2k;
-  const [sortKey, setSortKey] = useState("users");
-  const [sortDir, setSortDir] = useState(-1);
+  const { sortKey, sortDir, hidden, toggleSort, toggleCol } =
+    useTablePrefs("servers", { sortKey: "users", sortDir: -1, hidden: [] });
   const [addr, setAddr] = useState("");
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
@@ -33,11 +33,6 @@ export function ServersPanel({ isGuest }) {
   useEffect(() => {
     if (ed2k && ed2k.state !== "connecting") setConnectingEcid(null);
   }, [ed2k && ed2k.state]);
-
-  const toggleSort = (key) => {
-    if (sortKey === key) setSortDir(-sortDir);
-    else { setSortKey(key); setSortDir(1); }
-  };
 
   const connect = async (ecid) => {
     setConnectingEcid(ecid);
@@ -81,14 +76,16 @@ export function ServersPanel({ isGuest }) {
     && ed2k.server_port === s.port;
 
   const columns = [
-    { key: "name", label: t("networks_server_name"), cls: "name", sortable: true,
+    { key: "name", always: true, label: t("networks_server_name"), cls: "name", sortable: true,
       sortVal: (s) => (s.name || "").toLowerCase(),
       // flex cell so a long name ellipsizes without hiding the "static" badge
       cell: (s) => html`<div class="name-cell" title=${s.name}><span class="name-text">${s.name}</span>${s.static ? html`<${Badge} title=${t("networks_server_badge_static_title")}>${t("networks_server_badge_static")}<//>` : null}</div>` },
     { key: "description", label: t("networks_server_description"), width: "180px", sortable: true,
       sortVal: (s) => (s.description || "").toLowerCase(), cell: (s) => s.description || "" },
-    { label: t("networks_server_version"), width: "90px", cell: (s) => s.version || "" },
-    { label: t("networks_server_address"), num: true, width: "180px",
+    { key: "version", label: t("networks_server_version"), width: "90px", sortable: true,
+      sortVal: (s) => s.version || "", cell: (s) => s.version || "" },
+    { key: "address", label: t("networks_server_address"), num: true, width: "180px", sortable: true,
+      sortVal: (s) => s.address || "",
       cell: (s) => s.address && s.address.includes(":") ? s.address : (s.address + ":" + s.port) },
     { key: "users", label: t("networks_server_users"), num: true, width: "130px", sortable: true,
       sortVal: (s) => s.users || 0,
@@ -97,8 +94,9 @@ export function ServersPanel({ isGuest }) {
       sortVal: (s) => s.files || 0, cell: (s) => formatInt(s.files) },
     { key: "ping", label: t("networks_server_ping"), num: true, width: "90px", sortable: true,
       sortVal: (s) => s.ping_ms || 0, cell: (s) => s.ping_ms ? s.ping_ms + " ms" : "—" },
-    { label: t("networks_server_priority"), width: "90px", cell: (s) => s.priority || "" },
-    ...(isGuest ? [] : [{ label: t("networks_server_actions"), cls: "row-actions admin-only", width: "90px",
+    { key: "priority", label: t("networks_server_priority"), width: "90px", sortable: true,
+      sortVal: (s) => s.priority || "", cell: (s) => s.priority || "" },
+    ...(isGuest ? [] : [{ key: "actions", label: t("networks_server_actions"), cls: "row-actions admin-only", width: "90px",
       cell: (s) => html`
         <button class="btn btn-icon btn-sm" title=${t("networks_server_connect")} onClick=${() => connect(s.ecid)}>
           <${Icon} name="connect" />
@@ -109,6 +107,7 @@ export function ServersPanel({ isGuest }) {
   ];
 
   const list = sortRows(servers, columns, sortKey, sortDir);
+  const shown = columns.filter((c) => !c.key || !hidden.has(c.key));
   const rowClass = (s) => isConnected(s) ? "connected" : connectingEcid === s.ecid ? "connecting" : "";
 
   return html`
@@ -124,9 +123,11 @@ export function ServersPanel({ isGuest }) {
         <input class="input input-sm input-url" placeholder="http(s)://…/server.met"
                value=${url} onInput=${(e) => setUrl(e.target.value)} />
         <button class="btn btn-sm" type="submit">${t("networks_server_update_from_url")}</button>
+        <div class="spacer"></div>
+        <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
       </form>
     </div>
-    <${VirtualTable} columns=${columns} rows=${list} rowKey=${(s) => s.ecid} rowClass=${rowClass}
+    <${VirtualTable} columns=${shown} rows=${list} rowKey=${(s) => s.ecid} rowClass=${rowClass}
                      sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
                      empty=${html`<${Placeholder} kind="info">${t("networks_server_empty")}<//>`} />`;
 }

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -7,7 +7,7 @@ import { api, bulkFailures } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
 import { Placeholder, toast } from "../components.js";
-import { VirtualTable, sortRows, textMatcher } from "../table.js";
+import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes, formatInt, twin } from "../format.js";
 import { t, tn, terr } from "../i18n.js";
 import { SharedDetail } from "./shared-detail.js";
@@ -19,8 +19,8 @@ const PRIORITIES = ["auto", "very_low", "low", "normal", "high", "release"]
 export default function Shared({ isGuest }) {
   const shared = useStore("shared") || [];
   const [selection, setSelection] = useState(() => new Set());
-  const [sortKey, setSortKey] = useState("name");
-  const [sortDir, setSortDir] = useState(1);
+  const { sortKey, sortDir, hidden, toggleSort, toggleCol } =
+    useTablePrefs("shared", { sortKey: "name", sortDir: 1, hidden: [] });
   const [filterText, setFilterText] = useState("");
   const [detailHash, setDetailHash] = useState(null); // row shown in the detail panel
 
@@ -42,10 +42,6 @@ export default function Shared({ isGuest }) {
     if (detailHash && !shared.some((s) => s.hash === detailHash)) setDetailHash(null);
   }, [shared]);
 
-  const toggleSort = (key) => {
-    if (sortKey === key) setSortDir(-sortDir);
-    else { setSortKey(key); setSortDir(1); }
-  };
   const toggleRow = (hash, checked) => {
     const next = new Set(selection);
     if (checked) next.add(hash); else next.delete(hash);
@@ -92,10 +88,10 @@ export default function Shared({ isGuest }) {
   }, [filterText]);
 
   const columns = [
-    { label: html`<input type="checkbox" title=${t("shared_select_all")} checked=${allSelected}
+    { always: true, label: html`<input type="checkbox" title=${t("shared_select_all")} checked=${allSelected}
                          onChange=${(e) => toggleAll(e.target.checked)} />`, width: "40px",
       cell: (s) => html`<input type="checkbox" checked=${selection.has(s.hash)} onChange=${(e) => toggleRow(s.hash, e.target.checked)} />` },
-    { key: "name", label: t("shared_name"), cls: "name", sortable: true,
+    { key: "name", always: true, label: t("shared_name"), cls: "name", sortable: true,
       sortVal: (s) => (s.name || "").toLowerCase(),
       cell: (s) => html`<span title=${s.name}>${s.name}</span>` },
     { key: "size", label: t("shared_size"), num: true, width: "110px", sortable: true,
@@ -111,7 +107,8 @@ export default function Shared({ isGuest }) {
       cell: (s) => twin(s.accepts, "session", "total", formatInt) },
     { key: "sources", label: t("shared_complete_src"), num: true, width: "90px", sortable: true,
       sortVal: (s) => s.complete_sources || 0, cell: (s) => formatInt(s.complete_sources) },
-    { label: t("shared_priority"), width: "160px", cell: (s) => isGuest
+    { key: "priority", label: t("shared_priority"), width: "160px", sortable: true,
+      sortVal: (s) => s.priority || "", cell: (s) => isGuest
         ? prioLabel(s)
         : html`
             <select class="input input-sm admin-only" value=${prioValue(s)}
@@ -121,6 +118,7 @@ export default function Shared({ isGuest }) {
   ];
 
   list = sortRows(list, columns, sortKey, sortDir);
+  const shown = columns.filter((c) => !c.key || !hidden.has(c.key));
   const rowClass = (s) =>
     (selection.has(s.hash) ? "row-selected " : "") + (s.hash === detailHash ? "row-active" : "");
 
@@ -156,9 +154,10 @@ export default function Shared({ isGuest }) {
         <div class="toolbar">
           <span>${t("shared_filter")}:</span>
           <input class="input input-sm" type="text" value=${filterText} onInput=${(e) => setFilterText(e.target.value)} />
+          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
         </div>
       </div>
-        <${VirtualTable} columns=${columns} rows=${list} rowKey=${(s) => s.hash} rowClass=${rowClass}
+        <${VirtualTable} columns=${shown} rows=${list} rowKey=${(s) => s.hash} rowClass=${rowClass}
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort} onRowClick=${onRowClick}
                          maxHeight="none"
                          empty=${html`<${Placeholder} kind="info">${t("shared_empty")}<//>`} />

--- a/src/webapi/static/js/views/split-detail.js
+++ b/src/webapi/static/js/views/split-detail.js
@@ -6,12 +6,13 @@
 // app.css).
 
 import { html, useState, useRef } from "../dom.js";
+import { loadPref, savePref } from "../store.js";
 import { Icon } from "../icons.js";
 import { t } from "../i18n.js";
 
 export function SplitDetail({ storageKey, open, onClose, top, children }) {
   const [splitH, setSplitH] = useState(() => {
-    const v = Number(localStorage.getItem(storageKey));
+    const v = loadPref(storageKey, 340);
     return v > 0 ? v : 340;
   });
   const splitRef = useRef(null);
@@ -36,7 +37,7 @@ export function SplitDetail({ storageKey, open, onClose, top, children }) {
     const g = dragRef.current;
     if (!g) return;
     try { g.el.releasePointerCapture(g.id); } catch (_) {}
-    if (g.lastH != null) localStorage.setItem(storageKey, String(g.lastH));
+    if (g.lastH != null) savePref(storageKey, g.lastH);
     dragRef.current = null;
   };
 


### PR DESCRIPTION
Every VirtualTable-based table (downloads, shared, search, clients, ed2k servers) now has a column picker to show/hide columns, and remembers its sort direction and hidden columns per-table in localStorage.

- store.js: add loadPref/savePref, a guarded localStorage JSON get/set that degrades to the fallback when localStorage is disabled/full. Kept next to the in-memory pub/sub store rather than in a separate module.
- table.js: useTablePrefs hook persists sort + hidden columns under amule.table.<key>; ColumnPicker renders a native <details> checkbox menu for toggleable columns (those with a key and not flagged 'always').
- views: each table swaps its local sort state for useTablePrefs and drops a ColumnPicker into its toolbar; the full column set feeds sortRows while only the visible subset feeds VirtualTable. Checkbox + name columns are flagged 'always' (fixed); everything else, actions included, is toggleable. Columns that lacked a key (server version/address/priority, shared priority) gain one so they sort and hide too.
- split-detail.js: use the shared loadPref/savePref for the panel height instead of a bespoke unguarded localStorage access.
- app.css: styles for the .col-picker dropdown, with a scrollable menu and roomier tap targets on touch screens.
- i18n (en/es): add the 'Columns' key.