### PR TITLE
feat(web-ui): fill the height in Clients, Searches and Networks; refine charts

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -479,11 +479,15 @@ table.data.virtual td .name-cell .badge { flex-shrink: 0; }
 /* --- stats --- */
 .charts-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px; margin-bottom: 16px; }
 /* Statistics page: fixed 2×2 grid like the desktop statsDlg —
-   Download | Upload on top, Connections | Statistics Tree below. */
-.stats-grid { grid-template-columns: 1fr 1fr; }
-.stats-tree-card { display: flex; flex-direction: column; min-height: 0; max-height: 340px; }
+   Download | Upload on top, Connections | Statistics Tree below. All four
+   cards share one row height so the charts match the stats-tree card. */
+.stats-grid { grid-template-columns: 1fr 1fr; grid-auto-rows: 340px; }
+.stats-tree-card { display: flex; flex-direction: column; min-height: 0; }
 .stats-tree-card .stats-tree { overflow-y: auto; min-height: 0; }
-.chart-card { margin-bottom: 0; }
+/* Chart card fills its cell; the canvas host takes the space left by the title
+   and legend (charts.js sizes the canvas to the host height). */
+.chart-card { margin-bottom: 0; display: flex; flex-direction: column; }
+.chart-card .chart-host { flex: 1 1 auto; min-height: 0; }
 .chart-legend {
   display: flex; gap: 16px; flex-wrap: wrap; margin-top: 8px;
   font-size: 12px; color: var(--text-dim); font-variant-numeric: tabular-nums;
@@ -565,7 +569,26 @@ table.data.virtual td .name-cell .badge { flex-shrink: 0; }
 .tab.active .tab-badge { background: var(--accent); color: var(--accent-contrast); }
 
 /* --- Networks split (top: ED2K/Kad, bottom: log/server info) --- */
-.net-split { display: flex; flex-direction: column; gap: 16px; }
+/* No gap on desktop: the draggable .splitter (+ its own margin) is the visual
+   divider between the two panes, like Downloads. Mobile restores a gap since
+   the splitter is hidden there (see the responsive block). */
+.net-split { display: flex; flex-direction: column; gap: 0; }
+/* Small breathing room below the splitter so it doesn't sit flush against the
+   bottom pane's tab strip. Lives on the splitter (hidden on mobile) so it adds
+   no extra gap there. */
+.net-split .splitter { margin: 2px 0 8px; }
+/* Bottom pane (log/server info) keeps the dragged pixel height; its body fills
+   so the log box grows to the pane instead of its default 30vh cap — otherwise
+   dragging the splitter would just move empty space. */
+.net-split .net-pane:last-child { flex: none; min-height: 0; }
+.net-split .net-pane:last-child .net-pane-body { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+/* Column so the <pre> is stretched to the wrapper width (cross axis) and wraps,
+   instead of a flex row where it keeps its longest-line width and overflows. */
+.net-split .logbox-wrap { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+.net-split .logbox { flex: 1 1 auto; max-height: none; min-height: 0; }
+/* Kad tab graph fills the top pane so it grows/shrinks with the splitter
+   (charts.js sizes the canvas to the host and redraws via a ResizeObserver). */
+.net-split .chart-bare { flex: 1 1 auto; min-height: 0; }
 /* notebook: content box hangs off the tab strip's bottom line, no outer card */
 .net-pane { display: flex; flex-direction: column; }
 .net-pane .tabs { margin-bottom: 0; }
@@ -580,18 +603,22 @@ table.data.virtual td .name-cell .badge { flex-shrink: 0; }
    page fills the viewport and scrolls its regions internally (app-like)
    instead of scrolling the whole page. */
 .split-view { height: 100%; display: flex; flex-direction: column; min-height: 0; }
+/* Full-height page without a detail split: the root fills the viewport and its
+   marked region (.pane-fill) scrolls internally, reusing the .split-view flex
+   chain below. Used by Clients, Searches and Networks. */
+.fill-view { height: 100%; display: flex; flex-direction: column; min-height: 0; }
 /* The table region (net-pane on Downloads, card on Shared) fills the top pane;
    the detail (.split-bottom) is a sibling below the splitter, no longer nested
    in the table's box (it draws no box of its own — see .split-bottom below). */
-.split-view .net-pane { flex: 1 1 auto; min-height: 0; }
-.split-view .net-pane-body { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+.split-view .net-pane, .fill-view .pane-fill { flex: 1 1 auto; min-height: 0; }
+.split-view .net-pane-body, .fill-view .pane-fill .net-pane-body { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
 /* Shared Files' top region is a plain .card (no category-tab net-pane like
    Downloads), and it's the fill region — now nested in .split-top. The
    direct-child form also covers the Categories panel card shown in Downloads'
    manage-categories mode. */
 .split-top > .card, .split-view > .card { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; margin-bottom: 0; }
 /* fill the region and scroll rows internally (overrides the default 70vh cap) */
-.split-view .table-wrap.virtual { flex: 1 1 auto; min-height: 0; }
+.split-view .table-wrap.virtual, .fill-view .table-wrap.virtual { flex: 1 1 auto; min-height: 0; }
 .split-view table.data.virtual tbody tr:not(.spacer) { cursor: pointer; }
 
 .split { flex: 1 1 auto; display: flex; flex-direction: column; min-height: 0; }
@@ -704,18 +731,27 @@ table.data.virtual td .name-cell .badge { flex-shrink: 0; }
   .route-title { display: block; font-size: 18px; font-weight: 600; }
   .brand-logo { height: 26px; }
   .stats-grid { grid-template-columns: 1fr; }
-  /* notebook tab strips: single scrolling row instead of wrapping to 2 lines */
-  .net-pane .tabs { flex-wrap: nowrap; overflow-x: auto; }
+  /* notebook tab strips: single scrolling row instead of wrapping to 2 lines.
+     overflow-y:hidden stops the browser from computing overflow-x:auto's pair
+     to auto and showing a spurious 1px vertical scrollbar. */
+  .net-pane .tabs { flex-wrap: nowrap; overflow-x: auto; overflow-y: hidden; }
   .net-pane .tab { flex: 0 0 auto; }
 
   /* Downloads on phones: no viewport-fit/splitter. The table stacks and the
      page scrolls; the detail opens as a full-screen drill-down sheet over the
      list (below the top bar) so the tap clearly changes the screen and the
      info is reachable without scrolling past a tall table. */
-  .split-view { height: auto; }
-  .split-view .net-pane, .split-view .net-pane-body, .split-top > .card, .split-view > .card { flex: 0 0 auto; }
+  .split-view, .fill-view { height: auto; }
+  .split-view .net-pane, .split-view .net-pane-body, .split-top > .card, .split-view > .card,
+  .fill-view .pane-fill, .fill-view .pane-fill .net-pane-body { flex: 0 0 auto; }
   .splitter { display: none; }
-  .split-view .table-wrap.virtual { flex: none; min-height: 0; max-height: 60vh; }
+  .split-view .table-wrap.virtual, .fill-view .table-wrap.virtual { flex: none; min-height: 0; max-height: 60vh; }
+  /* Networks: no splitter on phones — restore the inter-pane gap, let the
+     bottom pane flow, and give the log box back its own height cap. */
+  .net-split { gap: 16px; }
+  .net-split .net-pane:last-child { height: auto !important; flex: 0 0 auto; }
+  .net-split .logbox { flex: none; max-height: 30vh; }
+  .net-split .logbox-sm { max-height: 22vh; }
   .split-bottom {
     position: fixed; inset: var(--toolbar-h) 0 0 0; z-index: 60;
     height: auto !important; overflow: auto;

--- a/src/webapi/static/js/charts.js
+++ b/src/webapi/static/js/charts.js
@@ -7,11 +7,20 @@
 // as a thinner line (g.avgColor) with a GUI-style legend below the canvas.
 
 import { html, useEffect, useRef } from "./dom.js";
-import { t } from "./i18n.js";
+import { t, getLang } from "./i18n.js";
+
+// Time-axis clock, localized to the UI language, 24h (no AM/PM). The axis uses
+// hour:minute; the hover readout adds seconds. Formatters are built once —
+// constructing Intl.DateTimeFormat per label is expensive.
+const clockHM = new Intl.DateTimeFormat(getLang(), { hour: "2-digit", minute: "2-digit", hour12: false });
+const clockHMS = new Intl.DateTimeFormat(getLang(), { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+const clock = (unixSeconds, withSeconds) =>
+  (withSeconds ? clockHMS : clockHM).format(new Date((Number(unixSeconds) || 0) * 1000));
 
 const HEIGHT = 180;
-const GUTTER_LEFT = 56;   // y-axis labels
-const GUTTER_BOTTOM = 20; // x-axis labels
+const AXIS_FONT = "12px system-ui, sans-serif"; // matches the .chart-legend size
+const GUTTER_LEFT = 44;   // hover-mapping fallback until the first draw sizes it
+const GUTTER_BOTTOM = 22; // x-axis labels
 const PAD_TOP = 8;
 const PAD_RIGHT = 8;
 
@@ -20,7 +29,12 @@ export function Chart({ g, data, bare }) {
   const state = useRef({ data: null, hover: -1 });
 
   const redraw = () => {
-    if (canvas.current && state.current.data) draw(canvas.current, g, state.current.data, state.current.hover);
+    if (canvas.current && state.current.data) {
+      // draw() returns the plot's horizontal bounds (the left gutter is sized
+      // dynamically to the labels), so hover mapping stays accurate.
+      const box = draw(canvas.current, g, state.current.data, state.current.hover);
+      if (box) { state.current.x0 = box.x0; state.current.x1 = box.x1; }
+    }
   };
 
   useEffect(() => {
@@ -30,11 +44,14 @@ export function Chart({ g, data, bare }) {
     mo.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     mq.addEventListener("change", redraw);
-    window.addEventListener("resize", redraw);
+    // Redraw on any host-size change: covers window resizes and the Networks
+    // slider, which resizes the pane without firing a window resize event.
+    const ro = new ResizeObserver(redraw);
+    if (canvas.current && canvas.current.parentNode) ro.observe(canvas.current.parentNode);
     return () => {
       mo.disconnect();
       mq.removeEventListener("change", redraw);
-      window.removeEventListener("resize", redraw);
+      ro.disconnect();
     };
   }, []);
 
@@ -48,7 +65,9 @@ export function Chart({ g, data, bare }) {
     const d = state.current.data;
     if (!d || !d[0].length) return;
     const rect = canvas.current.getBoundingClientRect();
-    const frac = (e.clientX - rect.left - GUTTER_LEFT) / Math.max(1, rect.width - GUTTER_LEFT - PAD_RIGHT);
+    const x0 = state.current.x0 != null ? state.current.x0 : GUTTER_LEFT;
+    const x1 = state.current.x1 != null ? state.current.x1 : rect.width - PAD_RIGHT;
+    const frac = (e.clientX - rect.left - x0) / Math.max(1, x1 - x0);
     const idx = Math.max(0, Math.min(d[0].length - 1, Math.round(frac * (d[0].length - 1))));
     if (idx !== state.current.hover) { state.current.hover = idx; redraw(); }
   };
@@ -60,7 +79,7 @@ export function Chart({ g, data, bare }) {
     <div class=${bare ? "chart-card chart-bare" : "card chart-card"}>
       <h3>${g.title}</h3>
       <div class="chart-host">
-        <canvas ref=${canvas} style="width:100%;height:${HEIGHT}px;display:block"
+        <canvas ref=${canvas} style="width:100%;height:100%;display:block"
           onMouseMove=${onMove} onMouseLeave=${onLeave}></canvas>
       </div>
       ${avg ? html`
@@ -80,26 +99,50 @@ function niceStep(raw) {
 
 function draw(cv, g, [xs, ys, avg], hover) {
   const cssW = cv.parentNode.clientWidth || 400;
+  // Height follows the host: fixed 180px for the bare (Kad) chart, but on the
+  // Stats grid the canvas is height:100% so the host fills its card cell.
+  const h = cv.parentNode.clientHeight || HEIGHT;
   const dpr = window.devicePixelRatio || 1;
   cv.width = cssW * dpr;
-  cv.height = HEIGHT * dpr;
+  cv.height = h * dpr;
   const ctx = cv.getContext("2d");
   ctx.scale(dpr, dpr);
 
   const styles = getComputedStyle(document.documentElement);
   const fg = styles.getPropertyValue("--text").trim() || "#000";
   const grid = styles.getPropertyValue("--border").trim() || "#0001";
-  ctx.clearRect(0, 0, cssW, HEIGHT);
-  ctx.font = "11px system-ui, sans-serif";
+  ctx.clearRect(0, 0, cssW, h);
+  ctx.font = AXIS_FONT;
 
-  const x0 = GUTTER_LEFT, x1 = cssW - PAD_RIGHT;
-  const y0 = PAD_TOP, y1 = HEIGHT - GUTTER_BOTTOM;
   const n = xs.length;
   if (!n) return;
 
   // y scale: 0 .. max*1.05, ticks on a nice step (shared by both series)
   const yMax = Math.max(1, Math.max(...ys, ...(avg || [0])) * 1.05);
   const step = Math.max(1, niceStep(yMax / 4)); // values are integer counts/B·s⁻¹
+
+  // Axis unit: charts with `g.axis` (speeds) pick ONE unit for the whole axis so
+  // ticks are bare numbers with the unit shown once; others keep g.fmt per tick.
+  const axis = g.axis ? g.axis(yMax) : null;
+  const tickLabel = (v) => {
+    if (!axis) return g.fmt(v);
+    if (v === 0) return "0";
+    const s = v / axis.div;
+    const raw = s >= 100 ? s.toFixed(0) : s >= 10 ? s.toFixed(1) : s.toFixed(2);
+    return raw.indexOf(".") < 0 ? raw : raw.replace(/\.?0+$/, "");
+  };
+  const ticks = [];
+  for (let v = 0; v <= yMax; v += step) ticks.push([v, tickLabel(v)]);
+
+  // Left gutter sized to the widest label (+ 6px gap + 6px margin) instead of a
+  // fixed width, so short numeric axes don't waste horizontal space.
+  let labelW = 0;
+  for (const [, label] of ticks) labelW = Math.max(labelW, ctx.measureText(label).width);
+  const x0 = Math.ceil(labelW) + 12;
+  const x1 = cssW - PAD_RIGHT;
+  // reserve a line at the top for the unit caption when present
+  const y0 = axis ? PAD_TOP + 15 : PAD_TOP;
+  const y1 = h - GUTTER_BOTTOM;
   const sx = (i) => x0 + (n < 2 ? 0 : (i / (n - 1)) * (x1 - x0));
   const sy = (v) => y1 - (v / yMax) * (y1 - y0);
 
@@ -109,10 +152,17 @@ function draw(cv, g, [xs, ys, avg], hover) {
   ctx.lineWidth = 1;
   ctx.textAlign = "right";
   ctx.textBaseline = "middle";
-  for (let v = 0; v <= yMax; v += step) {
+  for (const [v, label] of ticks) {
     const y = Math.round(sy(v)) + 0.5;
     ctx.beginPath(); ctx.moveTo(x0, y); ctx.lineTo(x1, y); ctx.stroke();
-    ctx.fillText(g.fmt(v), x0 - 6, y);
+    ctx.fillText(label, x0 - 6, y);
+  }
+  // unit shown once, above the axis numbers (dim, right-aligned to match them)
+  if (axis) {
+    ctx.fillStyle = styles.getPropertyValue("--text-dim").trim() || fg;
+    ctx.textBaseline = "top";
+    ctx.fillText(axis.unit, x0 - 6, 1);
+    ctx.fillStyle = fg;
   }
 
   // x labels: ~4 evenly spaced timestamps
@@ -121,7 +171,7 @@ function draw(cv, g, [xs, ys, avg], hover) {
   const nLabels = Math.min(4, n);
   for (let k = 0; k < nLabels; k++) {
     const i = Math.round((k / Math.max(1, nLabels - 1)) * (n - 1));
-    const label = new Date(xs[i] * 1000).toLocaleTimeString();
+    const label = clock(xs[i]);
     // keep edge labels inside the plot
     const x = Math.max(x0 + 20, Math.min(x1 - 20, sx(i)));
     ctx.fillText(label, x, y1 + 5);
@@ -159,7 +209,9 @@ function draw(cv, g, [xs, ys, avg], hover) {
     ctx.fillStyle = fg;
     ctx.textBaseline = "top";
     ctx.textAlign = hx > (x0 + x1) / 2 ? "right" : "left";
-    const text = g.fmt(ys[hover]) + " · " + new Date(xs[hover] * 1000).toLocaleTimeString();
+    const text = g.fmt(ys[hover]) + " · " + clock(xs[hover], true);
     ctx.fillText(text, hx > (x0 + x1) / 2 ? hx - 8 : hx + 8, y0);
   }
+
+  return { x0, x1 }; // plot bounds, for accurate hover mapping (see redraw)
 }

--- a/src/webapi/static/js/format.js
+++ b/src/webapi/static/js/format.js
@@ -19,6 +19,15 @@ export function formatSpeed(bps) {
   return formatBytes(bps) + "/s";
 }
 
+// Pick ONE byte unit for a whole axis from its max value, so chart ticks can be
+// bare numbers with the unit shown once instead of repeating "KB/s" per tick.
+// Returns the divisor to scale raw values by and the unit label to display.
+export function bytesAxis(max, perSec) {
+  let i = 0, n = Number(max) || 0;
+  while (n >= 1024 && i < UNITS.length - 1) { n /= 1024; i++; }
+  return { div: Math.pow(1024, i), unit: UNITS[i] + (perSec ? "/s" : "") };
+}
+
 export function formatPercent(p) {
   p = Number(p) || 0;
   return p.toFixed(p >= 100 || p === 0 ? 0 : 1) + "%";

--- a/src/webapi/static/js/views/clients.js
+++ b/src/webapi/static/js/views/clients.js
@@ -113,12 +113,13 @@ export default function ClientsPanel() {
   }
 
   return html`
-    <div class="view-header">
-      <h3 class="section-title">${t("app_nav_clients")}</h3>
-    </div>
-    <section class="net-pane">
-      <${Tabs} tabs=${tabs} active=${filter} onSelect=${setFilter} />
-      <div class="net-pane-body">
+    <div class="fill-view">
+      <div class="view-header">
+        <h3 class="section-title">${t("app_nav_clients")}</h3>
+      </div>
+      <section class="net-pane pane-fill">
+        <${Tabs} tabs=${tabs} active=${filter} onSelect=${setFilter} />
+        <div class="net-pane-body">
         <div class="toolbar pane-toolbar">
           <label>${t("downloads_peer_identity")}:</label>
           <select class="input input-sm" value=${ident} onChange=${(e) => setIdent(e.target.value)}>
@@ -132,8 +133,9 @@ export default function ClientsPanel() {
         <${VirtualTable} columns=${shown} rows=${list} rowKey=${(c) => c.client_ecid}
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
                          empty=${html`<${Placeholder} kind="info">${t("downloads_peer_empty")}<//>`} />
-      </div>
-    </section>`;
+        </div>
+      </section>
+    </div>`;
 }
 
 // Compact status icons (replacing the ident/obfuscation/friend columns). Each

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -7,6 +7,7 @@ import { api } from "../api.js";
 import { Tabs, toast, confirmDialog } from "../components.js";
 import { t, terr } from "../i18n.js";
 import { Icon } from "../icons.js";
+import { useSplitHeight } from "./split-detail.js";
 import { ServersPanel } from "./servers.js";
 import { KadPanel, KadInfoPanel } from "./kad.js";
 import { Ed2kInfoPanel } from "./ed2k.js";
@@ -15,6 +16,10 @@ import { AmuleLogPanel, ServerInfoPanel } from "./logs.js";
 export default function Networks({ isGuest }) {
   const [top, setTop] = useState("ed2k");
   const [bottom, setBottom] = useState("amulelog");
+  // Draggable divider between the top (servers/Kad) and bottom (log/info)
+  // panes, like the desktop NetDialog's wxSplitterWindow. On phones the CSS
+  // hides the splitter and both panes flow (see .net-split in app.css).
+  const { height, containerRef, splitterProps } = useSplitHeight("net:split");
 
   const topTabs = [
     { key: "ed2k", label: t("networks_tab_ed2k") },
@@ -28,8 +33,8 @@ export default function Networks({ isGuest }) {
   ];
 
   return html`
-    <div class="net-split">
-      <section class="net-pane">
+    <div class="net-split fill-view" ref=${containerRef}>
+      <section class="net-pane pane-fill">
         <${Tabs} tabs=${topTabs} active=${top} onSelect=${setTop}
                  extra=${html`<${ConnectButton} />`} />
         <div class="net-pane-body">
@@ -39,7 +44,9 @@ export default function Networks({ isGuest }) {
         </div>
       </section>
 
-      <section class="net-pane">
+      <div class="splitter" ...${splitterProps}></div>
+
+      <section class="net-pane" style=${{ height: height + "px" }}>
         <${Tabs} tabs=${bottomTabs} active=${bottom} onSelect=${setBottom} />
         <div class="net-pane-body">
           ${bottom === "amulelog"

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -246,6 +246,7 @@ export default function Search({ isGuest }) {
   const rowClass = (r) => selection.has(r.hash) ? "row-selected" : "";
 
   return html`
+    <div class="fill-view">
     <form class="card search-form" onSubmit=${startSearch}>
       <div class="search-grid">
         ${field(t("search_query"), html`<input class="input" type="text" placeholder=${t("search_terms_ph")} required value=${query} onInput=${(e) => setQuery(e.target.value)} />`, "field-wide")}
@@ -274,7 +275,7 @@ export default function Search({ isGuest }) {
       ${isGuest ? html`<p class="hint">${t("search_guest_readonly")}</p>` : null}
     </form>
 
-    <section class="net-pane">
+    <section class="net-pane pane-fill">
       <${Tabs} tabs=${[{ key: "results", label: t("search_results") + " (" + results.length + ")" }]}
                active="results" onSelect=${() => {}} />
       <div class="net-pane-body">
@@ -295,7 +296,8 @@ export default function Search({ isGuest }) {
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
                          empty=${html`<${Placeholder} kind="info">${t("search_empty")}<//>`} />
       </div>
-    </section>`;
+    </section>
+    </div>`;
 }
 
 function field(label, control, cls = "") {

--- a/src/webapi/static/js/views/split-detail.js
+++ b/src/webapi/static/js/views/split-detail.js
@@ -10,30 +10,33 @@ import { loadPref, savePref } from "../store.js";
 import { Icon } from "../icons.js";
 import { t } from "../i18n.js";
 
-export function SplitDetail({ storageKey, open, onClose, top, children }) {
-  const [splitH, setSplitH] = useState(() => {
-    const v = loadPref(storageKey, 340);
-    return v > 0 ? v : 340;
+// Bottom-anchored resizable-height hook, shared by the Downloads/Shared detail
+// panel and the Networks bottom pane. Drag the splitter (moving up grows the
+// bottom region); the height is clamped so neither region collapses and
+// persisted per `storageKey`. Returns the current height plus the props to
+// spread onto a `.splitter` element and the ref for the enclosing container.
+export function useSplitHeight(storageKey, def = 340) {
+  const [height, setHeight] = useState(() => {
+    const v = loadPref(storageKey, def);
+    return v > 0 ? v : def;
   });
-  const splitRef = useRef(null);
+  const containerRef = useRef(null);
   const dragRef = useRef(null);
 
-  // Drag the splitter to resize the detail panel (bottom-anchored: moving up
-  // grows it). Clamp so neither region collapses; persist the final height.
-  const onSplitDown = (e) => {
+  const onPointerDown = (e) => {
     e.preventDefault();
     e.currentTarget.setPointerCapture(e.pointerId);
-    dragRef.current = { startY: e.clientY, startH: splitH, id: e.pointerId, el: e.currentTarget };
+    dragRef.current = { startY: e.clientY, startH: height, id: e.pointerId, el: e.currentTarget };
   };
-  const onSplitMove = (e) => {
+  const onPointerMove = (e) => {
     const g = dragRef.current;
     if (!g) return;
-    const total = splitRef.current ? splitRef.current.clientHeight : window.innerHeight;
+    const total = containerRef.current ? containerRef.current.clientHeight : window.innerHeight;
     const h = Math.max(160, Math.min(total - 160, g.startH + (g.startY - e.clientY)));
     g.lastH = h;
-    setSplitH(h);
+    setHeight(h);
   };
-  const onSplitUp = () => {
+  const onPointerUp = () => {
     const g = dragRef.current;
     if (!g) return;
     try { g.el.releasePointerCapture(g.id); } catch (_) {}
@@ -41,13 +44,19 @@ export function SplitDetail({ storageKey, open, onClose, top, children }) {
     dragRef.current = null;
   };
 
+  const splitterProps = { onPointerDown, onPointerMove, onPointerUp, onPointerCancel: onPointerUp };
+  return { height, containerRef, splitterProps };
+}
+
+export function SplitDetail({ storageKey, open, onClose, top, children }) {
+  const { height, containerRef, splitterProps } = useSplitHeight(storageKey);
+
   return html`
-    <div class="split" ref=${splitRef}>
+    <div class="split" ref=${containerRef}>
       <div class="split-top">${top}</div>
       ${open ? html`
-        <div class="splitter" onPointerDown=${onSplitDown} onPointerMove=${onSplitMove}
-             onPointerUp=${onSplitUp} onPointerCancel=${onSplitUp}></div>
-        <div class="split-bottom" style=${{ height: splitH + "px" }}>
+        <div class="splitter" ...${splitterProps}></div>
+        <div class="split-bottom" style=${{ height: height + "px" }}>
           <button class="btn btn-icon btn-sm detail-close" title=${t("downloads_detail_close")}
                   onClick=${onClose}><${Icon} name="cancel" /></button>
           ${children}

--- a/src/webapi/static/js/views/stats.js
+++ b/src/webapi/static/js/views/stats.js
@@ -8,7 +8,7 @@ import { api } from "../api.js";
 import { html, useState, useEffect } from "../dom.js";
 import { Placeholder } from "../components.js";
 import { Chart } from "../charts.js";
-import { formatBytes, formatSpeed, formatInt, formatDuration } from "../format.js";
+import { formatBytes, formatSpeed, formatInt, formatDuration, bytesAxis } from "../format.js";
 import { t, terr } from "../i18n.js";
 
 const GRAPH_POLL_MS = 2000;
@@ -16,9 +16,10 @@ const TREE_EVERY = 3; // refresh tree every N graph ticks
 const GRAPH_WIDTH = 300; // samples per fetch (~chart pixel width; full window is ~1800)
 const SMA_WINDOW = 50; // ponytail: SMA over ~5 min of samples; amulegui makes this a pref
 
+const speedAxis = (max) => bytesAxis(max, true);
 const GRAPHS = [
-  { name: "download", title: t("stats_download_speed"), color: "#3aaf5d", avgColor: "#1fb5ad", fmt: formatSpeed },
-  { name: "upload", title: t("stats_upload_speed"), color: "#3b86e0", avgColor: "#8a5cd6", fmt: formatSpeed },
+  { name: "download", title: t("stats_download_speed"), color: "#3aaf5d", avgColor: "#1fb5ad", fmt: formatSpeed, axis: speedAxis },
+  { name: "upload", title: t("stats_upload_speed"), color: "#3b86e0", avgColor: "#8a5cd6", fmt: formatSpeed, axis: speedAxis },
   { name: "connections", title: t("stats_connections"), color: "#d68a0c", avgColor: "#c94f7c", fmt: formatInt },
 ];
 


### PR DESCRIPTION
The desktop-app viewport-fit layout (content fills the window and scrolls its regions internally) was only used by Downloads and Shared Files, via the .split-view flex chain. Clients, Searches and Networks collapsed to their content height, leaving empty space below.

Layout:
- Add a .fill-view class that reuses the existing .split-view flex chain (height:100% column + a .pane-fill region that grows and scrolls). Apply it to Clients, Searches and Networks so their main table/pane fills the viewport. On phones (<=860px) it falls back to page scroll like .split-view already does.
- Stop a spurious 1px vertical scrollbar on the mobile notebook tab strips (overflow-x:auto makes overflow-y compute to auto).

Networks:
- Add a draggable splitter between the top (servers/Kad) and bottom (log/server info) panes, mirroring the desktop NetDialog. Extract the drag/persist logic from SplitDetail into a shared useSplitHeight() hook used by both. The bottom pane keeps a persisted pixel height and its log box fills the pane (wrapping instead of overflowing); the splitter is hidden on phones, with a small gap below it so it doesn't sit flush against the bottom tab strip.

Stats:
- Give the 2x2 grid a uniform row height so all four cards match the stats-tree card, and let the charts fill their cells.

Charts:
- Size the canvas to its host height (height:100%) instead of a fixed 180px, and redraw via a ResizeObserver so the Kad graph resizes when the Networks splitter moves (a window resize event does not fire then).
- Bump the axis font to 12px (matching the legend).
- Show one unit per axis (bytesAxis) with bare numeric ticks instead of repeating 'KB/s' per tick, and size the left gutter to the widest label so short axes don't waste horizontal space.
- Format the time axis as localized 24h HH:MM (no seconds, no AM/PM); the hover readout keeps seconds.