### PR TITLE
feat(ed2k): BDP-adaptive request/upload depth (up to ~12x on WAN) + drop dead VBT path

### DIFF
--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -274,10 +274,9 @@ void CUpDownClient::Init()
 	m_lastClientSoft = (uint32)(-1);
 	m_lastClientVersion = 0;
 
-	m_MaxBlockRequests = STANDARD_BLOCKS_REQUEST; // Safe starting amount
-
 	m_last_block_start = 0;
 	m_lastaverage = 0;
+	m_minRTT = 0;
 
 	SetLastBuddyPingPongTime();
 	m_fRequestsCryptLayer = 0;
@@ -347,7 +346,6 @@ void CUpDownClient::ClearHelloProperties()
 	m_fSharedDirectories = 0;
 	m_bMultiPacket = 0;
 	m_fOsInfoSupport = 0;
-	m_fValueBasedTypeTags = 0;
 	SecIdentSupRec = 0;
 	m_byKadVersion = 0;
 	m_fRequestsCryptLayer = 0;
@@ -624,8 +622,6 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 		// Special tag for Compat. Clients Misc options.
 		case CT_EMULECOMPAT_OPTIONS:
 			//  1 Operative System Info
-			//	1 Value-based-type int tags (experimental!)
-			m_fValueBasedTypeTags = (temptag.GetInt() >> 1 * 1) & 0x01;
 			m_fOsInfoSupport = (temptag.GetInt() >> 1 * 0) & 0x01;
 			break;
 
@@ -1052,7 +1048,7 @@ void CUpDownClient::SendHelloTypePacket(CMemFile *data)
 	CTagString tagname(CT_NAME, thePrefs::GetUserNick());
 	tagname.WriteTagToFile(data, utf8strRaw);
 
-	CTagVarInt tagversion(CT_VERSION, EDONKEYVERSION, GetVBTTags() ? 0 : 32);
+	CTagVarInt tagversion(CT_VERSION, EDONKEYVERSION, 32);
 	tagversion.WriteTagToFile(data);
 	// eMule UDP Ports
 
@@ -1068,21 +1064,19 @@ void CUpDownClient::SendHelloTypePacket(CMemFile *data)
 		}
 	}
 
-	CTagVarInt tagUdpPorts(CT_EMULE_UDPPORTS,
-		(kadUDPPort << 16) | ((uint32)thePrefs::GetEffectiveUDPPort()),
-		GetVBTTags() ? 0 : 32);
+	CTagVarInt tagUdpPorts(
+		CT_EMULE_UDPPORTS, (kadUDPPort << 16) | ((uint32)thePrefs::GetEffectiveUDPPort()), 32);
 	tagUdpPorts.WriteTagToFile(data);
 
 	if (theApp->clientlist->GetBuddy() && theApp->IsFirewalled()) {
-		CTagVarInt tagBuddyIP(
-			CT_EMULE_BUDDYIP, theApp->clientlist->GetBuddy()->GetIP(), GetVBTTags() ? 0 : 32);
+		CTagVarInt tagBuddyIP(CT_EMULE_BUDDYIP, theApp->clientlist->GetBuddy()->GetIP(), 32);
 		tagBuddyIP.WriteTagToFile(data);
 
 		CTagVarInt tagBuddyPort(CT_EMULE_BUDDYUDP,
 			//					( RESERVED
 			//)
 			((uint32)theApp->clientlist->GetBuddy()->GetUDPPort()),
-			GetVBTTags() ? 0 : 32);
+			32);
 		tagBuddyPort.WriteTagToFile(data);
 	}
 
@@ -1091,7 +1085,7 @@ void CUpDownClient::SendHelloTypePacket(CMemFile *data)
 		(SO_AMULE << 24) | make_full_ed2k_version(VERSION_MJR, VERSION_MIN, VERSION_UPDATE)
 		// | (RESERVED			     )
 		,
-		GetVBTTags() ? 0 : 32);
+		32);
 	tagMuleVersion.WriteTagToFile(data);
 
 	// eMule Misc. Options #1
@@ -1117,7 +1111,7 @@ void CUpDownClient::SendHelloTypePacket(CMemFile *data)
 			(uSourceExchangeVer << 4 * 3) | (uExtendedRequestsVer << 4 * 2) |
 			(uAcceptCommentVer << 4 * 1) | (uPeerCache << 1 * 3) | (uNoViewSharedFiles << 1 * 2) |
 			(uMultiPacket << 1 * 1) | (uSupportPreview << 1 * 0),
-		GetVBTTags() ? 0 : 32);
+		32);
 	tagMisOptions.WriteTagToFile(data);
 
 	// eMule Misc. Options #2
@@ -1150,15 +1144,12 @@ void CUpDownClient::SendHelloTypePacket(CMemFile *data)
 			(uRequiresCryptLayer << 9) | (uRequestsCryptLayer << 8) | (uSupportsCryptLayer << 7) |
 			(uReserved << 6) | (uExtMultiPacket << 5) | (uSupportLargeFiles << 4) |
 			(uKadVersion << 0),
-		GetVBTTags() ? 0 : 32);
+		32);
 	tagMisOptions2.WriteTagToFile(data);
 
-	const uint32 nOSInfoSupport = 1;      // We support OS_INFO
-	const uint32 nValueBasedTypeTags = 0; // Experimental, disabled
+	const uint32 nOSInfoSupport = 1; // We support OS_INFO
 
-	CTagVarInt tagMisCompatOptions(CT_EMULECOMPAT_OPTIONS,
-		(nValueBasedTypeTags << 1 * 1) | (nOSInfoSupport << 1 * 0),
-		GetVBTTags() ? 0 : 32);
+	CTagVarInt tagMisCompatOptions(CT_EMULECOMPAT_OPTIONS, (nOSInfoSupport << 1 * 0), 32);
 
 	tagMisCompatOptions.WriteTagToFile(data);
 

--- a/src/ClientTCPSocket.cpp
+++ b/src/ClientTCPSocket.cpp
@@ -1979,16 +1979,6 @@ bool CClientTCPSocket::ProcessED2Kv2Packet(const uint8_t *buffer, uint32 size, u
 			break;
 		}
 
-		case OP_REQUESTPARTS: {
-			AddDebugLogLineN(logRemoteClient,
-				"Remote Client: ED2Kv2 OP_REQUESTPARTS from " + m_client->GetFullIP());
-
-			m_client->ProcessRequestPartsPacketv2(data);
-
-			theStats::AddDownOverheadFileRequest(size);
-			break;
-		}
-
 		default:
 			theStats::AddDownOverheadOther(size);
 			AddDebugLogLineN(logRemoteClient,

--- a/src/DownloadClient.cpp
+++ b/src/DownloadClient.cpp
@@ -586,48 +586,67 @@ void CUpDownClient::ProcessHashSet(const uint8_t *packet, uint32 size)
 
 void CUpDownClient::SendBlockRequests()
 {
-	uint64 current_time = ::GetTickCount64();
-	if (GetVBTTags()) {
-
-		// Ask new blocks only when all completed
-		if (!m_PendingBlocks_list.empty()) {
-			return;
-		}
-
-		if ((m_dwLastBlockReceived + SEC2MS(5)) > current_time) {
-			// We received last block in less than 5 secs? Let's request faster.
-			m_MaxBlockRequests = m_MaxBlockRequests << 1;
-			if (m_MaxBlockRequests > 0x20) {
-				m_MaxBlockRequests = 0x20;
-			}
-		} else {
-			m_MaxBlockRequests = m_MaxBlockRequests >> 1;
-			if (m_MaxBlockRequests < STANDARD_BLOCKS_REQUEST) {
-				m_MaxBlockRequests = STANDARD_BLOCKS_REQUEST;
-			}
-		}
-	}
-
-	m_dwLastBlockReceived = current_time;
+	m_dwLastBlockReceived = ::GetTickCount64();
 
 	if (!m_reqfile) {
 		return;
 	}
 
-	if (m_DownloadBlocks_list.empty()) {
-		// Barry - instead of getting 3, just get how many is needed
-		uint16 count = m_MaxBlockRequests - m_PendingBlocks_list.size();
-		std::vector<Requested_Block_Struct *> toadd;
-		if (m_reqfile->GetNextRequestedBlock(this, toadd, count)) {
-			for (int i = 0; i != count; i++) {
-				m_DownloadBlocks_list.push_back(toadd[i]);
+	// RTT/BDP-adaptive request-pipeline depth. The number of outstanding block
+	// requests needed to keep a link busy is the bandwidth-delay product:
+	// bytes_in_flight = rate * RTT. On a low-latency link (LAN) the BDP is a
+	// fraction of a 180 KB block, so we stay shallow and avoid the burst/starve
+	// oscillation a deep pipeline provokes against a fast local peer; on a
+	// high-latency link the BDP is large, so we go deep and hide the round-trip.
+	// Unlike a speed-only ladder this distinguishes a fast LAN peer from a fast
+	// WAN peer -- the thing that actually determines the depth needed. m_minRTT is
+	// the min-filtered request->first-byte round-trip (see ProcessBlockPacket).
+	//
+	// The flat cap-24 clamp is deliberate, not a placeholder. Benchmarking showed the
+	// WAN ceiling is the OS TCP socket-buffer autotune limit (~4 MB by default), which
+	// pins throughput near 40 MB/s at 100 ms RTT no matter how deep the request
+	// pipeline runs -- and cap 24 (24 * 180 KB = 4.3 MB of authorised in-flight data)
+	// already covers that. A deeper pipe buys no throughput, and 24 still sits inside
+	// eMule's own pending range (its gate is 2*blockCount = 18, with a top-up batch
+	// reaching ~27); lifting the OS buffer is host tuning, not a client concern. (The
+	// 2x overshoot factor below is still an empirical constant.)
+	const float rttMs = (m_minRTT > 0) ? (float)m_minRTT : 1.0f;
+	const float bdpBlocks = ((float)GetKBpsDown() * 1024.0f) * (rttMs / 1000.0f) / (float)EMBLOCKSIZE;
+	// 2x overshoot + margin: sizing the pipe to exactly the current BDP is
+	// self-limiting (the measured rate is itself capped by the current pipe, so it
+	// can never grow past a low equilibrium). Over-provisioning gives headroom for
+	// the rate to climb until it hits the link's real ceiling, at which point the
+	// BDP -- and thus the depth -- settles at the bandwidth-delay product.
+	size_t pendingCap = 2 * (size_t)bdpBlocks + STANDARD_BLOCKS_REQUEST;
+	if (pendingCap < STANDARD_BLOCKS_REQUEST) {
+		// The floor doubles as the slow-source guard: a trickle source -- or one with
+		// no RTT sample yet (rttMs defaults to 1) -- has a near-zero BDP and is held at
+		// the 3-block minimum, never handed a deep pipe.
+		pendingCap = STANDARD_BLOCKS_REQUEST;
+	} else if (pendingCap > 24) {
+		pendingCap = 24; // OS-buffer ceiling (see above); still within eMule's pending range
+	}
+
+	// Smooth continuous refill: top the in-flight + staged block count up to
+	// pendingCap by the exact shortfall each call, never in bursts. Bursty refill
+	// makes the leecher emit requests in clusters that overfill then starve a fast
+	// peer's send queue, leaving it idle between bursts (and tanking throughput on
+	// a low-latency link). Requests still ride the wire 3 to an OP_REQUESTPARTS
+	// packet, emitted across successive calls (see below).
+	{
+		const size_t inSystem = m_PendingBlocks_list.size() + m_DownloadBlocks_list.size();
+		if (inSystem < pendingCap) {
+			uint16 count = (uint16)(pendingCap - inSystem);
+			std::vector<Requested_Block_Struct *> toadd;
+			if (m_reqfile->GetNextRequestedBlock(this, toadd, count)) {
+				for (uint16 i = 0; i < count; i++) {
+					m_DownloadBlocks_list.push_back(toadd[i]);
+				}
 			}
 		}
 	}
 
-	// Barry - Why are unfinished blocks requested again, not just new ones?
-
-	while (m_PendingBlocks_list.size() < m_MaxBlockRequests && !m_DownloadBlocks_list.empty()) {
+	while (m_PendingBlocks_list.size() < pendingCap && !m_DownloadBlocks_list.empty()) {
 		Pending_Block_Struct *pblock = new Pending_Block_Struct;
 		pblock->block = m_DownloadBlocks_list.front();
 		pblock->zStream = NULL;
@@ -635,6 +654,7 @@ void CUpDownClient::SendBlockRequests()
 		pblock->fZStreamError = 0;
 		pblock->fRecovered = 0;
 		pblock->fQueued = 0; // Block sits in our local queue, not yet asked over the wire.
+		pblock->sentTime = 0;
 		m_PendingBlocks_list.push_back(pblock);
 		m_DownloadBlocks_list.pop_front();
 	}
@@ -682,7 +702,7 @@ void CUpDownClient::SendBlockRequests()
 					slower_client->GetFullIP());
 			wxASSERT(m_DownloadBlocks_list.empty());
 			wxASSERT(m_PendingBlocks_list.empty());
-			uint16 count = m_MaxBlockRequests;
+			uint16 count = (uint16)pendingCap;
 			std::vector<Requested_Block_Struct *> toadd;
 			if (m_reqfile->GetNextRequestedBlock(this, toadd, count)) {
 				for (int i = 0; i != count; i++) {
@@ -693,6 +713,7 @@ void CUpDownClient::SendBlockRequests()
 					pblock->fZStreamError = 0;
 					pblock->fRecovered = 0;
 					pblock->fQueued = 0;
+					pblock->sentTime = 0;
 					m_PendingBlocks_list.push_back(pblock);
 				}
 			} else {
@@ -726,32 +747,22 @@ void CUpDownClient::SendBlockRequests()
 		}
 	}
 
-	// Collect up to N pending blocks that have not yet been written to a
-	// REQUESTPARTS packet (fQueued == 0).  N is the protocol's
-	// per-packet limit:
+	// Collect up to 3 pending blocks that have not yet been written to a
+	// REQUESTPARTS packet (fQueued == 0). OP_REQUESTPARTS / OP_REQUESTPARTS_I64
+	// carry exactly 3 <start,end> pairs on the wire (see ProcessRequestPartsPacket
+	// in UploadClient.cpp, which unconditionally reads 3 pairs); asking for more
+	// in one packet corrupts the wire format and the sender ignores us. Pad with
+	// zero-pairs if we have fewer than 3 unqueued blocks.
 	//
-	//   - Legacy OP_REQUESTPARTS / OP_REQUESTPARTS_I64 carry exactly 3
-	//     <start,end> pairs on the wire (see ProcessRequestPartsPacket
-	//     in UploadClient.cpp, which unconditionally reads 3 pairs).
-	//     Asking for more than 3 in one packet corrupts the wire format
-	//     and the sender ignores us, leaving the receiver stuck "On
-	//     queue".  Pad with zero-pairs if we have fewer than 3 unqueued
-	//     blocks.
-	//
-	//   - The aMule-only ED2Kv2 OP_REQUESTPARTS variant (gated by
-	//     GetVBTTags()) carries a leading uint8 block count and can
-	//     hold up to m_MaxBlockRequests blocks per packet.
-	//
-	// To take more than 3 blocks in flight on legacy peers we therefore
-	// emit one 3-block packet per call to SendBlockRequests() and let
-	// the caller's existing re-invocation loop (after each
-	// OP_SENDINGPART, OP_ACCEPTUPLOADREQ, etc.) issue further packets
-	// until m_PendingBlocks_list is fully queued.  This is the same
-	// pattern eMule 0.70 uses (eMule0.70b srchybrid/DownloadClient.cpp
-	// ::CreateBlockRequests + ::SendBlockRequests).
+	// To take more than 3 blocks in flight we emit one 3-block packet per call to
+	// SendBlockRequests() and let the caller's existing re-invocation loop (after
+	// each OP_SENDINGPART, OP_ACCEPTUPLOADREQ, etc.) issue further packets until
+	// m_PendingBlocks_list is fully queued -- the same pattern eMule uses
+	// (eMule0.70b srchybrid/DownloadClient.cpp ::CreateBlockRequests +
+	// ::SendBlockRequests).
 	std::vector<Pending_Block_Struct *> toRequest;
 	bool bHasLongBlocks = false;
-	const size_t perPacketLimit = GetVBTTags() ? m_MaxBlockRequests : (size_t)STANDARD_BLOCKS_REQUEST;
+	const size_t perPacketLimit = STANDARD_BLOCKS_REQUEST;
 	toRequest.reserve(perPacketLimit);
 
 	for (std::list<Pending_Block_Struct *>::iterator it = m_PendingBlocks_list.begin();
@@ -791,68 +802,49 @@ void CUpDownClient::SendBlockRequests()
 
 	CPacket *packet = NULL;
 
-	if (GetVBTTags()) {
-		// ED2Kv2 packet: hash + nBlocks + per-block <start,end> tag pair.
-		const uint8 nBlocks = (uint8)toRequest.size();
-		CMemFile data(16 + 1 + nBlocks * ((2 + 4) * 2));
-		data.WriteHash(m_reqfile->GetFileHash());
-		data.WriteUInt8(nBlocks);
-		for (Pending_Block_Struct *pending : toRequest) {
+	// OP_REQUESTPARTS / OP_REQUESTPARTS_I64: always 3 blocks on the wire. Pad
+	// missing entries with zero <start,end> pairs; the upload-side parser
+	// (UploadClient.cpp ProcessRequestPartsPacket) silently skips entries with
+	// end <= start, so zero pairs are inert.
+	const size_t kWireBlocks = STANDARD_BLOCKS_REQUEST;
+	const size_t offsetSize = bHasLongBlocks ? 8 : 4;
+	CMemFile data(16 + kWireBlocks * offsetSize * 2);
+	data.WriteHash(m_reqfile->GetFileHash());
+
+	for (size_t i = 0; i < kWireBlocks; ++i) {
+		uint64 start = 0;
+		if (i < toRequest.size()) {
+			Pending_Block_Struct *pending = toRequest[i];
 			pending->fZStreamError = 0;
 			pending->fRecovered = 0;
 			pending->fQueued = 1;
-			CTagVarInt(/*Noname*/ 0, pending->block->StartOffset).WriteTagToFile(&data);
-			CTagVarInt(/*Noname*/ 0, pending->block->EndOffset).WriteTagToFile(&data);
+			pending->sentTime = ::GetTickCount64();
+			start = pending->block->StartOffset;
 		}
-		packet = new CPacket(data, OP_ED2KV2HEADER, OP_REQUESTPARTS);
-		AddDebugLogLineN(logLocalClient,
-			CFormat("Local Client ED2Kv2: OP_REQUESTPARTS(%i) to %s") % (int)nBlocks %
-				GetFullIP());
-	} else {
-		// Legacy OP_REQUESTPARTS / OP_REQUESTPARTS_I64: always 3 blocks
-		// on the wire.  Pad missing entries with zero <start,end> pairs;
-		// the upload-side parser (UploadClient.cpp ProcessRequestPartsPacket)
-		// silently skips entries with end <= start, so zero pairs are inert.
-		const size_t kWireBlocks = STANDARD_BLOCKS_REQUEST;
-		const size_t offsetSize = bHasLongBlocks ? 8 : 4;
-		CMemFile data(16 + kWireBlocks * offsetSize * 2);
-		data.WriteHash(m_reqfile->GetFileHash());
-
-		for (size_t i = 0; i < kWireBlocks; ++i) {
-			uint64 start = 0;
-			if (i < toRequest.size()) {
-				Pending_Block_Struct *pending = toRequest[i];
-				pending->fZStreamError = 0;
-				pending->fRecovered = 0;
-				pending->fQueued = 1;
-				start = pending->block->StartOffset;
-			}
-			if (bHasLongBlocks) {
-				data.WriteUInt64(start);
-			} else {
-				data.WriteUInt32((uint32)start);
-			}
+		if (bHasLongBlocks) {
+			data.WriteUInt64(start);
+		} else {
+			data.WriteUInt32((uint32)start);
 		}
-		for (size_t i = 0; i < kWireBlocks; ++i) {
-			uint64 end = 0;
-			if (i < toRequest.size()) {
-				end = toRequest[i]->block->EndOffset + 1;
-			}
-			if (bHasLongBlocks) {
-				data.WriteUInt64(end);
-			} else {
-				data.WriteUInt32((uint32)end);
-			}
-		}
-		packet = new CPacket(data,
-			(bHasLongBlocks ? OP_EMULEPROT : OP_EDONKEYPROT),
-			(bHasLongBlocks ? (uint8)OP_REQUESTPARTS_I64 : (uint8)OP_REQUESTPARTS));
-		AddDebugLogLineN(logLocalClient,
-			CFormat("Local Client: %s(%u of %u pending) to %s") %
-				(bHasLongBlocks ? "OP_REQUESTPARTS_I64" : "OP_REQUESTPARTS") %
-				(unsigned)toRequest.size() % (unsigned)m_PendingBlocks_list.size() %
-				GetFullIP());
 	}
+	for (size_t i = 0; i < kWireBlocks; ++i) {
+		uint64 end = 0;
+		if (i < toRequest.size()) {
+			end = toRequest[i]->block->EndOffset + 1;
+		}
+		if (bHasLongBlocks) {
+			data.WriteUInt64(end);
+		} else {
+			data.WriteUInt32((uint32)end);
+		}
+	}
+	packet = new CPacket(data,
+		(bHasLongBlocks ? OP_EMULEPROT : OP_EDONKEYPROT),
+		(bHasLongBlocks ? (uint8)OP_REQUESTPARTS_I64 : (uint8)OP_REQUESTPARTS));
+	AddDebugLogLineN(logLocalClient,
+		CFormat("Local Client: %s(%u of %u pending) to %s") %
+			(bHasLongBlocks ? "OP_REQUESTPARTS_I64" : "OP_REQUESTPARTS") %
+			(unsigned)toRequest.size() % (unsigned)m_PendingBlocks_list.size() % GetFullIP());
 
 	if (packet) {
 		theStats::AddUpOverheadFileRequest(packet->GetPacketSize());
@@ -953,6 +945,17 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 				if (cur_block->block->StartOffset == nStartPos) {
 					// This block just started transferring. Set the start time.
 					m_last_block_start = ::GetTickCount64();
+					// RTT sample: the matched request->first-byte round-trip for
+					// this block. Min-filtered so pipeline queuing delay never
+					// inflates the estimate (BBR-style min-RTT floor); used to size
+					// the request pipeline to the bandwidth-delay product.
+					if (cur_block->sentTime != 0) {
+						uint64 sample = m_last_block_start - cur_block->sentTime;
+						if (m_minRTT == 0 || sample < m_minRTT) {
+							m_minRTT = sample;
+						}
+						cur_block->sentTime = 0;
+					}
 				}
 
 				if (cur_block->fZStreamError) {

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -1313,30 +1313,25 @@ void CKnownFile::CreateOfferedFilePacket(CMemFile *files, CServer *pServer, CUpD
 	// The printable filename is used because it's destined for another user.
 	tags.push_back(new CTagString(FT_FILENAME, GetFileName().GetPrintable()));
 
-	if (pClient && pClient->GetVBTTags()) {
-		tags.push_back(new CTagVarInt(FT_FILESIZE, GetFileSize()));
+	if (!IsLargeFile()) {
+		tags.push_back(new CTagInt32(FT_FILESIZE, GetFileSize()));
 	} else {
-		if (!IsLargeFile()) {
-			tags.push_back(new CTagInt32(FT_FILESIZE, GetFileSize()));
-		} else {
-			// Large file
-			// we send 2*32 bit tags to servers, but a real 64 bit tag to other clients.
-			if (pServer) {
-				if (!pServer->SupportsLargeFilesTCP()) {
-					wxFAIL;
-					tags.push_back(new CTagInt32(FT_FILESIZE, 0));
-				} else {
-					tags.push_back(new CTagInt32(FT_FILESIZE, (uint32)GetFileSize()));
-					tags.push_back(
-						new CTagInt32(FT_FILESIZE_HI, (uint32)(GetFileSize() >> 32)));
-				}
+		// Large file
+		// we send 2*32 bit tags to servers, but a real 64 bit tag to other clients.
+		if (pServer) {
+			if (!pServer->SupportsLargeFilesTCP()) {
+				wxFAIL;
+				tags.push_back(new CTagInt32(FT_FILESIZE, 0));
 			} else {
-				if (!pClient->SupportsLargeFiles()) {
-					wxFAIL;
-					tags.push_back(new CTagInt32(FT_FILESIZE, 0));
-				} else {
-					tags.push_back(new CTagInt64(FT_FILESIZE, GetFileSize()));
-				}
+				tags.push_back(new CTagInt32(FT_FILESIZE, (uint32)GetFileSize()));
+				tags.push_back(new CTagInt32(FT_FILESIZE_HI, (uint32)(GetFileSize() >> 32)));
+			}
+		} else {
+			if (!pClient->SupportsLargeFiles()) {
+				wxFAIL;
+				tags.push_back(new CTagInt32(FT_FILESIZE, 0));
+			} else {
+				tags.push_back(new CTagInt64(FT_FILESIZE, GetFileSize()));
 			}
 		}
 	}
@@ -1349,8 +1344,7 @@ void CKnownFile::CreateOfferedFilePacket(CMemFile *files, CServer *pServer, CUpD
 			// otherwise remote clients decode it as 0. Servers themselves want the raw 0-5.
 			ratingValue *= (255 / 5);
 		}
-		tags.push_back(new CTagVarInt(
-			FT_FILERATING, ratingValue, (pClient && pClient->GetVBTTags()) ? 0 : 32));
+		tags.push_back(new CTagVarInt(FT_FILERATING, ratingValue, 32));
 	}
 
 	// NOTE: Archives and CD-Images are published+searched with file type "Pro"
@@ -1378,15 +1372,13 @@ void CKnownFile::CreateOfferedFilePacket(CMemFile *files, CServer *pServer, CUpD
 	// Media metadata (populated by MediaProbe at share-add time).
 	// Emit each tag only when nonzero / non-empty; older ed2k
 	// clients / servers happily ignore unknown tag IDs but should
-	// never be asked to parse a 0-valued FT_MEDIA_LENGTH. VBT
-	// (variable-bit) encoding for capable eMule clients and the
-	// TYPETAGINTEGER-capable servers; fixed 32-bit otherwise.
-	const bool useVBT = pClient && pClient->GetVBTTags();
+	// never be asked to parse a 0-valued FT_MEDIA_LENGTH. Fixed 32-bit
+	// encoding, as for every other client-bound tag here.
 	if (uint32 len = GetIntTagValue(FT_MEDIA_LENGTH)) {
-		tags.push_back(new CTagVarInt(FT_MEDIA_LENGTH, len, useVBT ? 0 : 32));
+		tags.push_back(new CTagVarInt(FT_MEDIA_LENGTH, len, 32));
 	}
 	if (uint32 br = GetIntTagValue(FT_MEDIA_BITRATE)) {
-		tags.push_back(new CTagVarInt(FT_MEDIA_BITRATE, br, useVBT ? 0 : 32));
+		tags.push_back(new CTagVarInt(FT_MEDIA_BITRATE, br, 32));
 	}
 	const wxString &codec = GetStrTagValue(FT_MEDIA_CODEC);
 	if (!codec.IsEmpty()) {

--- a/src/OtherStructs.h
+++ b/src/OtherStructs.h
@@ -90,9 +90,12 @@ struct Pending_Block_Struct
 	uint32 fZStreamError : 1, fRecovered : 1,
 		fQueued : 1; // 0 = block sits in m_PendingBlocks_list waiting to be asked over the wire,
 			     // 1 = block has been written to an OP_REQUESTPARTS packet and the sender owes us
-			     // bytes for it. Lets m_MaxBlockRequests act as the local queue depth while each
+			     // bytes for it. Lets the pending list act as the local queue depth while each
 			     // wire packet still carries the protocol-mandated 3 blocks (eMule 0.70
 			     // SendBlockRequests pattern).
+	// Tick when this block's request went on the wire; reset to 0 once its first byte
+	// arrives (used for the per-source min-RTT / BDP depth estimate).
+	uint64 sentTime;
 };
 
 struct Gap_Struct

--- a/src/UploadClient.cpp
+++ b/src/UploadClient.cpp
@@ -751,42 +751,4 @@ void CUpDownClient::ProcessRequestPartsPacket(const uint8_t *pachPacket, uint32 
 	}
 }
 
-void CUpDownClient::ProcessRequestPartsPacketv2(const CMemFile &data)
-{
-
-	CMD4Hash reqfilehash = data.ReadHash();
-
-	uint8 numblocks = data.ReadUInt8();
-
-	for (int i = 0; i < numblocks; i++) {
-		Requested_Block_Struct *reqblock = new Requested_Block_Struct;
-		try {
-			reqblock->StartOffset = data.GetIntTagValue();
-			// We have to do +1, because the block matching uses that.
-			reqblock->EndOffset = data.GetIntTagValue() + 1;
-			if ((reqblock->StartOffset || reqblock->EndOffset) &&
-				(reqblock->StartOffset > reqblock->EndOffset)) {
-				AddDebugLogLineN(logClient,
-					CFormat("Client %s request is invalid! %d / %d") % GetFullIP() %
-						reqblock->StartOffset % reqblock->EndOffset);
-				throw wxString("Client request is invalid!");
-			}
-
-			AddDebugLogLineN(logClient,
-				CFormat("Client %s requests %d File block %d-%d (%d bytes):") % GetFullIP() %
-					i % reqblock->StartOffset % reqblock->EndOffset %
-					(reqblock->EndOffset - reqblock->StartOffset));
-
-			md4cpy(reqblock->FileID, reqfilehash.GetHash());
-			reqblock->transferred = 0;
-			AddReqBlock(reqblock, false);
-		} catch (...) {
-			delete reqblock;
-			throw;
-		}
-	}
-	if (theApp->uploadDiskIOThread) {
-		theApp->uploadDiskIOThread->NewBlockRequestsAvailable();
-	}
-}
 // File_checked_for_headers

--- a/src/UploadDiskIOThread.cpp
+++ b/src/UploadDiskIOThread.cpp
@@ -198,7 +198,14 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 
 	// eMule ref: lines 199-201
 	bool bFastUpload = client->GetUploadDatarate() > BIGBUFFER_MINDATARATE;
-	const uint32 nBufferLimit = bFastUpload ? ((5 * EMBLOCKSIZE) + 1) : (EMBLOCKSIZE + 1);
+	// Send-ahead depth: how many blocks this thread primes into a fast slot's async send
+	// queue (1 otherwise). This is the upload-side in-flight depth -- the mirror of the
+	// leecher's request cap -- so it is bandwidth-delay-product limited: on a high-RTT link
+	// a shallow buffer drains before the next refill and caps throughput. eMule's 5 is a
+	// low-BDP default; 10 keeps a fast slot fed across moderate WAN RTTs. The cost is a
+	// transient ~1.8 MB of send-queue data per active fast slot, and it is self-bounded by
+	// the OS TCP send buffer (so a deeper value buys nothing once that ceiling is hit).
+	const uint32 nBufferLimit = bFastUpload ? ((10 * EMBLOCKSIZE) + 1) : (EMBLOCKSIZE + 1);
 
 	if (client->m_BlockRequests_queue.empty() ||
 		(addedPayloadQueueSession > nCurQueueSessionPayloadUp &&

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -274,7 +274,6 @@ public:
 	bool SafeSendPacket(CPacket *packet);
 
 	void ProcessRequestPartsPacket(const uint8_t *pachPacket, uint32 nSize, bool largeblocks);
-	void ProcessRequestPartsPacketv2(const CMemFile &data);
 
 	void SendPublicKeyPacket();
 	void SendSignaturePacket();
@@ -630,8 +629,6 @@ public:
 
 	bool GetOSInfoSupport() const { return m_fOsInfoSupport; }
 
-	bool GetVBTTags() const { return m_fValueBasedTypeTags; }
-
 	uint16 GetLastPartAsked() const { return m_lastPartAsked; }
 
 	void SetLastPartAsked(uint16 nPart) { m_lastPartAsked = nPart; }
@@ -884,7 +881,7 @@ private:
 		m_fSupportsCryptLayer : 1, m_fRequiresCryptLayer : 1, m_fSupportsSourceEx2 : 1,
 		m_fSupportsCaptcha : 1, m_fDirectUDPCallback : 1;
 
-	unsigned int m_fOsInfoSupport : 1, m_fValueBasedTypeTags : 1;
+	unsigned int m_fOsInfoSupport : 1;
 
 	/* Razor 1a - Modif by MikaelB */
 
@@ -929,8 +926,6 @@ private:
 
 	CKnownFile *m_uploadingfile;
 
-	uint8 m_MaxBlockRequests;
-
 	// needed for stats
 	uint32 m_lastClientSoft;
 	uint32 m_lastClientVersion;
@@ -939,6 +934,8 @@ private:
 	/* Calculation of last average speed */
 	uint32 m_lastaverage;
 	uint64 m_last_block_start;
+	uint64 m_minRTT; // smoothed floor (ms) of measured request->first-byte round-trips from this
+			 // source; 0 = not yet measured. Drives the BDP-adaptive request depth.
 
 	/* Save the encryption status for display when disconnected */
 	bool m_hasbeenobfuscatinglately;


### PR DESCRIPTION
Sizes the ed2k block-transfer pipeline to the bandwidth-delay product (BDP) in both directions, so throughput holds up on low-latency LAN links and high-latency internet links alike, and removes the dead VBT (value-based-type-tags) ed2k-v2 code path.

**Download — adaptive request depth.** Instead of a fixed 3-deep request queue, each source's depth is sized to its BDP: `2*(rate*minRTT/EMBLOCKSIZE)+3`, clamped to `[3,24]`. It stays shallow against a fast LAN peer (avoiding the burst/starve oscillation a deep queue provokes on a sub-millisecond link) and goes deep against a high-latency WAN peer (hiding the round-trip). `minRTT` is measured per source as the minimum request->first-byte time; the wire still carries the protocol-mandated 3 blocks per `OP_REQUESTPARTS`. The 24 clamp is deliberate: socket telemetry showed the WAN ceiling is the OS TCP send-buffer autotune limit (~4 MB -> ~40 MB/s at 100 ms RTT), which 24 (~4.3 MB in flight) already covers -- a deeper queue buys nothing, and 24 still sits within eMule's own pending range (its gate is `2*blockCount` = 18, with a top-up batch reaching ~27).

**Upload — adaptive send-ahead depth.** Raises the disk I/O thread's fast-slot send-ahead buffer from 5 to 10 blocks. This is the upload-side mirror of the same BDP limit: it sets how much data is primed into a fast slot's async send queue, so a shallow buffer drains before the next refill and caps throughput on a high-RTT link. Cost is a transient ~1.8 MB per active fast slot, self-bounded by the OS TCP send buffer.

**VBT removal.** Drops the value-based-type-tags ed2k-v2 path, which never shipped in a release (`nValueBasedTypeTags` was hardcoded 0 on send and `GetVBTTags()` always returned false), simplifying the block-request and known-file packet builders.

## Benchmarks

**Setup.** macOS leecher (Apple Silicon) <-> bare-metal Linux seeder, gigabit LAN. Latency injected on the leecher via macOS dummynet (`dnctl`/`pfctl`), TCP-scoped to the seeder IP so ICMP is unaffected and only the ed2k connection sees the added RTT. `MaxUpload` unlimited; 5 GB and 30 GB test files (the 30 GB for the 120 s WAN runs, so nothing completes mid-run); 30-120 s runs reported at steady state. RTT verified per run by timing the TCP handshake.

### End-to-end: current master vs this PR

Same-session before/after, both binaries built from `origin/master` (stock) and this branch (PR), leecher AND seeder matched per config. WAN rows are 120 s runs (fully-ramped steady-state plateau on both sides); LAN is a 30 s run (both plateau by T+30):

| RTT | Stock master (fixed-3 + buf-5) | This PR (adaptive cap-24 + buf-10) | Delta |
|---|---|---|---|
| 1 ms (LAN) | 131 MB/s | 128 MB/s | no regression |
| 50 ms | 5.8 MB/s | 65 MB/s | ~11x |
| 100 ms | 3.0 MB/s | 35 MB/s | ~12x |

LAN throughput is unchanged (both run 3-deep on a sub-millisecond link). On WAN links stock's fixed 3-block queue is effectively stop-and-wait -- it refills only once a batch of blocks completes, so each batch pays ~2x RTT and throughput collapses as latency grows. Stock master is fixed 3-deep because its legacy `m_MaxBlockRequests` doubling/halving adaptivity is dead code behind the always-false `GetVBTTags()` gate that this PR removes. The sections below isolate each contributing change.

### Upload send-ahead depth — the seeder change (leecher at the shipped adaptive cap-24)

| Seeder fast-slot buffer | 50 ms RTT | 100 ms RTT |
|---|---|---|
| 5 blocks (stock = eMule's value) | 34 MB/s | 18 MB/s |
| **10 blocks (this PR)** | **62 MB/s** | **35 MB/s** |
| 20 blocks | 64 MB/s | 35 MB/s |

10 blocks nearly doubles WAN throughput and captures ~95%+ of the available gain; 20 adds nothing at 100 ms (OS-buffer bound, below) and ~3% at 50 ms -- so 10 is the knee. Seeder cost at 60 MB/s: ~14% of one core, ~59 MB RSS.

### Download request depth on a fast LAN peer (1 ms RTT) — why the adaptive cap stays shallow

| Fixed request depth | Throughput |
|---|---|
| 2 | 90 MB/s |
| 6 | 130 MB/s |
| 12 | 67 MB/s |
| 18 | 54 MB/s |

A deep queue collapses throughput on a sub-millisecond link (burst/starve oscillation). The adaptive cap sizes to the BDP and picks ~3 here -> ~130 MB/s, staying in the shallow high-throughput region instead of a fixed deep queue.

### WAN ceiling — why the depth clamp is 24, not higher

| RTT | OS 4 MB TCP send-buffer ceiling | Achieved (this PR) |
|---|---|---|
| 50 ms | ~80 MB/s | 62 MB/s |
| 100 ms | ~40 MB/s | 35 MB/s |

Socket telemetry (`ss -tmi`) showed the WAN throughput ceiling is the OS TCP send-buffer autotune limit (~4 MB), not request depth -- the congestion window had headroom while the send buffer sat full. A request cap of 24 (~4.3 MB in flight) already covers that ceiling, so a deeper queue is wasted; 24 also stays within eMule's own pending range (gate `2*blockCount` = 18, batch overshoot to ~27). Raising the OS `tcp_wmem` max is host tuning, out of scope for the client.
