### PR TITLE
feat(web-ui): add an already-have status filter to search results

### DIFF
--- a/src/webapi/static/i18n/en.json
+++ b/src/webapi/static/i18n/en.json
@@ -176,6 +176,8 @@
   "search_selected": "Selected",
   "search_size": "Size",
   "search_sources": "Sources",
+  "search_have_no": "Not Have",
+  "search_have_yes": "Already Have",
   "search_status_downloaded": "Downloaded",
   "search_status_queued": "Queued",
   "search_status_canceled": "Canceled",

--- a/src/webapi/static/i18n/es.json
+++ b/src/webapi/static/i18n/es.json
@@ -176,6 +176,8 @@
   "search_selected": "Seleccionados",
   "search_size": "Tamaño",
   "search_sources": "Fuentes",
+  "search_have_no": "No lo tengo",
+  "search_have_yes": "Ya lo tengo",
   "search_status_downloaded": "Descargado",
   "search_status_queued": "En cola",
   "search_status_canceled": "Cancelado",

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -43,6 +43,7 @@ export default function Search({ isGuest }) {
 
   const [results, setResults] = useState([]);
   const [filter, setFilter] = useState("");
+  const [filterHave, setFilterHave] = useState("all");
   const [selection, setSelection] = useState(() => new Set());
   // Sort + hidden columns persist per-table via useTablePrefs.
   const { sortKey, sortDir, hidden, toggleSort, toggleCol } = useTablePrefs("search", {
@@ -190,7 +191,9 @@ export default function Search({ isGuest }) {
     setSelection(checked ? new Set(list.map((r) => r.hash)) : new Set());
 
   const match = textMatcher(filter);
-  const filtered = filter ? results.filter((r) => match(r.name)) : results;
+  let filtered = filter ? results.filter((r) => match(r.name)) : results;
+  if (filterHave !== "all")
+    filtered = filtered.filter((r) => (filterHave === "have") === !!r.already_have);
   const allSelected = filtered.length > 0 && filtered.every((r) => selection.has(r.hash));
   const selectedCount = filtered.filter((r) => selection.has(r.hash)).length;
 
@@ -202,7 +205,7 @@ export default function Search({ isGuest }) {
       const next = new Set(); prev.forEach((h) => vis.has(h) && next.add(h));
       return next.size === prev.size ? prev : next;
     });
-  }, [filter]);
+  }, [filter, filterHave]);
 
   const catOptions = () => html`
     <option value=${0}>${t("search_category_none")}</option>
@@ -304,6 +307,11 @@ export default function Search({ isGuest }) {
           <span class="selected-count admin-only">${t("search_selected")} ${selectedCount}</span>
           <span class="search-progress">${progress}</span>
           <div class="spacer"></div>
+          <select class="input input-sm" value=${filterHave} onChange=${(e) => setFilterHave(e.target.value)}>
+            <option value="all">${t("downloads_status_all")}</option>
+            <option value="not_have">${t("search_have_no")}</option>
+            <option value="have">${t("search_have_yes")}</option>
+          </select>
           <input class="input input-sm" type="text" placeholder=${t("search_filter")} value=${filter} onInput=${(e) => setFilter(e.target.value)} />
           <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
         </div>


### PR DESCRIPTION
Add a status dropdown to the search results toolbar (All Status / Not Have / Already Have) that filters rows by the already_have flag, mirroring the status filter pattern used in the downloads table.

- search.js: new filterHave state, filter results on already_have, render the <select> in the pane toolbar, and include filterHave in the selection-pruning effect deps.
- en.json/es.json: add search_have_no and search_have_yes labels; reuse the existing downloads_status_all key for 'All Status'.
